### PR TITLE
feat: update pricing tiers with concrete limits

### DIFF
--- a/packages/styrby-web/src/app/(dashboard)/pricing/page.tsx
+++ b/packages/styrby-web/src/app/(dashboard)/pricing/page.tsx
@@ -158,12 +158,79 @@ export default async function PricingPage() {
           })}
         </div>
 
-        {/* FAQ or additional info */}
+        {/* Limits comparison table */}
+        <div className="mt-16">
+          <h2 className="text-xl font-semibold text-zinc-100 text-center mb-8">
+            Compare Plans
+          </h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800">
+                  <th className="text-left py-3 px-4 text-zinc-400 font-medium">Feature</th>
+                  <th className="text-center py-3 px-4 text-zinc-400 font-medium">Free</th>
+                  <th className="text-center py-3 px-4 text-zinc-400 font-medium">Pro</th>
+                  <th className="text-center py-3 px-4 text-zinc-400 font-medium">Power</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-800">
+                <tr>
+                  <td className="py-3 px-4 text-zinc-300">Connected machines</td>
+                  <td className="py-3 px-4 text-center text-zinc-400">1</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">5</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">15</td>
+                </tr>
+                <tr>
+                  <td className="py-3 px-4 text-zinc-300">Session history</td>
+                  <td className="py-3 px-4 text-center text-zinc-400">7 days</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">90 days</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">1 year</td>
+                </tr>
+                <tr>
+                  <td className="py-3 px-4 text-zinc-300">Messages/month</td>
+                  <td className="py-3 px-4 text-center text-zinc-400">1,000</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">25,000</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">100,000</td>
+                </tr>
+                <tr>
+                  <td className="py-3 px-4 text-zinc-300">Budget alerts</td>
+                  <td className="py-3 px-4 text-center text-zinc-500">-</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">3</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">10</td>
+                </tr>
+                <tr>
+                  <td className="py-3 px-4 text-zinc-300">Team members</td>
+                  <td className="py-3 px-4 text-center text-zinc-500">-</td>
+                  <td className="py-3 px-4 text-center text-zinc-500">-</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">5</td>
+                </tr>
+                <tr>
+                  <td className="py-3 px-4 text-zinc-300">API access</td>
+                  <td className="py-3 px-4 text-center text-zinc-500">-</td>
+                  <td className="py-3 px-4 text-center text-zinc-500">-</td>
+                  <td className="py-3 px-4 text-center text-green-500">Yes</td>
+                </tr>
+                <tr>
+                  <td className="py-3 px-4 text-zinc-300">Support</td>
+                  <td className="py-3 px-4 text-center text-zinc-500">-</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">Email</td>
+                  <td className="py-3 px-4 text-center text-zinc-100">Priority email</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* FAQ */}
         <div className="mt-12 text-center">
           <p className="text-zinc-500">
-            All plans include a 7-day free trial.{' '}
+            Questions?{' '}
+            <a href="mailto:support@styrby.dev" className="text-orange-500 hover:text-orange-400">
+              Contact support
+            </a>
+            {' '}or{' '}
             <Link href="/settings" className="text-orange-500 hover:text-orange-400">
-              Manage your subscription
+              manage your subscription
             </Link>
           </p>
         </div>

--- a/packages/styrby-web/src/app/page.tsx
+++ b/packages/styrby-web/src/app/page.tsx
@@ -320,7 +320,13 @@ export default function Home() {
                   <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  Basic cost tracking
+                  1,000 messages/month
+                </li>
+                <li className="flex items-center gap-2 text-sm text-zinc-400">
+                  <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  All 3 agents supported
                 </li>
               </ul>
               <Link
@@ -339,7 +345,7 @@ export default function Home() {
               <h3 className="text-xl font-semibold text-zinc-100">Pro</h3>
               <p className="mt-2 text-sm text-zinc-500">For daily use</p>
               <div className="mt-4">
-                <span className="text-4xl font-bold text-zinc-100">$9</span>
+                <span className="text-4xl font-bold text-zinc-100">$19</span>
                 <span className="text-zinc-500">/month</span>
               </div>
               <ul className="mt-6 space-y-3">
@@ -353,26 +359,26 @@ export default function Home() {
                   <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  Unlimited session history
+                  90-day session history
                 </li>
                 <li className="flex items-center gap-2 text-sm text-zinc-400">
                   <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  Advanced analytics
+                  25,000 messages/month
                 </li>
                 <li className="flex items-center gap-2 text-sm text-zinc-400">
                   <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  Budget alerts
+                  Budget alerts + analytics
                 </li>
               </ul>
               <Link
                 href="/login"
                 className="mt-8 block w-full rounded-lg bg-orange-500 py-3 text-center text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
               >
-                Start 7-Day Trial
+                Start Free Trial
               </Link>
             </div>
 
@@ -381,7 +387,7 @@ export default function Home() {
               <h3 className="text-xl font-semibold text-zinc-100">Power</h3>
               <p className="mt-2 text-sm text-zinc-500">For teams and power users</p>
               <div className="mt-4">
-                <span className="text-4xl font-bold text-zinc-100">$29</span>
+                <span className="text-4xl font-bold text-zinc-100">$49</span>
                 <span className="text-zinc-500">/month</span>
               </div>
               <ul className="mt-6 space-y-3">
@@ -389,32 +395,32 @@ export default function Home() {
                   <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  Unlimited machines
+                  15 machines, 5 team members
                 </li>
                 <li className="flex items-center gap-2 text-sm text-zinc-400">
                   <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  Team sharing
+                  1-year session history
                 </li>
                 <li className="flex items-center gap-2 text-sm text-zinc-400">
                   <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  API access
+                  100,000 messages/month
                 </li>
                 <li className="flex items-center gap-2 text-sm text-zinc-400">
                   <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  Priority support
+                  API access + priority support
                 </li>
               </ul>
               <Link
                 href="/login"
                 className="mt-8 block w-full rounded-lg bg-zinc-800 py-3 text-center text-sm font-semibold text-zinc-100 hover:bg-zinc-700 transition-colors"
               >
-                Start 7-Day Trial
+                Start Free Trial
               </Link>
             </div>
           </div>

--- a/packages/styrby-web/src/lib/polar.ts
+++ b/packages/styrby-web/src/lib/polar.ts
@@ -16,6 +16,11 @@ export const polar = new Polar({
 
 /**
  * Subscription tier configuration.
+ *
+ * Limits are enforced to prevent abuse:
+ * - Machines: Supabase Realtime connections
+ * - Messages: Relay bandwidth
+ * - History: Database storage
  */
 export const TIERS = {
   free: {
@@ -26,43 +31,63 @@ export const TIERS = {
     features: [
       '1 connected machine',
       '7-day session history',
-      'Basic cost tracking',
+      '1,000 messages/month',
+      'Error notifications only',
+      'All 3 agents supported',
     ],
     limits: {
       machines: 1,
       historyDays: 7,
+      messagesPerMonth: 1_000,
+      budgetAlerts: 0,
+      teamMembers: 1,
     },
   },
   pro: {
     id: 'pro',
     name: 'Pro',
-    price: 9,
+    price: 19,
     polarProductId: process.env.POLAR_PRO_PRODUCT_ID,
     features: [
       '5 connected machines',
-      'Unlimited session history',
-      'Advanced analytics',
-      'Budget alerts',
+      '90-day session history',
+      '25,000 messages/month',
+      'All push notifications',
+      '3 budget alerts',
+      'Full cost analytics',
+      'CSV export',
+      'Email support',
     ],
     limits: {
       machines: 5,
-      historyDays: -1, // unlimited
+      historyDays: 90,
+      messagesPerMonth: 25_000,
+      budgetAlerts: 3,
+      teamMembers: 1,
     },
   },
   power: {
     id: 'power',
     name: 'Power',
-    price: 29,
+    price: 49,
     polarProductId: process.env.POLAR_POWER_PRODUCT_ID,
     features: [
-      'Unlimited machines',
-      'Team sharing',
-      'API access',
-      'Priority support',
+      '15 connected machines',
+      '1-year session history',
+      '100,000 messages/month',
+      'Custom notification rules',
+      '10 budget alerts',
+      'Up to 5 team members',
+      'API access (read-only)',
+      'CSV + JSON export',
+      'Priority email support',
     ],
     limits: {
-      machines: -1, // unlimited
-      historyDays: -1,
+      machines: 15,
+      historyDays: 365,
+      messagesPerMonth: 100_000,
+      budgetAlerts: 10,
+      teamMembers: 5,
     },
   },
 } as const;


### PR DESCRIPTION
## Summary
- **Pro tier**: $19/mo with 5 machines, 25k messages/month, 90-day history, 3 budget alerts
- **Power tier**: $49/mo with 15 machines, 100k messages/month, 1-year history, 10 budget alerts, 5 team members, API access
- **Free tier**: 1 machine, 1k messages/month, 7-day history (no budget alerts)
- Replaced all "unlimited" language with specific numeric limits to prevent abuse
- Added comparison table on pricing page showing all limits
- Removed Discord support references (email support only for solo dev workflow)

## Test plan
- [ ] Verify pricing page renders correctly with new prices
- [ ] Check landing page pricing section shows $19/$49
- [ ] Verify comparison table displays all limits correctly
- [ ] Confirm no Discord references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)