### PR TITLE
feat(mobile): add cost dashboard screen and components

### DIFF
--- a/packages/styrby-mobile/app/(tabs)/costs.tsx
+++ b/packages/styrby-mobile/app/(tabs)/costs.tsx
@@ -1,0 +1,203 @@
+/**
+ * Costs Screen
+ *
+ * Main cost dashboard showing spending summaries, agent breakdown,
+ * and a 7-day cost chart. Users can track their AI coding costs here.
+ */
+
+import { View, Text, ScrollView, RefreshControl, ActivityIndicator, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useCosts, formatCost, formatTokens } from '../../src/hooks/useCosts';
+import { CostCard } from '../../src/components/CostCard';
+import { AgentCostBar, AgentCostBarEmpty } from '../../src/components/AgentCostBar';
+import { DailyMiniChart, DailyMiniChartEmpty, DailyMiniChartSkeleton } from '../../src/components/DailyMiniChart';
+
+/**
+ * Cost Dashboard Screen
+ *
+ * Displays:
+ * - Cost summaries for today, this week, and this month
+ * - Cost breakdown by agent with visual progress bars
+ * - 7-day cost chart
+ * - Pull-to-refresh functionality
+ */
+export default function CostsScreen() {
+  const { data, isLoading, isRefreshing, error, refresh } = useCosts();
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center">
+        <ActivityIndicator size="large" color="#f97316" />
+        <Text className="text-zinc-500 mt-4">Loading costs...</Text>
+      </View>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center px-6">
+        <Ionicons name="alert-circle-outline" size={48} color="#ef4444" />
+        <Text className="text-white text-lg font-semibold mt-4">Failed to Load Costs</Text>
+        <Text className="text-zinc-500 text-center mt-2">{error}</Text>
+        <Pressable
+          onPress={refresh}
+          className="bg-brand px-6 py-3 rounded-xl mt-6 active:opacity-80"
+        >
+          <Text className="text-white font-semibold">Try Again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  // No data state (shouldn't happen normally, but handle gracefully)
+  if (!data) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center">
+        <Text className="text-zinc-500">No cost data available</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background"
+      contentContainerStyle={{ paddingBottom: 24 }}
+      refreshControl={
+        <RefreshControl
+          refreshing={isRefreshing}
+          onRefresh={refresh}
+          tintColor="#f97316"
+          colors={['#f97316']}
+        />
+      }
+    >
+      {/* Cost Summary Cards */}
+      <View className="px-4 pt-4">
+        <Text className="text-zinc-400 text-sm font-medium mb-3">SPENDING</Text>
+
+        {/* Today - featured card */}
+        <CostCard
+          title="Today"
+          amount={data.today.totalCost}
+          subtitle={`${data.today.requestCount} requests`}
+          icon="today"
+          iconColor="#f97316"
+        />
+
+        {/* Week and Month - compact row */}
+        <View className="flex-row mt-3 gap-3">
+          <CostCard
+            title="This Week"
+            amount={data.week.totalCost}
+            subtitle={`${data.week.requestCount} req`}
+            icon="calendar"
+            iconColor="#3b82f6"
+            compact
+          />
+          <CostCard
+            title="This Month"
+            amount={data.month.totalCost}
+            subtitle={`${data.month.requestCount} req`}
+            icon="calendar-number"
+            iconColor="#22c55e"
+            compact
+          />
+        </View>
+      </View>
+
+      {/* 7-Day Chart */}
+      <View className="px-4 mt-6">
+        {data.dailyCosts.length > 0 ? (
+          <DailyMiniChart data={data.dailyCosts} />
+        ) : (
+          <DailyMiniChartEmpty />
+        )}
+      </View>
+
+      {/* Agent Breakdown */}
+      <View className="px-4 mt-6">
+        <Text className="text-zinc-400 text-sm font-medium mb-3">BY AGENT</Text>
+        <View className="bg-background-secondary rounded-xl p-4">
+          {data.byAgent.length > 0 ? (
+            data.byAgent.map((agent) => (
+              <AgentCostBar
+                key={agent.agent}
+                agent={agent.agent}
+                cost={agent.cost}
+                percentage={agent.percentage}
+                requestCount={agent.requestCount}
+              />
+            ))
+          ) : (
+            <AgentCostBarEmpty />
+          )}
+        </View>
+      </View>
+
+      {/* Token Usage Summary */}
+      <View className="px-4 mt-6">
+        <Text className="text-zinc-400 text-sm font-medium mb-3">TOKEN USAGE (MONTH)</Text>
+        <View className="bg-background-secondary rounded-xl p-4">
+          <View className="flex-row">
+            {/* Input Tokens */}
+            <View className="flex-1 items-center">
+              <View className="flex-row items-center mb-1">
+                <Ionicons name="arrow-up-circle" size={16} color="#3b82f6" />
+                <Text className="text-zinc-400 text-xs ml-1">Input</Text>
+              </View>
+              <Text className="text-white font-semibold text-lg">
+                {formatTokens(data.month.inputTokens)}
+              </Text>
+            </View>
+
+            {/* Divider */}
+            <View className="w-px bg-zinc-800 mx-4" />
+
+            {/* Output Tokens */}
+            <View className="flex-1 items-center">
+              <View className="flex-row items-center mb-1">
+                <Ionicons name="arrow-down-circle" size={16} color="#22c55e" />
+                <Text className="text-zinc-400 text-xs ml-1">Output</Text>
+              </View>
+              <Text className="text-white font-semibold text-lg">
+                {formatTokens(data.month.outputTokens)}
+              </Text>
+            </View>
+
+            {/* Divider */}
+            <View className="w-px bg-zinc-800 mx-4" />
+
+            {/* Total */}
+            <View className="flex-1 items-center">
+              <View className="flex-row items-center mb-1">
+                <Ionicons name="analytics" size={16} color="#f97316" />
+                <Text className="text-zinc-400 text-xs ml-1">Total</Text>
+              </View>
+              <Text className="text-white font-semibold text-lg">
+                {formatTokens(data.month.inputTokens + data.month.outputTokens)}
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+
+      {/* Budget Alert Hint (for future feature) */}
+      <View className="px-4 mt-6">
+        <View className="bg-background-secondary rounded-xl p-4 flex-row items-center">
+          <View className="w-10 h-10 rounded-xl bg-yellow-500/20 items-center justify-center mr-3">
+            <Ionicons name="notifications" size={20} color="#eab308" />
+          </View>
+          <View className="flex-1">
+            <Text className="text-white font-medium">Budget Alerts</Text>
+            <Text className="text-zinc-500 text-sm">
+              Set spending limits and get notified
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={20} color="#71717a" />
+        </View>
+      </View>
+    </ScrollView>
+  );
+}

--- a/packages/styrby-mobile/src/components/AgentCostBar.tsx
+++ b/packages/styrby-mobile/src/components/AgentCostBar.tsx
@@ -1,0 +1,108 @@
+/**
+ * Agent Cost Bar Component
+ *
+ * Displays a horizontal progress bar showing an agent's cost contribution.
+ * Includes agent name, cost amount, and percentage of total.
+ */
+
+import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { AgentType } from 'styrby-shared';
+import { getAgentHexColor, getAgentDisplayName, formatCost } from '../hooks/useCosts';
+
+/**
+ * Props for the AgentCostBar component.
+ */
+interface AgentCostBarProps {
+  /** Agent type identifier */
+  agent: AgentType;
+  /** Cost amount in USD */
+  cost: number;
+  /** Percentage of total cost (0-100) */
+  percentage: number;
+  /** Number of requests made by this agent */
+  requestCount?: number;
+}
+
+/**
+ * Agent icon mapping.
+ */
+const AGENT_ICONS: Record<AgentType, keyof typeof Ionicons.glyphMap> = {
+  claude: 'terminal',
+  codex: 'code-slash',
+  gemini: 'sparkles',
+  opencode: 'logo-github',
+  aider: 'git-branch',
+};
+
+/**
+ * AgentCostBar displays a single agent's cost with a visual progress bar.
+ *
+ * @param props - Component props
+ * @returns Rendered agent cost bar
+ *
+ * @example
+ * <AgentCostBar
+ *   agent="claude"
+ *   cost={45.67}
+ *   percentage={75}
+ *   requestCount={42}
+ * />
+ */
+export function AgentCostBar({ agent, cost, percentage, requestCount }: AgentCostBarProps) {
+  const color = getAgentHexColor(agent);
+  const name = getAgentDisplayName(agent);
+  const icon = AGENT_ICONS[agent] || 'terminal';
+
+  return (
+    <View className="mb-4">
+      {/* Header row: icon, name, cost, percentage */}
+      <View className="flex-row items-center justify-between mb-2">
+        <View className="flex-row items-center flex-1">
+          <View
+            className="w-8 h-8 rounded-lg items-center justify-center mr-2"
+            style={{ backgroundColor: `${color}20` }}
+          >
+            <Ionicons name={icon} size={16} color={color} />
+          </View>
+          <View className="flex-1">
+            <Text className="text-white font-medium">{name}</Text>
+            {requestCount !== undefined && (
+              <Text className="text-zinc-500 text-xs">{requestCount} requests</Text>
+            )}
+          </View>
+        </View>
+        <View className="items-end">
+          <Text className="text-white font-semibold">{formatCost(cost)}</Text>
+          <Text className="text-zinc-500 text-xs">{percentage.toFixed(1)}%</Text>
+        </View>
+      </View>
+
+      {/* Progress bar */}
+      <View className="h-2 bg-zinc-800 rounded-full overflow-hidden">
+        <View
+          className="h-full rounded-full"
+          style={{
+            backgroundColor: color,
+            width: `${Math.min(100, Math.max(0, percentage))}%`,
+          }}
+        />
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Empty state shown when there are no agent costs.
+ */
+export function AgentCostBarEmpty() {
+  return (
+    <View className="items-center py-6">
+      <Ionicons name="analytics-outline" size={32} color="#3f3f46" />
+      <Text className="text-zinc-500 mt-2 text-center">No cost data yet</Text>
+      <Text className="text-zinc-600 text-sm text-center mt-1">
+        Start using AI agents to see your costs here
+      </Text>
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/components/CostCard.tsx
+++ b/packages/styrby-mobile/src/components/CostCard.tsx
@@ -1,0 +1,99 @@
+/**
+ * Cost Card Component
+ *
+ * Displays a single cost metric with title, amount, and optional subtitle.
+ * Used on the cost dashboard to show today/week/month totals.
+ */
+
+import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+/**
+ * Props for the CostCard component.
+ */
+interface CostCardProps {
+  /** Card title (e.g., "Today", "This Week") */
+  title: string;
+  /** Cost amount in USD */
+  amount: number;
+  /** Optional subtitle text (e.g., "12 requests") */
+  subtitle?: string;
+  /** Icon name from Ionicons */
+  icon?: keyof typeof Ionicons.glyphMap;
+  /** Icon color (defaults to brand orange) */
+  iconColor?: string;
+  /** Whether this is a compact card (used in horizontal row) */
+  compact?: boolean;
+}
+
+/**
+ * Cost Card displays a cost metric with visual styling.
+ *
+ * @param props - Component props
+ * @returns Rendered cost card
+ *
+ * @example
+ * <CostCard
+ *   title="Today"
+ *   amount={12.34}
+ *   subtitle="5 requests"
+ *   icon="today"
+ *   iconColor="#f97316"
+ * />
+ */
+export function CostCard({
+  title,
+  amount,
+  subtitle,
+  icon = 'wallet',
+  iconColor = '#f97316',
+  compact = false,
+}: CostCardProps) {
+  /**
+   * Format the cost amount for display.
+   * Shows more decimals for small amounts.
+   */
+  const formatAmount = (value: number): string => {
+    if (value === 0) return '$0.00';
+    if (value < 0.01) return `$${value.toFixed(4)}`;
+    if (value < 1) return `$${value.toFixed(3)}`;
+    return `$${value.toFixed(2)}`;
+  };
+
+  if (compact) {
+    return (
+      <View className="flex-1 bg-background-secondary rounded-xl p-4">
+        <View className="flex-row items-center mb-2">
+          <Ionicons name={icon} size={16} color={iconColor} />
+          <Text className="text-zinc-400 text-xs font-medium ml-1.5">{title}</Text>
+        </View>
+        <Text className="text-white text-lg font-bold">{formatAmount(amount)}</Text>
+        {subtitle && <Text className="text-zinc-500 text-xs mt-0.5">{subtitle}</Text>}
+      </View>
+    );
+  }
+
+  return (
+    <View className="bg-background-secondary rounded-xl p-4">
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center">
+          <View
+            className="w-10 h-10 rounded-xl items-center justify-center"
+            style={{ backgroundColor: `${iconColor}20` }}
+          >
+            <Ionicons name={icon} size={20} color={iconColor} />
+          </View>
+          <View className="ml-3">
+            <Text className="text-zinc-400 text-sm">{title}</Text>
+            <Text className="text-white text-2xl font-bold">{formatAmount(amount)}</Text>
+          </View>
+        </View>
+        {subtitle && (
+          <View className="items-end">
+            <Text className="text-zinc-500 text-sm">{subtitle}</Text>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/components/DailyMiniChart.tsx
+++ b/packages/styrby-mobile/src/components/DailyMiniChart.tsx
@@ -1,0 +1,151 @@
+/**
+ * Daily Mini Chart Component
+ *
+ * Simple 7-day bar chart showing daily cost totals.
+ * Designed to be compact and fit in the cost dashboard.
+ */
+
+import { View, Text } from 'react-native';
+import type { DailyCostDataPoint } from '../hooks/useCosts';
+
+/**
+ * Props for the DailyMiniChart component.
+ */
+interface DailyMiniChartProps {
+  /** Array of daily cost data points (should be 7 days) */
+  data: DailyCostDataPoint[];
+  /** Maximum height of the bars in pixels (default 80) */
+  maxBarHeight?: number;
+}
+
+/**
+ * Get the day of week abbreviation from a date string.
+ *
+ * @param dateStr - Date string in YYYY-MM-DD format
+ * @returns 3-letter day abbreviation (e.g., "Mon", "Tue")
+ */
+function getDayLabel(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00'); // Force local timezone
+  const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  return days[date.getDay()];
+}
+
+/**
+ * Check if a date string represents today.
+ *
+ * @param dateStr - Date string in YYYY-MM-DD format
+ * @returns True if the date is today
+ */
+function isToday(dateStr: string): boolean {
+  const today = new Date().toISOString().split('T')[0];
+  return dateStr === today;
+}
+
+/**
+ * DailyMiniChart renders a compact bar chart of daily costs.
+ *
+ * The chart automatically scales based on the maximum daily cost.
+ * Today's bar is highlighted with the brand orange color.
+ *
+ * @param props - Component props
+ * @returns Rendered mini chart
+ *
+ * @example
+ * <DailyMiniChart
+ *   data={[
+ *     { date: '2024-01-01', total: 5.00, ... },
+ *     { date: '2024-01-02', total: 8.50, ... },
+ *     ...
+ *   ]}
+ * />
+ */
+export function DailyMiniChart({ data, maxBarHeight = 80 }: DailyMiniChartProps) {
+  // Find the maximum value for scaling
+  const maxValue = Math.max(...data.map((d) => d.total), 0.01); // Min 0.01 to avoid division by zero
+
+  // Calculate total for the week
+  const weekTotal = data.reduce((sum, d) => sum + d.total, 0);
+
+  return (
+    <View className="bg-background-secondary rounded-xl p-4">
+      {/* Header */}
+      <View className="flex-row items-center justify-between mb-4">
+        <Text className="text-zinc-400 text-sm font-medium">LAST 7 DAYS</Text>
+        <Text className="text-white font-semibold">${weekTotal.toFixed(2)}</Text>
+      </View>
+
+      {/* Chart */}
+      <View className="flex-row items-end justify-between" style={{ height: maxBarHeight + 24 }}>
+        {data.map((day) => {
+          // Calculate bar height (minimum 4px for visibility)
+          const barHeight = Math.max(4, (day.total / maxValue) * maxBarHeight);
+          const today = isToday(day.date);
+
+          return (
+            <View key={day.date} className="flex-1 items-center mx-0.5">
+              {/* Cost label (only show for non-zero values) */}
+              {day.total > 0 && (
+                <Text
+                  className="text-zinc-500 text-[10px] mb-1"
+                  numberOfLines={1}
+                >
+                  ${day.total < 1 ? day.total.toFixed(2) : day.total.toFixed(0)}
+                </Text>
+              )}
+
+              {/* Bar */}
+              <View
+                className={`w-full rounded-t-sm ${today ? 'bg-brand' : 'bg-zinc-700'}`}
+                style={{ height: barHeight }}
+              />
+
+              {/* Day label */}
+              <Text
+                className={`text-[10px] mt-1 ${today ? 'text-brand font-medium' : 'text-zinc-500'}`}
+              >
+                {getDayLabel(day.date)}
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Empty state for the mini chart when there's no data.
+ */
+export function DailyMiniChartEmpty() {
+  return (
+    <View className="bg-background-secondary rounded-xl p-4 items-center py-8">
+      <Text className="text-zinc-400 text-sm font-medium mb-2">LAST 7 DAYS</Text>
+      <Text className="text-zinc-500 text-center">No cost data for this period</Text>
+    </View>
+  );
+}
+
+/**
+ * Loading skeleton for the mini chart.
+ */
+export function DailyMiniChartSkeleton() {
+  return (
+    <View className="bg-background-secondary rounded-xl p-4">
+      <View className="flex-row items-center justify-between mb-4">
+        <View className="bg-zinc-800 h-4 w-20 rounded" />
+        <View className="bg-zinc-800 h-5 w-16 rounded" />
+      </View>
+      <View className="flex-row items-end justify-between" style={{ height: 104 }}>
+        {[...Array(7)].map((_, i) => (
+          <View key={i} className="flex-1 items-center mx-0.5">
+            <View
+              className="w-full bg-zinc-800 rounded-t-sm"
+              style={{ height: Math.random() * 60 + 20 }}
+            />
+            <View className="bg-zinc-800 h-3 w-6 rounded mt-1" />
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/hooks/useCosts.ts
+++ b/packages/styrby-mobile/src/hooks/useCosts.ts
@@ -1,0 +1,437 @@
+/**
+ * Cost Data Hook
+ *
+ * Fetches and manages cost data from Supabase for the mobile cost dashboard.
+ * Handles loading states, error handling, and pull-to-refresh functionality.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import type { AgentType } from 'styrby-shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Cost summary for a time period (today, week, month).
+ */
+export interface CostSummary {
+  /** Total cost in USD */
+  totalCost: number;
+  /** Total input tokens */
+  inputTokens: number;
+  /** Total output tokens */
+  outputTokens: number;
+  /** Number of requests/records */
+  requestCount: number;
+}
+
+/**
+ * Cost breakdown by agent with percentage of total.
+ */
+export interface AgentCostBreakdown {
+  /** Agent type identifier */
+  agent: AgentType;
+  /** Total cost in USD for this agent */
+  cost: number;
+  /** Input tokens for this agent */
+  inputTokens: number;
+  /** Output tokens for this agent */
+  outputTokens: number;
+  /** Number of requests */
+  requestCount: number;
+  /** Percentage of total cost (0-100) */
+  percentage: number;
+}
+
+/**
+ * Daily cost data point for the mini chart.
+ */
+export interface DailyCostDataPoint {
+  /** Date string (YYYY-MM-DD) */
+  date: string;
+  /** Total cost for the day */
+  total: number;
+  /** Cost breakdown by agent */
+  claude: number;
+  codex: number;
+  gemini: number;
+  opencode: number;
+}
+
+/**
+ * Complete cost data for the dashboard.
+ */
+export interface CostData {
+  /** Cost summary for today */
+  today: CostSummary;
+  /** Cost summary for last 7 days */
+  week: CostSummary;
+  /** Cost summary for last 30 days */
+  month: CostSummary;
+  /** Cost breakdown by agent (last 30 days) */
+  byAgent: AgentCostBreakdown[];
+  /** Daily costs for the mini chart (last 7 days) */
+  dailyCosts: DailyCostDataPoint[];
+}
+
+/**
+ * Return type for the useCosts hook.
+ */
+export interface UseCostsReturn {
+  /** Cost data (null if loading or error) */
+  data: CostData | null;
+  /** Whether data is currently loading */
+  isLoading: boolean;
+  /** Whether data is refreshing (pull-to-refresh) */
+  isRefreshing: boolean;
+  /** Error message if fetch failed */
+  error: string | null;
+  /** Trigger a refresh */
+  refresh: () => Promise<void>;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Get the start date for a time period.
+ *
+ * @param period - Time period ('today', 'week', 'month')
+ * @returns Date object for the start of the period
+ */
+function getPeriodStartDate(period: 'today' | 'week' | 'month'): Date {
+  const now = new Date();
+  const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  switch (period) {
+    case 'today':
+      return startOfDay;
+    case 'week':
+      const weekAgo = new Date(startOfDay);
+      weekAgo.setDate(weekAgo.getDate() - 7);
+      return weekAgo;
+    case 'month':
+      const monthAgo = new Date(startOfDay);
+      monthAgo.setDate(monthAgo.getDate() - 30);
+      return monthAgo;
+  }
+}
+
+/**
+ * Format a date as YYYY-MM-DD string.
+ *
+ * @param date - Date to format
+ * @returns Formatted date string
+ */
+function formatDateString(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+/**
+ * Fetch cost summary for a specific time period.
+ *
+ * @param period - Time period to fetch
+ * @returns Cost summary for the period
+ */
+async function fetchCostSummary(period: 'today' | 'week' | 'month'): Promise<CostSummary> {
+  const startDate = getPeriodStartDate(period);
+
+  const { data, error } = await supabase
+    .from('cost_records')
+    .select('cost_usd, input_tokens, output_tokens')
+    .gte('record_date', formatDateString(startDate));
+
+  if (error) {
+    console.error(`Error fetching ${period} cost summary:`, error);
+    return { totalCost: 0, inputTokens: 0, outputTokens: 0, requestCount: 0 };
+  }
+
+  return (data || []).reduce(
+    (acc, record) => ({
+      totalCost: acc.totalCost + (Number(record.cost_usd) || 0),
+      inputTokens: acc.inputTokens + (record.input_tokens || 0),
+      outputTokens: acc.outputTokens + (record.output_tokens || 0),
+      requestCount: acc.requestCount + 1,
+    }),
+    { totalCost: 0, inputTokens: 0, outputTokens: 0, requestCount: 0 }
+  );
+}
+
+/**
+ * Fetch cost breakdown by agent for the last 30 days.
+ *
+ * @returns Array of agent cost breakdowns sorted by cost descending
+ */
+async function fetchCostsByAgent(): Promise<AgentCostBreakdown[]> {
+  const startDate = getPeriodStartDate('month');
+
+  const { data, error } = await supabase
+    .from('cost_records')
+    .select('agent_type, cost_usd, input_tokens, output_tokens')
+    .gte('record_date', formatDateString(startDate));
+
+  if (error) {
+    console.error('Error fetching costs by agent:', error);
+    return [];
+  }
+
+  // Aggregate by agent
+  const agentMap = new Map<string, Omit<AgentCostBreakdown, 'percentage'>>();
+
+  for (const record of data || []) {
+    const agent = (record.agent_type || 'unknown') as AgentType;
+    const existing = agentMap.get(agent) || {
+      agent,
+      cost: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      requestCount: 0,
+    };
+
+    agentMap.set(agent, {
+      agent,
+      cost: existing.cost + (Number(record.cost_usd) || 0),
+      inputTokens: existing.inputTokens + (record.input_tokens || 0),
+      outputTokens: existing.outputTokens + (record.output_tokens || 0),
+      requestCount: existing.requestCount + 1,
+    });
+  }
+
+  // Calculate percentages and sort by cost
+  const totalCost = Array.from(agentMap.values()).reduce((sum, a) => sum + a.cost, 0);
+  return Array.from(agentMap.values())
+    .map((a) => ({
+      ...a,
+      percentage: totalCost > 0 ? (a.cost / totalCost) * 100 : 0,
+    }))
+    .sort((a, b) => b.cost - a.cost);
+}
+
+/**
+ * Fetch daily cost data for the last 7 days.
+ *
+ * @returns Array of daily cost data points sorted by date ascending
+ */
+async function fetchDailyCosts(): Promise<DailyCostDataPoint[]> {
+  const startDate = getPeriodStartDate('week');
+
+  const { data, error } = await supabase
+    .from('cost_records')
+    .select('record_date, agent_type, cost_usd')
+    .gte('record_date', formatDateString(startDate))
+    .order('record_date', { ascending: true });
+
+  if (error) {
+    console.error('Error fetching daily costs:', error);
+    return [];
+  }
+
+  // Aggregate by date and agent
+  const dateMap = new Map<string, DailyCostDataPoint>();
+
+  // Pre-populate all 7 days with zeros for consistent chart display
+  for (let i = 6; i >= 0; i--) {
+    const date = new Date();
+    date.setDate(date.getDate() - i);
+    const dateStr = formatDateString(date);
+    dateMap.set(dateStr, {
+      date: dateStr,
+      total: 0,
+      claude: 0,
+      codex: 0,
+      gemini: 0,
+      opencode: 0,
+    });
+  }
+
+  // Aggregate actual data
+  for (const record of data || []) {
+    const date = record.record_date;
+    const existing = dateMap.get(date);
+    if (!existing) continue; // Skip dates outside our 7-day window
+
+    const cost = Number(record.cost_usd) || 0;
+    existing.total += cost;
+
+    switch (record.agent_type) {
+      case 'claude':
+        existing.claude += cost;
+        break;
+      case 'codex':
+        existing.codex += cost;
+        break;
+      case 'gemini':
+        existing.gemini += cost;
+        break;
+      default:
+        existing.opencode += cost;
+    }
+
+    dateMap.set(date, existing);
+  }
+
+  return Array.from(dateMap.values()).sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook for fetching and managing cost data.
+ *
+ * Fetches cost summaries (today, week, month), agent breakdown, and daily costs
+ * in parallel. Provides loading/error states and pull-to-refresh functionality.
+ *
+ * @returns Cost data, loading states, and refresh function
+ *
+ * @example
+ * const { data, isLoading, error, refresh, isRefreshing } = useCosts();
+ *
+ * if (isLoading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage message={error} />;
+ *
+ * return (
+ *   <ScrollView refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={refresh} />}>
+ *     <CostCard title="Today" amount={data.today.totalCost} />
+ *   </ScrollView>
+ * );
+ */
+export function useCosts(): UseCostsReturn {
+  const [data, setData] = useState<CostData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * Fetch all cost data in parallel.
+   */
+  const fetchAllData = useCallback(async () => {
+    try {
+      const [today, week, month, byAgent, dailyCosts] = await Promise.all([
+        fetchCostSummary('today'),
+        fetchCostSummary('week'),
+        fetchCostSummary('month'),
+        fetchCostsByAgent(),
+        fetchDailyCosts(),
+      ]);
+
+      setData({ today, week, month, byAgent, dailyCosts });
+      setError(null);
+    } catch (err) {
+      console.error('Error fetching cost data:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load cost data');
+    }
+  }, []);
+
+  /**
+   * Initial load on mount.
+   */
+  useEffect(() => {
+    const load = async () => {
+      setIsLoading(true);
+      await fetchAllData();
+      setIsLoading(false);
+    };
+    load();
+  }, [fetchAllData]);
+
+  /**
+   * Pull-to-refresh handler.
+   */
+  const refresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await fetchAllData();
+    setIsRefreshing(false);
+  }, [fetchAllData]);
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    error,
+    refresh,
+  };
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Format a cost value as a USD currency string.
+ *
+ * @param cost - Cost value in USD
+ * @param decimals - Number of decimal places (default 2)
+ * @returns Formatted currency string (e.g., "$12.34")
+ */
+export function formatCost(cost: number, decimals: number = 2): string {
+  return `$${cost.toFixed(decimals)}`;
+}
+
+/**
+ * Format a token count with K/M suffix for readability.
+ *
+ * @param tokens - Number of tokens
+ * @returns Formatted token string (e.g., "1.2M", "500K", "123")
+ */
+export function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    return `${(tokens / 1_000_000).toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) {
+    return `${(tokens / 1_000).toFixed(1)}K`;
+  }
+  return tokens.toString();
+}
+
+/**
+ * Get the hex color for an agent type.
+ *
+ * @param agent - Agent type
+ * @returns Hex color code for the agent
+ */
+export function getAgentHexColor(agent: AgentType): string {
+  switch (agent) {
+    case 'claude':
+      return '#f97316'; // orange-500
+    case 'codex':
+      return '#22c55e'; // green-500
+    case 'gemini':
+      return '#3b82f6'; // blue-500
+    case 'opencode':
+      return '#a855f7'; // purple-500
+    case 'aider':
+      return '#ec4899'; // pink-500
+    default:
+      return '#71717a'; // zinc-500
+  }
+}
+
+/**
+ * Get the display name for an agent type.
+ *
+ * @param agent - Agent type
+ * @returns Human-readable agent name
+ */
+export function getAgentDisplayName(agent: AgentType): string {
+  switch (agent) {
+    case 'claude':
+      return 'Claude';
+    case 'codex':
+      return 'Codex';
+    case 'gemini':
+      return 'Gemini';
+    case 'opencode':
+      return 'OpenCode';
+    case 'aider':
+      return 'Aider';
+    default:
+      return agent;
+  }
+}


### PR DESCRIPTION
## Summary
- **CostsScreen**: Full cost dashboard with today/week/month summaries, 7-day chart, agent breakdown, token usage
- **useCosts hook**: Fetches cost data from Supabase with pull-to-refresh support
- **CostCard**: Displays cost metric with icon and formatting
- **AgentCostBar**: Horizontal progress bar for agent cost contribution
- **DailyMiniChart**: 7-day bar chart with day labels
- Added "Costs" tab to bottom navigation with wallet icon
- Enhanced sessions screen with Supabase queries and search filtering

## Test plan
- [ ] Verify cost dashboard renders on iOS and Android
- [ ] Test pull-to-refresh functionality
- [ ] Verify loading and error states
- [ ] Test with empty cost data

🤖 Generated with [Claude Code](https://claude.com/claude-code)