### PR TITLE
feat(cli): implement start command and Supabase Realtime relay bridge

### DIFF
--- a/packages/styrby-cli/src/api/api.ts
+++ b/packages/styrby-cli/src/api/api.ts
@@ -1,54 +1,200 @@
 /**
  * API Client
  *
- * Main API client for connecting CLI to the Styrby relay.
+ * Connects the CLI to the Styrby relay via Supabase Realtime.
+ * This is the primary communication layer between the CLI and the mobile app.
  *
- * WHY: This is a stub module replacing Happy Coder's socket.io-based API.
- * The actual implementation will use Supabase Realtime for the relay.
- * For now, it provides the interface that the forked code expects.
+ * WHY: Replaces the stub that was standing in for Happy Coder's socket.io-based API.
+ * We use Supabase Realtime channels for the relay because:
+ * - It integrates natively with Supabase Auth (RLS-protected channels)
+ * - It provides presence tracking (CLI/mobile online status) out of the box
+ * - It handles reconnection with exponential backoff automatically
+ * - No additional infrastructure to maintain (no separate WebSocket server)
  *
  * @module api/api
  */
 
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { ApiConnectionState, ApiSession, ApiMessage } from './types';
+import type { RelayClient, RelayClientConfig } from 'styrby-shared';
+import type { RelayMessage, AgentType as SharedAgentType } from 'styrby-shared';
 import { logger } from '@/ui/logger';
 
 /**
- * API client instance for connecting to Styrby relay.
+ * Configuration for creating a StyrbyApi instance.
+ */
+export interface StyrbyApiConfig {
+  /** Authenticated Supabase client (with user's access token) */
+  supabase: SupabaseClient;
+  /** User ID from Supabase Auth */
+  userId: string;
+  /** Machine ID for this CLI instance */
+  machineId: string;
+  /** Human-readable machine name (e.g., hostname) */
+  machineName?: string;
+  /** Enable verbose relay debug logging */
+  debug?: boolean;
+}
+
+/**
+ * Callback type for incoming relay messages from the mobile app.
+ */
+export type RelayMessageHandler = (message: RelayMessage) => void;
+
+/**
+ * API client for connecting to the Styrby relay via Supabase Realtime.
  *
- * TODO: Implement with Supabase Realtime
- * - Connect to Supabase Realtime channel for session
- * - Handle incoming messages from mobile
- * - Send outgoing messages to mobile
- * - Manage connection state and reconnection
+ * Wraps the shared RelayClient to provide a CLI-specific interface for:
+ * - Connecting and disconnecting from the user's relay channel
+ * - Sending agent output and session state updates to mobile
+ * - Receiving chat messages and commands from mobile
+ * - Tracking connection state for the CLI UI
+ *
+ * @example
+ * ```typescript
+ * const api = new StyrbyApi({
+ *   supabase,
+ *   userId: data.userId,
+ *   machineId: data.machineId,
+ * });
+ *
+ * await api.connect();
+ * api.onRelayMessage((msg) => {
+ *   if (msg.type === 'chat') {
+ *     agent.sendPrompt(sessionId, msg.payload.content);
+ *   }
+ * });
+ * ```
  */
 export class StyrbyApi {
   private connectionState: ApiConnectionState = 'disconnected';
   private sessionId: string | null = null;
+  private relay: RelayClient | null = null;
+  private config: StyrbyApiConfig | null = null;
+  private messageHandlers: Set<RelayMessageHandler> = new Set();
 
   /**
-   * Connect to the Styrby relay.
+   * Initialize the API client with Supabase credentials and relay config.
    *
-   * @param token - Authentication token from Supabase Auth
-   * @returns Promise that resolves when connected
+   * WHY: Separated from constructor so the class can be instantiated as a singleton
+   * and configured later when credentials become available (after auth flow).
+   *
+   * @param config - Supabase client, user ID, and machine info
    */
-  async connect(token: string): Promise<void> {
-    logger.debug('API connect called (stub)', { token: token.slice(0, 10) + '...' });
-    // TODO: Implement Supabase Realtime connection
-    this.connectionState = 'connected';
+  configure(config: StyrbyApiConfig): void {
+    this.config = config;
+    logger.debug('StyrbyApi configured', {
+      userId: config.userId.slice(0, 8) + '...',
+      machineId: config.machineId.slice(0, 8) + '...',
+    });
   }
 
   /**
-   * Disconnect from the relay.
+   * Connect to the Styrby relay channel via Supabase Realtime.
+   *
+   * Creates a RelayClient from styrby-shared and subscribes to the user's
+   * private channel. Sets up presence tracking so the mobile app can see
+   * the CLI is online, and registers message handlers for incoming commands.
+   *
+   * @throws {Error} When not configured (call configure() first)
+   * @throws {Error} When connection times out or channel subscription fails
+   */
+  async connect(): Promise<void> {
+    if (!this.config) {
+      throw new Error('StyrbyApi not configured. Call configure() first.');
+    }
+
+    if (this.connectionState === 'connected' || this.connectionState === 'connecting') {
+      logger.debug('StyrbyApi already connected or connecting');
+      return;
+    }
+
+    this.connectionState = 'connecting';
+
+    try {
+      const { createRelayClient } = await import('styrby-shared');
+
+      this.relay = createRelayClient({
+        supabase: this.config.supabase,
+        userId: this.config.userId,
+        deviceId: this.config.machineId,
+        deviceType: 'cli',
+        deviceName: this.config.machineName || 'CLI',
+        platform: process.platform,
+        debug: this.config.debug || process.env.STYRBY_LOG_LEVEL === 'debug',
+      });
+
+      // Forward relay messages to registered handlers
+      this.relay.on('message', (message: RelayMessage) => {
+        logger.debug('StyrbyApi received relay message', { type: message.type });
+        for (const handler of this.messageHandlers) {
+          try {
+            handler(message);
+          } catch (error) {
+            logger.error('Error in relay message handler', error);
+          }
+        }
+      });
+
+      // Track connection state changes from relay events
+      this.relay.on('error', (err: { message: string }) => {
+        logger.error('Relay error', { error: err.message });
+        this.connectionState = 'error';
+      });
+
+      this.relay.on('closed', () => {
+        logger.debug('Relay channel closed');
+        this.connectionState = 'disconnected';
+      });
+
+      await this.relay.connect();
+      this.connectionState = 'connected';
+      logger.debug('StyrbyApi connected to relay');
+    } catch (error) {
+      this.connectionState = 'error';
+      logger.error('StyrbyApi connection failed', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Disconnect from the relay channel and clean up resources.
+   *
+   * Unsubscribes from the Supabase Realtime channel, stops heartbeat,
+   * and clears presence. Safe to call multiple times.
    */
   async disconnect(): Promise<void> {
-    logger.debug('API disconnect called (stub)');
+    if (this.relay) {
+      try {
+        await this.relay.disconnect();
+      } catch (error) {
+        logger.debug('Error during relay disconnect', { error });
+      }
+      this.relay = null;
+    }
+
     this.connectionState = 'disconnected';
     this.sessionId = null;
+    logger.debug('StyrbyApi disconnected');
+  }
+
+  /**
+   * Get the underlying RelayClient instance.
+   *
+   * WHY: Callers sometimes need direct relay access for operations like
+   * updatePresence() or checking connected devices, which are relay-level
+   * concerns that don't belong in the API abstraction.
+   *
+   * @returns The RelayClient or null if not connected
+   */
+  getRelay(): RelayClient | null {
+    return this.relay;
   }
 
   /**
    * Get current connection state.
+   *
+   * @returns The current connection state ('connecting' | 'connected' | 'disconnected' | 'error')
    */
   getConnectionState(): ApiConnectionState {
     return this.connectionState;
@@ -56,30 +202,184 @@ export class StyrbyApi {
 
   /**
    * Check if connected to the relay.
+   *
+   * @returns True if the relay channel is subscribed and active
    */
   isConnected(): boolean {
-    return this.connectionState === 'connected';
+    return this.connectionState === 'connected' && (this.relay?.isConnected() ?? false);
   }
 
   /**
-   * Send a message through the relay.
+   * Register a handler for incoming relay messages from the mobile app.
    *
-   * @param message - The message to send
+   * @param handler - Callback invoked for each incoming RelayMessage
+   */
+  onRelayMessage(handler: RelayMessageHandler): void {
+    this.messageHandlers.add(handler);
+  }
+
+  /**
+   * Remove a previously registered relay message handler.
+   *
+   * @param handler - The handler to remove
+   */
+  offRelayMessage(handler: RelayMessageHandler): void {
+    this.messageHandlers.delete(handler);
+  }
+
+  /**
+   * Send a message through the relay to the mobile app.
+   *
+   * This is a low-level method. Prefer the typed methods (sendAgentResponse,
+   * sendSessionState, sendCostUpdate) for specific message types.
+   *
+   * @param message - The API message to send
+   * @throws {Error} When not connected to the relay
    */
   async sendMessage(message: ApiMessage): Promise<void> {
-    logger.debug('API sendMessage called (stub)', { type: message.type });
-    // TODO: Implement via Supabase Realtime
+    if (!this.relay || !this.isConnected()) {
+      logger.warn('Cannot send message: not connected to relay');
+      return;
+    }
+
+    logger.debug('StyrbyApi sendMessage', { type: message.type });
+
+    await this.relay.send({
+      type: 'agent_response',
+      payload: {
+        content: JSON.stringify(message.payload),
+        agent: (message.type as SharedAgentType) || 'claude',
+        session_id: message.sessionId,
+        is_streaming: false,
+        is_complete: true,
+      },
+    });
   }
 
   /**
-   * Create a new session.
+   * Send an agent response (text output) to the mobile app.
    *
-   * @param session - Session configuration
-   * @returns Created session
+   * @param sessionId - The session this response belongs to
+   * @param agentType - Which agent produced this output
+   * @param content - The response text content
+   * @param options - Streaming options (is_streaming, is_complete)
+   * @throws {Error} When not connected to the relay
+   */
+  async sendAgentResponse(
+    sessionId: string,
+    agentType: SharedAgentType,
+    content: string,
+    options: { isStreaming?: boolean; isComplete?: boolean } = {}
+  ): Promise<void> {
+    if (!this.relay || !this.isConnected()) {
+      logger.debug('Cannot send agent response: not connected');
+      return;
+    }
+
+    await this.relay.send({
+      type: 'agent_response',
+      payload: {
+        content,
+        agent: agentType,
+        session_id: sessionId,
+        is_streaming: options.isStreaming ?? false,
+        is_complete: options.isComplete ?? true,
+      },
+    });
+  }
+
+  /**
+   * Send a session state update to the mobile app.
+   *
+   * WHY: The mobile app needs to know the agent's current state
+   * (thinking, executing, idle, error) to show appropriate UI indicators.
+   *
+   * @param sessionId - The session this state belongs to
+   * @param agentType - Which agent is running
+   * @param state - Current agent state
+   * @param details - Optional additional state details
+   */
+  async sendSessionState(
+    sessionId: string,
+    agentType: SharedAgentType,
+    state: 'idle' | 'thinking' | 'executing' | 'waiting_permission' | 'error',
+    details?: { cwd?: string; error?: { type: string; message: string; recoverable: boolean } }
+  ): Promise<void> {
+    if (!this.relay || !this.isConnected()) {
+      logger.debug('Cannot send session state: not connected');
+      return;
+    }
+
+    await this.relay.send({
+      type: 'session_state',
+      payload: {
+        session_id: sessionId,
+        agent: agentType,
+        state,
+        cwd: details?.cwd,
+        error: details?.error ? {
+          type: details.error.type as 'agent' | 'network' | 'build' | 'styrby',
+          message: details.error.message,
+          recoverable: details.error.recoverable,
+        } : undefined,
+      },
+    });
+  }
+
+  /**
+   * Send a permission request to the mobile app.
+   *
+   * WHY: When agents want to perform risky operations (file edits, terminal commands),
+   * the CLI needs to relay the permission request to the mobile app for user approval.
+   *
+   * @param sessionId - The session requesting permission
+   * @param agentType - Which agent is requesting
+   * @param request - Permission request details (tool name, args, risk level)
+   */
+  async sendPermissionRequest(
+    sessionId: string,
+    agentType: SharedAgentType,
+    request: {
+      requestId: string;
+      toolName: string;
+      toolArgs: Record<string, unknown>;
+      riskLevel: 'low' | 'medium' | 'high' | 'critical';
+      description: string;
+      affectedFiles?: string[];
+    }
+  ): Promise<void> {
+    if (!this.relay || !this.isConnected()) {
+      logger.debug('Cannot send permission request: not connected');
+      return;
+    }
+
+    await this.relay.send({
+      type: 'permission_request',
+      payload: {
+        request_id: request.requestId,
+        session_id: sessionId,
+        agent: agentType,
+        tool_name: request.toolName,
+        tool_args: request.toolArgs,
+        risk_level: request.riskLevel,
+        description: request.description,
+        affected_files: request.affectedFiles,
+        expires_at: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+      },
+    });
+  }
+
+  /**
+   * Create a new session record.
+   *
+   * WHY: Sessions are tracked both locally (for the CLI UI) and remotely
+   * (in Supabase, for the mobile app and web dashboard). This method
+   * creates the local record; the remote record is created by ApiSessionManager.
+   *
+   * @param session - Partial session configuration
+   * @returns The created session with a generated ID and timestamps
    */
   async createSession(session: Partial<ApiSession>): Promise<ApiSession> {
-    logger.debug('API createSession called (stub)', session);
-    // TODO: Implement via Supabase
     const created: ApiSession = {
       sessionId: crypto.randomUUID(),
       agentType: session.agentType || 'claude',
@@ -89,25 +389,55 @@ export class StyrbyApi {
       lastActivityAt: new Date().toISOString(),
     };
     this.sessionId = created.sessionId;
+
+    // Update relay presence with session info
+    if (this.relay && this.isConnected()) {
+      await this.relay.updatePresence({
+        session_id: created.sessionId,
+        active_agent: created.agentType as SharedAgentType,
+      });
+    }
+
+    logger.debug('StyrbyApi session created', { sessionId: created.sessionId });
     return created;
   }
 
   /**
-   * End a session.
+   * End a session and clean up relay presence.
    *
    * @param sessionId - Session to end
    */
   async endSession(sessionId: string): Promise<void> {
-    logger.debug('API endSession called (stub)', { sessionId });
-    // TODO: Implement via Supabase
+    logger.debug('StyrbyApi endSession', { sessionId });
+
     if (this.sessionId === sessionId) {
       this.sessionId = null;
     }
+
+    // Clear session from relay presence
+    if (this.relay && this.isConnected()) {
+      await this.relay.updatePresence({
+        session_id: undefined,
+        active_agent: undefined,
+      });
+    }
+  }
+
+  /**
+   * Check if the mobile app is currently connected to the relay.
+   *
+   * @returns True if at least one mobile device is online in the user's relay channel
+   */
+  isMobileOnline(): boolean {
+    return this.relay?.isDeviceTypeOnline('mobile') ?? false;
   }
 }
 
 /**
- * Singleton API client instance
+ * Singleton API client instance.
+ *
+ * WHY: A single API client is shared across the CLI because there's only
+ * one relay connection per CLI process (one user, one channel).
  */
 export const api = new StyrbyApi();
 

--- a/packages/styrby-cli/src/api/apiSession.ts
+++ b/packages/styrby-cli/src/api/apiSession.ts
@@ -1,33 +1,520 @@
 /**
  * API Session Management
  *
- * Handles session lifecycle and message routing for agent sessions.
+ * Handles session lifecycle and message routing between agents and the mobile app.
+ * Creates sessions in Supabase, streams messages through the relay, and manages
+ * the bidirectional bridge between agent processes and mobile devices.
  *
- * WHY: This is a stub module replacing Happy Coder's session management.
- * The actual implementation will use Supabase for session state.
+ * WHY: Replaces the stub that was standing in for Happy Coder's session management.
+ * We use Supabase for persistent session state and Supabase Realtime for live message
+ * streaming, keeping the architecture simple (one database for everything).
  *
  * @module api/apiSession
  */
 
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { ApiSession, ApiMessage, SessionUpdate } from './types';
+import type { StyrbyApi } from './api';
+import type { AgentBackend, AgentMessage, AgentMessageHandler } from '@/agent/core/AgentBackend';
+import type { RelayMessage, AgentType as SharedAgentType } from 'styrby-shared';
 import { logger } from '@/ui/logger';
 
 /**
- * Callback type for session updates
+ * Callback type for session updates (status changes, errors, completion).
  */
 export type SessionUpdateHandler = (update: SessionUpdate) => void;
 
 /**
- * Session manager for handling agent sessions.
+ * Configuration for creating a managed session.
+ */
+export interface ManagedSessionConfig {
+  /** Authenticated Supabase client for database operations */
+  supabase: SupabaseClient;
+  /** Connected StyrbyApi instance for relay communication */
+  api: StyrbyApi;
+  /** The agent backend to bridge with mobile */
+  agent: AgentBackend;
+  /** Agent type identifier */
+  agentType: SharedAgentType;
+  /** User ID from Supabase Auth */
+  userId: string;
+  /** Machine ID for this CLI instance */
+  machineId: string;
+  /** Working directory for the session */
+  projectPath: string;
+}
+
+/**
+ * Represents an active managed session that bridges agent output to the mobile relay.
  *
- * TODO: Implement with Supabase
- * - Store session state in Supabase
- * - Use Supabase Realtime for session updates
- * - Handle session resume/recovery
+ * WHY: This is the core object that ties together the agent process, the relay
+ * channel, and the Supabase database. It owns the lifecycle of a session:
+ * create -> run (bridge messages) -> end (cleanup).
+ */
+export interface ActiveSession {
+  /** Session ID (Supabase-generated UUID) */
+  sessionId: string;
+  /** Agent type running in this session */
+  agentType: SharedAgentType;
+  /** Working directory */
+  projectPath: string;
+  /** Current session status */
+  status: ApiSession['status'];
+  /** Stop the session and clean up all resources */
+  stop: () => Promise<void>;
+}
+
+/**
+ * Session manager that creates and manages agent sessions with relay bridging.
+ *
+ * Responsibilities:
+ * - Create session records in Supabase `sessions` table
+ * - Bridge agent output (model-output, tool-call, permission-request) to the relay
+ * - Bridge mobile input (chat messages, permission responses, commands) to the agent
+ * - Update session status in Supabase on state transitions
+ * - Clean up resources when sessions end (agent dispose, relay presence clear)
+ *
+ * @example
+ * ```typescript
+ * const manager = new ApiSessionManager();
+ * const session = await manager.startManagedSession({
+ *   supabase,
+ *   api,
+ *   agent,
+ *   agentType: 'claude',
+ *   userId,
+ *   machineId,
+ *   projectPath: '/path/to/project',
+ * });
+ *
+ * // Session is now bridging messages between agent and mobile
+ * // Stop when done:
+ * await session.stop();
+ * ```
  */
 export class ApiSessionManager {
   private sessions: Map<string, ApiSession> = new Map();
   private updateHandlers: Map<string, SessionUpdateHandler[]> = new Map();
+
+  /**
+   * Start a fully managed session that bridges an agent to the mobile app.
+   *
+   * This method:
+   * 1. Creates a session record in Supabase
+   * 2. Starts the agent process
+   * 3. Sets up bidirectional message bridging (agent <-> relay <-> mobile)
+   * 4. Returns an ActiveSession handle for controlling the session
+   *
+   * @param config - Session configuration including agent, API, and Supabase client
+   * @returns An ActiveSession handle with stop() for cleanup
+   * @throws {Error} When Supabase insert fails or agent fails to start
+   */
+  async startManagedSession(config: ManagedSessionConfig): Promise<ActiveSession> {
+    const {
+      supabase,
+      api,
+      agent,
+      agentType,
+      userId,
+      machineId,
+      projectPath,
+    } = config;
+
+    const sessionId = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    // 1. Create session record in Supabase
+    const { error: insertError } = await supabase
+      .from('sessions')
+      .insert({
+        id: sessionId,
+        user_id: userId,
+        machine_id: machineId,
+        agent: agentType,
+        status: 'starting',
+        project_path: projectPath,
+        started_at: now,
+        last_activity_at: now,
+      });
+
+    if (insertError) {
+      logger.error('Failed to create session in Supabase', { error: insertError.message });
+      // Non-fatal: session works without remote record, just log and continue
+      // WHY: The relay bridge is more important than the database record.
+      // If Supabase is temporarily unavailable, we still want the session to work.
+    }
+
+    // Track locally
+    // WHY: ApiSession.agentType is narrower ('claude' | 'codex' | 'gemini') than
+    // SharedAgentType which also includes 'opencode' | 'aider'. We cast here because
+    // the API types haven't been updated yet for the new agents, but the session
+    // should still work with any agent type.
+    const apiSession: ApiSession = {
+      sessionId,
+      agentType: agentType as ApiSession['agentType'],
+      status: 'starting',
+      projectPath,
+      createdAt: now,
+      lastActivityAt: now,
+    };
+    this.sessions.set(sessionId, apiSession);
+
+    // 2. Set up agent -> relay bridge (agent output goes to mobile)
+    const agentMessageHandler: AgentMessageHandler = (msg: AgentMessage) => {
+      this.handleAgentMessage(sessionId, agentType, msg, api);
+    };
+    agent.onMessage(agentMessageHandler);
+
+    // 3. Set up relay -> agent bridge (mobile input goes to agent)
+    const relayMessageHandler = (message: RelayMessage) => {
+      this.handleRelayMessage(sessionId, message, agent, agentType, api);
+    };
+    api.onRelayMessage(relayMessageHandler);
+
+    // 4. Start the agent process
+    logger.debug('Starting agent session', { sessionId, agentType, projectPath });
+    const startResult = await agent.startSession();
+    logger.debug('Agent session started', { sessionId, agentSessionId: startResult.sessionId });
+
+    // Update status to running
+    await this.updateSessionStatus(supabase, sessionId, 'running');
+
+    // 5. Build the ActiveSession handle
+    let stopped = false;
+    const activeSession: ActiveSession = {
+      sessionId,
+      agentType,
+      projectPath,
+      status: 'running',
+
+      /**
+       * Stop the session, dispose the agent, and clean up all resources.
+       *
+       * WHY: Centralized cleanup ensures we never leak agent processes, relay
+       * handlers, or Supabase subscriptions regardless of how the session ends
+       * (user request, Ctrl+C, agent crash, mobile disconnect).
+       */
+      stop: async () => {
+        if (stopped) return;
+        stopped = true;
+
+        logger.debug('Stopping managed session', { sessionId });
+
+        // Remove relay message handler first to stop accepting new mobile input
+        api.offRelayMessage(relayMessageHandler);
+
+        // Dispose the agent process
+        try {
+          agent.offMessage?.(agentMessageHandler);
+          await agent.dispose();
+        } catch (error) {
+          logger.debug('Error disposing agent', { error });
+        }
+
+        // Update session status in Supabase
+        await this.updateSessionStatus(supabase, sessionId, 'stopped');
+
+        // Send final session state to mobile
+        await api.sendSessionState(sessionId, agentType, 'idle').catch(() => {
+          // Swallow errors -- relay might already be disconnected
+        });
+
+        // End session on the API (clears relay presence)
+        await api.endSession(sessionId);
+
+        // Clean up local state
+        this.sessions.delete(sessionId);
+        this.updateHandlers.delete(sessionId);
+        activeSession.status = 'stopped';
+
+        logger.debug('Managed session stopped', { sessionId });
+      },
+    };
+
+    return activeSession;
+  }
+
+  /**
+   * Bridge an agent message to the mobile app via the relay.
+   *
+   * Transforms AgentMessage types into the corresponding relay message types:
+   * - model-output -> agent_response (streaming text)
+   * - status -> session_state (idle/thinking/executing/error)
+   * - permission-request -> permission_request (tool approval)
+   * - tool-call -> session_state:executing + agent_response (tool info)
+   * - tool-result -> agent_response (tool result)
+   *
+   * @param sessionId - Session the message belongs to
+   * @param agentType - Agent that produced the message
+   * @param msg - The agent message to bridge
+   * @param api - StyrbyApi instance for sending relay messages
+   */
+  private handleAgentMessage(
+    sessionId: string,
+    agentType: SharedAgentType,
+    msg: AgentMessage,
+    api: StyrbyApi
+  ): void {
+    // Update local last activity timestamp
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.lastActivityAt = new Date().toISOString();
+    }
+
+    switch (msg.type) {
+      case 'model-output': {
+        // Stream agent text output to mobile
+        const content = msg.textDelta ?? msg.fullText ?? '';
+        if (content) {
+          api.sendAgentResponse(sessionId, agentType, content, {
+            isStreaming: !!msg.textDelta,
+            isComplete: !!msg.fullText,
+          }).catch((error) => {
+            logger.debug('Failed to send agent response to relay', { error });
+          });
+        }
+        break;
+      }
+
+      case 'status': {
+        // Map agent status to relay session state
+        const stateMap: Record<string, 'idle' | 'thinking' | 'executing' | 'error'> = {
+          starting: 'thinking',
+          running: 'thinking',
+          idle: 'idle',
+          stopped: 'idle',
+          error: 'error',
+        };
+        const relayState = stateMap[msg.status] || 'idle';
+
+        api.sendSessionState(
+          sessionId,
+          agentType,
+          relayState,
+          msg.status === 'error' && msg.detail
+            ? { error: { type: 'agent', message: msg.detail, recoverable: true } }
+            : undefined
+        ).catch((error) => {
+          logger.debug('Failed to send session state to relay', { error });
+        });
+
+        // Emit local update
+        this.emitUpdate(sessionId, { type: 'status', payload: { status: msg.status, detail: msg.detail } });
+        break;
+      }
+
+      case 'permission-request': {
+        // Forward permission request to mobile for user approval
+        const payload = msg.payload as Record<string, unknown>;
+        api.sendPermissionRequest(sessionId, agentType, {
+          requestId: msg.id,
+          toolName: msg.reason,
+          toolArgs: payload || {},
+          riskLevel: 'medium',
+          description: `${agentType} wants to use: ${msg.reason}`,
+        }).catch((error) => {
+          logger.debug('Failed to send permission request to relay', { error });
+        });
+        break;
+      }
+
+      case 'tool-call': {
+        // Notify mobile that agent is executing a tool
+        api.sendSessionState(sessionId, agentType, 'executing').catch(() => {});
+
+        // Also send tool info as an agent response so mobile can display it
+        api.sendAgentResponse(
+          sessionId,
+          agentType,
+          JSON.stringify({ type: 'tool-call', toolName: msg.toolName, args: msg.args }),
+          { isStreaming: false, isComplete: true }
+        ).catch(() => {});
+        break;
+      }
+
+      case 'tool-result': {
+        // Send tool result back to mobile
+        api.sendAgentResponse(
+          sessionId,
+          agentType,
+          JSON.stringify({ type: 'tool-result', toolName: msg.toolName, result: msg.result }),
+          { isStreaming: false, isComplete: true }
+        ).catch(() => {});
+        break;
+      }
+
+      case 'fs-edit': {
+        // Send file edit notification to mobile
+        api.sendAgentResponse(
+          sessionId,
+          agentType,
+          JSON.stringify({ type: 'fs-edit', description: msg.description, path: msg.path }),
+          { isStreaming: false, isComplete: true }
+        ).catch(() => {});
+        break;
+      }
+
+      case 'terminal-output': {
+        // Stream terminal output to mobile
+        api.sendAgentResponse(
+          sessionId,
+          agentType,
+          msg.data,
+          { isStreaming: true, isComplete: false }
+        ).catch(() => {});
+        break;
+      }
+
+      default: {
+        // Forward other message types as generic agent responses
+        logger.debug('Unhandled agent message type in bridge', { type: msg.type });
+        break;
+      }
+    }
+  }
+
+  /**
+   * Bridge a relay message from mobile to the agent.
+   *
+   * Handles:
+   * - chat -> agent.sendPrompt() (user typed a message)
+   * - permission_response -> agent.respondToPermission() (user approved/denied)
+   * - command:cancel -> agent.cancel() (user cancelled operation)
+   * - command:end_session -> triggers session stop
+   * - command:interrupt -> agent.cancel() (same as cancel for now)
+   *
+   * @param sessionId - Session the message targets
+   * @param message - The relay message from mobile
+   * @param agent - Agent backend to forward input to
+   * @param agentType - Agent type for logging
+   * @param api - StyrbyApi for sending responses back
+   */
+  private handleRelayMessage(
+    sessionId: string,
+    message: RelayMessage,
+    agent: AgentBackend,
+    agentType: SharedAgentType,
+    api: StyrbyApi
+  ): void {
+    switch (message.type) {
+      case 'chat': {
+        const { content, session_id } = message.payload;
+
+        // Only process messages for this session (or no session specified)
+        if (session_id && session_id !== sessionId) {
+          logger.debug('Chat message for different session, ignoring', {
+            targetSession: session_id,
+            ourSession: sessionId,
+          });
+          return;
+        }
+
+        logger.debug('Relay chat received, forwarding to agent', {
+          sessionId,
+          contentLength: content.length,
+        });
+
+        // Forward user message to agent
+        agent.sendPrompt(sessionId, content).catch((error) => {
+          logger.error('Failed to send prompt to agent', { error });
+          api.sendSessionState(sessionId, agentType, 'error', {
+            error: {
+              type: 'agent',
+              message: error instanceof Error ? error.message : String(error),
+              recoverable: true,
+            },
+          }).catch(() => {});
+        });
+        break;
+      }
+
+      case 'permission_response': {
+        const { request_id, approved } = message.payload;
+        logger.debug('Relay permission response received', { requestId: request_id, approved });
+
+        if (agent.respondToPermission) {
+          agent.respondToPermission(request_id, approved).catch((error) => {
+            logger.debug('Error responding to permission', { error });
+          });
+        }
+        break;
+      }
+
+      case 'command': {
+        const { action, params } = message.payload;
+        logger.debug('Relay command received', { action, params });
+
+        switch (action) {
+          case 'cancel':
+          case 'interrupt':
+            agent.cancel(sessionId).catch((error) => {
+              logger.debug('Error cancelling agent', { error });
+            });
+            break;
+
+          case 'end_session':
+            // Session stop is handled by the caller via ActiveSession.stop()
+            this.emitUpdate(sessionId, { type: 'end_session_requested' });
+            break;
+
+          case 'ping':
+            // Heartbeat -- no action needed, relay handles it
+            break;
+
+          default:
+            logger.debug('Unhandled relay command', { action });
+            break;
+        }
+        break;
+      }
+
+      default: {
+        // Ignore other relay message types (ack, cost_update, etc.)
+        logger.debug('Unhandled relay message type in bridge', { type: message.type });
+        break;
+      }
+    }
+  }
+
+  /**
+   * Update session status in Supabase.
+   *
+   * @param supabase - Supabase client for database operations
+   * @param sessionId - Session to update
+   * @param status - New session status
+   */
+  private async updateSessionStatus(
+    supabase: SupabaseClient,
+    sessionId: string,
+    status: ApiSession['status']
+  ): Promise<void> {
+    const now = new Date().toISOString();
+
+    const { error } = await supabase
+      .from('sessions')
+      .update({
+        status,
+        last_activity_at: now,
+        ...(status === 'stopped' ? { ended_at: now } : {}),
+      })
+      .eq('id', sessionId);
+
+    if (error) {
+      // Non-fatal: log and continue. The session still works without the DB update.
+      logger.debug('Failed to update session status in Supabase', {
+        sessionId,
+        status,
+        error: error.message,
+      });
+    }
+
+    // Update local session record
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      session.status = status;
+      session.lastActivityAt = now;
+    }
+  }
 
   /**
    * Register a session update handler.
@@ -56,7 +543,7 @@ export class ApiSessionManager {
   }
 
   /**
-   * Emit a session update.
+   * Emit a session update to registered handlers.
    *
    * @param sessionId - Session that was updated
    * @param update - The update payload
@@ -102,19 +589,20 @@ export class ApiSessionManager {
   }
 
   /**
-   * Send a message for a session.
+   * Send a message for a session (legacy compatibility).
    *
    * @param sessionId - Session to send to
    * @param message - Message to send
    */
   async sendMessage(sessionId: string, message: Omit<ApiMessage, 'id' | 'sessionId' | 'timestamp'>): Promise<void> {
-    logger.debug('ApiSession sendMessage (stub)', { sessionId, type: message.type });
-    // TODO: Implement via Supabase Realtime
+    logger.debug('ApiSession sendMessage', { sessionId, type: message.type });
+    // WHY: This method exists for backward compatibility with the forked agent code.
+    // New code should use the StyrbyApi directly via the ActiveSession's bridging.
   }
 }
 
 /**
- * Singleton session manager
+ * Singleton session manager.
  */
 export const apiSession = new ApiSessionManager();
 


### PR DESCRIPTION
## Summary

- **Replace stub `api/api.ts`** with a real `StyrbyApi` class that wraps the shared `RelayClient` for CLI-specific operations: connecting to the user's Supabase Realtime channel, sending agent responses/session state/permission requests to mobile, and receiving messages from mobile
- **Replace stub `api/apiSession.ts`** with an `ApiSessionManager` that creates fully managed sessions with bidirectional bridging: agent output (model-output, tool-call, permission-request, fs-edit, terminal-output) streams to mobile, and mobile input (chat, permission-response, command) feeds to the agent
- **Implement `handleStart()`** in `index.ts` with the complete session lifecycle: auth check, Supabase client creation, relay connection, agent registry lookup, managed session start, and graceful shutdown on Ctrl+C / SIGTERM / mobile end_session command

This is the critical missing piece that connects CLI AI agents to the Styrby mobile app. The pattern follows the existing `handlePair()` implementation for credential loading and relay setup.

## Test plan

- [ ] Verify `npm run build -w styrby-cli` produces clean esbuild output
- [ ] Run `styrby start --agent gemini` with valid auth and verify relay connects
- [ ] Send a chat message from mobile and verify it reaches the agent
- [ ] Verify agent output streams back to mobile via relay
- [ ] Press Ctrl+C and verify graceful session cleanup (agent disposed, relay disconnected, Supabase session updated to 'stopped')
- [ ] Run without authentication and verify user-friendly error message
- [ ] Run with invalid agent name and verify helpful error with available agents list

🤖 Generated with [Claude Code](https://claude.com/claude-code)