### PR TITLE
feat(cli): implement daemon system and status command

### DIFF
--- a/packages/styrby-cli/src/daemon/controlClient.ts
+++ b/packages/styrby-cli/src/daemon/controlClient.ts
@@ -1,29 +1,37 @@
 /**
  * Daemon Control Client
  *
- * Client for communicating with the background daemon process.
+ * Client for communicating with the background daemon process via a Unix
+ * domain socket. Used by CLI commands (e.g., `styrby status`, `styrby stop`)
+ * to query or control the daemon.
  *
- * WHY: Stub module for Happy Coder's daemon control.
- * Used to send commands to the daemon from CLI invocations.
+ * WHY: The IPC socket enables richer interactions than the status file --
+ * real-time status, session listing, and graceful shutdown commands.
+ *
+ * Protocol: newline-delimited JSON over ~/.styrby/daemon.sock
  *
  * @module daemon/controlClient
  */
 
+import * as net from 'node:net';
 import { logger } from '@/ui/logger';
-import type { DaemonState } from './run';
+import { DAEMON_PATHS, type DaemonState } from './run';
 
 /**
- * Command types for daemon control
+ * Commands that can be sent to the daemon via IPC.
  */
 export type DaemonCommand =
   | { type: 'status' }
+  | { type: 'ping' }
+  | { type: 'stop' }
+  | { type: 'list-sessions' }
   | { type: 'start-session'; agentType: string; projectPath: string }
   | { type: 'stop-session'; sessionId: string }
   | { type: 'send-message'; sessionId: string; message: string }
   | { type: 'shutdown' };
 
 /**
- * Response from daemon
+ * Response received from the daemon via IPC.
  */
 export interface DaemonResponse {
   success: boolean;
@@ -31,35 +39,82 @@ export interface DaemonResponse {
   error?: string;
 }
 
+/** WHY: 3s is long enough for a response, short enough to not hang the CLI. */
+const IPC_TIMEOUT_MS = 3_000;
+
 /**
- * Send a command to the daemon.
+ * Send a command to the daemon via Unix domain socket.
  *
- * TODO: Implement IPC communication
- * Options:
- * - Unix socket
- * - Named pipe (Windows)
- * - HTTP on localhost
+ * Opens a connection to ~/.styrby/daemon.sock, sends newline-delimited JSON,
+ * reads the response, and closes the connection.
  *
- * @param command - Command to send
- * @returns Promise resolving to daemon response
+ * @param command - Command to send to the daemon
+ * @returns Promise resolving to the daemon's response
+ * @throws {Error} If the socket connection fails or times out
  */
 export async function sendDaemonCommand(command: DaemonCommand): Promise<DaemonResponse> {
-  logger.debug('Daemon command (stub)', { command });
-  // TODO: Implement actual IPC
-  return {
-    success: true,
-    data: null,
-  };
+  const socketPath = DAEMON_PATHS.socketPath;
+
+  return new Promise<DaemonResponse>((resolve, reject) => {
+    let buffer = '';
+    let resolved = false;
+
+    const socket = net.createConnection({ path: socketPath }, () => {
+      socket.write(JSON.stringify(command) + '\n');
+    });
+
+    socket.setTimeout(IPC_TIMEOUT_MS);
+
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString();
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex !== -1) {
+        const responseLine = buffer.substring(0, newlineIndex).trim();
+        if (responseLine && !resolved) {
+          resolved = true;
+          try {
+            socket.destroy();
+            resolve(JSON.parse(responseLine) as DaemonResponse);
+          } catch {
+            socket.destroy();
+            reject(new Error(`Invalid response from daemon: ${responseLine}`));
+          }
+        }
+      }
+    });
+
+    socket.on('timeout', () => {
+      if (!resolved) { resolved = true; socket.destroy(); reject(new Error('Daemon IPC timed out')); }
+    });
+
+    socket.on('error', (err) => {
+      if (!resolved) {
+        resolved = true;
+        const errCode = (err as NodeJS.ErrnoException).code;
+        if (errCode === 'ECONNREFUSED' || errCode === 'ENOENT') {
+          logger.debug('Daemon IPC socket not available', { code: errCode });
+          resolve({ success: false, error: 'Daemon not running or IPC not available' });
+        } else {
+          reject(err);
+        }
+      }
+    });
+
+    socket.on('close', () => {
+      if (!resolved) { resolved = true; resolve({ success: false, error: 'Connection closed before response' }); }
+    });
+  });
 }
 
 /**
- * Check if we can connect to the daemon.
+ * Check if we can connect to the daemon via IPC.
+ * Sends a ping and checks for a successful response.
  *
- * @returns True if daemon is reachable
+ * @returns True if the daemon responded to the ping
  */
 export async function canConnectToDaemon(): Promise<boolean> {
   try {
-    const response = await sendDaemonCommand({ type: 'status' });
+    const response = await sendDaemonCommand({ type: 'ping' });
     return response.success;
   } catch {
     return false;
@@ -67,20 +122,53 @@ export async function canConnectToDaemon(): Promise<boolean> {
 }
 
 /**
- * Get daemon status via IPC.
+ * Get daemon status via the IPC socket.
+ * Falls back to { running: false } if daemon is unreachable.
  *
- * @returns Daemon state
+ * @returns Daemon state as reported by the daemon itself
  */
 export async function getDaemonStatusViaIpc(): Promise<DaemonState> {
-  const response = await sendDaemonCommand({ type: 'status' });
-  return (response.data as DaemonState) || { running: false };
+  try {
+    const response = await sendDaemonCommand({ type: 'status' });
+    if (response.success && response.data) return response.data as DaemonState;
+  } catch {
+    logger.debug('Could not get daemon status via IPC');
+  }
+  return { running: false };
 }
 
 /**
- * Default export for compatibility
+ * Request the daemon to stop gracefully via IPC.
+ *
+ * @returns True if the daemon acknowledged the stop command
  */
+export async function requestDaemonStop(): Promise<boolean> {
+  try {
+    const response = await sendDaemonCommand({ type: 'stop' });
+    return response.success;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List connected devices/sessions via IPC.
+ *
+ * @returns Array of connected device presence states
+ */
+export async function listConnectedDevices(): Promise<unknown[]> {
+  try {
+    const response = await sendDaemonCommand({ type: 'list-sessions' });
+    if (response.success && response.data) {
+      return (response.data as { devices?: unknown[] }).devices || [];
+    }
+  } catch {
+    logger.debug('Could not list connected devices via IPC');
+  }
+  return [];
+}
+
 export default {
-  sendDaemonCommand,
-  canConnectToDaemon,
-  getDaemonStatusViaIpc,
+  sendDaemonCommand, canConnectToDaemon, getDaemonStatusViaIpc,
+  requestDaemonStop, listConnectedDevices,
 };

--- a/packages/styrby-cli/src/daemon/daemonProcess.ts
+++ b/packages/styrby-cli/src/daemon/daemonProcess.ts
@@ -1,0 +1,359 @@
+/**
+ * Daemon Child Process
+ *
+ * This is the entry point for the forked daemon process. It runs independently
+ * of the parent CLI process and maintains a persistent Supabase Realtime
+ * connection via the RelayClient.
+ *
+ * WHY: The daemon child is a separate process so it survives terminal closure.
+ * It connects to Supabase Realtime, tracks presence, and listens on a Unix
+ * domain socket for IPC commands from CLI invocations (e.g., styrby status).
+ *
+ * Lifecycle:
+ * 1. Parent forks this process with --daemon flag and IPC channel open
+ * 2. This process sets up signal handlers, Realtime connection, and IPC server
+ * 3. Sends { type: 'ready' } back to parent via IPC
+ * 4. Parent disconnects IPC and exits; this process continues running
+ * 5. Periodically writes status to ~/.styrby/daemon.status.json
+ * 6. On SIGTERM, disconnects cleanly and exits
+ *
+ * @module daemon/daemonProcess
+ */
+
+import * as fs from 'node:fs';
+import * as net from 'node:net';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { createClient } from '@supabase/supabase-js';
+import { createRelayClient, type RelayClient } from 'styrby-shared';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/**
+ * Interval in ms between status file updates.
+ * WHY: 10 seconds balances freshness with disk I/O. The CLI only reads this
+ * file on demand (e.g., styrby status), so sub-second freshness is not needed.
+ */
+const STATUS_WRITE_INTERVAL_MS = 10_000;
+
+const CONFIG_DIR = path.join(os.homedir(), '.styrby');
+
+const DAEMON_FILES = {
+  pidFile: path.join(CONFIG_DIR, 'daemon.pid'),
+  statusFile: path.join(CONFIG_DIR, 'daemon.status.json'),
+  socketPath: path.join(CONFIG_DIR, 'daemon.sock'),
+  dataFile: path.join(CONFIG_DIR, 'data.json'),
+  configFile: path.join(CONFIG_DIR, 'config.json'),
+};
+
+// ============================================================================
+// State
+// ============================================================================
+
+let relay: RelayClient | null = null;
+let ipcServer: net.Server | null = null;
+let statusInterval: ReturnType<typeof setInterval> | null = null;
+const startedAt = new Date().toISOString();
+let connectionState: 'connected' | 'connecting' | 'disconnected' | 'reconnecting' | 'error' = 'disconnected';
+let errorMessage: string | undefined;
+let shuttingDown = false;
+
+// ============================================================================
+// Entry Point
+// ============================================================================
+
+/**
+ * Main daemon loop. Only runs when invoked with --daemon flag.
+ */
+async function main(): Promise<void> {
+  if (!process.argv.includes('--daemon') && process.env.STYRBY_DAEMON !== '1') {
+    console.error('This script should only be run by the Styrby daemon system.');
+    process.exit(1);
+  }
+
+  log('Daemon process starting', { pid: process.pid });
+
+  ensureDir(CONFIG_DIR);
+  fs.writeFileSync(DAEMON_FILES.pidFile, String(process.pid), { mode: 0o600 });
+
+  setupSignalHandlers();
+  startIpcServer();
+  await connectToRelay();
+  startStatusWriter();
+
+  // Signal parent that we are ready.
+  // WHY: The parent waits for this before disconnecting IPC and exiting.
+  if (process.send) {
+    process.send({ type: 'ready' });
+  }
+
+  log('Daemon process ready');
+}
+
+// ============================================================================
+// Supabase Realtime Connection
+// ============================================================================
+
+/**
+ * Connect to Supabase Realtime using stored credentials.
+ */
+async function connectToRelay(): Promise<void> {
+  connectionState = 'connecting';
+
+  try {
+    const data = loadJsonFile<{
+      userId?: string;
+      accessToken?: string;
+      machineId?: string;
+    }>(DAEMON_FILES.dataFile);
+
+    if (!data?.userId || !data?.accessToken) {
+      errorMessage = 'Not authenticated. Run "styrby onboard" first.';
+      connectionState = 'error';
+      log('Cannot connect: no credentials found');
+      return;
+    }
+
+    const supabaseUrl = process.env.SUPABASE_URL || 'https://akmtmxunjhsgldjztdtt.supabase.co';
+    const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || '';
+
+    if (!supabaseAnonKey) {
+      // WHY: Without the anon key, Supabase client cannot authenticate.
+      errorMessage = 'SUPABASE_ANON_KEY not set. Cannot connect to relay.';
+      connectionState = 'error';
+      log('Cannot connect: no anon key');
+      return;
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      auth: { persistSession: false },
+      global: { headers: { Authorization: `Bearer ${data.accessToken}` } },
+    });
+
+    const machineId = data.machineId || `daemon_${process.pid}`;
+
+    relay = createRelayClient({
+      supabase,
+      userId: data.userId,
+      deviceId: machineId,
+      deviceType: 'cli',
+      deviceName: `${os.hostname()} (daemon)`,
+      platform: process.platform,
+      debug: process.env.STYRBY_LOG_LEVEL === 'debug',
+    });
+
+    relay.on('subscribed', () => {
+      connectionState = 'connected';
+      errorMessage = undefined;
+      log('Relay connected');
+    });
+
+    relay.on('error', (err) => {
+      connectionState = 'error';
+      errorMessage = err.message;
+      log('Relay error', err.message);
+    });
+
+    relay.on('closed', (info) => {
+      if (!shuttingDown) {
+        connectionState = 'reconnecting';
+        log('Relay closed, will reconnect', info.reason);
+      }
+    });
+
+    await relay.connect();
+  } catch (err) {
+    connectionState = 'error';
+    errorMessage = err instanceof Error ? err.message : 'Unknown connection error';
+    log('Failed to connect to relay', errorMessage);
+  }
+}
+
+// ============================================================================
+// IPC Server (Unix Domain Socket)
+// ============================================================================
+
+/**
+ * Start the IPC server on a Unix domain socket.
+ * WHY: Unix domain sockets are the standard POSIX mechanism for local IPC.
+ * They are faster than TCP and file-permission-secured.
+ */
+function startIpcServer(): void {
+  const socketPath = DAEMON_FILES.socketPath;
+
+  try { if (fs.existsSync(socketPath)) fs.unlinkSync(socketPath); } catch { /* ignore */ }
+
+  ipcServer = net.createServer((conn) => {
+    let buffer = '';
+    conn.on('data', (chunk) => {
+      buffer += chunk.toString();
+      // WHY: TCP is a stream protocol -- newline delimiting ensures complete JSON.
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        if (line.trim()) handleIpcCommand(line.trim(), conn);
+      }
+    });
+    conn.on('error', (err) => log('IPC client error', err.message));
+  });
+
+  ipcServer.on('error', (err) => log('IPC server error', err.message));
+  ipcServer.listen(socketPath, () => {
+    try { fs.chmodSync(socketPath, 0o600); } catch { /* non-fatal */ }
+    log('IPC server listening', { socketPath });
+  });
+}
+
+/**
+ * Handle an incoming IPC command from a CLI client.
+ *
+ * @param rawMessage - Raw JSON string from the client
+ * @param conn - The socket connection to respond on
+ */
+function handleIpcCommand(rawMessage: string, conn: net.Socket): void {
+  try {
+    const command = JSON.parse(rawMessage) as { type: string };
+    let response: Record<string, unknown>;
+
+    switch (command.type) {
+      case 'ping':
+        response = { success: true, data: { pong: true, pid: process.pid } };
+        break;
+
+      case 'status':
+        response = {
+          success: true,
+          data: {
+            running: true, pid: process.pid, startedAt, connectionState,
+            activeSessions: relay ? relay.getConnectedDevices().length : 0,
+            uptimeSeconds: Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000),
+            lastHeartbeat: new Date().toISOString(), errorMessage,
+          },
+        };
+        break;
+
+      case 'stop':
+        response = { success: true, data: { stopping: true } };
+        conn.write(JSON.stringify(response) + '\n', () => gracefulShutdown('IPC stop command'));
+        return;
+
+      case 'list-sessions':
+        response = { success: true, data: { devices: relay ? relay.getConnectedDevices() : [] } };
+        break;
+
+      default:
+        response = { success: false, error: `Unknown command: ${command.type}` };
+    }
+
+    conn.write(JSON.stringify(response) + '\n');
+  } catch (err) {
+    conn.write(JSON.stringify({
+      success: false,
+      error: err instanceof Error ? err.message : 'Failed to parse command',
+    }) + '\n');
+  }
+}
+
+// ============================================================================
+// Status Writer
+// ============================================================================
+
+/**
+ * Start periodic writes to the daemon status file.
+ * WHY: Simplest mechanism for the CLI to check daemon state without IPC.
+ */
+function startStatusWriter(): void {
+  const writeStatus = (): void => {
+    try {
+      const status = {
+        pid: process.pid, startedAt, connectionState,
+        activeSessions: relay ? relay.getConnectedDevices().length : 0,
+        lastHeartbeat: new Date().toISOString(), errorMessage,
+      };
+      fs.writeFileSync(DAEMON_FILES.statusFile, JSON.stringify(status, null, 2), { mode: 0o600 });
+    } catch { /* non-fatal */ }
+  };
+
+  writeStatus();
+  statusInterval = setInterval(writeStatus, STATUS_WRITE_INTERVAL_MS);
+}
+
+// ============================================================================
+// Signal Handling & Cleanup
+// ============================================================================
+
+function setupSignalHandlers(): void {
+  process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+  process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+
+  process.on('uncaughtException', (err) => {
+    log('Uncaught exception', err.message);
+    errorMessage = `Uncaught: ${err.message}`;
+    connectionState = 'error';
+  });
+
+  process.on('unhandledRejection', (reason) => {
+    const msg = reason instanceof Error ? reason.message : String(reason);
+    log('Unhandled rejection', msg);
+    errorMessage = `Unhandled: ${msg}`;
+  });
+}
+
+/**
+ * Perform graceful shutdown: disconnect relay, close IPC, clean up files.
+ *
+ * @param reason - Human-readable reason for the shutdown (for logging)
+ */
+async function gracefulShutdown(reason: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log('Graceful shutdown initiated', { reason });
+
+  if (statusInterval) { clearInterval(statusInterval); statusInterval = null; }
+
+  if (relay) {
+    try { await relay.disconnect(); } catch (err) {
+      log('Error disconnecting relay', err instanceof Error ? err.message : 'unknown');
+    }
+    relay = null;
+  }
+
+  if (ipcServer) { ipcServer.close(); ipcServer = null; }
+
+  for (const f of [DAEMON_FILES.socketPath, DAEMON_FILES.pidFile, DAEMON_FILES.statusFile]) {
+    try { if (fs.existsSync(f)) fs.unlinkSync(f); } catch { /* best-effort */ }
+  }
+
+  log('Daemon shut down cleanly');
+  process.exit(0);
+}
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+function ensureDir(dirPath: string): void {
+  if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+}
+
+function loadJsonFile<T>(filePath: string): T | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+  } catch { return null; }
+}
+
+function log(message: string, ...args: unknown[]): void {
+  console.log(`[${new Date().toISOString()}] [daemon] ${message}`, ...args);
+}
+
+// ============================================================================
+// Run
+// ============================================================================
+
+main().catch((err) => {
+  console.error('Daemon fatal error:', err);
+  process.exit(1);
+});

--- a/packages/styrby-cli/src/daemon/run.ts
+++ b/packages/styrby-cli/src/daemon/run.ts
@@ -1,86 +1,326 @@
 /**
  * Daemon Runner
  *
- * Handles running the CLI in daemon mode for persistent connections.
+ * Manages a background daemon process that maintains a persistent Supabase
+ * Realtime connection. The daemon allows the CLI to stay connected even when
+ * no terminal is open, so the mobile app can reach the machine at any time.
  *
- * WHY: Stub module for Happy Coder's daemon system.
- * The daemon keeps the CLI connected to the relay even when
- * no terminal is active. This allows mobile to connect anytime.
+ * WHY: Without a daemon, closing the terminal kills the Realtime connection
+ * and the mobile app loses contact with the machine. The daemon forks a
+ * detached child process that survives terminal closure and writes its state
+ * to well-known file paths so any CLI invocation can check status or stop it.
+ *
+ * File layout under ~/.styrby/:
+ *   daemon.pid          - PID of the running daemon (plain text)
+ *   daemon.status.json  - Connection state, uptime, session info (JSON)
+ *   daemon.log          - Stdout/stderr of daemon child process
+ *   daemon.sock         - Unix domain socket for IPC commands
  *
  * @module daemon/run
  */
 
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as childProcess from 'node:child_process';
+import { CONFIG_DIR, ensureConfigDir } from '@/configuration';
 import { logger } from '@/ui/logger';
 
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Path to the daemon PID file. Contains the numeric PID. */
+const PID_FILE = path.join(CONFIG_DIR, 'daemon.pid');
+
+/** Path to the daemon status file. JSON updated periodically by the daemon. */
+const STATUS_FILE = path.join(CONFIG_DIR, 'daemon.status.json');
+
+/** Path to the daemon log file. Captures stdout/stderr from the child process. */
+const LOG_FILE = path.join(CONFIG_DIR, 'daemon.log');
+
+// ============================================================================
+// Types
+// ============================================================================
+
 /**
- * Daemon state
+ * Represents the current state of the daemon process.
+ * Returned by getDaemonStatus() and written to daemon.status.json by the daemon.
  */
 export interface DaemonState {
+  /** Whether the daemon process is currently running */
   running: boolean;
+  /** PID of the daemon process (if running) */
   pid?: number;
+  /** ISO 8601 timestamp of when the daemon started */
   startedAt?: string;
-  connectionState?: 'connected' | 'connecting' | 'disconnected';
+  /** Current Supabase Realtime connection state */
+  connectionState?: 'connected' | 'connecting' | 'disconnected' | 'reconnecting' | 'error';
+  /** Number of active relay sessions being managed */
+  activeSessions?: number;
+  /** Seconds since the daemon started */
+  uptimeSeconds?: number;
+  /** Last heartbeat timestamp from the daemon */
+  lastHeartbeat?: string;
+  /** Error message if the daemon is in an error state */
+  errorMessage?: string;
 }
+
+/**
+ * Internal status payload written to daemon.status.json by the child process.
+ */
+interface DaemonStatusFile {
+  pid: number;
+  startedAt: string;
+  connectionState: DaemonState['connectionState'];
+  activeSessions: number;
+  lastHeartbeat: string;
+  errorMessage?: string;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
 
 /**
  * Start the daemon process.
  *
- * TODO: Implement daemon
- * - Fork a child process that stays alive
- * - Keep Supabase Realtime connection open
- * - Handle agent sessions in background
- * - Write PID file for management
+ * Forks a detached child process that runs the daemon entry point
+ * (daemon/daemonProcess.ts). The child is unref'd so the parent can
+ * exit immediately. The child writes its PID to ~/.styrby/daemon.pid
+ * and continuously updates ~/.styrby/daemon.status.json.
  *
- * @returns Promise resolving to daemon state
+ * If a daemon is already running, returns its current state without duplicating.
+ *
+ * @returns Promise resolving to the daemon state after start attempt
+ * @throws {Error} If the fork fails for a system-level reason
+ *
+ * @example
+ * const state = await startDaemon();
+ * if (state.running) {
+ *   console.log(`Daemon running with PID ${state.pid}`);
+ * }
  */
 export async function startDaemon(): Promise<DaemonState> {
-  logger.info('Daemon start requested (stub)');
-  // TODO: Implement actual daemon
-  return {
-    running: true,
-    pid: process.pid,
-    startedAt: new Date().toISOString(),
-    connectionState: 'connected',
-  };
+  const existingStatus = getDaemonStatus();
+  if (existingStatus.running) {
+    logger.debug('Daemon already running', { pid: existingStatus.pid });
+    return existingStatus;
+  }
+
+  ensureConfigDir();
+  cleanupStaleFiles();
+
+  const daemonScript = resolveDaemonScript();
+  logger.debug('Starting daemon', { script: daemonScript });
+
+  const logFd = fs.openSync(LOG_FILE, 'a');
+
+  // WHY: detached: true + unref() lets the parent exit while the child
+  // stays alive. stdio goes to the log file so closing the terminal
+  // does not kill the daemon.
+  const child = childProcess.fork(daemonScript, ['--daemon'], {
+    detached: true,
+    stdio: ['ignore', logFd, logFd, 'ipc'],
+    env: { ...process.env, STYRBY_DAEMON: '1' },
+  });
+
+  const started = await new Promise<boolean>((resolve) => {
+    const timeout = setTimeout(() => {
+      logger.debug('Daemon start timed out waiting for ready signal');
+      resolve(false);
+    }, 10_000);
+
+    child.once('message', (msg: unknown) => {
+      clearTimeout(timeout);
+      if (typeof msg === 'object' && msg !== null && (msg as Record<string, unknown>).type === 'ready') {
+        resolve(true);
+      } else {
+        resolve(false);
+      }
+    });
+
+    child.once('error', (err) => {
+      clearTimeout(timeout);
+      logger.error('Daemon child process error', { error: err.message });
+      resolve(false);
+    });
+
+    child.once('exit', (code) => {
+      clearTimeout(timeout);
+      logger.debug('Daemon child exited prematurely', { code });
+      resolve(false);
+    });
+  });
+
+  // WHY: After the ready signal, the parent no longer needs the IPC channel.
+  child.disconnect();
+  child.unref();
+  fs.closeSync(logFd);
+
+  if (started && child.pid) {
+    fs.writeFileSync(PID_FILE, String(child.pid), { mode: 0o600 });
+    logger.debug('Daemon started', { pid: child.pid });
+    return { running: true, pid: child.pid, startedAt: new Date().toISOString(), connectionState: 'connecting' };
+  }
+
+  logger.error('Failed to start daemon');
+  return { running: false, errorMessage: 'Daemon failed to start within timeout' };
 }
 
 /**
- * Stop the daemon process.
+ * Stop the running daemon process.
  *
- * @returns Promise resolving when stopped
+ * Reads the PID from ~/.styrby/daemon.pid, sends SIGTERM, and cleans up
+ * state files. Escalates to SIGKILL after 5 seconds.
+ *
+ * @returns Promise resolving when the daemon has been stopped
  */
 export async function stopDaemon(): Promise<void> {
-  logger.info('Daemon stop requested (stub)');
-  // TODO: Implement actual daemon stop
+  const pid = readPidFile();
+  if (!pid) { cleanupStaleFiles(); return; }
+  if (!isProcessAlive(pid)) { cleanupStaleFiles(); return; }
+
+  logger.debug('Sending SIGTERM to daemon', { pid });
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') { cleanupStaleFiles(); return; }
+    throw err;
+  }
+
+  // WHY: 5 seconds is generous for a clean Realtime disconnect.
+  const exited = await waitForProcessExit(pid, 5_000);
+  if (!exited) {
+    logger.debug('Daemon did not exit after SIGTERM, sending SIGKILL', { pid });
+    try { process.kill(pid, 'SIGKILL'); } catch { /* may have exited */ }
+    await waitForProcessExit(pid, 2_000);
+  }
+
+  cleanupStaleFiles();
+  logger.debug('Daemon stopped and cleaned up');
 }
 
 /**
- * Get current daemon status.
+ * Get the current status of the daemon.
  *
- * @returns Daemon state
+ * Checks PID file, verifies process is alive (signal 0), reads status file.
+ *
+ * @returns Current daemon state (always returns, never throws)
  */
 export function getDaemonStatus(): DaemonState {
-  // TODO: Read from PID file and check if running
-  return {
-    running: false,
-  };
+  const pid = readPidFile();
+  if (!pid) return { running: false };
+
+  if (!isProcessAlive(pid)) {
+    logger.debug('Found stale daemon PID file', { pid });
+    return { running: false, errorMessage: 'Daemon process not found (stale PID file)' };
+  }
+
+  const statusData = readStatusFile();
+  if (statusData) {
+    const uptimeSeconds = Math.floor((Date.now() - new Date(statusData.startedAt).getTime()) / 1000);
+    return {
+      running: true, pid: statusData.pid, startedAt: statusData.startedAt,
+      connectionState: statusData.connectionState, activeSessions: statusData.activeSessions,
+      uptimeSeconds, lastHeartbeat: statusData.lastHeartbeat, errorMessage: statusData.errorMessage,
+    };
+  }
+
+  return { running: true, pid, connectionState: 'connecting' };
 }
 
 /**
- * Check if daemon is running.
+ * Check if the daemon is currently running.
  *
- * @returns True if daemon is active
+ * @returns True if the daemon process is alive
  */
 export function isDaemonRunning(): boolean {
   return getDaemonStatus().running;
 }
 
 /**
- * Default export for compatibility
+ * Write or update the daemon status file.
+ * Called by the daemon child process to report its state.
+ *
+ * @param status - Status data to write
  */
+export function writeDaemonStatusFile(status: DaemonStatusFile): void {
+  ensureConfigDir();
+  fs.writeFileSync(STATUS_FILE, JSON.stringify(status, null, 2), { mode: 0o600 });
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+function readPidFile(): number | null {
+  try {
+    if (!fs.existsSync(PID_FILE)) return null;
+    const pid = parseInt(fs.readFileSync(PID_FILE, 'utf-8').trim(), 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch { return null; }
+}
+
+/**
+ * WHY: Signal 0 checks if the process exists without delivering a signal.
+ * Standard POSIX way to probe for a running process.
+ */
+function isProcessAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function readStatusFile(): DaemonStatusFile | null {
+  try {
+    if (!fs.existsSync(STATUS_FILE)) return null;
+    return JSON.parse(fs.readFileSync(STATUS_FILE, 'utf-8')) as DaemonStatusFile;
+  } catch { return null; }
+}
+
+function cleanupStaleFiles(): void {
+  for (const f of [PID_FILE, STATUS_FILE]) {
+    try { if (fs.existsSync(f)) fs.unlinkSync(f); } catch { /* best-effort */ }
+  }
+}
+
+/**
+ * WHY: In dev we run via tsx (.ts files). In production, esbuild bundles
+ * to dist/daemon/daemonProcess.js. We check compiled JS first.
+ */
+function resolveDaemonScript(): string {
+  const distDir = path.resolve(new URL('.', import.meta.url).pathname, '..');
+  const jsPath = path.join(distDir, 'daemon', 'daemonProcess.js');
+  if (fs.existsSync(jsPath)) return jsPath;
+
+  const srcDir = path.dirname(new URL(import.meta.url).pathname);
+  const tsPath = path.join(srcDir, 'daemonProcess.ts');
+  if (fs.existsSync(tsPath)) return tsPath;
+
+  return path.join(srcDir, 'daemonProcess.js');
+}
+
+function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const interval = setInterval(() => {
+      if (!isProcessAlive(pid)) { clearInterval(interval); resolve(true); return; }
+      if (Date.now() - start >= timeoutMs) { clearInterval(interval); resolve(false); }
+    }, 100);
+  });
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+/** Paths to daemon files, exported for use by controlClient and daemonProcess. */
+export const DAEMON_PATHS = {
+  pidFile: PID_FILE,
+  statusFile: STATUS_FILE,
+  logFile: LOG_FILE,
+  socketPath: path.join(CONFIG_DIR, 'daemon.sock'),
+} as const;
+
 export default {
-  startDaemon,
-  stopDaemon,
-  getDaemonStatus,
-  isDaemonRunning,
+  startDaemon, stopDaemon, getDaemonStatus, isDaemonRunning,
+  writeDaemonStatusFile, DAEMON_PATHS,
 };

--- a/packages/styrby-cli/src/index.ts
+++ b/packages/styrby-cli/src/index.ts
@@ -322,15 +322,198 @@ async function handleStart(args: string[]): Promise<void> {
 
 /**
  * Handle the 'status' command.
- * Shows current connection and session status.
+ *
+ * Displays a formatted status table showing:
+ * - Daemon process state (running/stopped, PID, uptime)
+ * - Supabase Realtime connection state
+ * - Authentication status (user ID if authenticated)
+ * - Mobile pairing status
+ * - Active sessions count
+ *
+ * Gathers information from multiple sources:
+ * 1. Daemon status (PID file + status file via getDaemonStatus)
+ * 2. IPC socket for live daemon data (if daemon is responsive)
+ * 3. Persisted credentials for auth state
+ * 4. Persisted data for pairing state
+ * 5. Local session storage for active sessions
  */
 async function handleStatus(): Promise<void> {
-  logger.info('Checking status...');
-  // TODO: Implement
-  // 1. Check if daemon is running
-  // 2. Check connection to Supabase
-  // 3. List active sessions
-  logger.warn('Status not yet implemented');
+  const chalk = (await import('chalk')).default;
+  const { getDaemonStatus } = await import('@/daemon/run');
+  const { canConnectToDaemon, getDaemonStatusViaIpc, listConnectedDevices } = await import('@/daemon/controlClient');
+  const { loadPersistedData, listSessions } = await import('@/persistence');
+
+  // ── Gather data from all sources in parallel ──────────────────────────
+  // WHY: We fetch from multiple independent sources. Doing it in parallel
+  // saves time (~3s IPC timeout if daemon is dead) and avoids sequential waits.
+  const [fileStatus, ipcReachable, persistedData, storedSessions] = await Promise.all([
+    Promise.resolve(getDaemonStatus()),
+    canConnectToDaemon(),
+    Promise.resolve(loadPersistedData()),
+    Promise.resolve(listSessions()),
+  ]);
+
+  // If IPC is reachable, prefer its live data over the status file
+  let daemonStatus = fileStatus;
+  let connectedDevices: unknown[] = [];
+
+  if (ipcReachable) {
+    const [ipcStatus, devices] = await Promise.all([
+      getDaemonStatusViaIpc(),
+      listConnectedDevices(),
+    ]);
+    if (ipcStatus.running) {
+      daemonStatus = ipcStatus;
+    }
+    connectedDevices = devices;
+  }
+
+  // ── Format uptime ─────────────────────────────────────────────────────
+  /**
+   * Convert seconds into a human-readable uptime string.
+   *
+   * @param seconds - Total seconds of uptime
+   * @returns Formatted string like "2h 15m" or "45s"
+   */
+  const formatUptime = (seconds: number): string => {
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    return `${h}h ${m}m`;
+  };
+
+  /**
+   * Format a duration in milliseconds as a human-readable "time ago" string.
+   *
+   * @param ms - Duration in milliseconds
+   * @returns Human-readable relative time (e.g., "2m", "3h", "5d")
+   */
+  const formatTimeAgo = (ms: number): string => {
+    const secs = Math.floor(ms / 1000);
+    if (secs < 60) return `${secs}s`;
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return `${mins}m`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h`;
+    const days = Math.floor(hrs / 24);
+    return `${days}d`;
+  };
+
+  // ── Build status lines ────────────────────────────────────────────────
+  const SEPARATOR = chalk.gray('\u2500'.repeat(45));
+  const LABEL_WIDTH = 14;
+
+  /**
+   * Format a status row with consistent label alignment.
+   *
+   * @param label - Left-side label text
+   * @param value - Right-side value text (already chalk-colored)
+   * @returns Formatted row string
+   */
+  const row = (label: string, value: string): string => {
+    return `  ${chalk.bold(label.padEnd(LABEL_WIDTH))} ${value}`;
+  };
+
+  console.log('');
+  console.log(chalk.bold.cyan('  Styrby Status'));
+  console.log(`  ${SEPARATOR}`);
+
+  // ── Daemon ────────────────────────────────────────────────────────────
+  if (daemonStatus.running) {
+    const pidStr = daemonStatus.pid ? ` (PID ${daemonStatus.pid})` : '';
+    const uptimeStr = daemonStatus.uptimeSeconds
+      ? chalk.gray(` | uptime ${formatUptime(daemonStatus.uptimeSeconds)}`)
+      : '';
+    console.log(row('Daemon:', chalk.green('Running') + chalk.gray(pidStr) + uptimeStr));
+  } else {
+    const hint = daemonStatus.errorMessage
+      ? chalk.gray(` (${daemonStatus.errorMessage})`)
+      : '';
+    console.log(row('Daemon:', chalk.red('Stopped') + hint));
+  }
+
+  // ── Connection ────────────────────────────────────────────────────────
+  if (daemonStatus.running) {
+    const stateColors: Record<string, (s: string) => string> = {
+      connected: chalk.green,
+      connecting: chalk.yellow,
+      reconnecting: chalk.yellow,
+      disconnected: chalk.red,
+      error: chalk.red,
+    };
+    const state = daemonStatus.connectionState || 'unknown';
+    const colorFn = stateColors[state] || chalk.gray;
+    const stateLabel = state.charAt(0).toUpperCase() + state.slice(1);
+    const errorHint = state === 'error' && daemonStatus.errorMessage
+      ? chalk.gray(` (${daemonStatus.errorMessage})`)
+      : '';
+    console.log(row('Connection:', colorFn(stateLabel) + errorHint));
+  } else {
+    console.log(row('Connection:', chalk.gray('N/A (daemon not running)')));
+  }
+
+  // ── Auth ──────────────────────────────────────────────────────────────
+  if (persistedData?.userId && persistedData?.accessToken) {
+    // WHY: We don't store the email in persisted data currently, so we show
+    // the user ID (truncated) as a proxy. A future enhancement could decode
+    // the JWT to extract the email claim.
+    const userDisplay = persistedData.userId.length > 12
+      ? `${persistedData.userId.substring(0, 12)}...`
+      : persistedData.userId;
+    const authDate = persistedData.authenticatedAt
+      ? chalk.gray(` (since ${new Date(persistedData.authenticatedAt).toLocaleDateString()})`)
+      : '';
+    console.log(row('Auth:', chalk.green('Authenticated') + chalk.gray(` [${userDisplay}]`) + authDate));
+  } else {
+    console.log(row('Auth:', chalk.red('Not authenticated') + chalk.gray(' (run: styrby onboard)')));
+  }
+
+  // ── Mobile Pairing ────────────────────────────────────────────────────
+  if (persistedData?.pairedAt) {
+    const pairedDate = new Date(persistedData.pairedAt);
+    const timeSincePair = Date.now() - pairedDate.getTime();
+    const timeAgo = formatTimeAgo(timeSincePair);
+
+    // Check if mobile is currently connected via relay
+    const mobileOnline = connectedDevices.some((d) => {
+      const device = d as { device_type?: string };
+      return device.device_type === 'mobile';
+    });
+
+    if (mobileOnline) {
+      console.log(row('Mobile:', chalk.green('Online') + chalk.gray(` (paired ${timeAgo} ago)`)));
+    } else {
+      console.log(row('Mobile:', chalk.yellow('Paired') + chalk.gray(` (last paired ${timeAgo} ago, currently offline)`)));
+    }
+  } else {
+    console.log(row('Mobile:', chalk.red('Not paired') + chalk.gray(' (run: styrby pair)')));
+  }
+
+  // ── Sessions ──────────────────────────────────────────────────────────
+  const activeSessions = storedSessions.filter(s => s.status === 'active' || s.status === 'running');
+  if (activeSessions.length > 0) {
+    const sessionDescs = activeSessions.map(s => {
+      const project = s.projectPath.split('/').pop() || s.projectPath;
+      return `${s.agentType}/${project}`;
+    });
+    const sessionStr = `${activeSessions.length} active (${sessionDescs.join(', ')})`;
+    console.log(row('Sessions:', chalk.green(sessionStr)));
+  } else if (daemonStatus.activeSessions && daemonStatus.activeSessions > 0) {
+    console.log(row('Sessions:', chalk.green(`${daemonStatus.activeSessions} active`)));
+  } else {
+    console.log(row('Sessions:', chalk.gray('None')));
+  }
+
+  console.log(`  ${SEPARATOR}`);
+
+  // ── Hints ─────────────────────────────────────────────────────────────
+  if (!daemonStatus.running) {
+    console.log('');
+    console.log(chalk.gray('  Tip: Start the daemon with: styrby start'));
+  }
+
+  console.log('');
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Implement `daemon/run.ts`**: Full daemon lifecycle management with `child_process.fork()`, PID file tracking, status file reads, SIGTERM/SIGKILL shutdown escalation, and stale file cleanup
- **Add `daemon/daemonProcess.ts`**: New child process entry point that maintains a persistent Supabase Realtime connection, runs a Unix domain socket IPC server for CLI commands, writes periodic status updates, and handles graceful shutdown on SIGTERM
- **Implement `daemon/controlClient.ts`**: Unix domain socket IPC client with `sendDaemonCommand()`, `canConnectToDaemon()`, `getDaemonStatusViaIpc()`, `requestDaemonStop()`, and `listConnectedDevices()` -- all with timeout handling and graceful error recovery
- **Implement `handleStatus()` in `index.ts`**: Parallel data gathering from daemon status, IPC socket, persisted credentials, and session storage. Displays a formatted chalk table showing daemon state, connection, auth, mobile pairing, and active sessions
- **Update `build.mjs`**: Add daemon process as a separate esbuild entry point (`dist/daemon/daemonProcess.js`) since it runs as an independent forked process

## Test plan

- [ ] Run `npm run build -w styrby-cli` -- verify all three entry points build (index.js, lib.js, daemon/daemonProcess.js)
- [ ] Run `npx tsc --noEmit` in styrby-cli -- verify zero TypeScript errors
- [ ] Run `styrby status` with no daemon running -- verify "Stopped" output with hints
- [ ] Run `styrby status` with no auth -- verify "Not authenticated" row
- [ ] Run `styrby status` after `styrby onboard` -- verify "Authenticated" row
- [ ] Verify daemon PID file and status file are created under `~/.styrby/`
- [ ] Verify daemon IPC socket accepts ping/status commands
- [ ] Verify `stopDaemon()` sends SIGTERM and cleans up files

🤖 Generated with [Claude Code](https://claude.com/claude-code)