### PR TITLE
feat(mobile): complete core mobile implementation

### DIFF
--- a/packages/styrby-mobile/.env.example
+++ b/packages/styrby-mobile/.env.example
@@ -1,0 +1,29 @@
+# =============================================================================
+# Styrby Mobile - Environment Variables
+# =============================================================================
+#
+# Copy this file to .env and replace the placeholder values with your own.
+#
+#   cp .env.example .env
+#
+# IMPORTANT:
+#   - Only variables prefixed with EXPO_PUBLIC_ are exposed to the client bundle.
+#   - Never commit the real .env file to version control.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Supabase
+# -----------------------------------------------------------------------------
+# Your Supabase project URL and anon (public) key.
+# Find these at: Supabase Dashboard > Project Settings > API
+# The anon key is safe to embed in client code — RLS policies protect data.
+EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+
+# -----------------------------------------------------------------------------
+# EAS (Expo Application Services)
+# -----------------------------------------------------------------------------
+# Your EAS project ID, required for push notifications via Expo's push service.
+# Find this at: https://expo.dev > Your Project > Project Settings > Project ID
+# Also used in app.json under extra.eas.projectId.
+EXPO_PUBLIC_PROJECT_ID=your-eas-project-id

--- a/packages/styrby-mobile/app/(tabs)/chat.tsx
+++ b/packages/styrby-mobile/app/(tabs)/chat.tsx
@@ -2,7 +2,14 @@
  * Chat Screen
  *
  * Main chat interface for communicating with AI agents.
- * Shows messages, permission requests, and input for new messages.
+ * Provides session persistence (Supabase), typing indicators,
+ * stop/cancel controls, and permission approval feedback.
+ *
+ * Session lifecycle:
+ * 1. On mount, checks for an existing sessionId in route params or resumes the most recent active session
+ * 2. On first user message (if no active session), creates a new session in Supabase
+ * 3. Every sent/received message is persisted to session_messages
+ * 4. When the user navigates away, the session stays active for later resumption
  */
 
 import { View, Text, FlatList, TextInput, Pressable, KeyboardAvoidingView, Platform } from 'react-native';
@@ -12,116 +19,576 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRelay } from '../../src/hooks/useRelay';
 import { ChatMessage, type ChatMessageData } from '../../src/components/ChatMessage';
 import { PermissionCard, type PermissionRequest } from '../../src/components/PermissionCard';
+import { TypingIndicatorInline, type AgentState } from '../../src/components/TypingIndicator';
+import { StopButtonIcon } from '../../src/components/StopButton';
+import { supabase } from '../../src/lib/supabase';
 import type { AgentType } from 'styrby-shared';
 
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Supabase session_messages row shape matching the `session_messages` table.
+ * Used for persisting and loading chat messages.
+ */
+interface SessionMessageRow {
+  /** UUID primary key */
+  id: string;
+  /** Foreign key to sessions.id */
+  session_id: string;
+  /** Message role: user, assistant, system, or tool */
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  /** Plaintext message content (E2E encryption comes later) */
+  content: string | null;
+  /** Encrypted content blob (not used yet) */
+  encrypted_content: string | null;
+  /** Encryption nonce (not used yet) */
+  nonce: string | null;
+  /** Input tokens consumed by this message */
+  input_tokens: number | null;
+  /** Output tokens produced by this message */
+  output_tokens: number | null;
+  /** Cost in USD for this message */
+  cost_usd: number | null;
+  /** Model used for this message */
+  model: string | null;
+  /** When the message was created */
+  created_at: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Visual configuration for each supported agent type.
+ */
 const AGENT_CONFIG: Record<AgentType, { name: string; color: string; bgColor: string }> = {
   claude: { name: 'Claude', color: '#f97316', bgColor: 'rgba(249, 115, 22, 0.1)' },
   codex: { name: 'Codex', color: '#22c55e', bgColor: 'rgba(34, 197, 94, 0.1)' },
   gemini: { name: 'Gemini', color: '#3b82f6', bgColor: 'rgba(59, 130, 246, 0.1)' },
+  opencode: { name: 'OpenCode', color: '#8b5cf6', bgColor: 'rgba(139, 92, 246, 0.1)' },
+  aider: { name: 'Aider', color: '#ec4899', bgColor: 'rgba(236, 72, 153, 0.1)' },
 };
 
+/**
+ * Only these agents are shown in the selector bar for now.
+ * WHY: opencode and aider are not yet integrated into the CLI relay.
+ */
+const SELECTABLE_AGENTS: AgentType[] = ['claude', 'codex', 'gemini'];
+
+// ============================================================================
+// Dev Logger
+// ============================================================================
+
+/**
+ * Development-only logger that suppresses output in production.
+ * WHY: Prevents session and message data from appearing in production logs.
+ */
+const logger = {
+  log: (...args: unknown[]) => { if (__DEV__) console.log('[Chat]', ...args); },
+  error: (...args: unknown[]) => { if (__DEV__) console.error('[Chat]', ...args); },
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Main chat screen component.
+ *
+ * Manages the full lifecycle of a chat session:
+ * - Loads existing messages from Supabase on mount
+ * - Creates a new session on first message if none exists
+ * - Persists every message to session_messages
+ * - Integrates the typing indicator and stop button
+ * - Handles permission request approve/deny with visual feedback
+ *
+ * @returns React element for the chat screen
+ */
 export default function ChatScreen() {
   const params = useLocalSearchParams<{ agent?: string; sessionId?: string }>();
   const { isConnected, isOnline, isCliOnline, pairingInfo, sendMessage, lastMessage } = useRelay();
 
-  const [inputText, setInputText] = useState('');
+  // --------------------------------------------------------------------------
+  // State
+  // --------------------------------------------------------------------------
+
+  const [inputText, setInputText] = useState<string>('');
   const [messages, setMessages] = useState<ChatMessageData[]>([]);
   const [pendingPermissions, setPendingPermissions] = useState<PermissionRequest[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [selectedAgent, setSelectedAgent] = useState<AgentType | null>(
     (params.agent as AgentType) || null
   );
 
+  /**
+   * WHY: Track the current session ID so we can persist messages to the
+   * correct session. Null means no session has been created yet -- the first
+   * message will trigger session creation.
+   */
+  const [sessionId, setSessionId] = useState<string | null>(params.sessionId ?? null);
+
+  /**
+   * WHY: Track the agent state so we can show the correct typing indicator
+   * variant and control the stop button visibility.
+   */
+  const [agentState, setAgentState] = useState<AgentState>('idle');
+
+  /**
+   * WHY: Track whether the agent is actively generating a response.
+   * This drives the stop button visibility in the input area.
+   */
+  const [isAgentThinking, setIsAgentThinking] = useState<boolean>(false);
+
+  /**
+   * WHY: Track whether we are currently loading messages from Supabase
+   * to show a loading state and prevent duplicate loads.
+   */
+  const [isLoadingHistory, setIsLoadingHistory] = useState<boolean>(false);
+
   const flatListRef = useRef<FlatList>(null);
 
-  // Handle incoming messages from relay
+  /**
+   * WHY: Prevent creating multiple sessions if the user sends messages
+   * rapidly before the first session creation completes.
+   */
+  const sessionCreationLockRef = useRef<boolean>(false);
+
+  // --------------------------------------------------------------------------
+  // Session Persistence: Load on Mount
+  // --------------------------------------------------------------------------
+
+  /**
+   * On mount, loads the session and its messages from Supabase.
+   * If a sessionId is provided via route params, loads that specific session.
+   * Otherwise, attempts to resume the most recent active session.
+   */
+  useEffect(() => {
+    loadSessionHistory();
+  }, []);
+
+  /**
+   * Loads the session history from Supabase.
+   * If sessionId is set (from params), loads messages for that session.
+   * If no sessionId, tries to find and resume the most recent active session.
+   *
+   * @returns void
+   */
+  async function loadSessionHistory(): Promise<void> {
+    try {
+      setIsLoadingHistory(true);
+
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        logger.log('No authenticated user, skipping session load');
+        return;
+      }
+
+      let targetSessionId = sessionId;
+
+      // If no session ID from route params, find the most recent active session
+      if (!targetSessionId) {
+        const { data: recentSession, error: sessionError } = await supabase
+          .from('sessions')
+          .select('id, agent, status')
+          .eq('user_id', user.id)
+          .eq('status', 'active')
+          .order('updated_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        if (sessionError) {
+          logger.error('Failed to find recent session:', sessionError.message);
+          return;
+        }
+
+        if (recentSession) {
+          targetSessionId = recentSession.id;
+          setSessionId(recentSession.id);
+
+          // WHY: Restore the agent selection to match the resumed session
+          // so the UI is consistent with what the user last used.
+          if (recentSession.agent && recentSession.agent in AGENT_CONFIG) {
+            setSelectedAgent(recentSession.agent as AgentType);
+          }
+
+          logger.log('Resuming active session:', recentSession.id);
+        }
+      }
+
+      // Load messages for the session
+      if (targetSessionId) {
+        await loadMessagesForSession(targetSessionId);
+      }
+    } catch (error) {
+      logger.error('Failed to load session history:', error);
+    } finally {
+      setIsLoadingHistory(false);
+    }
+  }
+
+  /**
+   * Fetches all messages for a given session from the session_messages table
+   * and populates the local messages state.
+   *
+   * @param targetSessionId - The session ID to load messages for
+   * @returns void
+   */
+  async function loadMessagesForSession(targetSessionId: string): Promise<void> {
+    const { data: messageRows, error } = await supabase
+      .from('session_messages')
+      .select('*')
+      .eq('session_id', targetSessionId)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      logger.error('Failed to load messages:', error.message);
+      return;
+    }
+
+    if (messageRows && messageRows.length > 0) {
+      const loadedMessages: ChatMessageData[] = (messageRows as SessionMessageRow[]).map((row) => ({
+        id: row.id,
+        role: row.role === 'tool' ? 'system' : row.role as ChatMessageData['role'],
+        content: [{ type: 'text' as const, content: row.content ?? '' }],
+        timestamp: row.created_at,
+        costUsd: row.cost_usd ?? undefined,
+      }));
+
+      setMessages(loadedMessages);
+      logger.log(`Loaded ${loadedMessages.length} messages for session ${targetSessionId}`);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Session Persistence: Create Session
+  // --------------------------------------------------------------------------
+
+  /**
+   * Creates a new session row in the Supabase `sessions` table.
+   * Called lazily on the first message if no session exists yet.
+   *
+   * WHY: We create sessions lazily (not on screen mount) because opening
+   * the chat screen without sending a message should not litter the database
+   * with empty sessions.
+   *
+   * @param agent - The agent type for this session
+   * @param firstMessageContent - The content of the first message (used for session title)
+   * @returns The new session ID, or null if creation failed
+   */
+  async function createSession(agent: AgentType | null, firstMessageContent: string): Promise<string | null> {
+    // WHY: Prevent race condition if user taps send rapidly
+    if (sessionCreationLockRef.current) {
+      logger.log('Session creation already in progress, waiting...');
+      // Wait for existing creation to complete
+      await new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (!sessionCreationLockRef.current) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 50);
+      });
+      return sessionId;
+    }
+
+    // Double-check: session may have been created while we waited
+    if (sessionId) return sessionId;
+
+    sessionCreationLockRef.current = true;
+
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        logger.error('Cannot create session: no authenticated user');
+        return null;
+      }
+
+      // WHY: Generate a short title from the first message so the session
+      // is identifiable in the session list/history screen.
+      const title = firstMessageContent.length > 80
+        ? firstMessageContent.substring(0, 77) + '...'
+        : firstMessageContent;
+
+      const { data: newSession, error } = await supabase
+        .from('sessions')
+        .insert({
+          user_id: user.id,
+          machine_id: pairingInfo?.machineId ?? null,
+          agent: agent ?? 'claude',
+          status: 'active',
+          title,
+          total_input_tokens: 0,
+          total_output_tokens: 0,
+          total_cost_usd: 0,
+          started_at: new Date().toISOString(),
+        })
+        .select('id')
+        .single();
+
+      if (error) {
+        logger.error('Failed to create session:', error.message);
+        return null;
+      }
+
+      const newId = newSession.id;
+      setSessionId(newId);
+      logger.log('Created new session:', newId);
+      return newId;
+    } finally {
+      sessionCreationLockRef.current = false;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Session Persistence: Save Message
+  // --------------------------------------------------------------------------
+
+  /**
+   * Persists a message to the Supabase `session_messages` table.
+   *
+   * @param targetSessionId - The session this message belongs to
+   * @param messageId - Unique message ID (used as the PK)
+   * @param role - The message role (user, assistant, system, tool)
+   * @param content - Plaintext message content
+   * @param tokenData - Optional token usage and cost data
+   * @returns void
+   */
+  async function saveMessageToDb(
+    targetSessionId: string,
+    messageId: string,
+    role: 'user' | 'assistant' | 'system' | 'tool',
+    content: string,
+    tokenData?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      costUsd?: number;
+      model?: string;
+    }
+  ): Promise<void> {
+    const { error } = await supabase
+      .from('session_messages')
+      .insert({
+        id: messageId,
+        session_id: targetSessionId,
+        role,
+        content,
+        encrypted_content: null,
+        nonce: null,
+        input_tokens: tokenData?.inputTokens ?? null,
+        output_tokens: tokenData?.outputTokens ?? null,
+        cost_usd: tokenData?.costUsd ?? null,
+        model: tokenData?.model ?? null,
+      });
+
+    if (error) {
+      logger.error('Failed to save message:', error.message);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Incoming Message Handling
+  // --------------------------------------------------------------------------
+
+  /**
+   * Processes incoming relay messages and updates local state.
+   * Handles agent responses, permission requests, permission responses,
+   * and session state updates.
+   */
   useEffect(() => {
     if (!lastMessage) return;
 
     switch (lastMessage.type) {
-      case 'agent_response':
-        // Add agent response to messages
+      case 'agent_response': {
         const responseData = lastMessage.payload as {
           content: string;
-          agent_type: AgentType;
+          agent_type?: AgentType;
+          agent?: AgentType;
           cost_usd?: number;
           duration_ms?: number;
+          is_complete?: boolean;
+          tokens?: {
+            input: number;
+            output: number;
+          };
         };
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: lastMessage.id,
-            role: 'assistant',
-            agentType: responseData.agent_type,
-            content: [{ type: 'text', content: responseData.content }],
-            timestamp: lastMessage.timestamp,
-            costUsd: responseData.cost_usd,
-            durationMs: responseData.duration_ms,
-          },
-        ]);
-        break;
 
-      case 'permission_request':
-        // Add permission request
+        const agentType = responseData.agent_type ?? responseData.agent;
+
+        const responseMessage: ChatMessageData = {
+          id: lastMessage.id,
+          role: 'assistant',
+          agentType,
+          content: [{ type: 'text', content: responseData.content }],
+          timestamp: lastMessage.timestamp,
+          costUsd: responseData.cost_usd,
+          durationMs: responseData.duration_ms,
+        };
+
+        setMessages((prev) => [...prev, responseMessage]);
+
+        // WHY: Reset the agent state when the response is complete so the
+        // typing indicator hides and the stop button disappears.
+        if (responseData.is_complete !== false) {
+          setAgentState('idle');
+          setIsAgentThinking(false);
+          setIsLoading(false);
+        }
+
+        // Persist the assistant message to Supabase
+        if (sessionId) {
+          saveMessageToDb(
+            sessionId,
+            lastMessage.id,
+            'assistant',
+            responseData.content,
+            {
+              inputTokens: responseData.tokens?.input,
+              outputTokens: responseData.tokens?.output,
+              costUsd: responseData.cost_usd,
+            }
+          );
+        }
+        break;
+      }
+
+      case 'permission_request': {
         const permData = lastMessage.payload as PermissionRequest;
         setPendingPermissions((prev) => [...prev, permData]);
-        break;
 
-      case 'permission_response':
-        // Remove handled permission
+        // WHY: When a permission is requested, the agent is waiting --
+        // update the state to reflect this in the typing indicator.
+        setAgentState('waiting_permission');
+        break;
+      }
+
+      case 'permission_response': {
         const { id } = lastMessage.payload as { id: string };
-        setPendingPermissions((prev) => prev.filter((p) => p.id !== id));
+        // WHY: Keep the card in the list briefly so the user sees the
+        // approved/denied feedback animation (handled by PermissionCard internally).
+        // The card is removed after a short delay.
+        setTimeout(() => {
+          setPendingPermissions((prev) => prev.filter((p) => p.id !== id));
+        }, 1500);
         break;
-    }
-  }, [lastMessage]);
+      }
 
-  // Scroll to bottom on new messages
+      case 'session_state': {
+        const stateData = lastMessage.payload as {
+          state: 'idle' | 'thinking' | 'executing' | 'waiting_permission' | 'error';
+        };
+
+        setAgentState(stateData.state as AgentState);
+        setIsAgentThinking(stateData.state === 'thinking' || stateData.state === 'executing');
+
+        // WHY: Clear loading state when the agent returns to idle.
+        if (stateData.state === 'idle') {
+          setIsLoading(false);
+        }
+        break;
+      }
+    }
+  }, [lastMessage, sessionId]);
+
+  // --------------------------------------------------------------------------
+  // Scroll to Bottom
+  // --------------------------------------------------------------------------
+
+  /**
+   * Scrolls to the bottom of the message list when new messages arrive
+   * or when the typing indicator appears.
+   */
   useEffect(() => {
-    if (messages.length > 0) {
+    if (messages.length > 0 || isAgentThinking) {
       setTimeout(() => {
         flatListRef.current?.scrollToEnd({ animated: true });
       }, 100);
     }
-  }, [messages.length, pendingPermissions.length]);
+  }, [messages.length, pendingPermissions.length, isAgentThinking]);
 
+  // --------------------------------------------------------------------------
+  // Send Message
+  // --------------------------------------------------------------------------
+
+  /**
+   * Handles sending a user message through the relay.
+   * Creates a session on first message, persists the message to Supabase,
+   * and sends it through the relay channel.
+   *
+   * @returns void
+   */
   const handleSend = useCallback(async () => {
     if (!inputText.trim() || !isConnected) return;
 
+    const content = inputText.trim();
+    const messageId = `msg_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+
     const userMessage: ChatMessageData = {
-      id: `msg_${Date.now()}`,
+      id: messageId,
       role: 'user',
-      content: [{ type: 'text', content: inputText.trim() }],
+      content: [{ type: 'text', content }],
       timestamp: new Date().toISOString(),
     };
 
     setMessages((prev) => [...prev, userMessage]);
     setInputText('');
     setIsLoading(true);
+    setAgentState('thinking');
+    setIsAgentThinking(true);
+
+    // Ensure we have a session
+    let currentSessionId = sessionId;
+    if (!currentSessionId) {
+      currentSessionId = await createSession(selectedAgent, content);
+    }
+
+    // Persist the user message
+    if (currentSessionId) {
+      saveMessageToDb(currentSessionId, messageId, 'user', content);
+    }
 
     try {
       await sendMessage({
         type: 'chat',
         payload: {
-          content: inputText.trim(),
+          content,
           agent_type: selectedAgent,
         },
       });
     } catch (error) {
-      // Add error message
+      const errorId = `error_${Date.now()}`;
+      const errorContent = 'Failed to send message. Please try again.';
+
       setMessages((prev) => [
         ...prev,
         {
-          id: `error_${Date.now()}`,
+          id: errorId,
           role: 'error',
-          content: [{ type: 'text', content: 'Failed to send message. Please try again.' }],
+          content: [{ type: 'text', content: errorContent }],
           timestamp: new Date().toISOString(),
         },
       ]);
-    } finally {
+
+      // WHY: Reset agent state on send failure so the typing indicator
+      // and stop button return to their default states.
+      setAgentState('idle');
+      setIsAgentThinking(false);
       setIsLoading(false);
     }
-  }, [inputText, isConnected, selectedAgent, sendMessage]);
+  }, [inputText, isConnected, selectedAgent, sendMessage, sessionId, pairingInfo]);
 
+  // --------------------------------------------------------------------------
+  // Permission Handling
+  // --------------------------------------------------------------------------
+
+  /**
+   * Approves a pending permission request by sending the approval through the relay.
+   *
+   * @param id - The permission request ID to approve
+   * @returns void
+   */
   const handleApprovePermission = useCallback(
     async (id: string) => {
       const permission = pendingPermissions.find((p) => p.id === id);
@@ -136,14 +603,29 @@ export default function ChatScreen() {
             approved: true,
           },
         });
-        setPendingPermissions((prev) => prev.filter((p) => p.id !== id));
+
+        // WHY: After approving, the agent will likely start executing.
+        // Update state preemptively so the UI feels responsive.
+        setAgentState('executing');
+        setIsAgentThinking(true);
+
+        // WHY: Delay removal so the PermissionCard can show the "Approved" feedback.
+        setTimeout(() => {
+          setPendingPermissions((prev) => prev.filter((p) => p.id !== id));
+        }, 1500);
       } catch (error) {
-        console.error('Failed to approve permission:', error);
+        logger.error('Failed to approve permission:', error);
       }
     },
     [pendingPermissions, sendMessage]
   );
 
+  /**
+   * Denies a pending permission request by sending the denial through the relay.
+   *
+   * @param id - The permission request ID to deny
+   * @returns void
+   */
   const handleDenyPermission = useCallback(
     async (id: string) => {
       const permission = pendingPermissions.find((p) => p.id === id);
@@ -158,22 +640,80 @@ export default function ChatScreen() {
             approved: false,
           },
         });
-        setPendingPermissions((prev) => prev.filter((p) => p.id !== id));
+
+        // WHY: After denying, the agent returns to idle (it can't proceed).
+        setAgentState('idle');
+        setIsAgentThinking(false);
+
+        // WHY: Delay removal so the PermissionCard can show the "Denied" feedback.
+        setTimeout(() => {
+          setPendingPermissions((prev) => prev.filter((p) => p.id !== id));
+        }, 1500);
       } catch (error) {
-        console.error('Failed to deny permission:', error);
+        logger.error('Failed to deny permission:', error);
       }
     },
     [pendingPermissions, sendMessage]
   );
 
+  // --------------------------------------------------------------------------
+  // Stop / Cancel
+  // --------------------------------------------------------------------------
+
+  /**
+   * Sends an interrupt command to the CLI agent to cancel the current operation.
+   * Called by the StopButton when the user wants to stop generation.
+   *
+   * @returns void
+   */
+  const handleStop = useCallback(async () => {
+    try {
+      await sendMessage({
+        type: 'command',
+        payload: {
+          action: 'interrupt',
+        },
+      });
+
+      setAgentState('idle');
+      setIsAgentThinking(false);
+      setIsLoading(false);
+    } catch (error) {
+      logger.error('Failed to send interrupt:', error);
+    }
+  }, [sendMessage]);
+
+  // --------------------------------------------------------------------------
+  // Navigation
+  // --------------------------------------------------------------------------
+
+  /**
+   * Navigates to the QR code scanning screen for pairing.
+   */
   const handlePairPress = () => {
     router.push('/(auth)/scan');
   };
 
-  // Check if we can send messages
-  const canSend = isConnected && inputText.trim().length > 0;
+  // --------------------------------------------------------------------------
+  // Derived State
+  // --------------------------------------------------------------------------
 
-  // Render empty state if not connected or no messages
+  /** Whether the send button should be enabled */
+  const canSend = isConnected && inputText.trim().length > 0 && !isLoading;
+
+  /** The currently resolved agent (for typing indicator) */
+  const activeAgent: AgentType = selectedAgent ?? 'claude';
+
+  // --------------------------------------------------------------------------
+  // Empty State
+  // --------------------------------------------------------------------------
+
+  /**
+   * Renders the appropriate empty state based on connection status.
+   * Shows different UI for: not paired, not connected, and ready to chat.
+   *
+   * @returns React element for the empty state
+   */
   const renderEmptyState = () => {
     if (!pairingInfo) {
       return (
@@ -190,6 +730,8 @@ export default function ChatScreen() {
           <Pressable
             onPress={handlePairPress}
             className="bg-brand px-6 py-3 rounded-xl flex-row items-center"
+            accessibilityRole="button"
+            accessibilityLabel="Scan QR code to pair CLI"
           >
             <Ionicons name="qr-code" size={20} color="white" />
             <Text className="text-white font-semibold ml-2">Scan QR Code</Text>
@@ -216,6 +758,22 @@ export default function ChatScreen() {
       );
     }
 
+    if (isLoadingHistory) {
+      return (
+        <View className="flex-1 items-center justify-center px-8">
+          <View className="w-16 h-16 rounded-2xl bg-brand/20 items-center justify-center mb-4">
+            <Ionicons name="chatbubbles" size={32} color="#f97316" />
+          </View>
+          <Text className="text-white text-xl font-semibold text-center mb-2">
+            Loading Messages...
+          </Text>
+          <Text className="text-zinc-500 text-center">
+            Restoring your conversation
+          </Text>
+        </View>
+      );
+    }
+
     return (
       <View className="flex-1 items-center justify-center px-8">
         <View className="w-16 h-16 rounded-2xl bg-brand/20 items-center justify-center mb-4">
@@ -231,15 +789,27 @@ export default function ChatScreen() {
     );
   };
 
-  // Combine messages and permissions for display
+  // --------------------------------------------------------------------------
+  // Chat Items (messages + permissions merged and sorted)
+  // --------------------------------------------------------------------------
+
+  /**
+   * WHY: Combine messages and permissions into a single sorted list so they
+   * appear in chronological order in the FlatList. The type discriminator
+   * is used in renderItem to render the correct component.
+   */
   const chatItems = [
     ...messages.map((m) => ({ type: 'message' as const, data: m })),
     ...pendingPermissions.map((p) => ({ type: 'permission' as const, data: p })),
   ].sort((a, b) => {
-    const aTime = 'timestamp' in a.data ? a.data.timestamp : a.data.timestamp;
-    const bTime = 'timestamp' in b.data ? b.data.timestamp : b.data.timestamp;
+    const aTime = a.data.timestamp;
+    const bTime = b.data.timestamp;
     return new Date(aTime).getTime() - new Date(bTime).getTime();
   });
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
 
   return (
     <KeyboardAvoidingView
@@ -258,7 +828,7 @@ export default function ChatScreen() {
       {/* Agent Selector */}
       {isConnected && (
         <View className="flex-row px-4 py-2 border-b border-zinc-800">
-          {(['claude', 'codex', 'gemini'] as AgentType[]).map((agent) => {
+          {SELECTABLE_AGENTS.map((agent) => {
             const config = AGENT_CONFIG[agent];
             const isSelected = selectedAgent === agent;
             return (
@@ -269,6 +839,9 @@ export default function ChatScreen() {
                   isSelected ? '' : 'opacity-50'
                 }`}
                 style={{ backgroundColor: isSelected ? config.bgColor : 'transparent' }}
+                accessibilityRole="button"
+                accessibilityLabel={`Select ${config.name} agent`}
+                accessibilityState={{ selected: isSelected }}
               >
                 <View
                   style={{ backgroundColor: config.color }}
@@ -289,7 +862,7 @@ export default function ChatScreen() {
       )}
 
       {/* Chat Messages */}
-      {chatItems.length === 0 ? (
+      {chatItems.length === 0 && !isAgentThinking ? (
         renderEmptyState()
       ) : (
         <FlatList
@@ -310,6 +883,18 @@ export default function ChatScreen() {
           }}
           contentContainerStyle={{ paddingVertical: 8 }}
           showsVerticalScrollIndicator={false}
+          ListFooterComponent={
+            /* WHY: The typing indicator is rendered as a FlatList footer so it
+             * always appears below all messages and scrolls naturally with the list. */
+            isAgentThinking ? (
+              <View className="px-4 pb-2">
+                <TypingIndicatorInline
+                  agentType={activeAgent}
+                  state={agentState}
+                />
+              </View>
+            ) : null
+          }
         />
       )}
 
@@ -326,24 +911,37 @@ export default function ChatScreen() {
             onChangeText={setInputText}
             multiline
             editable={isConnected}
+            accessibilityLabel="Message input"
+            accessibilityHint="Type a message to send to your AI agent"
           />
-          <Pressable
-            onPress={handleSend}
-            disabled={!canSend || isLoading}
-            className={`ml-2 w-10 h-10 rounded-full items-center justify-center ${
-              canSend && !isLoading ? 'bg-brand' : 'bg-zinc-800'
-            }`}
-          >
-            {isLoading ? (
-              <View className="w-5 h-5 rounded-full border-2 border-white border-t-transparent animate-spin" />
-            ) : (
+          {/* WHY: Show the stop button instead of the send button when the agent
+           * is actively generating, so the user can cancel without needing a
+           * separate UI element. The StopButtonIcon variant fits cleanly in the
+           * same circular button space as the send button. */}
+          {isAgentThinking ? (
+            <StopButtonIcon
+              isRunning={isAgentThinking}
+              onStop={handleStop}
+              accessibilityLabel="Stop agent generation"
+            />
+          ) : (
+            <Pressable
+              onPress={handleSend}
+              disabled={!canSend}
+              className={`ml-2 w-10 h-10 rounded-full items-center justify-center ${
+                canSend ? 'bg-brand' : 'bg-zinc-800'
+              }`}
+              accessibilityRole="button"
+              accessibilityLabel="Send message"
+              accessibilityState={{ disabled: !canSend }}
+            >
               <Ionicons
                 name="send"
                 size={20}
                 color={canSend ? 'white' : '#71717a'}
               />
-            )}
-          </Pressable>
+            </Pressable>
+          )}
         </View>
       </View>
     </KeyboardAvoidingView>

--- a/packages/styrby-mobile/app/(tabs)/index.tsx
+++ b/packages/styrby-mobile/app/(tabs)/index.tsx
@@ -3,19 +3,28 @@
  *
  * Multi-agent dashboard showing status of all connected AI agents.
  * Displays swipeable session cards, notifications, and quick stats.
+ *
+ * Data sources:
+ * - Active sessions: loaded from Supabase `sessions` table + real-time relay updates
+ * - Notifications: loaded from Supabase `audit_log` table (last 24 hours)
+ * - Agent status: derived from active sessions + relay presence
+ * - Quick stats: aggregated from `cost_records` table + live session count
  */
 
 import { View, Text, ScrollView, Pressable, RefreshControl } from 'react-native';
 import { useState, useCallback } from 'react';
-import { router } from 'expo-router';
+import { router, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useRelay } from '../../src/hooks/useRelay';
+import { useDashboardData } from '../../src/hooks/useDashboardData';
 import { SessionCarousel, type ActiveSession } from '../../src/components/SessionCarousel';
 import { NotificationStream, type Notification } from '../../src/components/NotificationStream';
 import type { AgentType } from 'styrby-shared';
 
 /**
- * Agent configuration with display properties.
+ * Agent configuration with display properties for the agent card list.
+ * These are the three primary agents shown on the dashboard regardless
+ * of whether they have active sessions.
  */
 const AGENTS: Array<{
   type: AgentType;
@@ -47,6 +56,19 @@ const AGENTS: Array<{
   },
 ];
 
+/**
+ * Dashboard screen component.
+ *
+ * Wires together the relay hook (for real-time CLI communication) and the
+ * dashboard data hook (for Supabase queries + relay-driven state updates).
+ *
+ * Refresh behavior:
+ * - Pull-to-refresh: re-establishes relay connection + reloads all Supabase data
+ * - Tab focus: reloads Supabase data when the user navigates back to this tab
+ * - Relay messages: updates session state, costs, and permissions in real time
+ *
+ * @returns The dashboard screen JSX
+ */
 export default function DashboardScreen() {
   const {
     isConnected,
@@ -54,34 +76,86 @@ export default function DashboardScreen() {
     isCliOnline,
     pairingInfo,
     pendingQueueCount,
+    connectedDevices,
+    lastMessage,
     connect,
     sendMessage,
   } = useRelay();
 
+  const {
+    activeSessions,
+    notifications: dashboardNotifications,
+    agentStatus,
+    quickStats,
+    isLoading,
+    refresh: refreshDashboardData,
+  } = useDashboardData(lastMessage, connectedDevices);
+
   const [refreshing, setRefreshing] = useState(false);
 
-  // Mock active sessions - will be populated from relay
-  const [activeSessions, setActiveSessions] = useState<ActiveSession[]>([]);
+  /**
+   * WHY: Notifications need local "read" state that persists during the session
+   * but doesn't need to be written back to the database (audit_log is immutable).
+   * We maintain a state set of read notification IDs and merge it with the data
+   * from the hook. Using state (not a ref) ensures the UI re-renders immediately
+   * when a notification is marked read, without triggering a Supabase re-fetch.
+   */
+  const [readNotificationIds, setReadNotificationIds] = useState<Set<string>>(new Set());
 
-  // Mock notifications - will be populated from relay
-  const [notifications, setNotifications] = useState<Notification[]>([]);
+  /**
+   * Merges dashboard notifications with locally tracked read state.
+   * Notifications fetched from the audit_log start as unread; once the user
+   * taps one, we mark it read locally for the duration of the app session.
+   */
+  const notifications: Notification[] = dashboardNotifications.map((n) => ({
+    ...n,
+    read: readNotificationIds.has(n.id) ? true : n.read,
+  }));
 
-  // Mock agent status
-  const [agentStatus] = useState<Record<AgentType, { online: boolean; cost: number }>>({
-    claude: { online: false, cost: 0 },
-    codex: { online: false, cost: 0 },
-    gemini: { online: false, cost: 0 },
-  });
+  // --------------------------------------------------------------------------
+  // Refresh
+  // --------------------------------------------------------------------------
 
+  /**
+   * Pull-to-refresh handler. Reconnects the relay and reloads all dashboard
+   * data from Supabase in parallel.
+   */
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      await connect();
+      await Promise.all([
+        connect(),
+        refreshDashboardData(),
+      ]);
     } finally {
       setRefreshing(false);
     }
-  }, [connect]);
+  }, [connect, refreshDashboardData]);
 
+  // --------------------------------------------------------------------------
+  // Focus Refresh
+  // --------------------------------------------------------------------------
+
+  /**
+   * WHY: When the user navigates away (e.g., to chat) and comes back, the
+   * session list and costs may be stale. useFocusEffect fires every time this
+   * tab receives focus, keeping data fresh without background polling.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      refreshDashboardData();
+    }, [refreshDashboardData])
+  );
+
+  // --------------------------------------------------------------------------
+  // Navigation Handlers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Navigates to the chat tab for a specific agent.
+   *
+   * @param agentType - The agent to open in the chat view
+   */
   const handleAgentPress = (agentType: AgentType) => {
     router.push({
       pathname: '/(tabs)/chat',
@@ -89,6 +163,11 @@ export default function DashboardScreen() {
     });
   };
 
+  /**
+   * Navigates to the chat tab for a specific session.
+   *
+   * @param session - The active session to open
+   */
   const handleSessionPress = (session: ActiveSession) => {
     router.push({
       pathname: '/(tabs)/chat',
@@ -96,35 +175,67 @@ export default function DashboardScreen() {
     });
   };
 
+  // --------------------------------------------------------------------------
+  // Permission Handlers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Approves a pending permission request for a session.
+   * Sends a permission_response message through the relay to the CLI.
+   *
+   * @param session - The session with the pending permission
+   */
   const handleApprove = async (session: ActiveSession) => {
     if (session.pendingPermission) {
       await sendMessage({
         type: 'permission_response',
         payload: {
-          session_id: session.id,
+          request_id: session.pendingPermission.requestId,
           approved: true,
         },
       });
     }
   };
 
+  /**
+   * Denies a pending permission request for a session.
+   * Sends a permission_response message through the relay to the CLI.
+   *
+   * @param session - The session with the pending permission
+   */
   const handleDeny = async (session: ActiveSession) => {
     if (session.pendingPermission) {
       await sendMessage({
         type: 'permission_response',
         payload: {
-          session_id: session.id,
+          request_id: session.pendingPermission.requestId,
           approved: false,
         },
       });
     }
   };
 
+  /**
+   * Navigates to the pairing/scan screen so the user can pair with a CLI.
+   */
   const handlePairPress = () => {
     router.push('/(auth)/scan');
   };
 
+  // --------------------------------------------------------------------------
+  // Notification Handlers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Handles a notification tap. If the notification is associated with a
+   * session, navigates to that session in the chat tab.
+   *
+   * @param notification - The tapped notification
+   */
   const handleNotificationPress = (notification: Notification) => {
+    // Mark as read immediately on press
+    setReadNotificationIds((prev) => new Set(prev).add(notification.id));
+
     if (notification.sessionId) {
       router.push({
         pathname: '/(tabs)/chat',
@@ -133,27 +244,47 @@ export default function DashboardScreen() {
     }
   };
 
+  /**
+   * Marks a notification as read in local state.
+   * WHY: We don't persist read state to the database because audit_log entries
+   * are immutable. Read state is session-scoped and resets on app restart.
+   * Using a state set (not a ref) ensures the component re-renders immediately
+   * without triggering a Supabase re-fetch.
+   *
+   * @param id - The notification ID to mark as read
+   */
   const handleMarkRead = (id: string) => {
-    setNotifications((prev) =>
-      prev.map((n) => (n.id === id ? { ...n, read: true } : n))
-    );
+    setReadNotificationIds((prev) => new Set(prev).add(id));
   };
 
-  // Calculate totals
-  const totalCostToday = Object.values(agentStatus).reduce((sum, a) => sum + a.cost, 0);
-  const activeAgentCount = Object.values(agentStatus).filter((a) => a.online).length;
+  // --------------------------------------------------------------------------
+  // Derived Values
+  // --------------------------------------------------------------------------
+
+  const { totalCostToday, activeAgentCount } = quickStats;
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
 
   return (
     <ScrollView
       className="flex-1 bg-background"
       contentContainerStyle={{ paddingBottom: 24 }}
       refreshControl={
-        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#f97316" />
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          tintColor="#f97316"
+          accessibilityLabel="Pull to refresh dashboard data"
+        />
       }
+      accessibilityRole="scrollbar"
+      accessibilityLabel="Dashboard"
     >
       {/* Connection Status Banner */}
       <View className="mx-4 mt-4">
-        <View
+        <Pressable
           className={`rounded-xl px-4 py-3 flex-row items-center justify-between ${
             isConnected && isCliOnline
               ? 'bg-green-500/10'
@@ -161,6 +292,19 @@ export default function DashboardScreen() {
                 ? 'bg-yellow-500/10'
                 : 'bg-zinc-800'
           }`}
+          accessibilityRole="button"
+          accessibilityLabel={
+            isConnected && isCliOnline
+              ? 'Connected to CLI'
+              : isConnected
+                ? 'Waiting for CLI to come online'
+                : pairingInfo
+                  ? 'Disconnected from relay'
+                  : 'Not paired with a CLI device'
+          }
+          accessibilityState={{
+            disabled: true,
+          }}
         >
           <View className="flex-row items-center">
             <View
@@ -187,6 +331,8 @@ export default function DashboardScreen() {
             <Pressable
               onPress={handlePairPress}
               className="bg-brand px-3 py-1.5 rounded-lg flex-row items-center"
+              accessibilityRole="button"
+              accessibilityLabel="Pair with a CLI device"
             >
               <Ionicons name="qr-code" size={14} color="white" />
               <Text className="text-white text-sm font-medium ml-1">Pair</Text>
@@ -197,11 +343,15 @@ export default function DashboardScreen() {
               <Text className="text-yellow-500 text-sm ml-1">Offline</Text>
             </View>
           ) : null}
-        </View>
+        </Pressable>
 
         {/* Pending queue indicator */}
         {pendingQueueCount > 0 && (
-          <View className="mt-2 bg-orange-500/10 rounded-lg px-3 py-2 flex-row items-center">
+          <View
+            className="mt-2 bg-orange-500/10 rounded-lg px-3 py-2 flex-row items-center"
+            accessibilityRole="text"
+            accessibilityLabel={`${pendingQueueCount} message${pendingQueueCount !== 1 ? 's' : ''} queued for delivery`}
+          >
             <Ionicons name="hourglass" size={14} color="#f97316" />
             <Text className="text-orange-400 text-sm ml-2">
               {pendingQueueCount} message{pendingQueueCount !== 1 ? 's' : ''} queued
@@ -212,7 +362,7 @@ export default function DashboardScreen() {
 
       {/* Active Sessions Carousel */}
       {activeSessions.length > 0 && (
-        <View className="mt-6">
+        <View className="mt-6" accessibilityRole="summary" accessibilityLabel="Active sessions">
           <Text className="text-zinc-400 text-sm font-medium mx-4 mb-3">ACTIVE SESSIONS</Text>
           <SessionCarousel
             sessions={activeSessions}
@@ -224,17 +374,25 @@ export default function DashboardScreen() {
       )}
 
       {/* Quick Stats */}
-      <View className="mx-4 mt-6">
+      <View className="mx-4 mt-6" accessibilityRole="summary" accessibilityLabel="Today's statistics">
         <Text className="text-zinc-400 text-sm font-medium mb-3">TODAY</Text>
         <View className="flex-row">
-          <View className="flex-1 bg-background-secondary rounded-xl p-4 mr-2">
+          <View
+            className="flex-1 bg-background-secondary rounded-xl p-4 mr-2"
+            accessibilityRole="text"
+            accessibilityLabel={`Total spend today: $${totalCostToday.toFixed(2)}`}
+          >
             <Ionicons name="wallet" size={20} color="#f97316" />
             <Text className="text-zinc-100 text-xl font-bold mt-2">
               ${totalCostToday.toFixed(2)}
             </Text>
             <Text className="text-zinc-500 text-sm">Total spend</Text>
           </View>
-          <View className="flex-1 bg-background-secondary rounded-xl p-4 ml-2">
+          <View
+            className="flex-1 bg-background-secondary rounded-xl p-4 ml-2"
+            accessibilityRole="text"
+            accessibilityLabel={`${activeAgentCount} active agent${activeAgentCount !== 1 ? 's' : ''}`}
+          >
             <Ionicons name="pulse" size={20} color="#22c55e" />
             <Text className="text-zinc-100 text-xl font-bold mt-2">{activeAgentCount}</Text>
             <Text className="text-zinc-500 text-sm">Active agents</Text>
@@ -252,6 +410,10 @@ export default function DashboardScreen() {
               key={agent.type}
               onPress={() => handleAgentPress(agent.type)}
               className="bg-background-secondary rounded-xl mb-3 overflow-hidden"
+              accessibilityRole="button"
+              accessibilityLabel={`${agent.name}, ${status?.online ? 'connected' : 'not connected'}${
+                status?.online ? `, $${status.cost.toFixed(2)} spent today` : ''
+              }`}
             >
               <View className="flex-row items-center p-4">
                 <View
@@ -263,16 +425,16 @@ export default function DashboardScreen() {
                 <View className="flex-1 ml-4">
                   <View className="flex-row items-center">
                     <Text className="text-zinc-100 font-semibold text-base">{agent.name}</Text>
-                    {status.online && (
+                    {status?.online && (
                       <View className="ml-2 w-2 h-2 rounded-full bg-green-500" />
                     )}
                   </View>
                   <Text className="text-zinc-500 text-sm mt-0.5">
-                    {status.online ? 'Connected' : 'Not connected'}
+                    {status?.online ? 'Connected' : 'Not connected'}
                   </Text>
                 </View>
                 <View className="items-end">
-                  {status.online ? (
+                  {status?.online ? (
                     <>
                       <Text className="text-zinc-300 font-medium">${status.cost.toFixed(2)}</Text>
                       <Text className="text-zinc-600 text-xs">today</Text>
@@ -288,7 +450,7 @@ export default function DashboardScreen() {
       </View>
 
       {/* Notifications */}
-      <View className="mx-4 mt-6">
+      <View className="mx-4 mt-6" accessibilityRole="list" accessibilityLabel="Recent notifications">
         <Text className="text-zinc-400 text-sm font-medium mb-3">NOTIFICATIONS</Text>
         <View className="bg-background-secondary rounded-xl overflow-hidden">
           <NotificationStream

--- a/packages/styrby-mobile/app/(tabs)/sessions.tsx
+++ b/packages/styrby-mobile/app/(tabs)/sessions.tsx
@@ -1,113 +1,527 @@
 /**
  * Sessions Screen
  *
- * List of past chat sessions with search and filtering.
+ * Displays the user's past coding sessions from Supabase with search,
+ * status/agent filtering, infinite-scroll pagination, and pull-to-refresh.
+ * Tapping a session card navigates to the chat screen with the session ID.
  */
 
-import { View, Text, FlatList, Pressable } from 'react-native';
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  TextInput,
+  RefreshControl,
+  ActivityIndicator,
+} from 'react-native';
+import { useCallback } from 'react';
 import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { formatCost } from '../../src/hooks/useCosts';
+import {
+  useSessions,
+  formatRelativeTime,
+  getFirstLine,
+  type SessionRow,
+  type SessionFilters,
+} from '../../src/hooks/useSessions';
+import type { AgentType } from 'styrby-shared';
 
-// Mock data for development
-const MOCK_SESSIONS = [
-  {
-    id: '1',
-    title: 'Authentication Flow',
-    agent: 'claude' as const,
-    lastMessage: 'Implemented OAuth with GitHub provider',
-    timestamp: '2 hours ago',
-    messageCount: 24,
-  },
-  {
-    id: '2',
-    title: 'Database Schema',
-    agent: 'codex' as const,
-    lastMessage: 'Created migration for user profiles',
-    timestamp: 'Yesterday',
-    messageCount: 18,
-  },
-  {
-    id: '3',
-    title: 'API Endpoints',
-    agent: 'gemini' as const,
-    lastMessage: 'Added rate limiting middleware',
-    timestamp: '3 days ago',
-    messageCount: 42,
-  },
-];
+// ============================================================================
+// Agent Config
+// ============================================================================
 
-const agentColors = {
-  claude: '#f97316',
-  codex: '#22c55e',
-  gemini: '#3b82f6',
+/**
+ * Visual configuration for each supported AI agent.
+ * Used for icon badges, background tints, and labels.
+ */
+const AGENT_CONFIG: Record<
+  string,
+  { label: string; color: string; icon: string }
+> = {
+  claude: { label: 'Claude', color: '#a855f7', icon: 'C' },
+  codex: { label: 'Codex', color: '#22c55e', icon: 'X' },
+  gemini: { label: 'Gemini', color: '#3b82f6', icon: 'G' },
 };
 
+/**
+ * Look up agent display config, falling back to a neutral grey for
+ * unknown agent types.
+ *
+ * @param agent - The agent_type string from the session row
+ * @returns Config object with label, hex colour, and short icon letter
+ */
+function getAgentConfig(agent: string) {
+  return AGENT_CONFIG[agent] ?? { label: agent, color: '#71717a', icon: '?' };
+}
+
+// ============================================================================
+// Status Config
+// ============================================================================
+
+/**
+ * Map of session status to display colour.
+ * Active statuses are green, terminal errors are red, and everything
+ * else (completed/expired/paused) is a neutral grey.
+ */
+const STATUS_COLORS: Record<string, string> = {
+  starting: '#22c55e',
+  running: '#22c55e',
+  idle: '#22c55e',
+  paused: '#eab308',
+  stopped: '#71717a',
+  error: '#ef4444',
+  expired: '#71717a',
+};
+
+/**
+ * Human-readable label for session statuses shown in the badge.
+ */
+const STATUS_LABELS: Record<string, string> = {
+  starting: 'Starting',
+  running: 'Active',
+  idle: 'Idle',
+  paused: 'Paused',
+  stopped: 'Completed',
+  error: 'Error',
+  expired: 'Expired',
+};
+
+// ============================================================================
+// Filter Chip Definitions
+// ============================================================================
+
+/** Status filter options displayed as chips. */
+const STATUS_CHIPS: Array<{ label: string; value: SessionFilters['status'] }> = [
+  { label: 'All', value: null },
+  { label: 'Active', value: 'active' },
+  { label: 'Completed', value: 'completed' },
+];
+
+/** Agent filter options displayed as chips. */
+const AGENT_CHIPS: Array<{ label: string; value: AgentType | null }> = [
+  { label: 'All', value: null },
+  { label: 'Claude', value: 'claude' },
+  { label: 'Codex', value: 'codex' },
+  { label: 'Gemini', value: 'gemini' },
+];
+
+// ============================================================================
+// Session Card Component
+// ============================================================================
+
+/**
+ * Props for the SessionCard component.
+ */
+interface SessionCardProps {
+  /** The session data to render */
+  session: SessionRow;
+  /** Callback fired when the card is tapped */
+  onPress: (session: SessionRow) => void;
+}
+
+/**
+ * A single session list item.
+ *
+ * Displays the agent icon, session title, status badge, cost, relative
+ * timestamp, and the first line of the AI-generated summary. Tapping
+ * the card triggers navigation to the chat screen.
+ *
+ * @param session - Session row from Supabase
+ * @param onPress - Navigation handler
+ */
+function SessionCard({ session, onPress }: SessionCardProps) {
+  const agentConfig = getAgentConfig(session.agent_type);
+  const statusColor = STATUS_COLORS[session.status] ?? '#71717a';
+  const statusLabel = STATUS_LABELS[session.status] ?? session.status;
+  const summaryPreview = getFirstLine(session.summary);
+
+  return (
+    <Pressable
+      onPress={() => onPress(session)}
+      className="px-4 py-3 border-b border-zinc-800/50 active:bg-zinc-900"
+      accessibilityRole="button"
+      accessibilityLabel={`Session: ${session.title || 'Untitled'}. ${statusLabel}. Cost ${formatCost(Number(session.total_cost_usd))}.`}
+    >
+      <View className="flex-row items-start">
+        {/* Agent Icon Badge */}
+        <View
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
+          style={{ backgroundColor: `${agentConfig.color}20` }}
+        >
+          <Text
+            className="text-base font-bold"
+            style={{ color: agentConfig.color }}
+          >
+            {agentConfig.icon}
+          </Text>
+        </View>
+
+        {/* Session Info */}
+        <View className="flex-1">
+          {/* Title + Timestamp Row */}
+          <View className="flex-row items-center justify-between mb-1">
+            <Text
+              className="text-white font-semibold flex-1 mr-2"
+              numberOfLines={1}
+            >
+              {session.title || 'Untitled Session'}
+            </Text>
+            <Text className="text-zinc-500 text-xs">
+              {formatRelativeTime(session.updated_at)}
+            </Text>
+          </View>
+
+          {/* Summary Preview */}
+          {summaryPreview && (
+            <Text className="text-zinc-400 text-sm mb-1" numberOfLines={1}>
+              {summaryPreview}
+            </Text>
+          )}
+
+          {/* Badges Row: agent, status, cost, messages */}
+          <View className="flex-row items-center flex-wrap mt-1">
+            {/* Agent Badge */}
+            <View
+              className="px-2 py-0.5 rounded mr-2"
+              style={{ backgroundColor: `${agentConfig.color}20` }}
+            >
+              <Text
+                className="text-xs font-medium"
+                style={{ color: agentConfig.color }}
+              >
+                {agentConfig.label}
+              </Text>
+            </View>
+
+            {/* Status Badge */}
+            <View
+              className="px-2 py-0.5 rounded mr-2"
+              style={{ backgroundColor: `${statusColor}20` }}
+            >
+              <Text
+                className="text-xs font-medium"
+                style={{ color: statusColor }}
+              >
+                {statusLabel}
+              </Text>
+            </View>
+
+            {/* Cost */}
+            <Text className="text-zinc-500 text-xs mr-2">
+              {formatCost(Number(session.total_cost_usd))}
+            </Text>
+
+            {/* Message Count */}
+            <Text className="text-zinc-500 text-xs">
+              {session.message_count} msg{session.message_count !== 1 ? 's' : ''}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+// ============================================================================
+// Main Screen
+// ============================================================================
+
+/**
+ * Sessions list screen.
+ *
+ * Fetches the authenticated user's sessions from Supabase and renders
+ * them in a FlatList with:
+ * - A functional search bar (debounced, searches title and summary)
+ * - Filter chips for status (All / Active / Completed) and agent
+ * - Infinite scroll pagination (20 per page)
+ * - Pull-to-refresh
+ * - Tap-to-navigate to the chat screen with the session ID
+ * - Loading, error, empty, and "no results" states
+ */
 export default function SessionsScreen() {
+  const {
+    sessions,
+    isLoading,
+    isRefreshing,
+    isLoadingMore,
+    hasMore,
+    error,
+    searchQuery,
+    filters,
+    setSearchQuery,
+    setFilters,
+    refresh,
+    loadMore,
+  } = useSessions();
+
+  // ---- Navigation ----
+
+  /**
+   * Navigate to the chat screen with the selected session's ID and
+   * agent type pre-filled.
+   *
+   * @param session - The session row that was tapped
+   */
+  const handleSessionPress = useCallback((session: SessionRow) => {
+    router.push({
+      pathname: '/(tabs)/chat',
+      params: {
+        sessionId: session.id,
+        agent: session.agent_type,
+      },
+    });
+  }, []);
+
+  // ---- Filter handlers ----
+
+  /**
+   * Update the status filter while preserving the current agent filter.
+   *
+   * @param status - The new status filter value
+   */
+  const handleStatusFilterChange = useCallback(
+    (status: SessionFilters['status']) => {
+      setFilters({ ...filters, status });
+    },
+    [filters, setFilters],
+  );
+
+  /**
+   * Update the agent filter while preserving the current status filter.
+   *
+   * @param agent - The new agent filter value
+   */
+  const handleAgentFilterChange = useCallback(
+    (agent: AgentType | null) => {
+      setFilters({ ...filters, agent });
+    },
+    [filters, setFilters],
+  );
+
+  // ---- Infinite scroll ----
+
+  /**
+   * FlatList onEndReached callback. Triggers the next page load
+   * when the user scrolls close to the bottom.
+   */
+  const handleEndReached = useCallback(() => {
+    loadMore();
+  }, [loadMore]);
+
+  // ---- Render: Loading state ----
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center">
+        <ActivityIndicator size="large" color="#f97316" />
+        <Text className="text-zinc-500 mt-4">Loading sessions...</Text>
+      </View>
+    );
+  }
+
+  // ---- Render: Error state ----
+
+  if (error && sessions.length === 0) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center px-6">
+        <Ionicons name="alert-circle-outline" size={48} color="#ef4444" />
+        <Text className="text-white text-lg font-semibold mt-4">
+          Failed to Load Sessions
+        </Text>
+        <Text className="text-zinc-500 text-center mt-2">{error}</Text>
+        <Pressable
+          onPress={refresh}
+          className="bg-brand px-6 py-3 rounded-xl mt-6 active:opacity-80"
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading sessions"
+        >
+          <Text className="text-white font-semibold">Try Again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  // ---- Determine empty / no-results state ----
+
+  const hasActiveFilters =
+    filters.status !== null ||
+    filters.agent !== null ||
+    searchQuery.trim().length > 0;
+
   return (
     <View className="flex-1 bg-background">
       {/* Search Bar */}
       <View className="px-4 py-3">
-        <Pressable className="flex-row items-center bg-background-secondary rounded-xl px-4 py-3">
+        <View className="flex-row items-center bg-background-secondary rounded-xl px-4 py-3">
           <Ionicons name="search" size={20} color="#71717a" />
-          <Text className="text-zinc-500 ml-2">Search sessions...</Text>
-        </Pressable>
+          <TextInput
+            className="flex-1 text-white text-base ml-2"
+            placeholder="Search sessions..."
+            placeholderTextColor="#71717a"
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+            returnKeyType="search"
+            autoCorrect={false}
+            autoCapitalize="none"
+            accessibilityRole="search"
+            accessibilityLabel="Search sessions by title or summary"
+          />
+          {/* Clear button - only visible when there is text */}
+          {searchQuery.length > 0 && (
+            <Pressable
+              onPress={() => setSearchQuery('')}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel="Clear search"
+            >
+              <Ionicons name="close-circle" size={20} color="#71717a" />
+            </Pressable>
+          )}
+        </View>
+      </View>
+
+      {/* Filter Chips */}
+      <View className="px-4 pb-2">
+        {/* Status Filters */}
+        <View className="flex-row mb-2">
+          {STATUS_CHIPS.map((chip) => {
+            const isSelected = filters.status === chip.value;
+            return (
+              <Pressable
+                key={chip.label}
+                onPress={() => handleStatusFilterChange(chip.value)}
+                className={`px-3 py-1.5 rounded-full mr-2 ${
+                  isSelected
+                    ? 'bg-brand'
+                    : 'bg-zinc-800'
+                }`}
+                accessibilityRole="button"
+                accessibilityLabel={`Filter by ${chip.label} status`}
+                accessibilityState={{ selected: isSelected }}
+              >
+                <Text
+                  className={`text-sm font-medium ${
+                    isSelected ? 'text-white' : 'text-zinc-400'
+                  }`}
+                >
+                  {chip.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        {/* Agent Filters */}
+        <View className="flex-row">
+          {AGENT_CHIPS.map((chip) => {
+            const isSelected = filters.agent === chip.value;
+            const agentConfig = chip.value
+              ? getAgentConfig(chip.value)
+              : null;
+
+            return (
+              <Pressable
+                key={chip.label}
+                onPress={() => handleAgentFilterChange(chip.value)}
+                className={`flex-row items-center px-3 py-1.5 rounded-full mr-2 ${
+                  isSelected
+                    ? ''
+                    : 'bg-zinc-800'
+                }`}
+                style={
+                  isSelected && agentConfig
+                    ? { backgroundColor: `${agentConfig.color}20` }
+                    : isSelected && !agentConfig
+                      ? { backgroundColor: '#f9731620' }
+                      : undefined
+                }
+                accessibilityRole="button"
+                accessibilityLabel={`Filter by ${chip.label} agent`}
+                accessibilityState={{ selected: isSelected }}
+              >
+                {/* Show a coloured dot for agent chips */}
+                {agentConfig && (
+                  <View
+                    className="w-2 h-2 rounded-full mr-1.5"
+                    style={{ backgroundColor: agentConfig.color }}
+                  />
+                )}
+                <Text
+                  className="text-sm font-medium"
+                  style={{
+                    color: isSelected
+                      ? agentConfig?.color ?? '#f97316'
+                      : '#a1a1aa',
+                  }}
+                >
+                  {chip.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
       </View>
 
       {/* Sessions List */}
       <FlatList
-        data={MOCK_SESSIONS}
+        data={sessions}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <Pressable className="px-4 py-3 border-b border-zinc-800/50 active:bg-zinc-900">
-            <View className="flex-row items-start">
-              {/* Agent Indicator */}
-              <View
-                className="w-10 h-10 rounded-full items-center justify-center mr-3"
-                style={{ backgroundColor: `${agentColors[item.agent]}20` }}
-              >
-                <Ionicons
-                  name="terminal"
-                  size={20}
-                  color={agentColors[item.agent]}
-                />
-              </View>
-
-              {/* Session Info */}
-              <View className="flex-1">
-                <View className="flex-row items-center justify-between mb-1">
-                  <Text className="text-white font-semibold" numberOfLines={1}>
-                    {item.title}
-                  </Text>
-                  <Text className="text-zinc-500 text-xs">{item.timestamp}</Text>
-                </View>
-                <Text className="text-zinc-400 text-sm" numberOfLines={1}>
-                  {item.lastMessage}
-                </Text>
-                <View className="flex-row items-center mt-1">
-                  <View
-                    className="px-2 py-0.5 rounded"
-                    style={{ backgroundColor: `${agentColors[item.agent]}20` }}
-                  >
-                    <Text
-                      className="text-xs font-medium capitalize"
-                      style={{ color: agentColors[item.agent] }}
-                    >
-                      {item.agent}
-                    </Text>
-                  </View>
-                  <Text className="text-zinc-500 text-xs ml-2">
-                    {item.messageCount} messages
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </Pressable>
+          <SessionCard session={item} onPress={handleSessionPress} />
         )}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.4}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={refresh}
+            tintColor="#f97316"
+            colors={['#f97316']}
+          />
+        }
+        ListFooterComponent={
+          isLoadingMore ? (
+            <View className="py-6 items-center">
+              <ActivityIndicator size="small" color="#f97316" />
+            </View>
+          ) : null
+        }
         ListEmptyComponent={
-          <View className="flex-1 items-center justify-center py-20">
-            <Ionicons name="chatbubbles-outline" size={48} color="#3f3f46" />
-            <Text className="text-zinc-500 mt-4">No sessions yet</Text>
+          <View className="flex-1 items-center justify-center py-20 px-6">
+            <Ionicons
+              name={hasActiveFilters ? 'search-outline' : 'chatbubbles-outline'}
+              size={48}
+              color="#3f3f46"
+            />
+            <Text className="text-zinc-400 font-semibold text-lg mt-4">
+              {hasActiveFilters ? 'No results' : 'No sessions yet'}
+            </Text>
+            <Text className="text-zinc-500 text-center mt-2">
+              {hasActiveFilters
+                ? 'Try adjusting your search or filters.'
+                : 'Your coding sessions will appear here once you start using Styrby.'}
+            </Text>
+            {hasActiveFilters && (
+              <Pressable
+                onPress={() => {
+                  setSearchQuery('');
+                  setFilters({ status: null, agent: null });
+                }}
+                className="bg-zinc-800 px-5 py-2.5 rounded-xl mt-4 active:opacity-80"
+                accessibilityRole="button"
+                accessibilityLabel="Clear all filters and search"
+              >
+                <Text className="text-zinc-300 font-medium">Clear Filters</Text>
+              </Pressable>
+            )}
           </View>
         }
+        contentContainerStyle={
+          sessions.length === 0 ? { flexGrow: 1 } : undefined
+        }
+        showsVerticalScrollIndicator={false}
       />
     </View>
   );

--- a/packages/styrby-mobile/app/(tabs)/settings.tsx
+++ b/packages/styrby-mobile/app/(tabs)/settings.tsx
@@ -2,21 +2,107 @@
  * Settings Screen
  *
  * User preferences, account settings, and app configuration.
+ * Loads the authenticated user on mount, persists preferences to Supabase
+ * (notification_preferences) and SecureStore (local-only settings like haptic
+ * feedback), and implements the sign-out flow.
  */
 
-import { View, Text, ScrollView, Pressable, Switch } from 'react-native';
-import { useState } from 'react';
+import { View, Text, ScrollView, Pressable, Switch, Alert, ActivityIndicator } from 'react-native';
+import { useState, useEffect, useCallback } from 'react';
 import { Ionicons } from '@expo/vector-icons';
+import Constants from 'expo-constants';
+import * as SecureStore from 'expo-secure-store';
+import { supabase, signOut } from '../../src/lib/supabase';
+import { clearPairingInfo } from '../../src/services/pairing';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * SecureStore key for the haptic feedback preference.
+ * WHY: Haptic feedback is a device-local preference that does not need to sync
+ * across devices, so we store it in SecureStore rather than the database.
+ */
+const HAPTIC_PREFERENCE_KEY = 'styrby_haptic_enabled';
+
+/**
+ * App version string derived from expo-constants.
+ * WHY: We read this once at module scope because the version never changes
+ * at runtime and avoids unnecessary re-reads inside the component render.
+ */
+const APP_VERSION = Constants.expoConfig?.version ?? '0.1.0';
+
+/**
+ * iOS build number from expo-constants, used in the version footer.
+ */
+const BUILD_NUMBER = Constants.expoConfig?.ios?.buildNumber ?? '1';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Represents the subset of notification_preferences columns that this screen
+ * reads and writes. Matches the Supabase table schema.
+ */
+interface NotificationPreferences {
+  /** Primary key */
+  id: string;
+  /** Foreign key to profiles */
+  user_id: string;
+  /** Master push notification toggle */
+  push_enabled: boolean;
+  /** Whether email notifications are enabled */
+  email_enabled: boolean;
+  /** Whether quiet hours are active */
+  quiet_hours_enabled: boolean;
+  /** Quiet hours start time (HH:MM:SS format) */
+  quiet_hours_start: string | null;
+  /** Quiet hours end time (HH:MM:SS format) */
+  quiet_hours_end: string | null;
+}
+
+/**
+ * Authenticated user data loaded on mount.
+ */
+interface UserInfo {
+  /** Supabase user ID */
+  id: string;
+  /** User's email address */
+  email: string;
+  /** Display name from user_metadata, if available */
+  displayName: string | null;
+  /** First letter of the display name or email for the avatar */
+  initial: string;
+}
+
+// ============================================================================
+// Sub-Components
+// ============================================================================
 
 interface SettingRowProps {
+  /** Ionicons icon name */
   icon: keyof typeof Ionicons.glyphMap;
+  /** Background tint color for the icon badge */
   iconColor?: string;
+  /** Primary label text */
   title: string;
+  /** Secondary description text */
   subtitle?: string;
+  /** Press handler — row shows a chevron when provided (without trailing) */
   onPress?: () => void;
+  /** Custom trailing element (e.g. a Switch) */
   trailing?: React.ReactNode;
 }
 
+/**
+ * A single settings row with an icon, title, optional subtitle, and
+ * either a trailing element or a chevron indicator.
+ *
+ * @param props - Row configuration
+ * @returns React element
+ */
 function SettingRow({
   icon,
   iconColor = '#71717a',
@@ -30,6 +116,8 @@ function SettingRow({
       className="flex-row items-center px-4 py-3 active:bg-zinc-900"
       onPress={onPress}
       disabled={!onPress && !trailing}
+      accessibilityRole="button"
+      accessibilityLabel={subtitle ? `${title}, ${subtitle}` : title}
     >
       <View
         className="w-8 h-8 rounded-lg items-center justify-center mr-3"
@@ -46,6 +134,12 @@ function SettingRow({
   );
 }
 
+/**
+ * Section header label for grouping related settings.
+ *
+ * @param props - Contains the section title string
+ * @returns React element
+ */
 function SectionHeader({ title }: { title: string }) {
   return (
     <Text className="text-zinc-500 text-xs font-semibold uppercase px-4 py-2 bg-background">
@@ -54,12 +148,316 @@ function SectionHeader({ title }: { title: string }) {
   );
 }
 
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Shows a native alert indicating that a feature is not yet available.
+ *
+ * @param featureName - Human-readable name of the feature for the alert message
+ */
+function showComingSoonAlert(featureName: string): void {
+  Alert.alert(
+    'Coming Soon',
+    `${featureName} will be available in a future update.`,
+  );
+}
+
+/**
+ * Extracts user display information from Supabase auth user metadata.
+ *
+ * WHY: Supabase stores display_name in user_metadata but the field name can
+ * vary depending on the auth provider (full_name for GitHub, display_name for
+ * email). We check both and fall back gracefully.
+ *
+ * @param user - The Supabase auth user object
+ * @returns Normalized UserInfo with email, display name, and initial
+ */
+function extractUserInfo(user: { id: string; email?: string; user_metadata?: Record<string, unknown> }): UserInfo {
+  const email = user.email ?? 'unknown';
+  const metadata = user.user_metadata ?? {};
+
+  // Check common metadata fields for display name
+  const displayName =
+    (metadata.display_name as string | undefined) ??
+    (metadata.full_name as string | undefined) ??
+    (metadata.name as string | undefined) ??
+    null;
+
+  // Derive initial from display name or email
+  const initial = displayName
+    ? displayName.charAt(0).toUpperCase()
+    : email.charAt(0).toUpperCase();
+
+  return { id: user.id, email, displayName, initial };
+}
+
+// ============================================================================
+// Screen Component
+// ============================================================================
+
+/**
+ * Settings screen component.
+ *
+ * On mount:
+ * 1. Fetches the authenticated user via supabase.auth.getUser()
+ * 2. Loads notification_preferences from Supabase (creates defaults if missing)
+ * 3. Loads haptic feedback preference from SecureStore
+ *
+ * Persists changes:
+ * - Push notification toggle -> notification_preferences.push_enabled in Supabase
+ * - Haptic feedback toggle -> SecureStore (device-local)
+ *
+ * Sign out:
+ * - Confirmation alert -> supabase.auth.signOut() + clearPairingInfo()
+ * - Root layout auth listener handles redirect to login
+ *
+ * @returns React element
+ */
 export default function SettingsScreen() {
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [pushEnabled, setPushEnabled] = useState(true);
   const [hapticEnabled, setHapticEnabled] = useState(true);
+  const [isLoadingUser, setIsLoadingUser] = useState(true);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  /**
+   * WHY: We track notification preference ID so we can distinguish between
+   * UPDATE (row exists) and INSERT (no row yet) when saving push toggle changes.
+   */
+  const [notifPrefId, setNotifPrefId] = useState<string | null>(null);
+
+  // --------------------------------------------------------------------------
+  // Mount: Load user data and preferences
+  // --------------------------------------------------------------------------
+
+  useEffect(() => {
+    loadUserData();
+    loadLocalPreferences();
+  }, []);
+
+  /**
+   * Fetches the authenticated user and their notification preferences from
+   * Supabase. If no notification_preferences row exists for the user, creates
+   * one with default values.
+   */
+  const loadUserData = useCallback(async () => {
+    setIsLoadingUser(true);
+    try {
+      // Fetch authenticated user
+      const { data: { user }, error: userError } = await supabase.auth.getUser();
+
+      if (userError || !user) {
+        // WHY: If getUser fails, the user is likely unauthenticated.
+        // The root layout auth listener will redirect to login.
+        setIsLoadingUser(false);
+        return;
+      }
+
+      setUserInfo(extractUserInfo(user));
+
+      // Fetch notification preferences
+      const { data: notifPrefs, error: notifError } = await supabase
+        .from('notification_preferences')
+        .select('id, user_id, push_enabled, email_enabled, quiet_hours_enabled, quiet_hours_start, quiet_hours_end')
+        .eq('user_id', user.id)
+        .single();
+
+      if (notifError && notifError.code === 'PGRST116') {
+        // WHY: PGRST116 means "no rows returned". This happens for new users
+        // who haven't had a notification_preferences row created yet.
+        // We create one with sensible defaults.
+        const { data: newPrefs, error: insertError } = await supabase
+          .from('notification_preferences')
+          .insert({ user_id: user.id, push_enabled: true })
+          .select('id, user_id, push_enabled, email_enabled, quiet_hours_enabled, quiet_hours_start, quiet_hours_end')
+          .single();
+
+        if (!insertError && newPrefs) {
+          setNotifPrefId(newPrefs.id);
+          setPushEnabled(newPrefs.push_enabled);
+        }
+      } else if (!notifError && notifPrefs) {
+        setNotifPrefId(notifPrefs.id);
+        setPushEnabled(notifPrefs.push_enabled);
+      }
+    } catch (error) {
+      // Non-fatal: UI will show fallback values
+      if (__DEV__) {
+        console.error('[Settings] Failed to load user data:', error);
+      }
+    } finally {
+      setIsLoadingUser(false);
+    }
+  }, []);
+
+  /**
+   * Loads device-local preferences from SecureStore.
+   * Currently only haptic feedback preference is stored locally.
+   */
+  const loadLocalPreferences = useCallback(async () => {
+    try {
+      const hapticValue = await SecureStore.getItemAsync(HAPTIC_PREFERENCE_KEY);
+
+      // WHY: If no value is stored, default to true (haptics enabled).
+      // We only store explicitly when the user toggles the setting.
+      if (hapticValue !== null) {
+        setHapticEnabled(hapticValue === 'true');
+      }
+    } catch (error) {
+      if (__DEV__) {
+        console.error('[Settings] Failed to load local preferences:', error);
+      }
+    }
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Preference Handlers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Toggles the push notification preference and persists it to Supabase.
+   *
+   * @param value - The new push notification enabled state
+   */
+  const handlePushToggle = useCallback(async (value: boolean) => {
+    // Optimistic update for responsive UI
+    setPushEnabled(value);
+
+    try {
+      if (!userInfo) return;
+
+      if (notifPrefId) {
+        // Update existing row
+        const { error } = await supabase
+          .from('notification_preferences')
+          .update({ push_enabled: value })
+          .eq('id', notifPrefId);
+
+        if (error) {
+          // Revert optimistic update on failure
+          setPushEnabled(!value);
+          if (__DEV__) {
+            console.error('[Settings] Failed to update push preference:', error);
+          }
+        }
+      } else {
+        // Insert new row (edge case: row was deleted between mount and toggle)
+        const { data, error } = await supabase
+          .from('notification_preferences')
+          .insert({ user_id: userInfo.id, push_enabled: value })
+          .select('id')
+          .single();
+
+        if (error) {
+          setPushEnabled(!value);
+          if (__DEV__) {
+            console.error('[Settings] Failed to insert push preference:', error);
+          }
+        } else if (data) {
+          setNotifPrefId(data.id);
+        }
+      }
+    } catch (error) {
+      setPushEnabled(!value);
+      if (__DEV__) {
+        console.error('[Settings] Push toggle error:', error);
+      }
+    }
+  }, [userInfo, notifPrefId]);
+
+  /**
+   * Toggles the haptic feedback preference and persists it to SecureStore.
+   *
+   * @param value - The new haptic feedback enabled state
+   */
+  const handleHapticToggle = useCallback(async (value: boolean) => {
+    setHapticEnabled(value);
+
+    try {
+      await SecureStore.setItemAsync(HAPTIC_PREFERENCE_KEY, value.toString());
+    } catch (error) {
+      // Revert on storage failure
+      setHapticEnabled(!value);
+      if (__DEV__) {
+        console.error('[Settings] Failed to save haptic preference:', error);
+      }
+    }
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Sign Out
+  // --------------------------------------------------------------------------
+
+  /**
+   * Shows a confirmation alert and, on confirm, executes the full sign-out
+   * flow: Supabase auth sign out, clear pairing info, and clear cached data.
+   *
+   * WHY: We show a confirmation because sign out is destructive — the user
+   * will need to re-pair with their CLI after signing back in. The root layout
+   * auth listener handles the redirect to the login screen after sign out.
+   */
+  const handleSignOut = useCallback(() => {
+    Alert.alert(
+      'Sign Out?',
+      "You'll need to re-pair with your CLI after signing back in.",
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Sign Out',
+          style: 'destructive',
+          onPress: async () => {
+            setIsSigningOut(true);
+            try {
+              // Step 1: Clear pairing info from SecureStore
+              // WHY: Clear pairing first so there is no orphan pairing data if
+              // signOut fails partway through. The relay hook in _layout will
+              // detect the missing pairing info and disconnect.
+              await clearPairingInfo();
+
+              // Step 2: Clear local preferences from SecureStore
+              await SecureStore.deleteItemAsync(HAPTIC_PREFERENCE_KEY);
+
+              // Step 3: Sign out from Supabase Auth
+              // This clears the session tokens and triggers onAuthStateChange
+              // in the root layout, which redirects to the login screen.
+              const { error } = await signOut();
+
+              if (error) {
+                Alert.alert('Sign Out Failed', error.message);
+                setIsSigningOut(false);
+              }
+              // On success, the root layout auth listener redirects to login,
+              // so we do not need to navigate here.
+            } catch (error) {
+              const message = error instanceof Error ? error.message : 'An unexpected error occurred.';
+              Alert.alert('Sign Out Failed', message);
+              setIsSigningOut(false);
+            }
+          },
+        },
+      ],
+    );
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
 
   return (
     <ScrollView className="flex-1 bg-background">
+      {/* Profile Header */}
+      {isLoadingUser ? (
+        <View className="items-center py-6">
+          <ActivityIndicator
+            size="small"
+            color="#f97316"
+            accessibilityLabel="Loading user data"
+          />
+        </View>
+      ) : null}
+
       {/* Account Section */}
       <SectionHeader title="Account" />
       <View className="bg-background-secondary">
@@ -67,22 +465,22 @@ export default function SettingsScreen() {
           icon="person"
           iconColor="#f97316"
           title="Profile"
-          subtitle="user@example.com"
-          onPress={() => {}}
+          subtitle={userInfo?.email ?? 'Not signed in'}
+          onPress={() => showComingSoonAlert('Profile editing')}
         />
         <SettingRow
           icon="card"
           iconColor="#22c55e"
           title="Subscription"
           subtitle="Pro Plan"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Subscription management')}
         />
         <SettingRow
           icon="stats-chart"
           iconColor="#3b82f6"
           title="Usage & Costs"
           subtitle="$12.45 this month"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Usage & Costs')}
         />
       </View>
 
@@ -94,21 +492,21 @@ export default function SettingsScreen() {
           iconColor="#f97316"
           title="Claude Code"
           subtitle="Connected"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Agent configurations')}
         />
         <SettingRow
           icon="terminal"
           iconColor="#22c55e"
           title="Codex"
           subtitle="Not connected"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Agent configurations')}
         />
         <SettingRow
           icon="terminal"
           iconColor="#3b82f6"
           title="Gemini"
           subtitle="Not connected"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Agent configurations')}
         />
       </View>
 
@@ -122,9 +520,11 @@ export default function SettingsScreen() {
           trailing={
             <Switch
               value={pushEnabled}
-              onValueChange={setPushEnabled}
+              onValueChange={handlePushToggle}
               trackColor={{ false: '#3f3f46', true: '#f9731650' }}
               thumbColor={pushEnabled ? '#f97316' : '#71717a'}
+              accessibilityRole="switch"
+              accessibilityLabel="Toggle push notifications"
             />
           }
         />
@@ -135,9 +535,11 @@ export default function SettingsScreen() {
           trailing={
             <Switch
               value={hapticEnabled}
-              onValueChange={setHapticEnabled}
+              onValueChange={handleHapticToggle}
               trackColor={{ false: '#3f3f46', true: '#f9731650' }}
               thumbColor={hapticEnabled ? '#f97316' : '#71717a'}
+              accessibilityRole="switch"
+              accessibilityLabel="Toggle haptic feedback"
             />
           }
         />
@@ -145,14 +547,14 @@ export default function SettingsScreen() {
           icon="shield-checkmark"
           iconColor="#06b6d4"
           title="Auto-Approve Low Risk"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Auto-approve configuration')}
         />
         <SettingRow
           icon="moon"
           iconColor="#6366f1"
           title="Quiet Hours"
           subtitle="10:00 PM - 7:00 AM"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Quiet Hours configuration')}
         />
       </View>
 
@@ -163,38 +565,48 @@ export default function SettingsScreen() {
           icon="help-circle"
           iconColor="#71717a"
           title="Help & FAQ"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Help & FAQ')}
         />
         <SettingRow
           icon="chatbox"
           iconColor="#71717a"
           title="Send Feedback"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Send Feedback')}
         />
         <SettingRow
           icon="document-text"
           iconColor="#71717a"
           title="Privacy Policy"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Privacy Policy')}
         />
         <SettingRow
           icon="document-text"
           iconColor="#71717a"
           title="Terms of Service"
-          onPress={() => {}}
+          onPress={() => showComingSoonAlert('Terms of Service')}
         />
       </View>
 
       {/* Sign Out */}
       <View className="mt-4 mb-8">
-        <Pressable className="mx-4 py-3 rounded-xl border border-red-500/30 items-center active:bg-red-500/10">
-          <Text className="text-red-500 font-semibold">Sign Out</Text>
+        <Pressable
+          className="mx-4 py-3 rounded-xl border border-red-500/30 items-center active:bg-red-500/10"
+          onPress={handleSignOut}
+          disabled={isSigningOut}
+          accessibilityRole="button"
+          accessibilityLabel="Sign out of your account"
+        >
+          {isSigningOut ? (
+            <ActivityIndicator size="small" color="#ef4444" />
+          ) : (
+            <Text className="text-red-500 font-semibold">Sign Out</Text>
+          )}
         </Pressable>
       </View>
 
       {/* Version */}
       <Text className="text-zinc-600 text-center text-xs mb-8">
-        Styrby v0.1.0 (1)
+        Styrby v{APP_VERSION} ({BUILD_NUMBER})
       </Text>
     </ScrollView>
   );

--- a/packages/styrby-mobile/src/components/ChatMessage.tsx
+++ b/packages/styrby-mobile/src/components/ChatMessage.tsx
@@ -49,6 +49,8 @@ const AGENT_CONFIG: Record<AgentType, { name: string; color: string; bgColor: st
   claude: { name: 'Claude', color: '#f97316', bgColor: 'rgba(249, 115, 22, 0.1)' },
   codex: { name: 'Codex', color: '#22c55e', bgColor: 'rgba(34, 197, 94, 0.1)' },
   gemini: { name: 'Gemini', color: '#3b82f6', bgColor: 'rgba(59, 130, 246, 0.1)' },
+  opencode: { name: 'OpenCode', color: '#8b5cf6', bgColor: 'rgba(139, 92, 246, 0.1)' },
+  aider: { name: 'Aider', color: '#ec4899', bgColor: 'rgba(236, 72, 153, 0.1)' },
 };
 
 function CodeBlock({ content, language }: { content: string; language?: string }) {

--- a/packages/styrby-mobile/src/components/NotificationStream.tsx
+++ b/packages/styrby-mobile/src/components/NotificationStream.tsx
@@ -47,6 +47,8 @@ const AGENT_COLORS: Record<AgentType, string> = {
   claude: '#f97316',
   codex: '#22c55e',
   gemini: '#3b82f6',
+  opencode: '#8b5cf6',
+  aider: '#ec4899',
 };
 
 const TYPE_CONFIG: Record<NotificationType, { icon: keyof typeof Ionicons.glyphMap; color: string }> = {

--- a/packages/styrby-mobile/src/components/PermissionCard.tsx
+++ b/packages/styrby-mobile/src/components/PermissionCard.tsx
@@ -2,11 +2,14 @@
  * Permission Card Component
  *
  * Displays a permission request from an agent with risk level
- * and approve/deny actions.
+ * and approve/deny actions. Includes visual feedback when a
+ * decision is made (color change, disabled buttons, status text).
  */
 
-import { View, Text, Pressable } from 'react-native';
+import { View, Text, Pressable, Animated } from 'react-native';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
 import type { AgentType } from 'styrby-shared';
 
 /**
@@ -15,13 +18,32 @@ import type { AgentType } from 'styrby-shared';
 export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
 
 /**
- * Permission request data
+ * The decision state of a permission card after the user acts on it.
+ * - 'pending': user has not yet acted
+ * - 'approved': user approved the request
+ * - 'denied': user denied the request
+ */
+export type PermissionDecision = 'pending' | 'approved' | 'denied';
+
+/**
+ * Permission request data received from the CLI agent via the relay.
+ *
+ * @property id - Unique identifier for this permission request
+ * @property sessionId - The session in which the agent made this request
+ * @property agentType - Which AI agent is requesting the permission
+ * @property type - Category of permission (e.g., 'file_write', 'command_execute')
+ * @property description - Human-readable explanation of what the agent wants to do
+ * @property details - Additional context about the request
+ * @property riskLevel - Assessed severity of the requested action
+ * @property timestamp - ISO 8601 timestamp of when the request was created
+ * @property filePath - File path affected, if applicable
+ * @property command - Shell command to execute, if applicable
  */
 export interface PermissionRequest {
   id: string;
   sessionId: string;
   agentType: AgentType;
-  type: string; // e.g., 'file_write', 'command_execute', 'api_call'
+  type: string;
   description: string;
   details?: string;
   riskLevel: RiskLevel;
@@ -30,6 +52,14 @@ export interface PermissionRequest {
   command?: string;
 }
 
+/**
+ * Props for the PermissionCard component.
+ *
+ * @property permission - The permission request data to display
+ * @property onApprove - Callback when the user approves the request
+ * @property onDeny - Callback when the user denies the request
+ * @property isLoading - Whether the parent is processing (external loading state)
+ */
 interface PermissionCardProps {
   permission: PermissionRequest;
   onApprove: (id: string) => void;
@@ -37,6 +67,9 @@ interface PermissionCardProps {
   isLoading?: boolean;
 }
 
+/**
+ * Visual configuration for each risk level.
+ */
 const RISK_CONFIG: Record<RiskLevel, { label: string; color: string; bgColor: string; icon: keyof typeof Ionicons.glyphMap }> = {
   low: {
     label: 'Low Risk',
@@ -64,12 +97,20 @@ const RISK_CONFIG: Record<RiskLevel, { label: string; color: string; bgColor: st
   },
 };
 
+/**
+ * Brand colors for each agent type.
+ */
 const AGENT_COLORS: Record<AgentType, string> = {
   claude: '#f97316',
   codex: '#22c55e',
   gemini: '#3b82f6',
+  opencode: '#8b5cf6',
+  aider: '#ec4899',
 };
 
+/**
+ * Icons for each permission type.
+ */
 const PERMISSION_ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {
   file_write: 'document-text',
   file_delete: 'trash',
@@ -79,16 +120,142 @@ const PERMISSION_ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {
   default: 'help-circle',
 };
 
+/**
+ * Visual configuration for the decided state of the card (approved/denied).
+ * WHY: After the user takes action, the card must clearly communicate what
+ * happened to prevent confusion and accidental double-taps.
+ */
+const DECISION_CONFIG: Record<Exclude<PermissionDecision, 'pending'>, {
+  label: string;
+  color: string;
+  bgColor: string;
+  icon: keyof typeof Ionicons.glyphMap;
+}> = {
+  approved: {
+    label: 'Approved',
+    color: '#22c55e',
+    bgColor: 'rgba(34, 197, 94, 0.15)',
+    icon: 'checkmark-circle',
+  },
+  denied: {
+    label: 'Denied',
+    color: '#ef4444',
+    bgColor: 'rgba(239, 68, 68, 0.15)',
+    icon: 'close-circle',
+  },
+};
+
+/**
+ * Renders a permission request card with risk level, action details,
+ * and approve/deny buttons. After the user acts, the card transitions
+ * to show a visual confirmation (color change, status badge, disabled buttons).
+ *
+ * @param props - Component props
+ * @returns React element for the permission card
+ *
+ * @example
+ * <PermissionCard
+ *   permission={permissionData}
+ *   onApprove={(id) => handleApprove(id)}
+ *   onDeny={(id) => handleDeny(id)}
+ * />
+ */
 export function PermissionCard({ permission, onApprove, onDeny, isLoading }: PermissionCardProps) {
   const riskConfig = RISK_CONFIG[permission.riskLevel];
-  const agentColor = AGENT_COLORS[permission.agentType];
+  const agentColor = AGENT_COLORS[permission.agentType] ?? '#71717a';
   const permissionIcon = PERMISSION_ICONS[permission.type] || PERMISSION_ICONS.default;
+
+  /**
+   * WHY: Track the decision state locally so the card can show feedback
+   * immediately, before the parent removes the permission from the list.
+   * This prevents the card from disappearing with no visual confirmation.
+   */
+  const [decision, setDecision] = useState<PermissionDecision>('pending');
+  const [isActing, setIsActing] = useState(false);
+
+  /**
+   * WHY: Animate the card background when a decision is made to draw
+   * the user's attention to the feedback. A subtle opacity flash
+   * communicates that the action was registered.
+   */
+  const feedbackOpacity = useRef(new Animated.Value(0)).current;
+
+  /**
+   * Plays the feedback animation when a decision is made.
+   * Flashes the decision color overlay then fades it to a steady state.
+   */
+  useEffect(() => {
+    if (decision !== 'pending') {
+      Animated.sequence([
+        Animated.timing(feedbackOpacity, {
+          toValue: 1,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(feedbackOpacity, {
+          toValue: 0.6,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    }
+  }, [decision, feedbackOpacity]);
+
+  /**
+   * Handles the approve button press.
+   * Sets local decision state, triggers haptic feedback, then calls the parent callback.
+   * Prevents double-taps by checking the isActing flag.
+   */
+  const handleApprove = useCallback(async () => {
+    if (isActing || decision !== 'pending') return;
+    setIsActing(true);
+    setDecision('approved');
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    onApprove(permission.id);
+  }, [isActing, decision, permission.id, onApprove]);
+
+  /**
+   * Handles the deny button press.
+   * Sets local decision state, triggers haptic feedback, then calls the parent callback.
+   * Prevents double-taps by checking the isActing flag.
+   */
+  const handleDeny = useCallback(async () => {
+    if (isActing || decision !== 'pending') return;
+    setIsActing(true);
+    setDecision('denied');
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+    onDeny(permission.id);
+  }, [isActing, decision, permission.id, onDeny]);
+
+  const isPending = decision === 'pending';
+  const decisionConfig = decision !== 'pending' ? DECISION_CONFIG[decision] : null;
+  const buttonsDisabled = isLoading || isActing || !isPending;
 
   return (
     <View
       className="mx-4 my-2 rounded-2xl overflow-hidden"
       style={{ backgroundColor: riskConfig.bgColor }}
+      accessibilityRole="none"
+      accessibilityLabel={`Permission request: ${permission.description}. Risk level: ${riskConfig.label}`}
     >
+      {/* Decision feedback overlay */}
+      {decisionConfig && (
+        <Animated.View
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: decisionConfig.bgColor,
+            opacity: feedbackOpacity,
+            borderRadius: 16,
+            zIndex: 0,
+          }}
+          pointerEvents="none"
+        />
+      )}
+
       {/* Risk Banner */}
       <View
         className="flex-row items-center justify-between px-4 py-2"
@@ -101,6 +268,18 @@ export function PermissionCard({ permission, onApprove, onDeny, isLoading }: Per
           </Text>
         </View>
         <View className="flex-row items-center">
+          {/* Decision badge (shown after approve/deny) */}
+          {decisionConfig && (
+            <View className="flex-row items-center mr-3">
+              <Ionicons name={decisionConfig.icon} size={14} color={decisionConfig.color} />
+              <Text
+                style={{ color: decisionConfig.color }}
+                className="text-xs font-bold ml-1"
+              >
+                {decisionConfig.label}
+              </Text>
+            </View>
+          )}
           <View style={{ backgroundColor: agentColor }} className="w-2 h-2 rounded-full" />
           <Text className="text-zinc-400 text-xs ml-2 capitalize">{permission.agentType}</Text>
         </View>
@@ -139,7 +318,7 @@ export function PermissionCard({ permission, onApprove, onDeny, isLoading }: Per
             )}
             {permission.command && (
               <View className="flex-row items-start">
-                <Ionicons name="chevron-forward" size={14} color="#71717a" className="mt-0.5" />
+                <Ionicons name="chevron-forward" size={14} color="#71717a" />
                 <Text className="text-zinc-300 text-sm ml-2 font-mono flex-1" numberOfLines={3}>
                   {permission.command}
                 </Text>
@@ -154,36 +333,70 @@ export function PermissionCard({ permission, onApprove, onDeny, isLoading }: Per
         {/* Actions */}
         <View className="flex-row mt-4">
           <Pressable
-            onPress={() => onApprove(permission.id)}
-            disabled={isLoading}
+            onPress={handleApprove}
+            disabled={buttonsDisabled}
             className={`flex-1 flex-row items-center justify-center py-3 rounded-xl mr-2 ${
-              isLoading ? 'bg-green-500/30' : 'bg-green-500'
+              decision === 'approved'
+                ? 'bg-green-500'
+                : buttonsDisabled
+                  ? 'bg-green-500/30'
+                  : 'bg-green-500'
             }`}
+            style={{ opacity: buttonsDisabled && decision !== 'approved' ? 0.4 : 1 }}
+            accessibilityRole="button"
+            accessibilityLabel={`Approve ${permission.description}`}
+            accessibilityState={{ disabled: buttonsDisabled }}
           >
-            <Ionicons name="checkmark" size={20} color="white" />
-            <Text className="text-white font-semibold ml-2">Approve</Text>
+            <Ionicons
+              name={decision === 'approved' ? 'checkmark-circle' : 'checkmark'}
+              size={20}
+              color="white"
+            />
+            <Text className="text-white font-semibold ml-2">
+              {decision === 'approved' ? 'Approved' : 'Approve'}
+            </Text>
           </Pressable>
           <Pressable
-            onPress={() => onDeny(permission.id)}
-            disabled={isLoading}
+            onPress={handleDeny}
+            disabled={buttonsDisabled}
             className={`flex-1 flex-row items-center justify-center py-3 rounded-xl ml-2 ${
-              isLoading ? 'bg-zinc-700/50' : 'bg-zinc-700'
+              decision === 'denied'
+                ? 'bg-red-500/60'
+                : buttonsDisabled
+                  ? 'bg-zinc-700/50'
+                  : 'bg-zinc-700'
             }`}
+            style={{ opacity: buttonsDisabled && decision !== 'denied' ? 0.4 : 1 }}
+            accessibilityRole="button"
+            accessibilityLabel={`Deny ${permission.description}`}
+            accessibilityState={{ disabled: buttonsDisabled }}
           >
-            <Ionicons name="close" size={20} color="#a1a1aa" />
-            <Text className="text-zinc-300 font-semibold ml-2">Deny</Text>
+            <Ionicons
+              name={decision === 'denied' ? 'close-circle' : 'close'}
+              size={20}
+              color={decision === 'denied' ? 'white' : '#a1a1aa'}
+            />
+            <Text
+              className="font-semibold ml-2"
+              style={{ color: decision === 'denied' ? 'white' : '#d4d4d8' }}
+            >
+              {decision === 'denied' ? 'Denied' : 'Deny'}
+            </Text>
           </Pressable>
         </View>
 
-        {/* Quick actions for low risk */}
-        {permission.riskLevel === 'low' && (
+        {/* Quick actions for low risk (only when still pending) */}
+        {permission.riskLevel === 'low' && isPending && (
           <Pressable
-            onPress={() => onApprove(permission.id)}
+            onPress={handleApprove}
+            disabled={buttonsDisabled}
             className="mt-2 flex-row items-center justify-center py-2"
+            accessibilityRole="button"
+            accessibilityLabel="Open settings to auto-approve low risk permissions"
           >
             <Text className="text-zinc-500 text-sm">
               Auto-approve low risk?{' '}
-              <Text className="text-brand">Settings →</Text>
+              <Text className="text-brand">Settings</Text>
             </Text>
           </Pressable>
         )}

--- a/packages/styrby-mobile/src/components/SessionCarousel.tsx
+++ b/packages/styrby-mobile/src/components/SessionCarousel.tsx
@@ -15,18 +15,32 @@ const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const CARD_WIDTH = SCREEN_WIDTH - 48; // 24px padding on each side
 
 /**
- * Active session data
+ * Represents an active coding session displayed in the dashboard carousel.
+ * Populated from the Supabase `sessions` table and updated in real time
+ * via relay messages (session_state, cost_update, permission_request).
  */
 export interface ActiveSession {
+  /** Session UUID from Supabase */
   id: string;
+  /** Which AI agent is running this session */
   agentType: AgentType;
+  /** Session title (auto-generated or user-set) */
   title: string;
+  /** Current session state for the carousel UI */
   status: 'running' | 'idle' | 'waiting_permission';
+  /** ISO timestamp of the most recent activity */
   lastActivity?: string;
+  /** Total number of messages in this session */
   messageCount: number;
+  /** Total cost in USD for this session */
   costUsd: number;
+  /** Pending permission request details, if the session is waiting for approval */
   pendingPermission?: {
+    /** The relay permission request ID, used when sending approval/denial */
+    requestId: string;
+    /** Tool name being requested (e.g., "Bash", "Write") */
     type: string;
+    /** Human-readable description of what the tool will do */
     description: string;
   };
 }
@@ -42,6 +56,8 @@ const AGENT_CONFIG: Record<AgentType, { name: string; color: string; bgColor: st
   claude: { name: 'Claude', color: '#f97316', bgColor: 'rgba(249, 115, 22, 0.15)', icon: 'terminal' },
   codex: { name: 'Codex', color: '#22c55e', bgColor: 'rgba(34, 197, 94, 0.15)', icon: 'code-slash' },
   gemini: { name: 'Gemini', color: '#3b82f6', bgColor: 'rgba(59, 130, 246, 0.15)', icon: 'sparkles' },
+  opencode: { name: 'OpenCode', color: '#8b5cf6', bgColor: 'rgba(139, 92, 246, 0.15)', icon: 'code-working' },
+  aider: { name: 'Aider', color: '#ec4899', bgColor: 'rgba(236, 72, 153, 0.15)', icon: 'people' },
 };
 
 export function SessionCarousel({ sessions, onSessionPress, onApprove, onDeny }: SessionCarouselProps) {

--- a/packages/styrby-mobile/src/components/StopButton.tsx
+++ b/packages/styrby-mobile/src/components/StopButton.tsx
@@ -234,12 +234,22 @@ export function FloatingStopButton({
  *   onStop={handleStop}
  * />
  */
+/**
+ * Props for the icon-only stop button variant.
+ * Extends the base props with an optional accessibility label.
+ */
+interface StopButtonIconProps extends Omit<StopButtonProps, 'size' | 'label'> {
+  /** Accessibility label for screen readers */
+  accessibilityLabel?: string;
+}
+
 export function StopButtonIcon({
   isRunning,
   isStopping = false,
   onStop,
   disabled = false,
-}: Omit<StopButtonProps, 'size' | 'label'>) {
+  accessibilityLabel = 'Stop generation',
+}: StopButtonIconProps) {
   const [localStopping, setLocalStopping] = useState(false);
 
   const isStoppingState = isStopping || localStopping;
@@ -274,6 +284,9 @@ export function StopButtonIcon({
         isDisabled ? 'bg-red-500/30' : 'bg-red-500'
       }`}
       hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ disabled: isDisabled }}
     >
       {isStoppingState ? (
         <ActivityIndicator size="small" color="white" />

--- a/packages/styrby-mobile/src/components/index.ts
+++ b/packages/styrby-mobile/src/components/index.ts
@@ -1,7 +1,43 @@
 /**
- * Cost Tracking Module
+ * Component Barrel Exports
  *
- * Exports JSONL parsing and cost calculation utilities.
+ * Re-exports all public components from the components directory.
+ * Components can be imported individually or through this barrel:
+ *
+ * @example
+ * // Direct import (used by app routes)
+ * import { CostCard } from '../../src/components/CostCard';
+ *
+ * // Barrel import
+ * import { CostCard, AgentCostBar } from '../../src/components';
  */
 
-export * from './jsonl-parser.js';
+export { AgentSelector, AgentSelectorPills } from './AgentSelector';
+export type { AgentSelectorProps, AgentConfig } from './AgentSelector';
+
+export { ChatMessage } from './ChatMessage';
+export type { ChatMessageData, ContentBlock, ContentBlockType, MessageRole } from './ChatMessage';
+
+export { ConnectionStatus, ConnectionStatusDot } from './ConnectionStatus';
+export type { ConnectionStatusProps } from './ConnectionStatus';
+
+export { CostCard } from './CostCard';
+
+export { AgentCostBar, AgentCostBarEmpty } from './AgentCostBar';
+
+export { DailyMiniChart, DailyMiniChartEmpty, DailyMiniChartSkeleton } from './DailyMiniChart';
+
+export { NotificationStream } from './NotificationStream';
+export type { Notification, NotificationType } from './NotificationStream';
+
+export { PermissionCard } from './PermissionCard';
+export type { PermissionRequest, RiskLevel, PermissionDecision } from './PermissionCard';
+
+export { SessionCarousel } from './SessionCarousel';
+export type { ActiveSession } from './SessionCarousel';
+
+export { StopButton, FloatingStopButton, StopButtonIcon } from './StopButton';
+export type { StopButtonProps } from './StopButton';
+
+export { TypingIndicator, TypingIndicatorInline, TypingIndicatorMinimal } from './TypingIndicator';
+export type { TypingIndicatorProps, AgentState } from './TypingIndicator';

--- a/packages/styrby-mobile/src/hooks/useDashboardData.ts
+++ b/packages/styrby-mobile/src/hooks/useDashboardData.ts
@@ -1,0 +1,702 @@
+/**
+ * Dashboard Data Hook
+ *
+ * Centralizes all data fetching for the dashboard screen:
+ * - Active sessions from Supabase
+ * - Notifications from audit_log
+ * - Per-agent cost and online status
+ * - Today's total cost
+ *
+ * Integrates with the relay hook to react to real-time session state changes
+ * and presence updates without polling.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { supabase } from '../lib/supabase';
+import type { ActiveSession } from '../components/SessionCarousel';
+import type { Notification, NotificationType } from '../components/NotificationStream';
+import type { AgentType, RelayMessage, PresenceState } from 'styrby-shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Per-agent status on the dashboard, including online state and daily cost.
+ */
+export interface AgentStatus {
+  /** Whether the agent has an active session or the CLI reports it online */
+  online: boolean;
+  /** Total cost in USD for this agent today */
+  cost: number;
+}
+
+/**
+ * Quick stats displayed at the top of the dashboard.
+ */
+export interface QuickStats {
+  /** Total cost in USD across all agents today */
+  totalCostToday: number;
+  /** Number of agents with at least one active session right now */
+  activeAgentCount: number;
+}
+
+/**
+ * Return type of the useDashboardData hook.
+ */
+export interface UseDashboardDataReturn {
+  /** Active coding sessions for the current user */
+  activeSessions: ActiveSession[];
+  /** Recent notifications from the audit log */
+  notifications: Notification[];
+  /** Per-agent online and cost status */
+  agentStatus: Record<AgentType, AgentStatus>;
+  /** Quick stats for the top cards */
+  quickStats: QuickStats;
+  /** Whether the initial data load is still in progress */
+  isLoading: boolean;
+  /** Reload all dashboard data from Supabase */
+  refresh: () => Promise<void>;
+}
+
+// ============================================================================
+// Default Agent Status
+// ============================================================================
+
+/**
+ * Returns a fresh default agent status map with all agents offline and zero cost.
+ *
+ * WHY: We need a factory function instead of a constant because each call site
+ * should get its own object reference. Using a shared constant would cause
+ * stale references when the state is updated via setAgentStatus.
+ *
+ * @returns Default agent status map
+ */
+function createDefaultAgentStatus(): Record<AgentType, AgentStatus> {
+  return {
+    claude: { online: false, cost: 0 },
+    codex: { online: false, cost: 0 },
+    gemini: { online: false, cost: 0 },
+    opencode: { online: false, cost: 0 },
+    aider: { online: false, cost: 0 },
+  };
+}
+
+// ============================================================================
+// Supabase Row Types
+// ============================================================================
+
+/**
+ * Row shape returned by the `sessions` table query.
+ * Only the columns we SELECT are listed here.
+ */
+interface SessionRow {
+  id: string;
+  agent_type: AgentType;
+  title: string | null;
+  status: string;
+  last_activity_at: string;
+  message_count: number;
+  total_cost_usd: number;
+}
+
+/**
+ * Row shape returned by the `audit_log` table query.
+ */
+interface AuditLogRow {
+  id: string;
+  action: string;
+  resource_type: string | null;
+  resource_id: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+/**
+ * Row shape returned by the `cost_records` aggregation query.
+ */
+interface CostRecordRow {
+  agent_type: AgentType;
+  cost_usd: number;
+}
+
+// ============================================================================
+// Mapping Helpers
+// ============================================================================
+
+/**
+ * Maps a database session status string to the UI status expected by SessionCarousel.
+ *
+ * WHY: The database uses a richer set of statuses (starting, running, idle, paused,
+ * stopped, error, expired) but the carousel only shows three: running, idle, and
+ * waiting_permission. We collapse the database states into carousel-compatible ones.
+ *
+ * @param dbStatus - The session status value from the database
+ * @returns The carousel-compatible status string
+ */
+function mapSessionStatus(dbStatus: string): ActiveSession['status'] {
+  switch (dbStatus) {
+    case 'running':
+    case 'starting':
+      return 'running';
+    case 'idle':
+    case 'paused':
+      return 'idle';
+    default:
+      return 'idle';
+  }
+}
+
+/**
+ * Maps a database session row to the ActiveSession shape used by SessionCarousel.
+ *
+ * @param row - Raw session row from Supabase
+ * @returns An ActiveSession object for the carousel
+ */
+function mapSessionRow(row: SessionRow): ActiveSession {
+  return {
+    id: row.id,
+    agentType: row.agent_type,
+    title: row.title || 'Untitled Session',
+    status: mapSessionStatus(row.status),
+    lastActivity: row.last_activity_at,
+    messageCount: row.message_count,
+    costUsd: Number(row.total_cost_usd) || 0,
+  };
+}
+
+/**
+ * Maps an audit_log action string to a NotificationType.
+ *
+ * WHY: The audit_log stores granular action enums (session_created, session_deleted,
+ * subscription_changed, etc.) but NotificationStream expects a smaller set of
+ * notification types (session_start, session_end, cost_alert, etc.).
+ *
+ * @param action - The audit action string from the database
+ * @returns A NotificationType, or null if the action should not be shown
+ */
+function mapAuditActionToNotificationType(action: string): NotificationType | null {
+  switch (action) {
+    case 'session_created':
+      return 'session_start';
+    case 'session_deleted':
+      return 'session_end';
+    case 'subscription_changed':
+      return 'cost_alert';
+    case 'machine_paired':
+    case 'machine_removed':
+    case 'settings_updated':
+      return 'info';
+    case 'login':
+    case 'logout':
+      return 'info';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Maps an audit action to a human-readable title for notifications.
+ *
+ * @param action - The audit action string from the database
+ * @returns A short, user-facing title string
+ */
+function mapAuditActionToTitle(action: string): string {
+  switch (action) {
+    case 'session_created':
+      return 'Session Started';
+    case 'session_deleted':
+      return 'Session Ended';
+    case 'subscription_changed':
+      return 'Subscription Updated';
+    case 'machine_paired':
+      return 'Device Paired';
+    case 'machine_removed':
+      return 'Device Removed';
+    case 'settings_updated':
+      return 'Settings Changed';
+    case 'login':
+      return 'Login';
+    case 'logout':
+      return 'Logout';
+    default:
+      return action.replace(/_/g, ' ');
+  }
+}
+
+/**
+ * Extracts a notification message from audit log metadata.
+ *
+ * @param action - The audit action string
+ * @param metadata - JSONB metadata from the audit log row
+ * @returns A descriptive message string
+ */
+function extractAuditMessage(action: string, metadata: Record<string, unknown> | null): string {
+  if (!metadata) {
+    return mapAuditActionToTitle(action);
+  }
+
+  if (action === 'session_created' && metadata.agent_type) {
+    return `A ${String(metadata.agent_type)} session was started`;
+  }
+  if (action === 'session_deleted' && metadata.agent_type) {
+    return `A ${String(metadata.agent_type)} session ended`;
+  }
+  if (action === 'subscription_changed' && metadata.new_tier) {
+    return `Subscription changed to ${String(metadata.new_tier)}`;
+  }
+  if (action === 'machine_paired' && metadata.device_name) {
+    return `Paired with ${String(metadata.device_name)}`;
+  }
+
+  return mapAuditActionToTitle(action);
+}
+
+/**
+ * Maps an audit_log row to the Notification shape used by NotificationStream.
+ *
+ * @param row - Raw audit log row from Supabase
+ * @returns A Notification object, or null if the action should be filtered out
+ */
+function mapAuditLogRow(row: AuditLogRow): Notification | null {
+  const type = mapAuditActionToNotificationType(row.action);
+  if (!type) return null;
+
+  // WHY: audit_log does not store agent_type directly, but the metadata JSONB
+  // may contain it. We default to 'claude' because the notification component
+  // requires an agentType for the colored dot indicator.
+  const agentType = (row.metadata?.agent_type as AgentType) || 'claude';
+
+  return {
+    id: row.id,
+    type,
+    agentType,
+    title: mapAuditActionToTitle(row.action),
+    message: extractAuditMessage(row.action, row.metadata),
+    timestamp: row.created_at,
+    read: false,
+    actionable: false,
+    sessionId: row.resource_type === 'session' && row.resource_id
+      ? row.resource_id
+      : undefined,
+  };
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * React hook that fetches and manages all dashboard data.
+ *
+ * Data sources:
+ * - **Active sessions**: `sessions` table, filtered to active statuses
+ * - **Notifications**: `audit_log` table, last 24 hours
+ * - **Agent costs**: `cost_records` table, today only
+ *
+ * Real-time updates come from the relay hook's `lastMessage` and
+ * `connectedDevices` which are passed in by the dashboard screen.
+ *
+ * @param lastMessage - The most recent relay message (from useRelay)
+ * @param connectedDevices - Currently connected relay devices (from useRelay)
+ * @returns Dashboard data, loading state, and refresh function
+ *
+ * @example
+ * const relay = useRelay();
+ * const dashboard = useDashboardData(relay.lastMessage, relay.connectedDevices);
+ *
+ * return (
+ *   <SessionCarousel sessions={dashboard.activeSessions} />
+ * );
+ */
+export function useDashboardData(
+  lastMessage: RelayMessage | null,
+  connectedDevices: PresenceState[]
+): UseDashboardDataReturn {
+  const [activeSessions, setActiveSessions] = useState<ActiveSession[]>([]);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [agentStatus, setAgentStatus] = useState<Record<AgentType, AgentStatus>>(
+    createDefaultAgentStatus
+  );
+  const [isLoading, setIsLoading] = useState(true);
+
+  /**
+   * WHY: Track the last processed message ID to avoid re-processing the same
+   * relay message when the component re-renders for unrelated reasons.
+   */
+  const lastProcessedMessageIdRef = useRef<string | null>(null);
+
+  // --------------------------------------------------------------------------
+  // Data Fetching: Active Sessions
+  // --------------------------------------------------------------------------
+
+  /**
+   * Fetches active sessions from Supabase for the currently authenticated user.
+   * Only returns sessions with status in (starting, running, idle, paused),
+   * ordered by most recently updated first.
+   *
+   * WHY: We use getUser() instead of getSession() to verify the JWT with
+   * Supabase Auth server, which is more secure for data-fetching operations.
+   *
+   * @returns Array of ActiveSession objects for the carousel
+   */
+  const fetchActiveSessions = useCallback(async (): Promise<ActiveSession[]> => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return [];
+
+    const { data, error } = await supabase
+      .from('sessions')
+      .select('id, agent_type, title, status, last_activity_at, message_count, total_cost_usd')
+      .eq('user_id', user.id)
+      .in('status', ['starting', 'running', 'idle', 'paused'])
+      .is('deleted_at', null)
+      .order('last_activity_at', { ascending: false })
+      .limit(10);
+
+    if (error) {
+      if (__DEV__) console.error('[Dashboard] Failed to fetch sessions:', error.message);
+      return [];
+    }
+
+    return (data || []).map((row) => mapSessionRow(row as SessionRow));
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Data Fetching: Notifications from Audit Log
+  // --------------------------------------------------------------------------
+
+  /**
+   * Fetches recent audit log entries and maps them to notifications.
+   * Only fetches events from the last 24 hours to keep the feed relevant.
+   *
+   * @returns Array of Notification objects for the notification stream
+   */
+  const fetchNotifications = useCallback(async (): Promise<Notification[]> => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return [];
+
+    const twentyFourHoursAgo = new Date();
+    twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
+
+    const { data, error } = await supabase
+      .from('audit_log')
+      .select('id, action, resource_type, resource_id, metadata, created_at')
+      .eq('user_id', user.id)
+      .gte('created_at', twentyFourHoursAgo.toISOString())
+      .order('created_at', { ascending: false })
+      .limit(20);
+
+    if (error) {
+      if (__DEV__) console.error('[Dashboard] Failed to fetch audit log:', error.message);
+      return [];
+    }
+
+    return (data || [])
+      .map((row) => mapAuditLogRow(row as AuditLogRow))
+      .filter((n): n is Notification => n !== null);
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Data Fetching: Per-Agent Cost Today
+  // --------------------------------------------------------------------------
+
+  /**
+   * Fetches today's cost per agent from the cost_records table.
+   * Returns a map of agent type to total cost in USD.
+   *
+   * @returns Record mapping each agent type to its cost today
+   */
+  const fetchAgentCostsToday = useCallback(async (): Promise<Record<AgentType, number>> => {
+    const { data: { user } } = await supabase.auth.getUser();
+    const costs: Record<AgentType, number> = {
+      claude: 0,
+      codex: 0,
+      gemini: 0,
+      opencode: 0,
+      aider: 0,
+    };
+    if (!user) return costs;
+
+    const today = new Date();
+    const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+
+    const { data, error } = await supabase
+      .from('cost_records')
+      .select('agent_type, cost_usd')
+      .eq('user_id', user.id)
+      .eq('record_date', todayStr);
+
+    if (error) {
+      if (__DEV__) console.error('[Dashboard] Failed to fetch agent costs:', error.message);
+      return costs;
+    }
+
+    for (const row of (data || []) as CostRecordRow[]) {
+      const agent = row.agent_type as AgentType;
+      if (agent in costs) {
+        costs[agent] += Number(row.cost_usd) || 0;
+      }
+    }
+
+    return costs;
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Combined Refresh
+  // --------------------------------------------------------------------------
+
+  /**
+   * Fetches all dashboard data in parallel: sessions, notifications, and costs.
+   * Updates all state atoms once the promises resolve.
+   *
+   * WHY: We fetch everything in parallel with Promise.all to minimize total
+   * wait time. Each query is independent and can run concurrently.
+   */
+  const refresh = useCallback(async () => {
+    try {
+      const [sessions, notifs, costs] = await Promise.all([
+        fetchActiveSessions(),
+        fetchNotifications(),
+        fetchAgentCostsToday(),
+      ]);
+
+      setActiveSessions(sessions);
+      setNotifications(notifs);
+
+      // Determine which agents are online by checking active sessions
+      const onlineAgents = new Set<AgentType>(
+        sessions
+          .filter((s) => s.status === 'running')
+          .map((s) => s.agentType)
+      );
+
+      // Also check relay presence for CLI-reported active agents
+      for (const device of connectedDevices) {
+        if (device.device_type === 'cli' && device.active_agent) {
+          onlineAgents.add(device.active_agent);
+        }
+      }
+
+      const newAgentStatus = createDefaultAgentStatus();
+      for (const agent of Object.keys(newAgentStatus) as AgentType[]) {
+        newAgentStatus[agent] = {
+          online: onlineAgents.has(agent),
+          cost: costs[agent] || 0,
+        };
+      }
+      setAgentStatus(newAgentStatus);
+    } catch (error) {
+      if (__DEV__) console.error('[Dashboard] Refresh failed:', error);
+    }
+  }, [fetchActiveSessions, fetchNotifications, fetchAgentCostsToday, connectedDevices]);
+
+  // --------------------------------------------------------------------------
+  // Initial Load
+  // --------------------------------------------------------------------------
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      await refresh();
+      if (!cancelled) {
+        setIsLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);  // eslint-disable-line react-hooks/exhaustive-deps -- only run on mount
+
+  // --------------------------------------------------------------------------
+  // Real-Time: Update agent status when relay presence changes
+  // --------------------------------------------------------------------------
+
+  /**
+   * WHY: connectedDevices from the relay hook changes whenever a CLI device
+   * joins or leaves the channel. We update agent online status accordingly
+   * without re-fetching from the database.
+   */
+  useEffect(() => {
+    setAgentStatus((prev) => {
+      const updated = { ...prev };
+
+      // First, reset all online flags
+      for (const agent of Object.keys(updated) as AgentType[]) {
+        updated[agent] = { ...updated[agent], online: false };
+      }
+
+      // Set online for agents that have active sessions
+      for (const session of activeSessions) {
+        if (session.status === 'running') {
+          const agent = session.agentType;
+          if (agent in updated) {
+            updated[agent] = { ...updated[agent], online: true };
+          }
+        }
+      }
+
+      // Set online for agents that the CLI reports as active via presence
+      for (const device of connectedDevices) {
+        if (device.device_type === 'cli' && device.active_agent) {
+          const agent = device.active_agent;
+          if (agent in updated) {
+            updated[agent] = { ...updated[agent], online: true };
+          }
+        }
+      }
+
+      return updated;
+    });
+  }, [connectedDevices, activeSessions]);
+
+  // --------------------------------------------------------------------------
+  // Real-Time: React to relay messages
+  // --------------------------------------------------------------------------
+
+  /**
+   * Processes incoming relay messages to update dashboard state in real time.
+   *
+   * WHY: Instead of polling Supabase on a timer, we react to relay messages
+   * which arrive instantly. This keeps the dashboard current without adding
+   * database load from repeated polling queries.
+   *
+   * Handled message types:
+   * - session_state: Updates an existing session's status or triggers a refresh
+   *   if the session is new (not in our current list).
+   * - cost_update: Updates the per-agent cost inline without a DB round-trip.
+   * - permission_request: Marks a session as waiting_permission with the
+   *   pending permission details so the carousel can show the approval UI.
+   */
+  useEffect(() => {
+    if (!lastMessage) return;
+    if (lastMessage.id === lastProcessedMessageIdRef.current) return;
+    lastProcessedMessageIdRef.current = lastMessage.id;
+
+    switch (lastMessage.type) {
+      case 'session_state': {
+        const { session_id, agent, state } = lastMessage.payload;
+
+        setActiveSessions((prev) => {
+          const existingIndex = prev.findIndex((s) => s.id === session_id);
+
+          if (existingIndex === -1) {
+            // WHY: A session_state message arrived for a session not in our list.
+            // This means either a new session was created or an old session became
+            // active again. Trigger a full refresh to pick it up from the database.
+            refresh();
+            return prev;
+          }
+
+          const updated = [...prev];
+          const session = { ...updated[existingIndex] };
+
+          // Map relay state to carousel status
+          switch (state) {
+            case 'thinking':
+            case 'executing':
+              session.status = 'running';
+              break;
+            case 'idle':
+              session.status = 'idle';
+              break;
+            case 'waiting_permission':
+              session.status = 'waiting_permission';
+              break;
+            case 'error':
+              // WHY: On error, we remove the session from the active list since
+              // it's no longer usable. A full refresh will update the list from DB.
+              refresh();
+              return prev;
+          }
+
+          session.agentType = agent;
+          session.lastActivity = new Date().toISOString();
+          updated[existingIndex] = session;
+          return updated;
+        });
+        break;
+      }
+
+      case 'cost_update': {
+        const { agent, session_total_usd, session_id } = lastMessage.payload;
+
+        // Update per-agent cost for today
+        setAgentStatus((prev) => {
+          if (!(agent in prev)) return prev;
+          const updated = { ...prev };
+          // WHY: cost_update gives us the session total, but we need the daily
+          // total across all sessions. We add the incremental cost_usd to the
+          // existing daily total rather than replacing it with session_total_usd.
+          updated[agent] = {
+            ...updated[agent],
+            cost: updated[agent].cost + (lastMessage.payload.cost_usd || 0),
+          };
+          return updated;
+        });
+
+        // Update the matching session's cost in the carousel
+        setActiveSessions((prev) =>
+          prev.map((s) =>
+            s.id === session_id
+              ? { ...s, costUsd: Number(session_total_usd) || s.costUsd }
+              : s
+          )
+        );
+        break;
+      }
+
+      case 'permission_request': {
+        const { request_id, session_id, tool_name, description } = lastMessage.payload;
+
+        setActiveSessions((prev) =>
+          prev.map((s) =>
+            s.id === session_id
+              ? {
+                  ...s,
+                  status: 'waiting_permission' as const,
+                  pendingPermission: {
+                    requestId: request_id,
+                    type: tool_name,
+                    description,
+                  },
+                }
+              : s
+          )
+        );
+        break;
+      }
+
+      default:
+        // Other message types (chat, agent_response, ack, command) are
+        // handled by other screens (chat, etc.) and not relevant here.
+        break;
+    }
+  }, [lastMessage, refresh]);
+
+  // --------------------------------------------------------------------------
+  // Computed: Quick Stats
+  // --------------------------------------------------------------------------
+
+  const quickStats: QuickStats = {
+    totalCostToday: Object.values(agentStatus).reduce((sum, a) => sum + a.cost, 0),
+    activeAgentCount: Object.values(agentStatus).filter((a) => a.online).length,
+  };
+
+  // --------------------------------------------------------------------------
+  // Return
+  // --------------------------------------------------------------------------
+
+  return {
+    activeSessions,
+    notifications,
+    agentStatus,
+    quickStats,
+    isLoading,
+    refresh,
+  };
+}

--- a/packages/styrby-mobile/src/hooks/useSessions.ts
+++ b/packages/styrby-mobile/src/hooks/useSessions.ts
@@ -1,0 +1,467 @@
+/**
+ * Sessions Data Hook
+ *
+ * Fetches and manages session data from Supabase for the sessions list screen.
+ * Supports infinite-scroll pagination, debounced search, status/agent filtering,
+ * and pull-to-refresh. Returns typed session rows along with loading, error,
+ * and pagination states.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { supabase } from '../lib/supabase';
+import type { AgentType, SessionStatus } from 'styrby-shared';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Number of sessions to load per page. */
+const PAGE_SIZE = 20;
+
+/** Debounce delay in milliseconds for search input. */
+const SEARCH_DEBOUNCE_MS = 300;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * A single session row returned from the Supabase `sessions` table.
+ * Only the columns needed for the list / card UI are selected.
+ */
+export interface SessionRow {
+  /** Primary key */
+  id: string;
+  /** Owner of the session */
+  user_id: string;
+  /** Machine that ran the session */
+  machine_id: string;
+  /** Which AI agent was used (claude, codex, gemini) */
+  agent_type: AgentType;
+  /** Session lifecycle status */
+  status: SessionStatus;
+  /** Human-readable session title (may be null for untitled sessions) */
+  title: string | null;
+  /** AI-generated summary of what happened in the session */
+  summary: string | null;
+  /** Total input tokens consumed */
+  total_input_tokens: number;
+  /** Total output tokens consumed */
+  total_output_tokens: number;
+  /** Total cost in USD for the session */
+  total_cost_usd: number;
+  /** When the session began */
+  started_at: string;
+  /** When the session ended (null if still active) */
+  ended_at: string | null;
+  /** User-defined tags for organisation */
+  tags: string[];
+  /** Last time the session was modified */
+  updated_at: string;
+  /** Number of messages exchanged */
+  message_count: number;
+}
+
+/**
+ * Combined filter state for the sessions list.
+ */
+export interface SessionFilters {
+  /** Status filter: null means "all" */
+  status: 'active' | 'completed' | null;
+  /** Agent filter: null means "all agents" */
+  agent: AgentType | null;
+}
+
+/**
+ * Return type for the useSessions hook.
+ */
+export interface UseSessionsReturn {
+  /** Array of loaded session rows */
+  sessions: SessionRow[];
+  /** Whether the initial load is in progress */
+  isLoading: boolean;
+  /** Whether a pull-to-refresh is in progress */
+  isRefreshing: boolean;
+  /** Whether more pages are being loaded */
+  isLoadingMore: boolean;
+  /** Whether there are more pages to load */
+  hasMore: boolean;
+  /** Error message if the most recent fetch failed */
+  error: string | null;
+  /** Current search query */
+  searchQuery: string;
+  /** Current active filters */
+  filters: SessionFilters;
+  /** Update the search query (debounced internally) */
+  setSearchQuery: (query: string) => void;
+  /** Update the filter state (triggers immediate re-fetch) */
+  setFilters: (filters: SessionFilters) => void;
+  /** Pull-to-refresh handler */
+  refresh: () => Promise<void>;
+  /** Load the next page of results (call on scroll-end) */
+  loadMore: () => Promise<void>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook for fetching, searching, filtering, and paginating session data.
+ *
+ * Sessions are fetched from the Supabase `sessions` table, ordered by
+ * `updated_at DESC`, filtered to the currently authenticated user, and
+ * paginated in increments of {@link PAGE_SIZE}.
+ *
+ * Search uses Postgres `.ilike()` against `title` and `summary` with a
+ * 300 ms debounce so the database is not hammered on every keystroke.
+ *
+ * @returns Session data, loading / error states, and control functions
+ *
+ * @example
+ * const {
+ *   sessions, isLoading, error, refresh, isRefreshing,
+ *   loadMore, hasMore, searchQuery, setSearchQuery,
+ *   filters, setFilters,
+ * } = useSessions();
+ */
+export function useSessions(): UseSessionsReturn {
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQueryState] = useState('');
+  const [filters, setFiltersState] = useState<SessionFilters>({
+    status: null,
+    agent: null,
+  });
+
+  // WHY: We keep a ref to the latest debounced search term so that the
+  // actual Supabase query always uses the most recent value, even when
+  // multiple debounced calls overlap.
+  const debouncedSearchRef = useRef('');
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // WHY: An incrementing "generation" counter lets us discard stale
+  // responses from out-of-order network requests. Each new fetch bumps
+  // the counter; when a response arrives we only apply it if its
+  // generation still matches the current value.
+  const fetchGenerationRef = useRef(0);
+
+  // -------------------------------------------------------------------------
+  // Core fetcher
+  // -------------------------------------------------------------------------
+
+  /**
+   * Build and execute the Supabase query for a page of sessions.
+   *
+   * @param offset - Number of rows to skip (for pagination)
+   * @param search - Search string to match against title/summary
+   * @param currentFilters - Active status and agent filters
+   * @returns The fetched rows, or throws on error
+   */
+  const fetchSessions = useCallback(
+    async (
+      offset: number,
+      search: string,
+      currentFilters: SessionFilters,
+    ): Promise<SessionRow[]> => {
+      // Start with the base query scoped to the authenticated user.
+      // RLS on the sessions table already enforces ownership, but we
+      // also filter explicitly so the covering index is used.
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        throw new Error('You must be logged in to view sessions.');
+      }
+
+      let query = supabase
+        .from('sessions')
+        .select(
+          'id, user_id, machine_id, agent_type, status, title, summary, ' +
+          'total_input_tokens, total_output_tokens, total_cost_usd, ' +
+          'started_at, ended_at, tags, updated_at, message_count',
+        )
+        .eq('user_id', user.id)
+        .is('deleted_at', null)
+        .order('updated_at', { ascending: false })
+        .range(offset, offset + PAGE_SIZE - 1);
+
+      // ---- Status filter ----
+      if (currentFilters.status === 'active') {
+        // WHY: "active" maps to multiple session_status enum values.
+        // A session is considered active if it hasn't reached a terminal
+        // state (stopped, error, expired).
+        query = query.in('status', ['starting', 'running', 'idle', 'paused']);
+      } else if (currentFilters.status === 'completed') {
+        query = query.in('status', ['stopped', 'expired']);
+      }
+
+      // ---- Agent filter ----
+      if (currentFilters.agent) {
+        query = query.eq('agent_type', currentFilters.agent);
+      }
+
+      // ---- Search filter ----
+      // WHY: We use `.ilike()` with a wildcard pattern because the
+      // pg_trgm GIN index on the sessions table accelerates ILIKE
+      // queries with patterns >= 3 characters. For shorter queries
+      // Postgres falls back to a sequential scan, which is acceptable
+      // given that each user has at most a few thousand sessions.
+      if (search.trim().length > 0) {
+        const pattern = `%${search.trim()}%`;
+        query = query.or(`title.ilike.${pattern},summary.ilike.${pattern}`);
+      }
+
+      const { data, error: queryError } = await query;
+
+      if (queryError) {
+        throw new Error(queryError.message);
+      }
+
+      // WHY: Supabase's generated types don't match our SessionRow interface
+      // exactly because we SELECT a subset of columns. The cast through
+      // `unknown` is safe because the SELECT list above matches SessionRow.
+      return (data as unknown as SessionRow[]) || [];
+    },
+    [],
+  );
+
+  // -------------------------------------------------------------------------
+  // Initial load & re-fetch on filter/search change
+  // -------------------------------------------------------------------------
+
+  /**
+   * Perform a fresh fetch (page 0) using the current search and filters.
+   * Resets pagination state.
+   */
+  const loadInitial = useCallback(
+    async (search: string, currentFilters: SessionFilters) => {
+      const generation = ++fetchGenerationRef.current;
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const rows = await fetchSessions(0, search, currentFilters);
+
+        // Discard stale response
+        if (generation !== fetchGenerationRef.current) return;
+
+        setSessions(rows);
+        setHasMore(rows.length === PAGE_SIZE);
+      } catch (err) {
+        if (generation !== fetchGenerationRef.current) return;
+        setError(err instanceof Error ? err.message : 'Failed to load sessions');
+      } finally {
+        if (generation === fetchGenerationRef.current) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [fetchSessions],
+  );
+
+  // Trigger a fresh load whenever debounced search or filters change.
+  useEffect(() => {
+    loadInitial(debouncedSearchRef.current, filters);
+  }, [loadInitial, filters]);
+
+  // -------------------------------------------------------------------------
+  // Debounced search
+  // -------------------------------------------------------------------------
+
+  /**
+   * Update the search query. Internally debounces the actual Supabase
+   * request by {@link SEARCH_DEBOUNCE_MS} so that we don't fire a query
+   * on every keystroke.
+   *
+   * @param query - The raw search input text
+   */
+  const setSearchQuery = useCallback(
+    (query: string) => {
+      setSearchQueryState(query);
+
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        debouncedSearchRef.current = query;
+        loadInitial(query, filters);
+      }, SEARCH_DEBOUNCE_MS);
+    },
+    [filters, loadInitial],
+  );
+
+  // Cleanup the debounce timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Filters
+  // -------------------------------------------------------------------------
+
+  /**
+   * Replace the current filter state. Triggers an immediate re-fetch
+   * (the useEffect on `filters` handles this).
+   *
+   * @param newFilters - The new status and agent filters to apply
+   */
+  const setFilters = useCallback((newFilters: SessionFilters) => {
+    setFiltersState(newFilters);
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Pull-to-refresh
+  // -------------------------------------------------------------------------
+
+  /**
+   * Pull-to-refresh handler. Reloads page 0 while keeping the current
+   * search and filters intact.
+   */
+  const refresh = useCallback(async () => {
+    const generation = ++fetchGenerationRef.current;
+    setIsRefreshing(true);
+    setError(null);
+
+    try {
+      const rows = await fetchSessions(
+        0,
+        debouncedSearchRef.current,
+        filters,
+      );
+
+      if (generation !== fetchGenerationRef.current) return;
+
+      setSessions(rows);
+      setHasMore(rows.length === PAGE_SIZE);
+    } catch (err) {
+      if (generation !== fetchGenerationRef.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to refresh sessions');
+    } finally {
+      if (generation === fetchGenerationRef.current) {
+        setIsRefreshing(false);
+      }
+    }
+  }, [fetchSessions, filters]);
+
+  // -------------------------------------------------------------------------
+  // Infinite scroll (load more)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Load the next page of sessions and append to the existing list.
+   * No-ops if there are no more pages or a load is already in progress.
+   */
+  const loadMore = useCallback(async () => {
+    if (!hasMore || isLoadingMore || isLoading) return;
+
+    const generation = ++fetchGenerationRef.current;
+    setIsLoadingMore(true);
+
+    try {
+      const rows = await fetchSessions(
+        sessions.length,
+        debouncedSearchRef.current,
+        filters,
+      );
+
+      if (generation !== fetchGenerationRef.current) return;
+
+      setSessions((prev) => [...prev, ...rows]);
+      setHasMore(rows.length === PAGE_SIZE);
+    } catch (err) {
+      if (generation !== fetchGenerationRef.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to load more sessions');
+    } finally {
+      if (generation === fetchGenerationRef.current) {
+        setIsLoadingMore(false);
+      }
+    }
+  }, [hasMore, isLoadingMore, isLoading, sessions.length, fetchSessions, filters]);
+
+  // -------------------------------------------------------------------------
+  // Return
+  // -------------------------------------------------------------------------
+
+  return {
+    sessions,
+    isLoading,
+    isRefreshing,
+    isLoadingMore,
+    hasMore,
+    error,
+    searchQuery,
+    filters,
+    setSearchQuery,
+    setFilters,
+    refresh,
+    loadMore,
+  };
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Convert an ISO timestamp string into a human-friendly relative time string.
+ *
+ * Returns "just now" for < 1 minute, "Xm ago" for < 1 hour, "Xh ago" for
+ * < 24 hours, "yesterday" for 24-48 hours, and a short date for anything
+ * older.
+ *
+ * @param isoTimestamp - An ISO 8601 date string (e.g. from Supabase)
+ * @returns A short relative time string suitable for display in a list item
+ *
+ * @example
+ * formatRelativeTime('2025-01-15T10:30:00Z'); // "3h ago" (if now is 1:30pm)
+ */
+export function formatRelativeTime(isoTimestamp: string): string {
+  const now = Date.now();
+  const then = new Date(isoTimestamp).getTime();
+  const diffMs = now - then;
+
+  if (diffMs < 0) return 'just now';
+
+  const MINUTE = 60_000;
+  const HOUR = 3_600_000;
+  const DAY = 86_400_000;
+
+  if (diffMs < MINUTE) return 'just now';
+  if (diffMs < HOUR) return `${Math.floor(diffMs / MINUTE)}m ago`;
+  if (diffMs < DAY) return `${Math.floor(diffMs / HOUR)}h ago`;
+  if (diffMs < DAY * 2) return 'yesterday';
+
+  // Older than 2 days: show "Jan 15" format
+  const date = new Date(isoTimestamp);
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  return `${months[date.getMonth()]} ${date.getDate()}`;
+}
+
+/**
+ * Get the first non-empty line of a potentially multi-line summary string.
+ *
+ * Used to display a preview of the AI-generated session summary in the
+ * session list card without showing the full (potentially long) text.
+ *
+ * @param summary - The full session summary (may be null)
+ * @returns The first line, or null if the summary is empty/null
+ */
+export function getFirstLine(summary: string | null): string | null {
+  if (!summary) return null;
+  const firstLine = summary.split('\n').find((line) => line.trim().length > 0);
+  return firstLine?.trim() || null;
+}

--- a/packages/styrby-mobile/src/services/notifications.ts
+++ b/packages/styrby-mobile/src/services/notifications.ts
@@ -87,7 +87,7 @@ export async function registerForPushNotifications(): Promise<string | null> {
   // Get the Expo push token
   try {
     const tokenData = await Notifications.getExpoPushTokenAsync({
-      projectId: process.env.EXPO_PROJECT_ID,
+      projectId: process.env.EXPO_PUBLIC_PROJECT_ID,
     });
     return tokenData.data;
   } catch (error) {


### PR DESCRIPTION
## Summary

Completes the core mobile app implementation across all 4 tab screens, components, and supporting hooks/services.

### Chat Screen
- Session creation in Supabase `sessions` table on first message
- Message persistence to `session_messages` (survives refresh)
- History loading on mount / session resume via route params
- Typing indicator integration (shows while agent responds)
- Stop button replaces send button during agent activity
- Permission card visual feedback (approve/deny with animation)

### Sessions Screen
- Real Supabase queries replace hardcoded mock data
- Paginated with infinite scroll (20 per page)
- Debounced search (300ms) on title and summary
- Status filter chips (All / Active / Completed)
- Agent filter chips (All / Claude / Codex / Gemini)
- Pull-to-refresh, tap-to-navigate to chat with session context

### Settings Screen
- Load authenticated user email from Supabase Auth
- Push notification toggle persists to `notification_preferences` table
- Haptic feedback toggle persists to SecureStore
- Sign out with confirmation dialog + full cleanup (pairing, prefs, auth)
- Coming-soon alerts for unimplemented sub-screens
- Dynamic app version from expo-constants

### Dashboard Screen
- Active sessions loaded from Supabase (status in active/running/idle)
- Real-time session state updates from relay messages
- Agent online status from relay presence
- Notifications from `audit_log` (last 24 hours)
- Live cost tracking from `cost_records` + relay cost updates
- Refresh on tab focus via `useFocusEffect`

### Housekeeping
- Created `.env.example` with all required mobile env vars
- Fixed `EXPO_PROJECT_ID` → `EXPO_PUBLIC_PROJECT_ID` prefix
- Added missing `opencode` and `aider` entries to component `Record<AgentType>` maps
- Fixed `src/components/index.ts` barrel export (was incorrectly referencing `jsonl-parser.js`)

## Test plan
- [ ] Chat: send message → verify session created in Supabase
- [ ] Chat: close and reopen → verify messages persist
- [ ] Chat: typing indicator appears while waiting for response
- [ ] Sessions: pull to refresh loads sessions from Supabase
- [ ] Sessions: search filters by title/summary
- [ ] Sessions: tap session navigates to chat with context
- [ ] Settings: toggle push notifications → verify saved to Supabase
- [ ] Settings: sign out → confirm dialog → redirects to login
- [ ] Dashboard: active sessions carousel shows real data
- [ ] Dashboard: notifications feed shows recent audit events

🤖 Generated with [Claude Code](https://claude.com/claude-code)