### PR TITLE
feat: add 1,097 tests, 3 CI jobs, and code quality fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,26 @@ jobs:
         continue-on-error: true
         run: pnpm --filter styrby-mobile run typecheck
 
+  # ─── Shared unit tests ───
+  test-shared:
+    name: Shared Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run shared tests
+        run: pnpm --filter @styrby/shared run test
+
   # ─── CLI unit tests ───
   test-cli:
     name: CLI Unit Tests
@@ -102,12 +122,44 @@ jobs:
       - name: Build shared (dependency)
         run: pnpm --filter @styrby/shared build
 
+      # Install CLI tool binaries needed by ripgrep/difftastic test modules
+      - name: Install ripgrep and difftastic
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ripgrep
+          # difftastic is not in apt — install from GitHub release
+          DIFFT_VERSION="0.63.0"
+          curl -fsSL "https://github.com/Wilfred/difftastic/releases/download/${DIFFT_VERSION}/difft-x86_64-unknown-linux-gnu.tar.gz" | sudo tar -xz -C /usr/local/bin
+
       - name: Run CLI tests
-        # TODO: add --coverage flag back once @vitest/coverage-v8 is installed in styrby-cli
-        # 9 tests in ripgrep/difftastic modules require tool binaries not available in CI.
-        # 252/261 tests pass. Remove continue-on-error once CI installs ripgrep + difftastic.
-        continue-on-error: true
-        run: pnpm --filter styrby-cli run test
+        run: pnpm --filter styrby-cli run test -- --coverage
+
+  # ─── Web unit tests ───
+  test-web:
+    name: Web Unit Tests
+    runs-on: ubuntu-latest
+    needs: build-shared
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download shared build
+        uses: actions/download-artifact@v4
+        with:
+          name: shared-build
+          path: packages/styrby-shared/dist/
+
+      - name: Run web unit tests
+        run: pnpm --filter styrby-web run test
 
   # ─── Security scanning ───
   security:
@@ -405,7 +457,7 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [quality, test-cli, security, build-shared, build-cli, build-web, build-mobile, e2e, bundle-size]
+    needs: [quality, test-shared, test-cli, test-web, security, build-shared, build-cli, build-web, build-mobile, e2e, bundle-size]
     if: always()
     steps:
       - name: Evaluate results
@@ -430,7 +482,9 @@ jobs:
           }
 
           check_job "Quality" "${{ needs.quality.result }}"
+          check_job "Shared Tests" "${{ needs.test-shared.result }}"
           check_job "CLI Tests" "${{ needs.test-cli.result }}"
+          check_job "Web Tests" "${{ needs.test-web.result }}"
           check_job "Security" "${{ needs.security.result }}"
           check_job "Build Shared" "${{ needs.build-shared.result }}"
           check_job "Build CLI" "${{ needs.build-cli.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,14 +122,27 @@ jobs:
       - name: Build shared (dependency)
         run: pnpm --filter @styrby/shared build
 
-      # Install CLI tool binaries needed by ripgrep/difftastic test modules
+      # Install CLI tool binaries needed by ripgrep/difftastic test modules.
+      # The forked Happy Coder code expects difft at tools/unpacked/difft
+      # and ripgrep via scripts/ripgrep_launcher.cjs — symlink system binaries.
       - name: Install ripgrep and difftastic
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq ripgrep
-          # difftastic is not in apt — install from GitHub release
           DIFFT_VERSION="0.63.0"
           curl -fsSL "https://github.com/Wilfred/difftastic/releases/download/${DIFFT_VERSION}/difft-x86_64-unknown-linux-gnu.tar.gz" | sudo tar -xz -C /usr/local/bin
+          # Symlink difft into expected tools/unpacked/ path
+          mkdir -p packages/styrby-cli/tools/unpacked
+          ln -sf "$(which difft)" packages/styrby-cli/tools/unpacked/difft
+          # Create ripgrep launcher script that delegates to system rg
+          mkdir -p packages/styrby-cli/scripts
+          cat > packages/styrby-cli/scripts/ripgrep_launcher.cjs << 'SCRIPT'
+          const { spawn } = require('child_process');
+          const args = JSON.parse(process.argv[2] || '[]');
+          const child = spawn('rg', args, { stdio: 'inherit' });
+          child.on('close', (code) => process.exit(code || 0));
+          child.on('error', () => process.exit(1));
+          SCRIPT
 
       - name: Run CLI tests
         run: pnpm --filter styrby-cli run test -- --coverage

--- a/packages/styrby-cli/package.json
+++ b/packages/styrby-cli/package.json
@@ -89,6 +89,7 @@
     "@types/qrcode-terminal": "^0.12.2",
     "@types/react": "^19.2.7",
     "@types/tmp": "^0.2.6",
+    "@vitest/coverage-v8": "4.0.18",
     "axios": "^1.13.4",
     "cross-spawn": "^7.0.6",
     "esbuild": "^0.27.2",

--- a/packages/styrby-cli/src/commands/doctor.ts
+++ b/packages/styrby-cli/src/commands/doctor.ts
@@ -1,0 +1,173 @@
+/**
+ * Doctor Command
+ *
+ * Runs a series of health checks to diagnose common issues
+ * with the Styrby CLI installation and configuration.
+ *
+ * Checks performed:
+ * 1. Node.js version compatibility
+ * 2. Configuration file existence and validity
+ * 3. Authentication status
+ * 4. Installed agent detection (Claude, Codex, Gemini)
+ *
+ * @module commands/doctor
+ */
+
+import { logger } from '@/ui/logger';
+import { isAuthenticated, loadConfig } from '@/configuration';
+import { getAllAgentStatus } from '@/auth/agent-credentials';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Result of a single health check */
+interface CheckResult {
+  /** Human-readable name of the check */
+  name: string;
+  /** Whether the check passed */
+  passed: boolean;
+  /** Optional detail message */
+  message?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Minimum supported Node.js major version */
+const MIN_NODE_MAJOR = 18;
+
+// ============================================================================
+// Health Checks
+// ============================================================================
+
+/**
+ * Checks that the current Node.js version meets the minimum requirement.
+ *
+ * @returns A CheckResult indicating whether the Node.js version is sufficient
+ */
+function checkNodeVersion(): CheckResult {
+  const major = parseInt(process.version.slice(1).split('.')[0], 10);
+  const passed = major >= MIN_NODE_MAJOR;
+  return {
+    name: 'Node.js version',
+    passed,
+    message: passed
+      ? `${process.version} (>= ${MIN_NODE_MAJOR} required)`
+      : `${process.version} is below minimum v${MIN_NODE_MAJOR}`,
+  };
+}
+
+/**
+ * Checks that the Styrby configuration file can be loaded.
+ *
+ * @returns A CheckResult indicating whether the config file is valid
+ */
+function checkConfig(): CheckResult {
+  try {
+    const config = loadConfig();
+    const hasConfig = config !== null && typeof config === 'object';
+    return {
+      name: 'Configuration',
+      passed: hasConfig,
+      message: hasConfig ? 'Config file loaded successfully' : 'No config found',
+    };
+  } catch {
+    return {
+      name: 'Configuration',
+      passed: false,
+      message: 'Failed to load config file',
+    };
+  }
+}
+
+/**
+ * Checks whether the user is currently authenticated.
+ *
+ * @returns A CheckResult indicating authentication status
+ */
+function checkAuth(): CheckResult {
+  const authed = isAuthenticated();
+  return {
+    name: 'Authentication',
+    passed: authed,
+    message: authed ? 'Authenticated' : 'Not authenticated — run `styrby onboard`',
+  };
+}
+
+/**
+ * Checks which AI agents are installed and accessible.
+ *
+ * getAllAgentStatus() returns Record<AgentType, AgentStatus>.
+ * We convert to an array and filter for installed agents.
+ *
+ * @returns A CheckResult summarizing agent availability
+ */
+async function checkAgents(): Promise<CheckResult> {
+  try {
+    const statusRecord = await getAllAgentStatus();
+    const statuses = Object.values(statusRecord);
+    const available = statuses.filter((s) => s.installed);
+    const names = available.map((s) => s.name).join(', ');
+    return {
+      name: 'AI Agents',
+      passed: available.length > 0,
+      message:
+        available.length > 0
+          ? `${available.length} agent(s) found: ${names}`
+          : 'No agents detected — run `styrby install-agent`',
+    };
+  } catch {
+    return {
+      name: 'AI Agents',
+      passed: false,
+      message: 'Could not detect agents',
+    };
+  }
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+/**
+ * Runs all health checks and prints a summary report.
+ *
+ * Called from the interactive menu or directly via `styrby doctor`.
+ * Each check runs independently; a single failure does not block others.
+ *
+ * @returns A promise that resolves when all checks are complete
+ */
+export async function runDoctor(): Promise<void> {
+  logger.info('Running Styrby health checks...\n');
+
+  const results: CheckResult[] = [];
+
+  // Synchronous checks
+  results.push(checkNodeVersion());
+  results.push(checkConfig());
+  results.push(checkAuth());
+
+  // Async checks
+  results.push(await checkAgents());
+
+  // Print results
+  let allPassed = true;
+  for (const result of results) {
+    const icon = result.passed ? '✓' : '✗';
+    const status = result.passed ? 'PASS' : 'FAIL';
+    const detail = result.message ? ` — ${result.message}` : '';
+    logger.info(`  ${icon} [${status}] ${result.name}${detail}`);
+    if (!result.passed) {
+      allPassed = false;
+    }
+  }
+
+  logger.info('');
+  if (allPassed) {
+    logger.info('All checks passed. Styrby is healthy.');
+  } else {
+    logger.info('Some checks failed. Review the issues above.');
+  }
+}

--- a/packages/styrby-cli/src/utils/serverConnectionErrors.test.ts
+++ b/packages/styrby-cli/src/utils/serverConnectionErrors.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { startOfflineReconnection, printOfflineWarning, connectionState, isNetworkError, NETWORK_ERROR_CODES } from './serverConnectionErrors';
+import { startOfflineReconnection, connectionState, isNetworkError, NETWORK_ERROR_CODES } from './serverConnectionErrors';
 
 // Mock axios - only isAxiosError needed for error type detection
 vi.mock('axios', () => ({
@@ -503,47 +503,6 @@ describe('startOfflineReconnection', () => {
             // Should not throw when cancelling without onCleanup
             expect(() => handle.cancel()).not.toThrow();
         });
-    });
-});
-
-// ============================================================================
-// printOfflineWarning Tests
-// ============================================================================
-
-describe('printOfflineWarning', () => {
-    beforeEach(() => {
-        connectionState.reset(); // Reset singleton state between tests
-    });
-
-    it('should print offline warning with unified format', () => {
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
-        printOfflineWarning();
-
-        // New unified format via connectionState.fail()
-        expect(consoleSpy).toHaveBeenCalledWith(
-            expect.stringContaining('⚠️  Happy server unreachable, offline mode with auto-reconnect enabled')
-        );
-        expect(consoleSpy).toHaveBeenCalledWith(
-            expect.stringContaining('Server connection failed')
-        );
-
-        consoleSpy.mockRestore();
-    });
-
-    it('should deduplicate repeated calls', () => {
-        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
-        printOfflineWarning('Claude');
-        const callCountAfterFirst = consoleSpy.mock.calls.length;
-
-        printOfflineWarning('Claude'); // Second call should be deduplicated
-        const callCountAfterSecond = consoleSpy.mock.calls.length;
-
-        // Should not print again (same call count)
-        expect(callCountAfterSecond).toBe(callCountAfterFirst);
-
-        consoleSpy.mockRestore();
     });
 });
 

--- a/packages/styrby-cli/src/utils/serverConnectionErrors.ts
+++ b/packages/styrby-cli/src/utils/serverConnectionErrors.ts
@@ -337,10 +337,3 @@ class OfflineState {
  */
 export const connectionState = new OfflineState();
 
-/**
- * @deprecated Use connectionState.fail() for deduplication and context tracking
- */
-export function printOfflineWarning(backendName: string = 'Claude'): void {
-    connectionState.setBackend(backendName);
-    connectionState.fail({ operation: 'Server connection' });
-}

--- a/packages/styrby-shared/package.json
+++ b/packages/styrby-shared/package.json
@@ -20,7 +20,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.10",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.18",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/styrby-shared/tests/encryption.test.ts
+++ b/packages/styrby-shared/tests/encryption.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for the Styrby E2E Encryption Module
+ *
+ * Validates NaCl box (public-key authenticated encryption) operations
+ * including key generation, encrypt/decrypt round-trips, base64 encoding,
+ * and fingerprint generation.
+ *
+ * Dependencies: tweetnacl, tweetnacl-util (installed in package)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generateKeyPair,
+  encrypt,
+  decrypt,
+  encryptForStorage,
+  decryptFromStorage,
+  encodeBase64,
+  decodeBase64,
+  generateFingerprint,
+} from '../src/encryption';
+
+describe('Encryption Module', () => {
+  // ==========================================================================
+  // Key Generation
+  // ==========================================================================
+
+  describe('generateKeyPair()', () => {
+    it('returns an object with publicKey and secretKey', () => {
+      const keypair = generateKeyPair();
+      expect(keypair).toHaveProperty('publicKey');
+      expect(keypair).toHaveProperty('secretKey');
+    });
+
+    it('returns a publicKey that is a Uint8Array of 32 bytes', () => {
+      const keypair = generateKeyPair();
+      expect(keypair.publicKey).toBeInstanceOf(Uint8Array);
+      expect(keypair.publicKey.length).toBe(32);
+    });
+
+    it('returns a secretKey that is a Uint8Array of 32 bytes', () => {
+      const keypair = generateKeyPair();
+      expect(keypair.secretKey).toBeInstanceOf(Uint8Array);
+      expect(keypair.secretKey.length).toBe(32);
+    });
+
+    it('generates different keypairs on each call', () => {
+      const keypair1 = generateKeyPair();
+      const keypair2 = generateKeyPair();
+      expect(keypair1.publicKey).not.toEqual(keypair2.publicKey);
+      expect(keypair1.secretKey).not.toEqual(keypair2.secretKey);
+    });
+  });
+
+  // ==========================================================================
+  // Encrypt + Decrypt Round-Trip
+  // ==========================================================================
+
+  describe('encrypt() + decrypt() round-trip', () => {
+    it('encrypts and decrypts a simple message', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+      const message = 'Hello from mobile!';
+
+      const { encrypted, nonce } = encrypt(message, recipient.publicKey, sender.secretKey);
+      const decrypted = decrypt(encrypted, nonce, sender.publicKey, recipient.secretKey);
+
+      expect(decrypted).toBe(message);
+    });
+
+    it('encrypts and decrypts a message with unicode characters', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+      const message = 'Hello! Symbols: @#$%^&*() and Unicode: \u00e9\u00e0\u00fc\u00f1';
+
+      const { encrypted, nonce } = encrypt(message, recipient.publicKey, sender.secretKey);
+      const decrypted = decrypt(encrypted, nonce, sender.publicKey, recipient.secretKey);
+
+      expect(decrypted).toBe(message);
+    });
+
+    it('encrypts and decrypts a long message', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+      const message = 'A'.repeat(10000);
+
+      const { encrypted, nonce } = encrypt(message, recipient.publicKey, sender.secretKey);
+      const decrypted = decrypt(encrypted, nonce, sender.publicKey, recipient.secretKey);
+
+      expect(decrypted).toBe(message);
+    });
+
+    it('produces different ciphertext for the same message (unique nonces)', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+      const message = 'Same message, different nonces';
+
+      const result1 = encrypt(message, recipient.publicKey, sender.secretKey);
+      const result2 = encrypt(message, recipient.publicKey, sender.secretKey);
+
+      expect(result1.nonce).not.toEqual(result2.nonce);
+      expect(result1.encrypted).not.toEqual(result2.encrypted);
+    });
+  });
+
+  // ==========================================================================
+  // Encrypt Failures
+  // ==========================================================================
+
+  describe('encrypt() with wrong keys fails', () => {
+    it('fails to decrypt with the wrong recipient secret key', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+      const wrongRecipient = generateKeyPair();
+      const message = 'Secret message';
+
+      const { encrypted, nonce } = encrypt(message, recipient.publicKey, sender.secretKey);
+
+      expect(() => {
+        decrypt(encrypted, nonce, sender.publicKey, wrongRecipient.secretKey);
+      }).toThrow('Decryption failed');
+    });
+
+    it('fails to decrypt with the wrong sender public key', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+      const wrongSender = generateKeyPair();
+      const message = 'Secret message';
+
+      const { encrypted, nonce } = encrypt(message, recipient.publicKey, sender.secretKey);
+
+      expect(() => {
+        decrypt(encrypted, nonce, wrongSender.publicKey, recipient.secretKey);
+      }).toThrow('Decryption failed');
+    });
+  });
+
+  describe('encrypt() with empty message throws', () => {
+    it('throws an error when message is empty string', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+
+      expect(() => {
+        encrypt('', recipient.publicKey, sender.secretKey);
+      }).toThrow('Cannot encrypt empty message');
+    });
+  });
+
+  describe('encrypt() with invalid key length throws', () => {
+    it('throws when recipient public key is too short', () => {
+      const sender = generateKeyPair();
+      const shortKey = new Uint8Array(16);
+
+      expect(() => {
+        encrypt('Hello', shortKey, sender.secretKey);
+      }).toThrow('Invalid recipient public key length: expected 32, got 16');
+    });
+
+    it('throws when recipient public key is too long', () => {
+      const sender = generateKeyPair();
+      const longKey = new Uint8Array(64);
+
+      expect(() => {
+        encrypt('Hello', longKey, sender.secretKey);
+      }).toThrow('Invalid recipient public key length: expected 32, got 64');
+    });
+
+    it('throws when sender secret key is too short', () => {
+      const recipient = generateKeyPair();
+      const shortKey = new Uint8Array(16);
+
+      expect(() => {
+        encrypt('Hello', recipient.publicKey, shortKey);
+      }).toThrow('Invalid sender secret key length: expected 32, got 16');
+    });
+
+    it('throws when sender secret key is too long', () => {
+      const recipient = generateKeyPair();
+      const longKey = new Uint8Array(64);
+
+      expect(() => {
+        encrypt('Hello', recipient.publicKey, longKey);
+      }).toThrow('Invalid sender secret key length: expected 32, got 64');
+    });
+  });
+
+  // ==========================================================================
+  // Decrypt Validation
+  // ==========================================================================
+
+  describe('decrypt() input validation', () => {
+    it('throws when nonce has invalid length', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+      const badNonce = new Uint8Array(10);
+
+      expect(() => {
+        decrypt(new Uint8Array(32), badNonce, sender.publicKey, recipient.secretKey);
+      }).toThrow('Invalid nonce length');
+    });
+
+    it('throws when sender public key has invalid length', () => {
+      const recipient = generateKeyPair();
+      const badKey = new Uint8Array(16);
+      const nonce = new Uint8Array(24);
+
+      expect(() => {
+        decrypt(new Uint8Array(32), nonce, badKey, recipient.secretKey);
+      }).toThrow('Invalid sender public key length');
+    });
+
+    it('throws when recipient secret key has invalid length', () => {
+      const sender = generateKeyPair();
+      const badKey = new Uint8Array(16);
+      const nonce = new Uint8Array(24);
+
+      expect(() => {
+        decrypt(new Uint8Array(32), nonce, sender.publicKey, badKey);
+      }).toThrow('Invalid recipient secret key length');
+    });
+  });
+
+  // ==========================================================================
+  // Base64 Storage Round-Trip
+  // ==========================================================================
+
+  describe('encryptForStorage() + decryptFromStorage() round-trip', () => {
+    it('encrypts to base64 and decrypts back to original message', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+      const message = 'Hello from the storage layer!';
+
+      const { encrypted, nonce } = encryptForStorage(
+        message,
+        recipient.publicKey,
+        sender.secretKey
+      );
+
+      // Verify the results are base64 strings
+      expect(typeof encrypted).toBe('string');
+      expect(typeof nonce).toBe('string');
+      expect(encrypted.length).toBeGreaterThan(0);
+      expect(nonce.length).toBeGreaterThan(0);
+
+      const decrypted = decryptFromStorage(
+        encrypted,
+        nonce,
+        sender.publicKey,
+        recipient.secretKey
+      );
+
+      expect(decrypted).toBe(message);
+    });
+
+    it('produces valid base64 strings', () => {
+      const sender = generateKeyPair();
+      const recipient = generateKeyPair();
+
+      const { encrypted, nonce } = encryptForStorage(
+        'Test message',
+        recipient.publicKey,
+        sender.secretKey
+      );
+
+      // Base64 strings should only contain valid characters
+      const base64Regex = /^[A-Za-z0-9+/]+=*$/;
+      expect(encrypted).toMatch(base64Regex);
+      expect(nonce).toMatch(base64Regex);
+    });
+  });
+
+  // ==========================================================================
+  // Base64 Encoding/Decoding
+  // ==========================================================================
+
+  describe('encodeBase64() + decodeBase64() round-trip', () => {
+    it('encodes and decodes a Uint8Array', () => {
+      const original = new Uint8Array([1, 2, 3, 4, 5, 100, 200, 255]);
+      const encoded = encodeBase64(original);
+      const decoded = decodeBase64(encoded);
+
+      expect(decoded).toEqual(original);
+    });
+
+    it('encodes and decodes an empty Uint8Array', () => {
+      const original = new Uint8Array(0);
+      const encoded = encodeBase64(original);
+      const decoded = decodeBase64(encoded);
+
+      expect(decoded).toEqual(original);
+    });
+
+    it('encodes and decodes a 32-byte key', () => {
+      const keypair = generateKeyPair();
+      const encoded = encodeBase64(keypair.publicKey);
+      const decoded = decodeBase64(encoded);
+
+      expect(decoded).toEqual(keypair.publicKey);
+    });
+
+    it('returns a string from encodeBase64', () => {
+      const bytes = new Uint8Array([0, 128, 255]);
+      const encoded = encodeBase64(bytes);
+      expect(typeof encoded).toBe('string');
+    });
+
+    it('returns a Uint8Array from decodeBase64', () => {
+      const bytes = new Uint8Array([10, 20, 30]);
+      const encoded = encodeBase64(bytes);
+      const decoded = decodeBase64(encoded);
+      expect(decoded).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  // ==========================================================================
+  // Fingerprint Generation
+  // ==========================================================================
+
+  describe('generateFingerprint()', () => {
+    it('returns a 16-character hex string', async () => {
+      const keypair = generateKeyPair();
+      const fingerprint = await generateFingerprint(keypair.publicKey);
+
+      expect(typeof fingerprint).toBe('string');
+      expect(fingerprint.length).toBe(16);
+      expect(fingerprint).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it('returns the same fingerprint for the same key', async () => {
+      const keypair = generateKeyPair();
+      const fingerprint1 = await generateFingerprint(keypair.publicKey);
+      const fingerprint2 = await generateFingerprint(keypair.publicKey);
+
+      expect(fingerprint1).toBe(fingerprint2);
+    });
+
+    it('returns different fingerprints for different keypairs', async () => {
+      const keypair1 = generateKeyPair();
+      const keypair2 = generateKeyPair();
+
+      const fingerprint1 = await generateFingerprint(keypair1.publicKey);
+      const fingerprint2 = await generateFingerprint(keypair2.publicKey);
+
+      expect(fingerprint1).not.toBe(fingerprint2);
+    });
+
+    it('produces only lowercase hex characters', async () => {
+      const keypair = generateKeyPair();
+      const fingerprint = await generateFingerprint(keypair.publicKey);
+
+      // Verify no uppercase letters
+      expect(fingerprint).toBe(fingerprint.toLowerCase());
+      // Verify only hex chars
+      for (const char of fingerprint) {
+        expect('0123456789abcdef').toContain(char);
+      }
+    });
+  });
+});

--- a/packages/styrby-shared/tests/relay/offline-queue.test.ts
+++ b/packages/styrby-shared/tests/relay/offline-queue.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Tests for the Offline Command Queue Utilities
+ *
+ * Validates queue item creation, message priority assignment,
+ * queue ID generation, retry delay calculation, and retry eligibility.
+ *
+ * This module tests the shared types and helper functions only --
+ * platform-specific queue implementations (SQLite, IndexedDB) are
+ * tested in their respective packages.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  createQueuedCommand,
+  getMessagePriority,
+  generateQueueId,
+  getRetryDelay,
+  shouldRetry,
+  QueuePriority,
+  DEFAULT_QUEUE_TTL_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  RETRY_BASE_DELAY_MS,
+} from '../../src/relay/offline-queue';
+import type { RelayMessage } from '../../src/relay/types';
+
+// ==========================================================================
+// Test Helpers
+// ==========================================================================
+
+/**
+ * Creates a minimal RelayMessage of the given type for testing.
+ * Only includes the fields required by the type discriminator.
+ */
+function createTestMessage(
+  type: RelayMessage['type'],
+  payloadOverrides?: Record<string, unknown>
+): RelayMessage {
+  const base = {
+    id: 'msg_test_123',
+    timestamp: new Date().toISOString(),
+    sender_device_id: 'device_test',
+    sender_type: 'mobile' as const,
+  };
+
+  switch (type) {
+    case 'permission_response':
+      return {
+        ...base,
+        type: 'permission_response',
+        payload: {
+          request_id: 'req_123',
+          approved: true,
+          ...payloadOverrides,
+        },
+      };
+    case 'command':
+      return {
+        ...base,
+        type: 'command',
+        payload: {
+          action: 'ping' as const,
+          ...payloadOverrides,
+        },
+      };
+    case 'chat':
+      return {
+        ...base,
+        type: 'chat',
+        payload: {
+          content: 'Hello',
+          agent: 'claude' as const,
+          ...payloadOverrides,
+        },
+      };
+    case 'ack':
+      return {
+        ...base,
+        type: 'ack',
+        payload: {
+          ack_id: 'msg_acked',
+          success: true,
+          ...payloadOverrides,
+        },
+      };
+    case 'agent_response':
+      return {
+        ...base,
+        type: 'agent_response',
+        payload: {
+          content: 'Response',
+          agent: 'claude' as const,
+          session_id: 'session_123',
+          is_streaming: false,
+          is_complete: true,
+          ...payloadOverrides,
+        },
+      };
+    case 'session_state':
+      return {
+        ...base,
+        type: 'session_state',
+        payload: {
+          session_id: 'session_123',
+          agent: 'claude' as const,
+          state: 'idle' as const,
+          ...payloadOverrides,
+        },
+      };
+    case 'cost_update':
+      return {
+        ...base,
+        type: 'cost_update',
+        payload: {
+          session_id: 'session_123',
+          agent: 'claude' as const,
+          cost_usd: 0.05,
+          session_total_usd: 0.25,
+          tokens: { input: 100, output: 50 },
+          model: 'claude-sonnet-4',
+          ...payloadOverrides,
+        },
+      };
+    default:
+      return {
+        ...base,
+        type: 'chat',
+        payload: {
+          content: 'Default',
+          agent: 'claude' as const,
+        },
+      };
+  }
+}
+
+describe('Offline Queue Utilities', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // createQueuedCommand()
+  // ==========================================================================
+
+  describe('createQueuedCommand()', () => {
+    it('creates a valid QueuedCommand with default options', () => {
+      const message = createTestMessage('chat');
+      const command = createQueuedCommand(message);
+
+      expect(command).toHaveProperty('id');
+      expect(command).toHaveProperty('message');
+      expect(command).toHaveProperty('status');
+      expect(command).toHaveProperty('attempts');
+      expect(command).toHaveProperty('maxAttempts');
+      expect(command).toHaveProperty('createdAt');
+      expect(command).toHaveProperty('expiresAt');
+      expect(command).toHaveProperty('priority');
+    });
+
+    it('sets status to pending', () => {
+      const message = createTestMessage('chat');
+      const command = createQueuedCommand(message);
+      expect(command.status).toBe('pending');
+    });
+
+    it('sets attempts to 0', () => {
+      const message = createTestMessage('chat');
+      const command = createQueuedCommand(message);
+      expect(command.attempts).toBe(0);
+    });
+
+    it('uses default maxAttempts of 3', () => {
+      const message = createTestMessage('chat');
+      const command = createQueuedCommand(message);
+      expect(command.maxAttempts).toBe(DEFAULT_MAX_ATTEMPTS);
+      expect(command.maxAttempts).toBe(3);
+    });
+
+    it('stores the original message', () => {
+      const message = createTestMessage('chat');
+      const command = createQueuedCommand(message);
+      expect(command.message).toBe(message);
+    });
+
+    it('sets expiresAt to 5 minutes after createdAt by default', () => {
+      const message = createTestMessage('chat');
+      const command = createQueuedCommand(message);
+
+      const createdAt = new Date(command.createdAt).getTime();
+      const expiresAt = new Date(command.expiresAt).getTime();
+      const diff = expiresAt - createdAt;
+
+      expect(diff).toBe(DEFAULT_QUEUE_TTL_MS);
+      expect(diff).toBe(5 * 60 * 1000);
+    });
+
+    it('assigns priority based on message type', () => {
+      const chatMessage = createTestMessage('chat');
+      const chatCommand = createQueuedCommand(chatMessage);
+      expect(chatCommand.priority).toBe(QueuePriority.HIGH);
+
+      const permMessage = createTestMessage('permission_response');
+      const permCommand = createQueuedCommand(permMessage);
+      expect(permCommand.priority).toBe(QueuePriority.CRITICAL);
+    });
+
+    it('overrides maxAttempts with custom options', () => {
+      const message = createTestMessage('chat');
+      const command = createQueuedCommand(message, { maxAttempts: 10 });
+      expect(command.maxAttempts).toBe(10);
+    });
+
+    it('overrides TTL with custom options', () => {
+      const message = createTestMessage('chat');
+      const customTtl = 60 * 1000; // 1 minute
+      const command = createQueuedCommand(message, { ttl: customTtl });
+
+      const createdAt = new Date(command.createdAt).getTime();
+      const expiresAt = new Date(command.expiresAt).getTime();
+      const diff = expiresAt - createdAt;
+
+      expect(diff).toBe(customTtl);
+    });
+
+    it('overrides priority with custom options', () => {
+      const message = createTestMessage('chat');
+      const command = createQueuedCommand(message, { priority: 999 });
+      expect(command.priority).toBe(999);
+    });
+
+    it('generates a unique id for each command', () => {
+      const message = createTestMessage('chat');
+      const ids = new Set<string>();
+      for (let i = 0; i < 20; i++) {
+        const command = createQueuedCommand(message);
+        ids.add(command.id);
+      }
+      expect(ids.size).toBe(20);
+    });
+  });
+
+  // ==========================================================================
+  // getMessagePriority()
+  // ==========================================================================
+
+  describe('getMessagePriority()', () => {
+    it('returns CRITICAL (100) for permission_response', () => {
+      const message = createTestMessage('permission_response');
+      expect(getMessagePriority(message)).toBe(QueuePriority.CRITICAL);
+      expect(getMessagePriority(message)).toBe(100);
+    });
+
+    it('returns CRITICAL (100) for cancel command', () => {
+      const message = createTestMessage('command', { action: 'cancel' });
+      expect(getMessagePriority(message)).toBe(QueuePriority.CRITICAL);
+    });
+
+    it('returns CRITICAL (100) for interrupt command', () => {
+      const message = createTestMessage('command', { action: 'interrupt' });
+      expect(getMessagePriority(message)).toBe(QueuePriority.CRITICAL);
+    });
+
+    it('returns HIGH (50) for chat messages', () => {
+      const message = createTestMessage('chat');
+      expect(getMessagePriority(message)).toBe(QueuePriority.HIGH);
+      expect(getMessagePriority(message)).toBe(50);
+    });
+
+    it('returns LOW (-50) for ack messages', () => {
+      const message = createTestMessage('ack');
+      expect(getMessagePriority(message)).toBe(QueuePriority.LOW);
+      expect(getMessagePriority(message)).toBe(-50);
+    });
+
+    it('returns NORMAL (0) for regular commands (ping, new_session, etc)', () => {
+      const pingMessage = createTestMessage('command', { action: 'ping' });
+      expect(getMessagePriority(pingMessage)).toBe(QueuePriority.NORMAL);
+
+      const newSessionMessage = createTestMessage('command', { action: 'new_session' });
+      expect(getMessagePriority(newSessionMessage)).toBe(QueuePriority.NORMAL);
+
+      const switchMessage = createTestMessage('command', { action: 'switch_agent' });
+      expect(getMessagePriority(switchMessage)).toBe(QueuePriority.NORMAL);
+    });
+
+    it('returns NORMAL (0) for agent_response messages', () => {
+      const message = createTestMessage('agent_response');
+      expect(getMessagePriority(message)).toBe(QueuePriority.NORMAL);
+    });
+
+    it('returns NORMAL (0) for session_state messages', () => {
+      const message = createTestMessage('session_state');
+      expect(getMessagePriority(message)).toBe(QueuePriority.NORMAL);
+    });
+
+    it('returns NORMAL (0) for cost_update messages', () => {
+      const message = createTestMessage('cost_update');
+      expect(getMessagePriority(message)).toBe(QueuePriority.NORMAL);
+    });
+  });
+
+  // ==========================================================================
+  // generateQueueId()
+  // ==========================================================================
+
+  describe('generateQueueId()', () => {
+    it('returns a string starting with "queue_"', () => {
+      const id = generateQueueId();
+      expect(id.startsWith('queue_')).toBe(true);
+    });
+
+    it('returns unique IDs on repeated calls', () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 50; i++) {
+        ids.add(generateQueueId());
+      }
+      expect(ids.size).toBe(50);
+    });
+
+    it('contains a timestamp component', () => {
+      const before = Date.now();
+      const id = generateQueueId();
+      const after = Date.now();
+
+      // Extract the timestamp part (between first and second underscore)
+      const parts = id.split('_');
+      expect(parts.length).toBe(3);
+
+      const timestamp = parseInt(parts[1], 10);
+      expect(timestamp).toBeGreaterThanOrEqual(before);
+      expect(timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('contains a random suffix component', () => {
+      const id = generateQueueId();
+      const parts = id.split('_');
+      // The random suffix should be alphanumeric
+      expect(parts[2]).toMatch(/^[a-z0-9]+$/);
+      expect(parts[2].length).toBeGreaterThan(0);
+    });
+  });
+
+  // ==========================================================================
+  // getRetryDelay()
+  // ==========================================================================
+
+  describe('getRetryDelay()', () => {
+    it('returns base delay (1000ms) for 0 attempts', () => {
+      expect(getRetryDelay(0)).toBe(RETRY_BASE_DELAY_MS);
+      expect(getRetryDelay(0)).toBe(1000);
+    });
+
+    it('implements exponential backoff', () => {
+      expect(getRetryDelay(0)).toBe(1000);   // 1s
+      expect(getRetryDelay(1)).toBe(2000);   // 2s
+      expect(getRetryDelay(2)).toBe(4000);   // 4s
+      expect(getRetryDelay(3)).toBe(8000);   // 8s
+      expect(getRetryDelay(4)).toBe(16000);  // 16s
+    });
+
+    it('caps delay at 30 seconds', () => {
+      expect(getRetryDelay(5)).toBe(30000);  // Would be 32000, capped at 30000
+      expect(getRetryDelay(10)).toBe(30000); // Way beyond cap
+      expect(getRetryDelay(100)).toBe(30000); // Extreme value
+    });
+
+    it('returns values increasing with attempt count up to cap', () => {
+      let prevDelay = 0;
+      for (let i = 0; i < 5; i++) {
+        const delay = getRetryDelay(i);
+        expect(delay).toBeGreaterThan(prevDelay);
+        prevDelay = delay;
+      }
+    });
+  });
+
+  // ==========================================================================
+  // shouldRetry()
+  // ==========================================================================
+
+  describe('shouldRetry()', () => {
+    it('returns true for a failed item within attempt limit and not expired', () => {
+      const item = createQueuedCommand(createTestMessage('chat'));
+      // Simulate: mark as failed with 1 attempt made, not at max
+      item.status = 'failed';
+      item.attempts = 1;
+      // Ensure not expired (default TTL is 5 minutes in the future)
+
+      expect(shouldRetry(item)).toBe(true);
+    });
+
+    it('returns false for a pending item (not failed)', () => {
+      const item = createQueuedCommand(createTestMessage('chat'));
+      // Status is 'pending' by default
+      expect(shouldRetry(item)).toBe(false);
+    });
+
+    it('returns false for a sent item', () => {
+      const item = createQueuedCommand(createTestMessage('chat'));
+      item.status = 'sent';
+      expect(shouldRetry(item)).toBe(false);
+    });
+
+    it('returns false for an expired item', () => {
+      const item = createQueuedCommand(createTestMessage('chat'));
+      item.status = 'failed';
+      item.attempts = 1;
+      // Set expiration to the past
+      item.expiresAt = new Date(Date.now() - 1000).toISOString();
+
+      expect(shouldRetry(item)).toBe(false);
+    });
+
+    it('returns false when attempts have been exhausted', () => {
+      const item = createQueuedCommand(createTestMessage('chat'));
+      item.status = 'failed';
+      item.attempts = item.maxAttempts; // Reached max
+
+      expect(shouldRetry(item)).toBe(false);
+    });
+
+    it('returns false when attempts exceed maxAttempts', () => {
+      const item = createQueuedCommand(createTestMessage('chat'));
+      item.status = 'failed';
+      item.attempts = item.maxAttempts + 5;
+
+      expect(shouldRetry(item)).toBe(false);
+    });
+
+    it('returns true when attempts are at maxAttempts - 1 (one more try available)', () => {
+      const item = createQueuedCommand(createTestMessage('chat'));
+      item.status = 'failed';
+      item.attempts = item.maxAttempts - 1;
+
+      expect(shouldRetry(item)).toBe(true);
+    });
+
+    it('returns false for an expired item even if attempts remain', () => {
+      const item = createQueuedCommand(createTestMessage('chat'));
+      item.status = 'failed';
+      item.attempts = 0;
+      item.expiresAt = new Date(Date.now() - 60000).toISOString();
+
+      expect(shouldRetry(item)).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Constants
+  // ==========================================================================
+
+  describe('Queue Constants', () => {
+    it('DEFAULT_QUEUE_TTL_MS is 5 minutes', () => {
+      expect(DEFAULT_QUEUE_TTL_MS).toBe(5 * 60 * 1000);
+    });
+
+    it('DEFAULT_MAX_ATTEMPTS is 3', () => {
+      expect(DEFAULT_MAX_ATTEMPTS).toBe(3);
+    });
+
+    it('RETRY_BASE_DELAY_MS is 1000', () => {
+      expect(RETRY_BASE_DELAY_MS).toBe(1000);
+    });
+
+    it('QueuePriority has expected values', () => {
+      expect(QueuePriority.CRITICAL).toBe(100);
+      expect(QueuePriority.HIGH).toBe(50);
+      expect(QueuePriority.NORMAL).toBe(0);
+      expect(QueuePriority.LOW).toBe(-50);
+    });
+  });
+});

--- a/packages/styrby-shared/tests/relay/pairing.test.ts
+++ b/packages/styrby-shared/tests/relay/pairing.test.ts
@@ -1,0 +1,500 @@
+/**
+ * Tests for the Styrby Pairing Flow Module
+ *
+ * Validates QR code-based pairing between CLI and mobile app, including
+ * token generation, payload creation, URL encoding/decoding,
+ * expiration checks, payload validation, and token hashing.
+ *
+ * Note: Uses Web Crypto API (crypto.subtle, crypto.getRandomValues)
+ * which is available in Node.js 20+ and vitest environments.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  generatePairingToken,
+  hashPairingToken,
+  createPairingPayload,
+  encodePairingUrl,
+  decodePairingUrl,
+  isPairingExpired,
+  validatePairingPayload,
+  PAIRING_EXPIRY_MINUTES,
+  PAIRING_TOKEN_EXPIRY_MS,
+  PAIRING_SCHEME,
+} from '../../src/relay/pairing';
+
+describe('Pairing Module', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // generatePairingToken()
+  // ==========================================================================
+
+  describe('generatePairingToken()', () => {
+    it('returns a non-empty string', () => {
+      const token = generatePairingToken();
+      expect(typeof token).toBe('string');
+      expect(token.length).toBeGreaterThan(0);
+    });
+
+    it('returns a base64url-encoded string (no +, /, or = characters)', () => {
+      const token = generatePairingToken();
+      // base64url uses - instead of + and _ instead of /
+      // and strips trailing = padding
+      expect(token).not.toContain('+');
+      expect(token).not.toContain('/');
+      expect(token).not.toContain('=');
+      // Should only contain alphanumeric, dash, and underscore
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('returns unique tokens on each call', () => {
+      const tokens = new Set<string>();
+      for (let i = 0; i < 20; i++) {
+        tokens.add(generatePairingToken());
+      }
+      expect(tokens.size).toBe(20);
+    });
+
+    it('returns a token of consistent length from 32 random bytes', () => {
+      // 32 bytes -> 44 base64 chars -> 43 base64url chars (no padding)
+      const token = generatePairingToken();
+      // base64url of 32 bytes is always 43 chars (44 minus trailing =)
+      expect(token.length).toBe(43);
+    });
+  });
+
+  // ==========================================================================
+  // createPairingPayload()
+  // ==========================================================================
+
+  describe('createPairingPayload()', () => {
+    it('creates a valid payload with version 1', () => {
+      const payload = createPairingPayload(
+        'test-token',
+        'user-123',
+        'machine-456',
+        'My MacBook',
+        'https://example.supabase.co'
+      );
+
+      expect(payload.version).toBe(1);
+    });
+
+    it('includes all provided fields', () => {
+      const payload = createPairingPayload(
+        'test-token',
+        'user-123',
+        'machine-456',
+        'My MacBook',
+        'https://example.supabase.co',
+        'claude'
+      );
+
+      expect(payload.token).toBe('test-token');
+      expect(payload.userId).toBe('user-123');
+      expect(payload.machineId).toBe('machine-456');
+      expect(payload.deviceName).toBe('My MacBook');
+      expect(payload.supabaseUrl).toBe('https://example.supabase.co');
+      expect(payload.activeAgent).toBe('claude');
+    });
+
+    it('sets activeAgent as undefined when not provided', () => {
+      const payload = createPairingPayload(
+        'test-token',
+        'user-123',
+        'machine-456',
+        'My MacBook',
+        'https://example.supabase.co'
+      );
+
+      expect(payload.activeAgent).toBeUndefined();
+    });
+
+    it('sets expiresAt to 5 minutes in the future', () => {
+      const before = Date.now();
+      const payload = createPairingPayload(
+        'test-token',
+        'user-123',
+        'machine-456',
+        'My MacBook',
+        'https://example.supabase.co'
+      );
+      const after = Date.now();
+
+      const expiresAt = new Date(payload.expiresAt).getTime();
+      // Should be ~5 minutes from now
+      expect(expiresAt).toBeGreaterThanOrEqual(before + PAIRING_TOKEN_EXPIRY_MS);
+      expect(expiresAt).toBeLessThanOrEqual(after + PAIRING_TOKEN_EXPIRY_MS);
+    });
+
+    it('returns a valid ISO timestamp for expiresAt', () => {
+      const payload = createPairingPayload(
+        'test-token',
+        'user-123',
+        'machine-456',
+        'My MacBook',
+        'https://example.supabase.co'
+      );
+
+      const parsed = new Date(payload.expiresAt);
+      expect(parsed.toISOString()).toBe(payload.expiresAt);
+    });
+  });
+
+  // ==========================================================================
+  // encodePairingUrl() + decodePairingUrl() Round-Trip
+  // ==========================================================================
+
+  describe('encodePairingUrl() + decodePairingUrl() round-trip', () => {
+    it('encodes and decodes a full payload', () => {
+      const payload = createPairingPayload(
+        'test-token-abc123',
+        'user-id-456',
+        'machine-id-789',
+        'Test MacBook Pro',
+        'https://test.supabase.co',
+        'claude'
+      );
+
+      const url = encodePairingUrl(payload);
+      const decoded = decodePairingUrl(url);
+
+      expect(decoded).not.toBeNull();
+      expect(decoded!.version).toBe(payload.version);
+      expect(decoded!.token).toBe(payload.token);
+      expect(decoded!.userId).toBe(payload.userId);
+      expect(decoded!.machineId).toBe(payload.machineId);
+      expect(decoded!.deviceName).toBe(payload.deviceName);
+      expect(decoded!.supabaseUrl).toBe(payload.supabaseUrl);
+      expect(decoded!.activeAgent).toBe(payload.activeAgent);
+      expect(decoded!.expiresAt).toBe(payload.expiresAt);
+    });
+
+    it('creates a URL starting with styrby://pair', () => {
+      const payload = createPairingPayload(
+        'token',
+        'user',
+        'machine',
+        'device',
+        'https://test.supabase.co'
+      );
+
+      const url = encodePairingUrl(payload);
+      expect(url.startsWith('styrby://pair')).toBe(true);
+    });
+
+    it('includes a data query parameter', () => {
+      const payload = createPairingPayload(
+        'token',
+        'user',
+        'machine',
+        'device',
+        'https://test.supabase.co'
+      );
+
+      const url = encodePairingUrl(payload);
+      expect(url).toContain('?data=');
+    });
+
+    it('handles special characters in device name', () => {
+      const payload = createPairingPayload(
+        'token',
+        'user',
+        'machine',
+        "John's MacBook Pro (2024)",
+        'https://test.supabase.co'
+      );
+
+      const url = encodePairingUrl(payload);
+      const decoded = decodePairingUrl(url);
+
+      expect(decoded).not.toBeNull();
+      expect(decoded!.deviceName).toBe("John's MacBook Pro (2024)");
+    });
+  });
+
+  // ==========================================================================
+  // decodePairingUrl() Edge Cases
+  // ==========================================================================
+
+  describe('decodePairingUrl() edge cases', () => {
+    it('returns null for completely invalid data', () => {
+      expect(decodePairingUrl('not-a-valid-url')).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(decodePairingUrl('')).toBeNull();
+    });
+
+    it('returns null for a URL with invalid base64 data', () => {
+      expect(decodePairingUrl('styrby://pair?data=!!!invalid!!!')).toBeNull();
+    });
+
+    it('returns null for a URL with valid base64 but invalid JSON', () => {
+      const invalidJson = btoa('not json');
+      expect(decodePairingUrl(`styrby://pair?data=${encodeURIComponent(invalidJson)}`)).toBeNull();
+    });
+
+    it('returns null for a URL with valid JSON but wrong version', () => {
+      const wrongVersion = btoa(JSON.stringify({ version: 2, token: 'abc' }));
+      expect(decodePairingUrl(`styrby://pair?data=${encodeURIComponent(wrongVersion)}`)).toBeNull();
+    });
+
+    it('returns null for a URL with missing data parameter', () => {
+      expect(decodePairingUrl('styrby://pair?other=value')).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // isPairingExpired()
+  // ==========================================================================
+
+  describe('isPairingExpired()', () => {
+    it('returns false for a freshly created payload', () => {
+      const payload = createPairingPayload(
+        'token',
+        'user',
+        'machine',
+        'device',
+        'https://test.supabase.co'
+      );
+
+      expect(isPairingExpired(payload)).toBe(false);
+    });
+
+    it('returns true for a payload with expiresAt in the past', () => {
+      const payload = createPairingPayload(
+        'token',
+        'user',
+        'machine',
+        'device',
+        'https://test.supabase.co'
+      );
+      // Override expiresAt to the past
+      payload.expiresAt = new Date(Date.now() - 60000).toISOString();
+
+      expect(isPairingExpired(payload)).toBe(true);
+    });
+
+    it('returns true for a payload that expired 5 minutes ago', () => {
+      const payload = createPairingPayload(
+        'token',
+        'user',
+        'machine',
+        'device',
+        'https://test.supabase.co'
+      );
+      payload.expiresAt = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+      expect(isPairingExpired(payload)).toBe(true);
+    });
+
+    it('returns false for a payload that expires 1 hour from now', () => {
+      const payload = createPairingPayload(
+        'token',
+        'user',
+        'machine',
+        'device',
+        'https://test.supabase.co'
+      );
+      payload.expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+      expect(isPairingExpired(payload)).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // validatePairingPayload()
+  // ==========================================================================
+
+  describe('validatePairingPayload()', () => {
+    it('returns true for a valid payload', () => {
+      const payload = createPairingPayload(
+        'token',
+        'user',
+        'machine',
+        'device',
+        'https://test.supabase.co'
+      );
+
+      expect(validatePairingPayload(payload)).toBe(true);
+    });
+
+    it('returns true for a valid payload with activeAgent', () => {
+      const payload = createPairingPayload(
+        'token',
+        'user',
+        'machine',
+        'device',
+        'https://test.supabase.co',
+        'claude'
+      );
+
+      expect(validatePairingPayload(payload)).toBe(true);
+    });
+
+    it('rejects null', () => {
+      expect(validatePairingPayload(null)).toBe(false);
+    });
+
+    it('rejects undefined', () => {
+      expect(validatePairingPayload(undefined)).toBe(false);
+    });
+
+    it('rejects a non-object', () => {
+      expect(validatePairingPayload('string')).toBe(false);
+      expect(validatePairingPayload(42)).toBe(false);
+      expect(validatePairingPayload(true)).toBe(false);
+    });
+
+    it('rejects payload with missing token', () => {
+      expect(validatePairingPayload({
+        version: 1,
+        userId: 'user',
+        machineId: 'machine',
+        deviceName: 'device',
+        supabaseUrl: 'https://test.supabase.co',
+        expiresAt: new Date().toISOString(),
+      })).toBe(false);
+    });
+
+    it('rejects payload with missing userId', () => {
+      expect(validatePairingPayload({
+        version: 1,
+        token: 'token',
+        machineId: 'machine',
+        deviceName: 'device',
+        supabaseUrl: 'https://test.supabase.co',
+        expiresAt: new Date().toISOString(),
+      })).toBe(false);
+    });
+
+    it('rejects payload with missing machineId', () => {
+      expect(validatePairingPayload({
+        version: 1,
+        token: 'token',
+        userId: 'user',
+        deviceName: 'device',
+        supabaseUrl: 'https://test.supabase.co',
+        expiresAt: new Date().toISOString(),
+      })).toBe(false);
+    });
+
+    it('rejects payload with missing deviceName', () => {
+      expect(validatePairingPayload({
+        version: 1,
+        token: 'token',
+        userId: 'user',
+        machineId: 'machine',
+        supabaseUrl: 'https://test.supabase.co',
+        expiresAt: new Date().toISOString(),
+      })).toBe(false);
+    });
+
+    it('rejects payload with missing supabaseUrl', () => {
+      expect(validatePairingPayload({
+        version: 1,
+        token: 'token',
+        userId: 'user',
+        machineId: 'machine',
+        deviceName: 'device',
+        expiresAt: new Date().toISOString(),
+      })).toBe(false);
+    });
+
+    it('rejects payload with missing expiresAt', () => {
+      expect(validatePairingPayload({
+        version: 1,
+        token: 'token',
+        userId: 'user',
+        machineId: 'machine',
+        deviceName: 'device',
+        supabaseUrl: 'https://test.supabase.co',
+      })).toBe(false);
+    });
+
+    it('rejects payload with wrong version', () => {
+      expect(validatePairingPayload({
+        version: 2,
+        token: 'token',
+        userId: 'user',
+        machineId: 'machine',
+        deviceName: 'device',
+        supabaseUrl: 'https://test.supabase.co',
+        expiresAt: new Date().toISOString(),
+      })).toBe(false);
+    });
+
+    it('rejects payload with non-string field types', () => {
+      expect(validatePairingPayload({
+        version: 1,
+        token: 123, // should be string
+        userId: 'user',
+        machineId: 'machine',
+        deviceName: 'device',
+        supabaseUrl: 'https://test.supabase.co',
+        expiresAt: new Date().toISOString(),
+      })).toBe(false);
+    });
+
+    it('rejects an empty object', () => {
+      expect(validatePairingPayload({})).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // hashPairingToken()
+  // ==========================================================================
+
+  describe('hashPairingToken()', () => {
+    it('returns a hex string', async () => {
+      const hash = await hashPairingToken('test-token');
+      expect(typeof hash).toBe('string');
+      expect(hash).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('returns a 64-character hex string (SHA-256 = 32 bytes = 64 hex chars)', async () => {
+      const hash = await hashPairingToken('test-token');
+      expect(hash.length).toBe(64);
+    });
+
+    it('returns the same hash for the same input', async () => {
+      const hash1 = await hashPairingToken('identical-token');
+      const hash2 = await hashPairingToken('identical-token');
+      expect(hash1).toBe(hash2);
+    });
+
+    it('returns different hashes for different inputs', async () => {
+      const hash1 = await hashPairingToken('token-one');
+      const hash2 = await hashPairingToken('token-two');
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('produces only lowercase hex characters', async () => {
+      const hash = await hashPairingToken('test-token');
+      expect(hash).toBe(hash.toLowerCase());
+    });
+  });
+
+  // ==========================================================================
+  // Constants
+  // ==========================================================================
+
+  describe('Pairing Constants', () => {
+    it('PAIRING_EXPIRY_MINUTES is 5', () => {
+      expect(PAIRING_EXPIRY_MINUTES).toBe(5);
+    });
+
+    it('PAIRING_TOKEN_EXPIRY_MS is 5 minutes in milliseconds', () => {
+      expect(PAIRING_TOKEN_EXPIRY_MS).toBe(5 * 60 * 1000);
+      expect(PAIRING_TOKEN_EXPIRY_MS).toBe(300000);
+    });
+
+    it('PAIRING_SCHEME is styrby://pair', () => {
+      expect(PAIRING_SCHEME).toBe('styrby://pair');
+    });
+  });
+});

--- a/packages/styrby-shared/tests/utils/api-keys.test.ts
+++ b/packages/styrby-shared/tests/utils/api-keys.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for the API Key Generation Utilities
+ *
+ * Validates API key generation, formatting, validation, prefix extraction,
+ * and masking for Styrby's Power tier API access feature.
+ *
+ * Key format: "styrby_" + 32 random alphanumeric characters
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generateApiKey,
+  generateRandomString,
+  extractApiKeyPrefix,
+  isValidApiKeyFormat,
+  maskApiKey,
+  API_KEY_PREFIX,
+  API_KEY_RANDOM_LENGTH,
+} from '../../src/utils/api-keys';
+
+describe('API Key Utilities', () => {
+  // ==========================================================================
+  // generateApiKey()
+  // ==========================================================================
+
+  describe('generateApiKey()', () => {
+    it('returns an object with key, prefix, and randomPart', () => {
+      const result = generateApiKey();
+      expect(result).toHaveProperty('key');
+      expect(result).toHaveProperty('prefix');
+      expect(result).toHaveProperty('randomPart');
+    });
+
+    it('returns a key that starts with the styrby_ prefix', () => {
+      const result = generateApiKey();
+      expect(result.key.startsWith('styrby_')).toBe(true);
+    });
+
+    it('returns the correct prefix value', () => {
+      const result = generateApiKey();
+      expect(result.prefix).toBe('styrby_');
+      expect(result.prefix).toBe(API_KEY_PREFIX);
+    });
+
+    it('returns a randomPart of 32 characters', () => {
+      const result = generateApiKey();
+      expect(result.randomPart.length).toBe(32);
+      expect(result.randomPart.length).toBe(API_KEY_RANDOM_LENGTH);
+    });
+
+    it('returns a key whose length is prefix + random part', () => {
+      const result = generateApiKey();
+      expect(result.key.length).toBe(API_KEY_PREFIX.length + API_KEY_RANDOM_LENGTH);
+    });
+
+    it('returns a key composed of prefix + randomPart', () => {
+      const result = generateApiKey();
+      expect(result.key).toBe(`${result.prefix}${result.randomPart}`);
+    });
+
+    it('generates unique keys on each call', () => {
+      const key1 = generateApiKey();
+      const key2 = generateApiKey();
+      expect(key1.key).not.toBe(key2.key);
+      expect(key1.randomPart).not.toBe(key2.randomPart);
+    });
+  });
+
+  // ==========================================================================
+  // generateRandomString()
+  // ==========================================================================
+
+  describe('generateRandomString()', () => {
+    it('returns a string of the requested length', () => {
+      expect(generateRandomString(10).length).toBe(10);
+      expect(generateRandomString(32).length).toBe(32);
+      expect(generateRandomString(64).length).toBe(64);
+    });
+
+    it('returns an empty string for length 0', () => {
+      expect(generateRandomString(0)).toBe('');
+    });
+
+    it('returns only alphanumeric characters', () => {
+      const result = generateRandomString(100);
+      // The ALPHABET used excludes ambiguous characters (0, O, l, 1)
+      // but all chars should be alphanumeric
+      expect(result).toMatch(/^[a-zA-Z0-9]+$/);
+    });
+
+    it('produces different strings on repeated calls', () => {
+      const results = new Set<string>();
+      for (let i = 0; i < 20; i++) {
+        results.add(generateRandomString(32));
+      }
+      // With 32 chars from 57-char alphabet, collisions are astronomically unlikely
+      expect(results.size).toBe(20);
+    });
+  });
+
+  // ==========================================================================
+  // extractApiKeyPrefix()
+  // ==========================================================================
+
+  describe('extractApiKeyPrefix()', () => {
+    it('returns the prefix for a valid key', () => {
+      const { key } = generateApiKey();
+      const prefix = extractApiKeyPrefix(key);
+      expect(prefix).toBe('styrby_');
+    });
+
+    it('returns the prefix for any string starting with styrby_', () => {
+      expect(extractApiKeyPrefix('styrby_anything')).toBe('styrby_');
+    });
+
+    it('returns null for a key with wrong prefix', () => {
+      expect(extractApiKeyPrefix('invalid_abc123')).toBeNull();
+    });
+
+    it('returns null for an empty string', () => {
+      expect(extractApiKeyPrefix('')).toBeNull();
+    });
+
+    it('returns null for null/undefined input', () => {
+      // @ts-expect-error -- testing runtime behavior with invalid input
+      expect(extractApiKeyPrefix(null)).toBeNull();
+      // @ts-expect-error -- testing runtime behavior with invalid input
+      expect(extractApiKeyPrefix(undefined)).toBeNull();
+    });
+
+    it('returns null for non-string input', () => {
+      // @ts-expect-error -- testing runtime behavior with invalid input
+      expect(extractApiKeyPrefix(12345)).toBeNull();
+      // @ts-expect-error -- testing runtime behavior with invalid input
+      expect(extractApiKeyPrefix({})).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // isValidApiKeyFormat()
+  // ==========================================================================
+
+  describe('isValidApiKeyFormat()', () => {
+    it('returns true for a correctly formatted key', () => {
+      const { key } = generateApiKey();
+      expect(isValidApiKeyFormat(key)).toBe(true);
+    });
+
+    it('returns true for multiple generated keys', () => {
+      for (let i = 0; i < 10; i++) {
+        const { key } = generateApiKey();
+        expect(isValidApiKeyFormat(key)).toBe(true);
+      }
+    });
+
+    it('rejects a key with wrong prefix', () => {
+      expect(isValidApiKeyFormat('wrong_abcdefghijklmnopqrstuvwxyz123456')).toBe(false);
+    });
+
+    it('rejects a key with correct prefix but wrong random length (too short)', () => {
+      expect(isValidApiKeyFormat('styrby_short')).toBe(false);
+    });
+
+    it('rejects a key with correct prefix but wrong random length (too long)', () => {
+      expect(isValidApiKeyFormat('styrby_' + 'a'.repeat(64))).toBe(false);
+    });
+
+    it('rejects an empty string', () => {
+      expect(isValidApiKeyFormat('')).toBe(false);
+    });
+
+    it('rejects null input', () => {
+      // @ts-expect-error -- testing runtime behavior with invalid input
+      expect(isValidApiKeyFormat(null)).toBe(false);
+    });
+
+    it('rejects undefined input', () => {
+      // @ts-expect-error -- testing runtime behavior with invalid input
+      expect(isValidApiKeyFormat(undefined)).toBe(false);
+    });
+
+    it('rejects a key with special characters in the random part', () => {
+      expect(isValidApiKeyFormat('styrby_abcdefgh!@#$%^&*()ijklmnop12')).toBe(false);
+    });
+
+    it('rejects just the prefix with no random part', () => {
+      expect(isValidApiKeyFormat('styrby_')).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // maskApiKey()
+  // ==========================================================================
+
+  describe('maskApiKey()', () => {
+    it('masks the middle of a valid key showing first 4 and last 4 of random part', () => {
+      const { key } = generateApiKey();
+      const masked = maskApiKey(key);
+
+      // Should start with prefix + first 4 chars of random
+      expect(masked.startsWith('styrby_')).toBe(true);
+      expect(masked).toContain('...');
+
+      // Extract the visible parts
+      const parts = masked.split('...');
+      expect(parts.length).toBe(2);
+      // First part: "styrby_" + first 4 chars
+      expect(parts[0].length).toBe(API_KEY_PREFIX.length + 4);
+      // Last part: last 4 chars
+      expect(parts[1].length).toBe(4);
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(maskApiKey('')).toBe('');
+    });
+
+    it('returns empty string for null input', () => {
+      // @ts-expect-error -- testing runtime behavior with invalid input
+      expect(maskApiKey(null)).toBe('');
+    });
+
+    it('returns empty string for undefined input', () => {
+      // @ts-expect-error -- testing runtime behavior with invalid input
+      expect(maskApiKey(undefined)).toBe('');
+    });
+
+    it('masks short keys without a valid prefix', () => {
+      // Keys <= 8 chars without a valid prefix get fully masked
+      expect(maskApiKey('short')).toBe('********');
+      expect(maskApiKey('12345678')).toBe('********');
+    });
+
+    it('partially masks longer keys without a valid prefix', () => {
+      const masked = maskApiKey('invalid_key_that_is_long_enough');
+      expect(masked.startsWith('inva')).toBe(true);
+      expect(masked).toContain('...');
+      expect(masked.endsWith('ough')).toBe(true);
+    });
+
+    it('handles a key with valid prefix but short random part', () => {
+      const masked = maskApiKey('styrby_abcd');
+      // Random part is 4 chars, which is <= 8, so returns prefix + ****
+      expect(masked).toBe('styrby_****');
+    });
+  });
+
+  // ==========================================================================
+  // Constants
+  // ==========================================================================
+
+  describe('API Key Constants', () => {
+    it('API_KEY_PREFIX is styrby_', () => {
+      expect(API_KEY_PREFIX).toBe('styrby_');
+    });
+
+    it('API_KEY_RANDOM_LENGTH is 32', () => {
+      expect(API_KEY_RANDOM_LENGTH).toBe(32);
+    });
+  });
+});

--- a/packages/styrby-shared/tests/utils/notification-priority.test.ts
+++ b/packages/styrby-shared/tests/utils/notification-priority.test.ts
@@ -1,0 +1,537 @@
+/**
+ * Tests for the Smart Notification Priority Scoring Module
+ *
+ * Validates priority calculation (1-5 scale), notification filtering
+ * based on tier/threshold, percentage estimates, and threshold descriptions.
+ *
+ * Priority Scale:
+ *   1 = Critical/Urgent
+ *   2 = High
+ *   3 = Medium
+ *   4 = Normal
+ *   5 = Informational
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  calculateNotificationPriority,
+  calculateNotificationPriorityDetailed,
+  shouldSendNotification,
+  getEstimatedNotificationPercentage,
+  getThresholdDescription,
+} from '../../src/utils/notification-priority';
+
+describe('Notification Priority Module', () => {
+  // ==========================================================================
+  // calculateNotificationPriority()
+  // ==========================================================================
+
+  describe('calculateNotificationPriority()', () => {
+    it('returns a number between 1 and 5', () => {
+      const priority = calculateNotificationPriority({
+        type: 'session_started',
+      });
+      expect(priority).toBeGreaterThanOrEqual(1);
+      expect(priority).toBeLessThanOrEqual(5);
+    });
+
+    it('returns 1 for budget_exceeded (always critical)', () => {
+      const priority = calculateNotificationPriority({
+        type: 'budget_exceeded',
+      });
+      expect(priority).toBe(1);
+    });
+
+    it('returns 5 for session_started (always informational)', () => {
+      const priority = calculateNotificationPriority({
+        type: 'session_started',
+      });
+      expect(priority).toBe(5);
+    });
+
+    it('returns 1 for permission_request with high risk and dangerous tool', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'high',
+        toolName: 'bash',
+      });
+      // Base 2 + risk(-1) + tool(-1) = 0, clamped to 1
+      expect(priority).toBe(1);
+    });
+
+    it('returns 3 or 4 for permission_request with low risk', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'low',
+      });
+      // Base 2 + low risk(+1) = 3
+      expect(priority).toBeGreaterThanOrEqual(3);
+      expect(priority).toBeLessThanOrEqual(4);
+    });
+
+    it('gives session_completed with high cost a lower priority number (more urgent)', () => {
+      const highCost = calculateNotificationPriority({
+        type: 'session_completed',
+        costUsd: 15.0,
+      });
+      const lowCost = calculateNotificationPriority({
+        type: 'session_completed',
+        costUsd: 0.10,
+      });
+      // High cost should have lower priority number (more urgent)
+      expect(highCost).toBeLessThan(lowCost);
+    });
+
+    it('gives session_completed with long duration a lower priority number (more urgent)', () => {
+      const longSession = calculateNotificationPriority({
+        type: 'session_completed',
+        sessionDurationMs: 2 * 60 * 60 * 1000, // 2 hours
+      });
+      const shortSession = calculateNotificationPriority({
+        type: 'session_completed',
+        sessionDurationMs: 5 * 60 * 1000, // 5 minutes
+      });
+      // Longer session should have lower priority number (more urgent)
+      expect(longSession).toBeLessThan(shortSession);
+    });
+
+    it('clamps results that would go below 1 to 1', () => {
+      // This combination would produce a negative raw score:
+      // budget_exceeded (1) + high cost(-2) = -1, clamped to 1
+      const priority = calculateNotificationPriority({
+        type: 'budget_exceeded',
+        costUsd: 50.0,
+      });
+      expect(priority).toBe(1);
+    });
+
+    it('clamps results that would go above 5 to 5', () => {
+      // session_started (5) + low cost(+1) = 6, clamped to 5
+      const priority = calculateNotificationPriority({
+        type: 'session_started',
+        costUsd: 0.01,
+      });
+      expect(priority).toBe(5);
+    });
+
+    it('returns base priority 2 for session_error', () => {
+      const priority = calculateNotificationPriority({
+        type: 'session_error',
+      });
+      expect(priority).toBe(2);
+    });
+
+    it('returns base priority 2 for budget_warning', () => {
+      const priority = calculateNotificationPriority({
+        type: 'budget_warning',
+      });
+      expect(priority).toBe(2);
+    });
+  });
+
+  // ==========================================================================
+  // Permission Request Priority Scenarios
+  // ==========================================================================
+
+  describe('permission_request priority scenarios', () => {
+    it('high risk + dangerous tool (bash) = priority 1', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'high',
+        toolName: 'bash',
+      });
+      expect(priority).toBe(1);
+    });
+
+    it('high risk + dangerous tool (write_file) = priority 1', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'high',
+        toolName: 'write_file',
+      });
+      expect(priority).toBe(1);
+    });
+
+    it('high risk + safe tool = priority 1', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'high',
+        toolName: 'read_file',
+      });
+      // Base 2 + high risk(-1) = 1
+      expect(priority).toBe(1);
+    });
+
+    it('medium risk + no specific tool = priority 2', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'medium',
+      });
+      // Base 2 + medium risk(0) = 2
+      expect(priority).toBe(2);
+    });
+
+    it('low risk + safe tool = priority 3', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'low',
+        toolName: 'read_file',
+      });
+      // Base 2 + low risk(+1) = 3
+      expect(priority).toBe(3);
+    });
+
+    it('recognizes tools containing "execute" as dangerous', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'medium',
+        toolName: 'execute_command',
+      });
+      // Base 2 + medium risk(0) + dangerous tool(-1) = 1
+      expect(priority).toBe(1);
+    });
+
+    it('recognizes tools containing "delete" as dangerous', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'medium',
+        toolName: 'delete_record',
+      });
+      // Base 2 + medium risk(0) + dangerous tool(-1) = 1
+      expect(priority).toBe(1);
+    });
+
+    it('recognizes tools containing "write" as dangerous', () => {
+      const priority = calculateNotificationPriority({
+        type: 'permission_request',
+        riskLevel: 'medium',
+        toolName: 'overwrite_config',
+      });
+      // Base 2 + medium risk(0) + dangerous tool(-1) = 1
+      expect(priority).toBe(1);
+    });
+  });
+
+  // ==========================================================================
+  // Cost and Duration Scenarios
+  // ==========================================================================
+
+  describe('cost and duration adjustments', () => {
+    it('high cost (>$10) lowers priority number by 2', () => {
+      const withCost = calculateNotificationPriority({
+        type: 'session_completed',
+        costUsd: 15.0,
+      });
+      const basePriority = calculateNotificationPriority({
+        type: 'session_completed',
+      });
+      // Base 4 + cost(-2) = 2
+      expect(withCost).toBe(basePriority - 2);
+    });
+
+    it('moderate cost ($5-$10) lowers priority number by 1', () => {
+      const withCost = calculateNotificationPriority({
+        type: 'session_completed',
+        costUsd: 7.50,
+      });
+      const basePriority = calculateNotificationPriority({
+        type: 'session_completed',
+      });
+      // Base 4 + cost(-1) = 3
+      expect(withCost).toBe(basePriority - 1);
+    });
+
+    it('low cost (<$1) raises priority number by 1 (less urgent)', () => {
+      const withCost = calculateNotificationPriority({
+        type: 'session_completed',
+        costUsd: 0.25,
+      });
+      // Base 4 + cost(+1) = 5
+      expect(withCost).toBe(5);
+    });
+
+    it('long session duration (>1hr) lowers priority number by 1', () => {
+      const longSession = calculateNotificationPriority({
+        type: 'session_completed',
+        sessionDurationMs: 2 * 60 * 60 * 1000,
+      });
+      // Base 4 + duration(-1) = 3
+      expect(longSession).toBe(3);
+    });
+
+    it('short session duration (<30min) raises priority number by 1', () => {
+      const shortSession = calculateNotificationPriority({
+        type: 'session_completed',
+        sessionDurationMs: 5 * 60 * 1000,
+      });
+      // Base 4 + duration(+1) = 5
+      expect(shortSession).toBe(5);
+    });
+
+    it('duration adjustment only applies to session_completed', () => {
+      // session_error with long duration should not get duration adjustment
+      const errorPriority = calculateNotificationPriority({
+        type: 'session_error',
+        sessionDurationMs: 2 * 60 * 60 * 1000,
+      });
+      // Base 2, no duration adjustment for non-session_completed
+      expect(errorPriority).toBe(2);
+    });
+  });
+
+  // ==========================================================================
+  // shouldSendNotification()
+  // ==========================================================================
+
+  describe('shouldSendNotification()', () => {
+    it('returns true for free tier regardless of priority', () => {
+      expect(shouldSendNotification(1, 1, false)).toBe(true);
+      expect(shouldSendNotification(3, 1, false)).toBe(true);
+      expect(shouldSendNotification(5, 1, false)).toBe(true);
+    });
+
+    it('returns true for free tier even with threshold 1', () => {
+      expect(shouldSendNotification(5, 1, false)).toBe(true);
+    });
+
+    it('filters correctly for paid tier - sends when priority <= threshold', () => {
+      // Priority 2, threshold 3 -> should send (2 <= 3)
+      expect(shouldSendNotification(2, 3, true)).toBe(true);
+    });
+
+    it('filters correctly for paid tier - blocks when priority > threshold', () => {
+      // Priority 4, threshold 2 -> should not send (4 > 2)
+      expect(shouldSendNotification(4, 2, true)).toBe(false);
+    });
+
+    it('sends when priority equals threshold (paid tier)', () => {
+      expect(shouldSendNotification(3, 3, true)).toBe(true);
+    });
+
+    it('blocks priority 5 when threshold is 1 (paid tier)', () => {
+      expect(shouldSendNotification(5, 1, true)).toBe(false);
+    });
+
+    it('sends priority 1 for any threshold (paid tier)', () => {
+      expect(shouldSendNotification(1, 1, true)).toBe(true);
+      expect(shouldSendNotification(1, 3, true)).toBe(true);
+      expect(shouldSendNotification(1, 5, true)).toBe(true);
+    });
+
+    it('sends all when threshold is 5 (paid tier)', () => {
+      expect(shouldSendNotification(1, 5, true)).toBe(true);
+      expect(shouldSendNotification(3, 5, true)).toBe(true);
+      expect(shouldSendNotification(5, 5, true)).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // getEstimatedNotificationPercentage()
+  // ==========================================================================
+
+  describe('getEstimatedNotificationPercentage()', () => {
+    it('returns 5 for threshold 1 (only critical)', () => {
+      expect(getEstimatedNotificationPercentage(1)).toBe(5);
+    });
+
+    it('returns 15 for threshold 2 (high priority)', () => {
+      expect(getEstimatedNotificationPercentage(2)).toBe(15);
+    });
+
+    it('returns 50 for threshold 3 (medium priority)', () => {
+      expect(getEstimatedNotificationPercentage(3)).toBe(50);
+    });
+
+    it('returns 85 for threshold 4 (most notifications)', () => {
+      expect(getEstimatedNotificationPercentage(4)).toBe(85);
+    });
+
+    it('returns 100 for threshold 5 (all notifications)', () => {
+      expect(getEstimatedNotificationPercentage(5)).toBe(100);
+    });
+
+    it('returns 50 for an out-of-range threshold', () => {
+      expect(getEstimatedNotificationPercentage(0)).toBe(50);
+      expect(getEstimatedNotificationPercentage(6)).toBe(50);
+      expect(getEstimatedNotificationPercentage(-1)).toBe(50);
+    });
+
+    it('returns increasing percentages as threshold increases', () => {
+      const pct1 = getEstimatedNotificationPercentage(1);
+      const pct2 = getEstimatedNotificationPercentage(2);
+      const pct3 = getEstimatedNotificationPercentage(3);
+      const pct4 = getEstimatedNotificationPercentage(4);
+      const pct5 = getEstimatedNotificationPercentage(5);
+
+      expect(pct1).toBeLessThan(pct2);
+      expect(pct2).toBeLessThan(pct3);
+      expect(pct3).toBeLessThan(pct4);
+      expect(pct4).toBeLessThan(pct5);
+    });
+  });
+
+  // ==========================================================================
+  // getThresholdDescription()
+  // ==========================================================================
+
+  describe('getThresholdDescription()', () => {
+    it('returns a string for each valid threshold', () => {
+      for (let i = 1; i <= 5; i++) {
+        const description = getThresholdDescription(i);
+        expect(typeof description).toBe('string');
+        expect(description.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('returns "Urgent only" for threshold 1', () => {
+      expect(getThresholdDescription(1)).toBe('Urgent only');
+    });
+
+    it('returns "High priority" for threshold 2', () => {
+      expect(getThresholdDescription(2)).toBe('High priority');
+    });
+
+    it('returns "Medium priority" for threshold 3', () => {
+      expect(getThresholdDescription(3)).toBe('Medium priority');
+    });
+
+    it('returns "Most notifications" for threshold 4', () => {
+      expect(getThresholdDescription(4)).toBe('Most notifications');
+    });
+
+    it('returns "All notifications" for threshold 5', () => {
+      expect(getThresholdDescription(5)).toBe('All notifications');
+    });
+
+    it('returns "Unknown" for out-of-range thresholds', () => {
+      expect(getThresholdDescription(0)).toBe('Unknown');
+      expect(getThresholdDescription(6)).toBe('Unknown');
+      expect(getThresholdDescription(-1)).toBe('Unknown');
+    });
+  });
+
+  // ==========================================================================
+  // calculateNotificationPriorityDetailed()
+  // ==========================================================================
+
+  describe('calculateNotificationPriorityDetailed()', () => {
+    it('returns an object with priority, reason, and factors', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'session_started',
+      });
+
+      expect(result).toHaveProperty('priority');
+      expect(result).toHaveProperty('reason');
+      expect(result).toHaveProperty('factors');
+    });
+
+    it('returns factors with all expected fields', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'session_started',
+      });
+
+      expect(result.factors).toHaveProperty('basePriority');
+      expect(result.factors).toHaveProperty('riskAdjustment');
+      expect(result.factors).toHaveProperty('costAdjustment');
+      expect(result.factors).toHaveProperty('durationAdjustment');
+      expect(result.factors).toHaveProperty('toolAdjustment');
+    });
+
+    it('returns correct base priority for each event type', () => {
+      const types: Array<{ type: 'permission_request' | 'session_started' | 'session_completed' | 'session_error' | 'budget_warning' | 'budget_exceeded'; base: number }> = [
+        { type: 'permission_request', base: 2 },
+        { type: 'session_started', base: 5 },
+        { type: 'session_completed', base: 4 },
+        { type: 'session_error', base: 2 },
+        { type: 'budget_warning', base: 2 },
+        { type: 'budget_exceeded', base: 1 },
+      ];
+
+      for (const { type, base } of types) {
+        const result = calculateNotificationPriorityDetailed({ type });
+        expect(result.factors.basePriority).toBe(base);
+      }
+    });
+
+    it('shows risk adjustment of -1 for high-risk permission request', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'permission_request',
+        riskLevel: 'high',
+      });
+      expect(result.factors.riskAdjustment).toBe(-1);
+    });
+
+    it('shows risk adjustment of +1 for low-risk permission request', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'permission_request',
+        riskLevel: 'low',
+      });
+      expect(result.factors.riskAdjustment).toBe(1);
+    });
+
+    it('shows risk adjustment of 0 for medium-risk permission request', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'permission_request',
+        riskLevel: 'medium',
+      });
+      expect(result.factors.riskAdjustment).toBe(0);
+    });
+
+    it('shows tool adjustment of -1 for dangerous tool', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'permission_request',
+        toolName: 'bash',
+      });
+      expect(result.factors.toolAdjustment).toBe(-1);
+    });
+
+    it('shows tool adjustment of 0 for safe tool', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'permission_request',
+        toolName: 'read_file',
+      });
+      expect(result.factors.toolAdjustment).toBe(0);
+    });
+
+    it('shows cost adjustment of -2 for high cost (>$10)', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'session_completed',
+        costUsd: 15.0,
+      });
+      expect(result.factors.costAdjustment).toBe(-2);
+    });
+
+    it('shows cost adjustment of -1 for moderate cost ($5-$10)', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'session_completed',
+        costUsd: 7.50,
+      });
+      expect(result.factors.costAdjustment).toBe(-1);
+    });
+
+    it('includes a reason string', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'budget_exceeded',
+      });
+      expect(typeof result.reason).toBe('string');
+      expect(result.reason.length).toBeGreaterThan(0);
+      expect(result.reason).toContain('Budget exceeded');
+    });
+
+    it('includes tool name in reason when dangerous tool is used', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'permission_request',
+        toolName: 'bash',
+      });
+      expect(result.reason).toContain('bash');
+    });
+
+    it('includes cost amount in reason when cost is notable', () => {
+      const result = calculateNotificationPriorityDetailed({
+        type: 'session_completed',
+        costUsd: 12.50,
+      });
+      expect(result.reason).toContain('12.50');
+    });
+  });
+});

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/summary-tab.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/summary-tab.test.tsx
@@ -13,7 +13,7 @@
  * Bugs here could leak Pro-only content to free users or show wrong states.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SummaryTab } from '../summary-tab';
 

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/summary-tab.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/summary-tab.test.tsx
@@ -1,0 +1,334 @@
+/**
+ * Session Summary Tab Component Tests
+ *
+ * Tests all 5 render states of the SummaryTab component:
+ * 1. Free tier upgrade prompt (shows Lock icon + pricing link)
+ * 2. Active session placeholder (no summary yet)
+ * 3. Generating state (animated clock, session completed but no summary)
+ * 4. No summary available (old session with summaryGeneratedAt but no text)
+ * 5. Summary available (collapsible card with AI summary text)
+ *
+ * WHY: The SummaryTab has complex conditional rendering based on
+ * userTier, sessionStatus, summary presence, and summaryGeneratedAt.
+ * Bugs here could leak Pro-only content to free users or show wrong states.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SummaryTab } from '../summary-tab';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+/**
+ * Mock next/link to render a plain <a> tag for testing.
+ */
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const BASE_PROPS = {
+  sessionId: 'session-uuid-001',
+  summary: null as string | null,
+  summaryGeneratedAt: null as string | null,
+  sessionStatus: 'stopped',
+  userTier: 'pro' as const,
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SummaryTab', () => {
+  describe('Free tier upgrade prompt', () => {
+    it('renders upgrade prompt for free tier users', () => {
+      render(<SummaryTab {...BASE_PROPS} userTier="free" />);
+
+      expect(screen.getByText('AI Session Summaries')).toBeInTheDocument();
+      expect(screen.getByText('Upgrade to Pro')).toBeInTheDocument();
+      expect(
+        screen.getByText('Available on Pro and Power plans')
+      ).toBeInTheDocument();
+    });
+
+    it('links to /pricing page', () => {
+      render(<SummaryTab {...BASE_PROPS} userTier="free" />);
+
+      const link = screen.getByRole('link', { name: /upgrade to pro/i });
+      expect(link).toHaveAttribute('href', '/pricing');
+    });
+
+    it('does not show summary content for free users even if summary exists', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          userTier="free"
+          summary="This should not be visible"
+          summaryGeneratedAt="2025-01-01T00:00:00Z"
+        />
+      );
+
+      expect(screen.queryByText('This should not be visible')).not.toBeInTheDocument();
+      expect(screen.getByText('Upgrade to Pro')).toBeInTheDocument();
+    });
+  });
+
+  describe('Active session placeholder', () => {
+    it.each(['starting', 'running', 'idle', 'paused'])(
+      'renders active placeholder for "%s" session status',
+      (status) => {
+        render(
+          <SummaryTab {...BASE_PROPS} sessionStatus={status} userTier="pro" />
+        );
+
+        expect(
+          screen.getByText('Summary Available After Session')
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/ai summary will be automatically generated/i)
+        ).toBeInTheDocument();
+      }
+    );
+
+    it('shows active placeholder for power tier users too', () => {
+      render(
+        <SummaryTab {...BASE_PROPS} sessionStatus="running" userTier="power" />
+      );
+
+      expect(
+        screen.getByText('Summary Available After Session')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Generating state', () => {
+    it('renders generating state when session is completed but no summary or timestamp', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="stopped"
+          summary={null}
+          summaryGeneratedAt={null}
+          userTier="pro"
+        />
+      );
+
+      expect(screen.getByText('Generating Summary...')).toBeInTheDocument();
+      expect(
+        screen.getByText(/analyzing your session/i)
+      ).toBeInTheDocument();
+    });
+
+    it.each(['stopped', 'expired', 'error'])(
+      'renders generating state for "%s" status without summary',
+      (status) => {
+        render(
+          <SummaryTab
+            {...BASE_PROPS}
+            sessionStatus={status}
+            summary={null}
+            summaryGeneratedAt={null}
+            userTier="pro"
+          />
+        );
+
+        expect(screen.getByText('Generating Summary...')).toBeInTheDocument();
+      }
+    );
+  });
+
+  describe('No summary available (old session)', () => {
+    it('renders "no summary" state when completed with summaryGeneratedAt but no summary text', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="stopped"
+          summary={null}
+          summaryGeneratedAt="2025-01-01T00:00:00Z"
+          userTier="pro"
+        />
+      );
+
+      expect(screen.getByText('No Summary Available')).toBeInTheDocument();
+      expect(
+        screen.getByText(/created before ai summaries were enabled/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Summary available', () => {
+    const SUMMARY_TEXT = 'This session focused on implementing user authentication with JWT tokens.';
+    const GENERATED_AT = '2025-06-15T14:30:00Z';
+
+    it('renders the AI summary text', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="stopped"
+          summary={SUMMARY_TEXT}
+          summaryGeneratedAt={GENERATED_AT}
+          userTier="pro"
+        />
+      );
+
+      expect(screen.getByText(SUMMARY_TEXT)).toBeInTheDocument();
+      expect(screen.getByText('AI Summary')).toBeInTheDocument();
+    });
+
+    it('displays the generated-at timestamp', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="stopped"
+          summary={SUMMARY_TEXT}
+          summaryGeneratedAt={GENERATED_AT}
+          userTier="pro"
+        />
+      );
+
+      // The timestamp is formatted as "Generated Jun 15, 2:30 PM" (locale-dependent)
+      expect(screen.getByText(/generated/i)).toBeInTheDocument();
+    });
+
+    it('starts expanded by default', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="stopped"
+          summary={SUMMARY_TEXT}
+          summaryGeneratedAt={GENERATED_AT}
+          userTier="pro"
+        />
+      );
+
+      const toggleButton = screen.getByRole('button', {
+        name: /ai summary/i,
+      });
+      // aria-expanded should be true by default
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('toggles collapsed/expanded state on click', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="stopped"
+          summary={SUMMARY_TEXT}
+          summaryGeneratedAt={GENERATED_AT}
+          userTier="pro"
+        />
+      );
+
+      const toggleButton = screen.getByRole('button', {
+        name: /ai summary/i,
+      });
+
+      // Initially expanded
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+
+      // Click to collapse
+      fireEvent.click(toggleButton);
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+
+      // Click to expand again
+      fireEvent.click(toggleButton);
+      expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('renders summary for power tier users', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="expired"
+          summary={SUMMARY_TEXT}
+          summaryGeneratedAt={GENERATED_AT}
+          userTier="power"
+        />
+      );
+
+      expect(screen.getByText(SUMMARY_TEXT)).toBeInTheDocument();
+    });
+
+    it('has accessible controls attribute on the toggle', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="stopped"
+          summary={SUMMARY_TEXT}
+          summaryGeneratedAt={GENERATED_AT}
+          userTier="pro"
+        />
+      );
+
+      const toggleButton = screen.getByRole('button', {
+        name: /ai summary/i,
+      });
+      expect(toggleButton).toHaveAttribute('aria-controls', 'summary-content');
+    });
+  });
+
+  describe('Tier gating logic', () => {
+    it('pro tier has summary access', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="stopped"
+          summary="Test summary"
+          summaryGeneratedAt="2025-01-01T00:00:00Z"
+          userTier="pro"
+        />
+      );
+
+      expect(screen.queryByText('Upgrade to Pro')).not.toBeInTheDocument();
+      expect(screen.getByText('Test summary')).toBeInTheDocument();
+    });
+
+    it('power tier has summary access', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="stopped"
+          summary="Test summary"
+          summaryGeneratedAt="2025-01-01T00:00:00Z"
+          userTier="power"
+        />
+      );
+
+      expect(screen.queryByText('Upgrade to Pro')).not.toBeInTheDocument();
+      expect(screen.getByText('Test summary')).toBeInTheDocument();
+    });
+
+    it('free tier is gated regardless of session state', () => {
+      render(
+        <SummaryTab
+          {...BASE_PROPS}
+          sessionStatus="running"
+          userTier="free"
+        />
+      );
+
+      // Should show upgrade prompt, not the active session state
+      expect(screen.getByText('AI Session Summaries')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Summary Available After Session')
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/styrby-web/src/app/dashboard/settings/templates/__tests__/template-card.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/templates/__tests__/template-card.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * TemplateCard Component Tests
+ *
+ * Tests the context template card rendering and interactions:
+ * - Template name, description, content preview
+ * - Variable count badge and display
+ * - Default badge rendering
+ * - Content truncation at 150 characters
+ * - Copy to clipboard action
+ * - Edit button click
+ * - Set default button (enabled/disabled states)
+ * - Delete confirmation dialog
+ *
+ * WHY: The template card is the primary display unit for context templates.
+ * Bugs here affect how users perceive and manage their templates.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TemplateCard } from '../template-card';
+import type { ContextTemplate } from '@styrby/shared';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+/**
+ * Mock clipboard API for copy tests.
+ */
+const mockWriteText = vi.fn().mockResolvedValue(undefined);
+Object.assign(navigator, {
+  clipboard: {
+    writeText: mockWriteText,
+  },
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createTemplate(overrides: Partial<ContextTemplate> = {}): ContextTemplate {
+  return {
+    id: 'template-001',
+    userId: 'user-001',
+    name: 'Code Review Template',
+    description: 'Template for reviewing pull requests',
+    content: 'You are reviewing a {{language}} project focused on {{project_name}}.',
+    variables: [
+      { name: 'language', description: 'Programming language', defaultValue: 'TypeScript' },
+      { name: 'project_name', description: 'Name of the project', defaultValue: '' },
+    ],
+    isDefault: false,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const defaultHandlers = {
+  onEdit: vi.fn(),
+  onDelete: vi.fn().mockResolvedValue(undefined),
+  onSetDefault: vi.fn().mockResolvedValue(undefined),
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('TemplateCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Basic rendering', () => {
+    it('renders template name', () => {
+      render(<TemplateCard template={createTemplate()} {...defaultHandlers} />);
+
+      expect(screen.getByText('Code Review Template')).toBeInTheDocument();
+    });
+
+    it('renders template description', () => {
+      render(<TemplateCard template={createTemplate()} {...defaultHandlers} />);
+
+      expect(
+        screen.getByText('Template for reviewing pull requests')
+      ).toBeInTheDocument();
+    });
+
+    it('does not render description when null', () => {
+      const template = createTemplate({ description: null });
+      render(<TemplateCard template={template} {...defaultHandlers} />);
+
+      expect(
+        screen.queryByText('Template for reviewing pull requests')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders content preview', () => {
+      render(<TemplateCard template={createTemplate()} {...defaultHandlers} />);
+
+      expect(
+        screen.getByText(
+          'You are reviewing a {{language}} project focused on {{project_name}}.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('truncates content longer than 150 characters', () => {
+      const longContent = 'A'.repeat(200);
+      const template = createTemplate({ content: longContent });
+      render(<TemplateCard template={template} {...defaultHandlers} />);
+
+      const truncated = 'A'.repeat(150) + '...';
+      expect(screen.getByText(truncated)).toBeInTheDocument();
+    });
+
+    it('does not truncate content at exactly 150 characters', () => {
+      const exactContent = 'B'.repeat(150);
+      const template = createTemplate({ content: exactContent });
+      render(<TemplateCard template={template} {...defaultHandlers} />);
+
+      expect(screen.getByText(exactContent)).toBeInTheDocument();
+    });
+  });
+
+  describe('Default badge', () => {
+    it('shows Default badge when isDefault is true', () => {
+      const template = createTemplate({ isDefault: true });
+      const { container } = render(<TemplateCard template={template} {...defaultHandlers} />);
+
+      // The badge is a <span> with rounded-full class
+      const badge = container.querySelector('span.inline-flex');
+      expect(badge).not.toBeNull();
+      expect(badge?.textContent).toContain('Default');
+    });
+
+    it('does not show Default badge when isDefault is false', () => {
+      const template = createTemplate({ isDefault: false });
+      const { container } = render(<TemplateCard template={template} {...defaultHandlers} />);
+
+      // The badge <span> with rounded-full should not exist
+      const badge = container.querySelector('span.inline-flex');
+      expect(badge).toBeNull();
+    });
+  });
+
+  describe('Variables badge', () => {
+    it('shows variable count and names', () => {
+      const { container } = render(<TemplateCard template={createTemplate()} {...defaultHandlers} />);
+
+      expect(screen.getByText(/2 variables/)).toBeInTheDocument();
+      // The variables badge section contains both variable names
+      const variableBadge = container.querySelector('.text-xs.text-zinc-500 span');
+      expect(variableBadge?.textContent).toContain('{{language}}');
+      expect(variableBadge?.textContent).toContain('{{project_name}}');
+    });
+
+    it('shows singular "variable" for count of 1', () => {
+      const template = createTemplate({
+        variables: [
+          { name: 'lang', description: '', defaultValue: '' },
+        ],
+      });
+      render(<TemplateCard template={template} {...defaultHandlers} />);
+
+      expect(screen.getByText(/1 variable:/)).toBeInTheDocument();
+    });
+
+    it('hides variables section when no variables', () => {
+      const template = createTemplate({ variables: [] });
+      render(<TemplateCard template={template} {...defaultHandlers} />);
+
+      expect(screen.queryByText(/variable/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Copy action', () => {
+    it('copies template content to clipboard on click', async () => {
+      const template = createTemplate();
+      render(<TemplateCard template={template} {...defaultHandlers} />);
+
+      const copyButton = screen.getByRole('button', {
+        name: /copy template content/i,
+      });
+      fireEvent.click(copyButton);
+
+      expect(mockWriteText).toHaveBeenCalledWith(template.content);
+    });
+
+    it('shows "Copied" feedback after copy', async () => {
+      render(<TemplateCard template={createTemplate()} {...defaultHandlers} />);
+
+      const copyButton = screen.getByRole('button', {
+        name: /copy template content/i,
+      });
+      fireEvent.click(copyButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /copied to clipboard/i })
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Edit action', () => {
+    it('calls onEdit with template when edit is clicked', () => {
+      const template = createTemplate();
+      const onEdit = vi.fn();
+      render(
+        <TemplateCard
+          template={template}
+          {...defaultHandlers}
+          onEdit={onEdit}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /edit template/i }));
+      expect(onEdit).toHaveBeenCalledWith(template);
+    });
+  });
+
+  describe('Set Default action', () => {
+    it('calls onSetDefault when button is clicked for non-default template', () => {
+      const template = createTemplate({ isDefault: false });
+      const onSetDefault = vi.fn().mockResolvedValue(undefined);
+      render(
+        <TemplateCard
+          template={template}
+          {...defaultHandlers}
+          onSetDefault={onSetDefault}
+        />
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /set as default template/i })
+      );
+      expect(onSetDefault).toHaveBeenCalledWith('template-001');
+    });
+
+    it('disables set-default button for already-default template', () => {
+      const template = createTemplate({ isDefault: true });
+      render(<TemplateCard template={template} {...defaultHandlers} />);
+
+      const button = screen.getByRole('button', {
+        name: /this is the default template/i,
+      });
+      expect(button).toBeDisabled();
+    });
+
+    it('does not call onSetDefault when template is already default', () => {
+      const template = createTemplate({ isDefault: true });
+      const onSetDefault = vi.fn();
+      render(
+        <TemplateCard
+          template={template}
+          {...defaultHandlers}
+          onSetDefault={onSetDefault}
+        />
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /this is the default template/i })
+      );
+      // The handler checks template.isDefault and returns early
+      // The button is also disabled, so the click may not fire
+      expect(onSetDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Delete action with confirmation', () => {
+    it('shows confirmation dialog when delete is clicked', () => {
+      render(<TemplateCard template={createTemplate()} {...defaultHandlers} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /delete template/i }));
+
+      expect(screen.getByText('Delete template?')).toBeInTheDocument();
+      expect(
+        screen.getByText(/are you sure you want to delete/i)
+      ).toBeInTheDocument();
+    });
+
+    it('includes template name in confirmation dialog', () => {
+      render(<TemplateCard template={createTemplate()} {...defaultHandlers} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /delete template/i }));
+
+      // The dialog text includes the template name in the confirmation message
+      expect(
+        screen.getByText(/are you sure you want to delete/i)
+      ).toBeInTheDocument();
+      // Verify the dialog content contains the template name
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.textContent).toContain('Code Review Template');
+    });
+
+    it('calls onDelete when delete is confirmed', async () => {
+      const onDelete = vi.fn().mockResolvedValue(undefined);
+      render(
+        <TemplateCard
+          template={createTemplate()}
+          {...defaultHandlers}
+          onDelete={onDelete}
+        />
+      );
+
+      // Open dialog
+      fireEvent.click(screen.getByRole('button', { name: /delete template/i }));
+
+      // Confirm delete
+      fireEvent.click(screen.getByText('Delete'));
+
+      expect(onDelete).toHaveBeenCalledWith('template-001');
+    });
+
+    it('closes dialog when cancel is clicked', () => {
+      render(<TemplateCard template={createTemplate()} {...defaultHandlers} />);
+
+      // Open dialog
+      fireEvent.click(screen.getByRole('button', { name: /delete template/i }));
+      expect(screen.getByText('Delete template?')).toBeInTheDocument();
+
+      // Cancel
+      fireEvent.click(screen.getByText('Cancel'));
+
+      // Dialog should be gone
+      expect(screen.queryByText('Delete template?')).not.toBeInTheDocument();
+    });
+
+    it('has accessible dialog attributes', () => {
+      render(<TemplateCard template={createTemplate()} {...defaultHandlers} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /delete template/i }));
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute(
+        'aria-labelledby',
+        'delete-template-title'
+      );
+    });
+  });
+});

--- a/packages/styrby-web/src/app/dashboard/settings/templates/__tests__/template-form.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/templates/__tests__/template-form.test.tsx
@@ -1,0 +1,489 @@
+/**
+ * TemplateForm Component Tests
+ *
+ * Tests the template create/edit modal form:
+ * - Modal visibility toggling
+ * - Create vs edit mode title
+ * - Form field rendering and updates
+ * - Required field validation (name, content)
+ * - Missing variable validation
+ * - Empty variable name validation
+ * - Variable add/remove/update
+ * - Auto-detect variables from content
+ * - isDefault toggle
+ * - Submit with correct data
+ * - Error display on submit failure
+ * - Loading state during submission
+ *
+ * WHY: The template form has complex validation logic that ensures
+ * {{variables}} in content have matching definitions. Bugs here could
+ * allow invalid templates that fail at runtime.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TemplateForm } from '../template-form';
+import type { ContextTemplate } from '@styrby/shared';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+/**
+ * Mock @/lib/utils for cn() class name utility.
+ */
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) =>
+    args
+      .flat()
+      .filter((a) => typeof a === 'string')
+      .join(' '),
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const EXISTING_TEMPLATE: ContextTemplate = {
+  id: 'template-001',
+  userId: 'user-001',
+  name: 'Existing Template',
+  description: 'A template for testing',
+  content: 'Working on {{project}} with {{language}}',
+  variables: [
+    { name: 'project', description: 'Project name', defaultValue: 'MyApp' },
+    { name: 'language', description: 'Language', defaultValue: 'TypeScript' },
+  ],
+  isDefault: false,
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+};
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  template: null as ContextTemplate | null,
+  onSubmit: vi.fn().mockResolvedValue(undefined),
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('TemplateForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Modal visibility', () => {
+    it('renders nothing when isOpen is false', () => {
+      const { container } = render(
+        <TemplateForm {...defaultProps} isOpen={false} />
+      );
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the modal when isOpen is true', () => {
+      render(<TemplateForm {...defaultProps} isOpen={true} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('has correct accessibility attributes on modal', () => {
+      render(<TemplateForm {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'template-form-title');
+    });
+  });
+
+  describe('Create vs Edit mode', () => {
+    it('shows "Create Template" title in create mode', () => {
+      render(<TemplateForm {...defaultProps} template={null} />);
+
+      // Use the heading element specifically to avoid matching the submit button
+      const title = screen.getByRole('heading', { name: /create template/i });
+      expect(title).toBeInTheDocument();
+    });
+
+    it('shows "Edit Template" title in edit mode', () => {
+      render(
+        <TemplateForm {...defaultProps} template={EXISTING_TEMPLATE} />
+      );
+
+      expect(screen.getByText('Edit Template')).toBeInTheDocument();
+    });
+
+    it('shows "Create Template" on submit button in create mode', () => {
+      render(<TemplateForm {...defaultProps} template={null} />);
+
+      expect(
+        screen.getByRole('button', { name: /create template/i })
+      ).toBeInTheDocument();
+    });
+
+    it('shows "Save Changes" on submit button in edit mode', () => {
+      render(
+        <TemplateForm {...defaultProps} template={EXISTING_TEMPLATE} />
+      );
+
+      expect(
+        screen.getByRole('button', { name: /save changes/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Form pre-population in edit mode', () => {
+    it('populates form fields from existing template', () => {
+      render(
+        <TemplateForm {...defaultProps} template={EXISTING_TEMPLATE} />
+      );
+
+      expect(screen.getByDisplayValue('Existing Template')).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue('A template for testing')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue(
+          'Working on {{project}} with {{language}}'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('populates variables from existing template', () => {
+      render(
+        <TemplateForm {...defaultProps} template={EXISTING_TEMPLATE} />
+      );
+
+      expect(screen.getByDisplayValue('project')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('language')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('MyApp')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('TypeScript')).toBeInTheDocument();
+    });
+
+    it('clears form fields in create mode', () => {
+      render(<TemplateForm {...defaultProps} template={null} />);
+
+      const nameInput = screen.getByLabelText(/name/i);
+      expect(nameInput).toHaveValue('');
+    });
+  });
+
+  describe('Required field validation', () => {
+    it('shows error when name is empty on submit', async () => {
+      const user = userEvent.setup();
+      render(<TemplateForm {...defaultProps} />);
+
+      // Leave name empty, add content
+      const contentField = screen.getByLabelText(/content/i);
+      await user.type(contentField, 'Some content');
+
+      // Submit
+      await user.click(
+        screen.getByRole('button', { name: /create template/i })
+      );
+
+      expect(screen.getByText('Template name is required')).toBeInTheDocument();
+      expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('shows error when content is empty on submit', async () => {
+      const user = userEvent.setup();
+      render(<TemplateForm {...defaultProps} />);
+
+      // Add name, leave content empty
+      const nameField = screen.getByLabelText(/name/i);
+      await user.type(nameField, 'My Template');
+
+      // Submit
+      await user.click(
+        screen.getByRole('button', { name: /create template/i })
+      );
+
+      expect(
+        screen.getByText('Template content is required')
+      ).toBeInTheDocument();
+      expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Variable validation', () => {
+    it('shows error when content has undefined variables on submit', async () => {
+      render(<TemplateForm {...defaultProps} />);
+
+      // Use fireEvent.change to set values in one shot (triggers state + effect)
+      fireEvent.change(screen.getByLabelText(/^name/i), {
+        target: { value: 'My Template' },
+      });
+      fireEvent.change(screen.getByLabelText(/content/i), {
+        target: { value: 'Using {{undefined_var}}' },
+      });
+
+      // Wait for the useEffect to detect missing variables
+      await waitFor(() => {
+        expect(screen.getByText(/undefined in content/i)).toBeInTheDocument();
+      });
+
+      // Submit without defining the variable
+      fireEvent.click(
+        screen.getByRole('button', { name: /create template/i })
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/define all variables/i)
+        ).toBeInTheDocument();
+      });
+      expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('shows error when a variable has empty name on submit', async () => {
+      const user = userEvent.setup();
+      render(<TemplateForm {...defaultProps} />);
+
+      const nameField = screen.getByLabelText(/name/i);
+      await user.type(nameField, 'My Template');
+
+      const contentField = screen.getByLabelText(/content/i);
+      await user.type(contentField, 'No variables used');
+
+      // Add a variable with empty name
+      await user.click(screen.getByText('Add Variable'));
+
+      // Submit with empty variable name
+      await user.click(
+        screen.getByRole('button', { name: /create template/i })
+      );
+
+      expect(
+        screen.getByText('All variables must have a name')
+      ).toBeInTheDocument();
+      expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Variable management', () => {
+    it('adds a new variable when "Add Variable" is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TemplateForm {...defaultProps} />);
+
+      // Initially shows "No variables defined" message
+      expect(screen.getByText(/no variables defined/i)).toBeInTheDocument();
+
+      await user.click(screen.getByText('Add Variable'));
+
+      // Should now have variable input fields
+      expect(screen.queryByText(/no variables defined/i)).not.toBeInTheDocument();
+    });
+
+    it('removes a variable when remove button is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <TemplateForm {...defaultProps} template={EXISTING_TEMPLATE} />
+      );
+
+      // Initially has 2 variables
+      expect(screen.getByDisplayValue('project')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('language')).toBeInTheDocument();
+
+      // Click first remove button
+      const removeButtons = screen.getAllByRole('button', {
+        name: /remove variable/i,
+      });
+      await user.click(removeButtons[0]);
+
+      // First variable should be removed
+      expect(screen.queryByDisplayValue('project')).not.toBeInTheDocument();
+      // Second variable should still exist
+      expect(screen.getByDisplayValue('language')).toBeInTheDocument();
+    });
+  });
+
+  describe('Auto-detect variables', () => {
+    it('shows auto-detect button when content has undefined variables', async () => {
+      render(<TemplateForm {...defaultProps} />);
+
+      // Use fireEvent.change to set the value directly (more reliable for effects)
+      fireEvent.change(screen.getByLabelText(/content/i), {
+        target: { value: 'Using {{my_var}} and {{other_var}}' },
+      });
+
+      // Auto-detect button should appear after useEffect runs
+      await waitFor(() => {
+        expect(screen.getByText('Auto-detect')).toBeInTheDocument();
+      });
+    });
+
+    it('auto-detects variables from content and adds them', async () => {
+      render(<TemplateForm {...defaultProps} />);
+
+      // Set content with a variable placeholder
+      fireEvent.change(screen.getByLabelText(/content/i), {
+        target: { value: 'Using {{my_var}}' },
+      });
+
+      // Wait for auto-detect to appear after useEffect processes content
+      await waitFor(() => {
+        expect(screen.getByText('Auto-detect')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Auto-detect'));
+
+      // Variable should be added with the detected name
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('my_var')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Successful submission', () => {
+    it('calls onSubmit with form data and closes on success in create mode', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      const onClose = vi.fn();
+
+      render(
+        <TemplateForm
+          {...defaultProps}
+          onSubmit={onSubmit}
+          onClose={onClose}
+          template={null}
+        />
+      );
+
+      const nameField = screen.getByLabelText(/name/i);
+      await user.type(nameField, 'New Template');
+
+      const contentField = screen.getByLabelText(/content/i);
+      await user.type(contentField, 'Simple content without variables');
+
+      await user.click(
+        screen.getByRole('button', { name: /create template/i })
+      );
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'New Template',
+            content: 'Simple content without variables',
+          }),
+          undefined // No template ID in create mode
+        );
+      });
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onSubmit with templateId in edit mode', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+      render(
+        <TemplateForm
+          {...defaultProps}
+          onSubmit={onSubmit}
+          template={EXISTING_TEMPLATE}
+        />
+      );
+
+      // Just submit without changes
+      await user.click(
+        screen.getByRole('button', { name: /save changes/i })
+      );
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'Existing Template',
+          }),
+          'template-001' // Template ID passed in edit mode
+        );
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('shows error when onSubmit throws', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi
+        .fn()
+        .mockRejectedValue(new Error('Database error'));
+
+      render(
+        <TemplateForm
+          {...defaultProps}
+          onSubmit={onSubmit}
+          template={null}
+        />
+      );
+
+      const nameField = screen.getByLabelText(/name/i);
+      await user.type(nameField, 'Test');
+
+      const contentField = screen.getByLabelText(/content/i);
+      await user.type(contentField, 'Content');
+
+      await user.click(
+        screen.getByRole('button', { name: /create template/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Database error')).toBeInTheDocument();
+      });
+    });
+
+    it('shows generic error for non-Error throws', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn().mockRejectedValue('string error');
+
+      render(
+        <TemplateForm
+          {...defaultProps}
+          onSubmit={onSubmit}
+          template={null}
+        />
+      );
+
+      const nameField = screen.getByLabelText(/name/i);
+      await user.type(nameField, 'Test');
+
+      const contentField = screen.getByLabelText(/content/i);
+      await user.type(contentField, 'Content');
+
+      await user.click(
+        screen.getByRole('button', { name: /create template/i })
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Failed to save template')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Close behavior', () => {
+    it('calls onClose when close button is clicked', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      render(<TemplateForm {...defaultProps} onClose={onClose} />);
+
+      await user.click(screen.getByRole('button', { name: /close modal/i }));
+
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('calls onClose when cancel button is clicked', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      render(<TemplateForm {...defaultProps} onClose={onClose} />);
+
+      await user.click(screen.getByText('Cancel'));
+
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/styrby-web/src/app/dashboard/settings/templates/__tests__/templates-client.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/templates/__tests__/templates-client.test.tsx
@@ -1,0 +1,329 @@
+/**
+ * TemplatesClient Component Tests
+ *
+ * Tests the main templates client component:
+ * - Initial rendering with templates list
+ * - Empty state rendering
+ * - Create template flow (opens modal, submits, updates list)
+ * - Edit template flow (opens modal with template data)
+ * - Delete template flow (optimistic delete, rollback on error)
+ * - Set default template (optimistic update, rollback on error)
+ *
+ * WHY: TemplatesClient is the orchestrating component for the templates
+ * feature. It manages state for the entire template list and coordinates
+ * between TemplateCard and TemplateForm. Bugs here affect all template
+ * operations.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TemplatesClient } from '../templates-client';
+import type { ContextTemplate } from '@styrby/shared';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockRefresh = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+/** Track Supabase operations */
+const mockSupabaseChain = {
+  update: vi.fn(),
+  insert: vi.fn(),
+  delete: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn(),
+  single: vi.fn(),
+};
+
+/**
+ * Configure the mock to be chainable and return the expected result.
+ */
+function setupSupabaseMock(
+  result: { data?: unknown; error?: unknown } = { data: null, error: null }
+) {
+  const chain = {
+    update: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+    then: (resolve: (v: unknown) => void) => resolve(result),
+  };
+
+  Object.assign(mockSupabaseChain, chain);
+
+  return chain;
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn(() => {
+      const chain = {
+        update: vi.fn(() => chain),
+        insert: vi.fn(() => chain),
+        delete: vi.fn(() => chain),
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        single: mockSupabaseChain.single,
+      };
+      return chain;
+    }),
+  })),
+}));
+
+vi.mock('@styrby/shared', async () => {
+  const actual = await vi.importActual('@styrby/shared');
+  return {
+    ...actual,
+  };
+});
+
+/**
+ * Mock clipboard API.
+ */
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockResolvedValue(undefined),
+  },
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createTemplate(overrides: Partial<ContextTemplate> = {}): ContextTemplate {
+  return {
+    id: 'template-001',
+    userId: 'user-001',
+    name: 'First Template',
+    description: 'Description one',
+    content: 'Content one with {{var1}}',
+    variables: [{ name: 'var1', description: '', defaultValue: '' }],
+    isDefault: false,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function createTemplateList(): ContextTemplate[] {
+  return [
+    createTemplate({
+      id: 'template-001',
+      name: 'First Template',
+      isDefault: true,
+    }),
+    createTemplate({
+      id: 'template-002',
+      name: 'Second Template',
+      content: 'Simple content',
+      variables: [],
+      isDefault: false,
+    }),
+    createTemplate({
+      id: 'template-003',
+      name: 'Third Template',
+      isDefault: false,
+    }),
+  ];
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('TemplatesClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupSupabaseMock();
+  });
+
+  describe('Initial rendering', () => {
+    it('renders the page header', () => {
+      render(
+        <TemplatesClient
+          initialTemplates={createTemplateList()}
+          userId="user-001"
+        />
+      );
+
+      expect(screen.getByText('Context Templates')).toBeInTheDocument();
+      expect(
+        screen.getByText(/create reusable context/i)
+      ).toBeInTheDocument();
+    });
+
+    it('renders all templates in the list', () => {
+      render(
+        <TemplatesClient
+          initialTemplates={createTemplateList()}
+          userId="user-001"
+        />
+      );
+
+      expect(screen.getByText('First Template')).toBeInTheDocument();
+      expect(screen.getByText('Second Template')).toBeInTheDocument();
+      expect(screen.getByText('Third Template')).toBeInTheDocument();
+    });
+
+    it('renders the Create Template button in header', () => {
+      render(
+        <TemplatesClient
+          initialTemplates={createTemplateList()}
+          userId="user-001"
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: /create new template/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Empty state', () => {
+    it('renders empty state when no templates exist', () => {
+      render(
+        <TemplatesClient initialTemplates={[]} userId="user-001" />
+      );
+
+      expect(screen.getByText('No templates yet')).toBeInTheDocument();
+      expect(
+        screen.getByText(/context templates let you define/i)
+      ).toBeInTheDocument();
+    });
+
+    it('renders create button in empty state', () => {
+      render(
+        <TemplatesClient initialTemplates={[]} userId="user-001" />
+      );
+
+      expect(
+        screen.getByRole('button', {
+          name: /create your first template/i,
+        })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Create template flow', () => {
+    it('opens form modal when Create Template is clicked', () => {
+      render(
+        <TemplatesClient
+          initialTemplates={createTemplateList()}
+          userId="user-001"
+        />
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /create new template/i })
+      );
+
+      // Form modal should be open
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      // Use heading role to avoid matching both title and button text
+      expect(
+        screen.getByRole('heading', { name: /create template/i })
+      ).toBeInTheDocument();
+    });
+
+    it('opens form modal from empty state button', () => {
+      render(
+        <TemplatesClient initialTemplates={[]} userId="user-001" />
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /create your first template/i })
+      );
+
+      // The dialog's title "Create Template" should appear
+      // (note: there might be button text "Create Template" too)
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edit template flow', () => {
+    it('opens form modal with template data when Edit is clicked', () => {
+      render(
+        <TemplatesClient
+          initialTemplates={createTemplateList()}
+          userId="user-001"
+        />
+      );
+
+      // Click edit on first template
+      const editButtons = screen.getAllByRole('button', {
+        name: /edit template/i,
+      });
+      fireEvent.click(editButtons[0]);
+
+      // Form should be in edit mode
+      expect(screen.getByText('Edit Template')).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue('First Template')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Delete template flow', () => {
+    it('removes template from list optimistically when delete is confirmed', async () => {
+      // Mock successful delete
+      mockSupabaseChain.single.mockResolvedValue({ data: null, error: null });
+
+      render(
+        <TemplatesClient
+          initialTemplates={createTemplateList()}
+          userId="user-001"
+        />
+      );
+
+      expect(screen.getByText('Second Template')).toBeInTheDocument();
+
+      // Click delete on second template
+      const deleteButtons = screen.getAllByRole('button', {
+        name: /delete template/i,
+      });
+      fireEvent.click(deleteButtons[1]);
+
+      // Confirm delete in dialog
+      fireEvent.click(screen.getByText('Delete'));
+
+      // Template should be removed optimistically
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Second Template')
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Error display', () => {
+    it('clears error when opening create modal', async () => {
+      render(
+        <TemplatesClient
+          initialTemplates={createTemplateList()}
+          userId="user-001"
+        />
+      );
+
+      // Open create modal (should clear any existing error)
+      fireEvent.click(
+        screen.getByRole('button', { name: /create new template/i })
+      );
+
+      // No error should be visible
+      const errorElements = screen.queryAllByText(/failed to/i);
+      expect(errorElements).toHaveLength(0);
+    });
+  });
+});

--- a/packages/styrby-web/src/components/cookie-consent.tsx
+++ b/packages/styrby-web/src/components/cookie-consent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useSyncExternalStore, useCallback } from 'react';
+import { useState, useSyncExternalStore } from 'react';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 

--- a/packages/styrby-web/src/components/session-replay/__tests__/controls.test.tsx
+++ b/packages/styrby-web/src/components/session-replay/__tests__/controls.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * ReplayControls Component Tests
+ *
+ * Tests the session replay control bar:
+ * - Play/pause button rendering and click handler
+ * - Previous/next message buttons with disabled states
+ * - Time display formatting (MM:SS and HH:MM:SS)
+ * - Speed control dropdown toggle and selection
+ * - Message counter display
+ * - Progress bar aria attributes
+ *
+ * WHY: Controls are the primary user interaction surface for session replay.
+ * Broken controls mean users cannot navigate through session history.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReplayControls } from '../controls';
+import type { ReplayControlsProps } from '../types';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createDefaultProps(overrides: Partial<ReplayControlsProps> = {}): ReplayControlsProps {
+  return {
+    isPlaying: false,
+    speed: 1,
+    currentTimeMs: 0,
+    totalDurationMs: 60000, // 1 minute
+    currentMessageIndex: 0,
+    totalMessages: 10,
+    onTogglePlay: vi.fn(),
+    onSpeedChange: vi.fn(),
+    onSeek: vi.fn(),
+    onJumpToMessage: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('ReplayControls', () => {
+  describe('Play/Pause button', () => {
+    it('shows Play label when paused', () => {
+      render(<ReplayControls {...createDefaultProps({ isPlaying: false })} />);
+
+      expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+    });
+
+    it('shows Pause label when playing', () => {
+      render(<ReplayControls {...createDefaultProps({ isPlaying: true })} />);
+
+      expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+    });
+
+    it('calls onTogglePlay when clicked', () => {
+      const onTogglePlay = vi.fn();
+      render(<ReplayControls {...createDefaultProps({ onTogglePlay })} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+      expect(onTogglePlay).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Previous/Next message buttons', () => {
+    it('disables previous button at index 0', () => {
+      render(
+        <ReplayControls {...createDefaultProps({ currentMessageIndex: 0 })} />
+      );
+
+      const prevButton = screen.getByRole('button', { name: 'Previous message' });
+      expect(prevButton).toBeDisabled();
+    });
+
+    it('enables previous button when index > 0', () => {
+      render(
+        <ReplayControls {...createDefaultProps({ currentMessageIndex: 3 })} />
+      );
+
+      const prevButton = screen.getByRole('button', { name: 'Previous message' });
+      expect(prevButton).not.toBeDisabled();
+    });
+
+    it('calls onJumpToMessage with index - 1 for previous', () => {
+      const onJumpToMessage = vi.fn();
+      render(
+        <ReplayControls
+          {...createDefaultProps({ currentMessageIndex: 5, onJumpToMessage })}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Previous message' }));
+      expect(onJumpToMessage).toHaveBeenCalledWith(4);
+    });
+
+    it('disables next button at last message', () => {
+      render(
+        <ReplayControls
+          {...createDefaultProps({
+            currentMessageIndex: 9,
+            totalMessages: 10,
+          })}
+        />
+      );
+
+      const nextButton = screen.getByRole('button', { name: 'Next message' });
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('enables next button when not at last message', () => {
+      render(
+        <ReplayControls
+          {...createDefaultProps({
+            currentMessageIndex: 3,
+            totalMessages: 10,
+          })}
+        />
+      );
+
+      const nextButton = screen.getByRole('button', { name: 'Next message' });
+      expect(nextButton).not.toBeDisabled();
+    });
+
+    it('calls onJumpToMessage with index + 1 for next', () => {
+      const onJumpToMessage = vi.fn();
+      render(
+        <ReplayControls
+          {...createDefaultProps({
+            currentMessageIndex: 3,
+            totalMessages: 10,
+            onJumpToMessage,
+          })}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Next message' }));
+      expect(onJumpToMessage).toHaveBeenCalledWith(4);
+    });
+
+    it('does not call onJumpToMessage when previous is disabled', () => {
+      const onJumpToMessage = vi.fn();
+      render(
+        <ReplayControls
+          {...createDefaultProps({ currentMessageIndex: 0, onJumpToMessage })}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Previous message' }));
+      expect(onJumpToMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Time display', () => {
+    it('formats MM:SS for times under an hour', () => {
+      render(
+        <ReplayControls
+          {...createDefaultProps({
+            currentTimeMs: 65000, // 1:05
+            totalDurationMs: 300000, // 5:00
+          })}
+        />
+      );
+
+      expect(screen.getByText('1:05')).toBeInTheDocument();
+      expect(screen.getByText('5:00')).toBeInTheDocument();
+    });
+
+    it('formats HH:MM:SS for times over an hour', () => {
+      render(
+        <ReplayControls
+          {...createDefaultProps({
+            currentTimeMs: 3661000, // 1:01:01
+            totalDurationMs: 7200000, // 2:00:00
+          })}
+        />
+      );
+
+      expect(screen.getByText('1:01:01')).toBeInTheDocument();
+      expect(screen.getByText('2:00:00')).toBeInTheDocument();
+    });
+
+    it('formats 0:00 for zero time', () => {
+      render(
+        <ReplayControls
+          {...createDefaultProps({
+            currentTimeMs: 0,
+            totalDurationMs: 60000,
+          })}
+        />
+      );
+
+      expect(screen.getByText('0:00')).toBeInTheDocument();
+    });
+  });
+
+  describe('Message counter', () => {
+    it('displays current message index (1-based) and total', () => {
+      render(
+        <ReplayControls
+          {...createDefaultProps({
+            currentMessageIndex: 4,
+            totalMessages: 10,
+          })}
+        />
+      );
+
+      // currentMessageIndex 4 => displayed as 5 (1-based)
+      expect(screen.getByText(/5\s*\/\s*10/)).toBeInTheDocument();
+    });
+
+    it('displays 0 when no message is current (index -1)', () => {
+      render(
+        <ReplayControls
+          {...createDefaultProps({
+            currentMessageIndex: -1,
+            totalMessages: 10,
+          })}
+        />
+      );
+
+      expect(screen.getByText(/0\s*\/\s*10/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Speed control', () => {
+    it('displays current speed', () => {
+      render(
+        <ReplayControls {...createDefaultProps({ speed: 2 })} />
+      );
+
+      expect(
+        screen.getByRole('button', { name: /playback speed.*2x/i })
+      ).toBeInTheDocument();
+    });
+
+    it('toggles speed dropdown on click', () => {
+      render(
+        <ReplayControls {...createDefaultProps({ speed: 1 })} />
+      );
+
+      const speedButton = screen.getByRole('button', { name: /playback speed/i });
+
+      // Dropdown should not be visible initially
+      expect(screen.queryByRole('button', { name: /set speed to 0.5x/i })).not.toBeInTheDocument();
+
+      // Click to open
+      fireEvent.click(speedButton);
+
+      // All speed options should be visible
+      expect(screen.getByRole('button', { name: /set speed to 0.5x/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /set speed to 1x/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /set speed to 2x/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /set speed to 4x/i })).toBeInTheDocument();
+    });
+
+    it('calls onSpeedChange and closes menu on selection', () => {
+      const onSpeedChange = vi.fn();
+      render(
+        <ReplayControls {...createDefaultProps({ speed: 1, onSpeedChange })} />
+      );
+
+      // Open dropdown
+      fireEvent.click(screen.getByRole('button', { name: /playback speed/i }));
+
+      // Select 4x
+      fireEvent.click(screen.getByRole('button', { name: /set speed to 4x/i }));
+
+      expect(onSpeedChange).toHaveBeenCalledWith(4);
+
+      // Dropdown should be closed
+      expect(screen.queryByRole('button', { name: /set speed to 0.5x/i })).not.toBeInTheDocument();
+    });
+
+    it('has aria-expanded on speed button', () => {
+      render(
+        <ReplayControls {...createDefaultProps({ speed: 1 })} />
+      );
+
+      const speedButton = screen.getByRole('button', { name: /playback speed/i });
+      expect(speedButton).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.click(speedButton);
+      expect(speedButton).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  describe('Progress bar accessibility', () => {
+    it('has slider role with correct aria attributes', () => {
+      render(
+        <ReplayControls
+          {...createDefaultProps({
+            currentTimeMs: 30000,
+            totalDurationMs: 60000,
+          })}
+        />
+      );
+
+      const slider = screen.getByRole('slider', { name: /replay progress/i });
+      expect(slider).toHaveAttribute('aria-valuemin', '0');
+      expect(slider).toHaveAttribute('aria-valuemax', '60000');
+      expect(slider).toHaveAttribute('aria-valuenow', '30000');
+      expect(slider).toHaveAttribute('aria-valuetext', '0:30 of 1:00');
+    });
+  });
+});

--- a/packages/styrby-web/src/components/session-replay/__tests__/player.test.tsx
+++ b/packages/styrby-web/src/components/session-replay/__tests__/player.test.tsx
@@ -1,0 +1,344 @@
+/**
+ * ReplayPlayer Component Tests
+ *
+ * Tests the main session replay player component:
+ * - Renders messages with correct type-based styling
+ * - Shows empty state for no messages
+ * - Renders header with message count
+ * - Renders exit button when callback provided
+ * - Skips permission_response messages
+ * - Integrates with ReplayControls
+ *
+ * WHY: The player is the core UI for reviewing past sessions.
+ * Rendering bugs could show messages with wrong styling, wrong order,
+ * or leak messages that should be hidden (permission_response).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ReplayPlayer } from '../player';
+import type { ReplayMessage } from '../types';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+/**
+ * Mock the useReplayState hook to control playback state in tests.
+ */
+vi.mock('../use-replay-state', () => ({
+  useReplayState: vi.fn(({ messages }: { messages: ReplayMessage[] }) => ({
+    playbackState: 'stopped' as const,
+    isPlaying: false,
+    speed: 1 as const,
+    currentTimeMs: 0,
+    totalDurationMs: 10000,
+    currentMessageIndex: messages.length - 1,
+    visibleMessages: messages,
+    play: vi.fn(),
+    pause: vi.fn(),
+    togglePlay: vi.fn(),
+    stop: vi.fn(),
+    setSpeed: vi.fn(),
+    seekToTime: vi.fn(),
+    jumpToMessage: vi.fn(),
+  })),
+}));
+
+/**
+ * Mock clipboard API for copy code buttons.
+ */
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockResolvedValue(undefined),
+  },
+});
+
+/**
+ * Mock scrollIntoView - not available in jsdom.
+ * WHY: The ReplayPlayer uses scrollIntoView for auto-scrolling to the
+ * current message during playback. jsdom doesn't implement it.
+ */
+Element.prototype.scrollIntoView = vi.fn();
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const BASE_TIME = new Date('2025-01-01T00:00:00Z').getTime();
+
+function createMessage(
+  id: string,
+  type: ReplayMessage['message_type'],
+  content: string,
+  offsetMs = 0,
+  extra: Partial<ReplayMessage> = {}
+): ReplayMessage {
+  return {
+    id,
+    session_id: 'session-001',
+    sequence_number: parseInt(id.replace('msg-', ''), 10),
+    message_type: type,
+    content_encrypted: content,
+    risk_level: null,
+    permission_granted: null,
+    tool_name: null,
+    duration_ms: null,
+    metadata: null,
+    created_at: new Date(BASE_TIME + offsetMs).toISOString(),
+    ...extra,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('ReplayPlayer', () => {
+  describe('Empty state', () => {
+    it('renders empty state when no messages', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[]}
+        />
+      );
+
+      expect(screen.getByText('No messages to replay')).toBeInTheDocument();
+      expect(
+        screen.getByText(/no recorded messages/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Header', () => {
+    it('shows Session Replay label', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'user_prompt', 'Hello'),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('Session Replay')).toBeInTheDocument();
+    });
+
+    it('shows message count', () => {
+      const messages = [
+        createMessage('msg-1', 'user_prompt', 'Hello', 0),
+        createMessage('msg-2', 'agent_response', 'Hi there', 1000),
+        createMessage('msg-3', 'tool_use', 'Running tool', 2000),
+      ];
+
+      render(
+        <ReplayPlayer sessionId="session-001" messages={messages} />
+      );
+
+      expect(screen.getByText('3 messages')).toBeInTheDocument();
+    });
+  });
+
+  describe('Exit button', () => {
+    it('renders exit button when onExitReplay is provided', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[createMessage('msg-1', 'user_prompt', 'Hello')]}
+          onExitReplay={vi.fn()}
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: /exit replay/i })
+      ).toBeInTheDocument();
+    });
+
+    it('does not render exit button when onExitReplay is omitted', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[createMessage('msg-1', 'user_prompt', 'Hello')]}
+        />
+      );
+
+      expect(
+        screen.queryByRole('button', { name: /exit replay/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onExitReplay when clicked', () => {
+      const onExitReplay = vi.fn();
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[createMessage('msg-1', 'user_prompt', 'Hello')]}
+          onExitReplay={onExitReplay}
+        />
+      );
+
+      screen.getByRole('button', { name: /exit replay/i }).click();
+      expect(onExitReplay).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Message rendering', () => {
+    it('renders user prompts with sender label "You"', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'user_prompt', 'Write a function'),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('You')).toBeInTheDocument();
+      expect(screen.getByText('Write a function')).toBeInTheDocument();
+    });
+
+    it('renders agent responses with sender label "Agent"', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'agent_response', 'Here is the function'),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('Agent')).toBeInTheDocument();
+      expect(screen.getByText('Here is the function')).toBeInTheDocument();
+    });
+
+    it('renders tool_use messages with sender label "Tool" and tool name', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'tool_use', 'Running file search', 0, {
+              tool_name: 'search_files',
+            }),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('Tool')).toBeInTheDocument();
+      expect(screen.getByText('search_files')).toBeInTheDocument();
+    });
+
+    it('renders error messages with sender label "Error"', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'error', 'Connection timeout'),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('Error')).toBeInTheDocument();
+      expect(screen.getByText('Connection timeout')).toBeInTheDocument();
+    });
+
+    it('renders system messages with sender label "System"', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'system', 'Session started'),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('System')).toBeInTheDocument();
+    });
+
+    it('skips permission_response messages', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'user_prompt', 'Hello'),
+            createMessage('msg-2', 'permission_response', 'granted', 1000),
+            createMessage('msg-3', 'agent_response', 'Hi there', 2000),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('Hello')).toBeInTheDocument();
+      expect(screen.getByText('Hi there')).toBeInTheDocument();
+      // The permission_response content should not be rendered
+      expect(screen.queryByText('granted')).not.toBeInTheDocument();
+    });
+
+    it('shows duration_ms when present', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'agent_response', 'Response text', 0, {
+              duration_ms: 2500,
+            }),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('2.5s')).toBeInTheDocument();
+    });
+  });
+
+  describe('Code block rendering', () => {
+    it('renders code blocks with language label and copy button', () => {
+      const content = 'Here is some code:\n```typescript\nconst x = 1;\n```';
+
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'agent_response', content),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('typescript')).toBeInTheDocument();
+      expect(screen.getByText('const x = 1;')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /copy code/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Message area accessibility', () => {
+    it('has log role on message area', () => {
+      render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[createMessage('msg-1', 'user_prompt', 'Hello')]}
+        />
+      );
+
+      expect(
+        screen.getByRole('log', { name: /session replay messages/i })
+      ).toBeInTheDocument();
+    });
+
+    it('sets data-message-id on each message', () => {
+      const { container } = render(
+        <ReplayPlayer
+          sessionId="session-001"
+          messages={[
+            createMessage('msg-1', 'user_prompt', 'Hello'),
+            createMessage('msg-2', 'agent_response', 'Hi', 1000),
+          ]}
+        />
+      );
+
+      const messageElements = container.querySelectorAll('[data-message-id]');
+      expect(messageElements).toHaveLength(2);
+      expect(messageElements[0]).toHaveAttribute('data-message-id', 'msg-1');
+      expect(messageElements[1]).toHaveAttribute('data-message-id', 'msg-2');
+    });
+  });
+});

--- a/packages/styrby-web/src/components/session-replay/__tests__/use-replay-state.test.ts
+++ b/packages/styrby-web/src/components/session-replay/__tests__/use-replay-state.test.ts
@@ -1,0 +1,462 @@
+/**
+ * useReplayState Hook Tests
+ *
+ * Tests the session replay timing hook that drives message visibility
+ * based on timestamp-relative playback position.
+ *
+ * Key behaviors tested:
+ * - totalDurationMs and messageTimestamps calculation
+ * - visibleMessages based on currentTimeMs
+ * - play/pause/stop/togglePlay state transitions
+ * - seekToTime clamping
+ * - jumpToMessage index bounds
+ * - setSpeed state
+ * - Empty messages edge case
+ * - Play from end restarts from beginning
+ *
+ * WHY: The replay hook has complex timing logic with requestAnimationFrame
+ * and speed multipliers. Bugs here cause messages to appear at wrong times
+ * or playback to freeze/skip.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useReplayState } from '../use-replay-state';
+import type { ReplayMessage } from '../types';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Creates a mock ReplayMessage with timestamp offset from a base time.
+ */
+function createMessage(
+  id: string,
+  offsetMs: number,
+  type: ReplayMessage['message_type'] = 'agent_response',
+  baseTime = new Date('2025-01-01T00:00:00Z').getTime()
+): ReplayMessage {
+  return {
+    id,
+    session_id: 'session-001',
+    sequence_number: parseInt(id.replace('msg-', ''), 10),
+    message_type: type,
+    content_encrypted: `Content for ${id}`,
+    risk_level: null,
+    permission_granted: null,
+    tool_name: null,
+    duration_ms: null,
+    metadata: null,
+    created_at: new Date(baseTime + offsetMs).toISOString(),
+  };
+}
+
+/**
+ * Creates a standard set of messages spread over 10 seconds.
+ */
+function createTestMessages(): ReplayMessage[] {
+  return [
+    createMessage('msg-1', 0, 'user_prompt'),         // 0s
+    createMessage('msg-2', 2000, 'agent_response'),    // 2s
+    createMessage('msg-3', 5000, 'tool_use'),          // 5s
+    createMessage('msg-4', 7000, 'tool_result'),       // 7s
+    createMessage('msg-5', 10000, 'agent_response'),   // 10s
+  ];
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useReplayState', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('initialization', () => {
+    it('initializes with stopped state', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      expect(result.current.playbackState).toBe('stopped');
+      expect(result.current.isPlaying).toBe(false);
+      expect(result.current.currentTimeMs).toBe(0);
+    });
+
+    it('defaults speed to 1', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      expect(result.current.speed).toBe(1);
+    });
+
+    it('accepts initialSpeed parameter', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages, initialSpeed: 2 })
+      );
+
+      expect(result.current.speed).toBe(2);
+    });
+
+    it('calculates totalDurationMs from first to last message', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      // 10s = 10000ms between first (0s) and last (10s) message
+      expect(result.current.totalDurationMs).toBe(10000);
+    });
+  });
+
+  describe('empty messages', () => {
+    it('handles empty messages array', () => {
+      const { result } = renderHook(() =>
+        useReplayState({ messages: [] })
+      );
+
+      expect(result.current.totalDurationMs).toBe(0);
+      expect(result.current.visibleMessages).toEqual([]);
+      expect(result.current.currentMessageIndex).toBe(-1);
+    });
+  });
+
+  describe('visibleMessages calculation', () => {
+    it('shows no messages at time 0 if first message is at offset 0', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      // At time 0, the first message (offset 0) should be visible
+      // because messageTimestamps[0] = 0 and currentTimeMs = 0, so 0 <= 0 is true
+      expect(result.current.visibleMessages).toHaveLength(1);
+      expect(result.current.visibleMessages[0].id).toBe('msg-1');
+      expect(result.current.currentMessageIndex).toBe(0);
+    });
+
+    it('shows correct messages after seeking', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      // Seek to 5000ms (should show messages at 0, 2000, and 5000)
+      act(() => {
+        result.current.seekToTime(5000);
+      });
+
+      expect(result.current.visibleMessages).toHaveLength(3);
+      expect(result.current.visibleMessages[0].id).toBe('msg-1');
+      expect(result.current.visibleMessages[1].id).toBe('msg-2');
+      expect(result.current.visibleMessages[2].id).toBe('msg-3');
+      expect(result.current.currentMessageIndex).toBe(2);
+    });
+
+    it('shows all messages at end time', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.seekToTime(10000);
+      });
+
+      expect(result.current.visibleMessages).toHaveLength(5);
+      expect(result.current.currentMessageIndex).toBe(4);
+    });
+  });
+
+  describe('play/pause/stop/togglePlay', () => {
+    it('play sets state to playing', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.play();
+      });
+
+      expect(result.current.playbackState).toBe('playing');
+      expect(result.current.isPlaying).toBe(true);
+    });
+
+    it('pause sets state to paused', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.play();
+      });
+
+      act(() => {
+        result.current.pause();
+      });
+
+      expect(result.current.playbackState).toBe('paused');
+      expect(result.current.isPlaying).toBe(false);
+    });
+
+    it('stop resets to beginning', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      // Seek forward, then stop
+      act(() => {
+        result.current.seekToTime(5000);
+        result.current.play();
+      });
+
+      act(() => {
+        result.current.stop();
+      });
+
+      expect(result.current.playbackState).toBe('stopped');
+      expect(result.current.currentTimeMs).toBe(0);
+    });
+
+    it('togglePlay switches between playing and paused', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      // Initially stopped, toggle should play
+      act(() => {
+        result.current.togglePlay();
+      });
+      expect(result.current.isPlaying).toBe(true);
+
+      // Toggle again should pause
+      act(() => {
+        result.current.togglePlay();
+      });
+      expect(result.current.isPlaying).toBe(false);
+      expect(result.current.playbackState).toBe('paused');
+    });
+
+    it('play from end position restarts from beginning', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      // Seek to end
+      act(() => {
+        result.current.seekToTime(10000);
+      });
+
+      expect(result.current.currentTimeMs).toBe(10000);
+
+      // Play should reset to 0 since we're at the end
+      act(() => {
+        result.current.play();
+      });
+
+      expect(result.current.currentTimeMs).toBe(0);
+      expect(result.current.isPlaying).toBe(true);
+    });
+  });
+
+  describe('seekToTime', () => {
+    it('clamps to 0 for negative values', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.seekToTime(-500);
+      });
+
+      expect(result.current.currentTimeMs).toBe(0);
+    });
+
+    it('clamps to totalDurationMs for values beyond end', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.seekToTime(99999);
+      });
+
+      expect(result.current.currentTimeMs).toBe(10000);
+    });
+
+    it('allows seeking to exact message timestamps', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.seekToTime(7000);
+      });
+
+      expect(result.current.currentTimeMs).toBe(7000);
+      // Messages at 0, 2000, 5000, 7000 should be visible (indices 0-3)
+      expect(result.current.currentMessageIndex).toBe(3);
+    });
+  });
+
+  describe('jumpToMessage', () => {
+    it('jumps to a specific message by index', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.jumpToMessage(2);
+      });
+
+      // Message at index 2 has offset 5000ms
+      expect(result.current.currentTimeMs).toBe(5000);
+      expect(result.current.currentMessageIndex).toBe(2);
+    });
+
+    it('ignores negative index', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.seekToTime(5000);
+      });
+
+      act(() => {
+        result.current.jumpToMessage(-1);
+      });
+
+      // Should not change
+      expect(result.current.currentTimeMs).toBe(5000);
+    });
+
+    it('ignores index beyond message count', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.seekToTime(5000);
+      });
+
+      act(() => {
+        result.current.jumpToMessage(99);
+      });
+
+      // Should not change
+      expect(result.current.currentTimeMs).toBe(5000);
+    });
+
+    it('jumps to first message at index 0', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.seekToTime(5000);
+      });
+
+      act(() => {
+        result.current.jumpToMessage(0);
+      });
+
+      expect(result.current.currentTimeMs).toBe(0);
+    });
+
+    it('jumps to last message', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.jumpToMessage(4);
+      });
+
+      expect(result.current.currentTimeMs).toBe(10000);
+    });
+  });
+
+  describe('setSpeed', () => {
+    it('changes playback speed', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      act(() => {
+        result.current.setSpeed(4);
+      });
+
+      expect(result.current.speed).toBe(4);
+    });
+
+    it('accepts all valid speed values', () => {
+      const messages = createTestMessages();
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      for (const speed of [0.5, 1, 2, 4] as const) {
+        act(() => {
+          result.current.setSpeed(speed);
+        });
+        expect(result.current.speed).toBe(speed);
+      }
+    });
+  });
+
+  describe('single message', () => {
+    it('handles a session with one message', () => {
+      const messages = [createMessage('msg-1', 0, 'user_prompt')];
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      expect(result.current.totalDurationMs).toBe(0);
+      expect(result.current.visibleMessages).toHaveLength(1);
+      expect(result.current.currentMessageIndex).toBe(0);
+    });
+  });
+
+  describe('messages with same timestamp', () => {
+    it('shows all messages at the same timestamp simultaneously', () => {
+      const messages = [
+        createMessage('msg-1', 0, 'user_prompt'),
+        createMessage('msg-2', 0, 'agent_response'), // Same time
+        createMessage('msg-3', 5000, 'tool_use'),
+      ];
+
+      const { result } = renderHook(() =>
+        useReplayState({ messages })
+      );
+
+      // At time 0, both msg-1 and msg-2 should be visible
+      expect(result.current.visibleMessages).toHaveLength(2);
+      expect(result.current.currentMessageIndex).toBe(1);
+    });
+  });
+});

--- a/packages/styrby-web/src/components/ui/calendar.tsx
+++ b/packages/styrby-web/src/components/ui/calendar.tsx
@@ -54,8 +54,8 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+        IconRight: () => <ChevronRight className="h-4 w-4" />,
       }}
       {...props}
     />

--- a/packages/styrby-web/src/components/ui/use-toast.ts
+++ b/packages/styrby-web/src/components/ui/use-toast.ts
@@ -15,12 +15,13 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: 'ADD_TOAST',
-  UPDATE_TOAST: 'UPDATE_TOAST',
-  DISMISS_TOAST: 'DISMISS_TOAST',
-  REMOVE_TOAST: 'REMOVE_TOAST',
-} as const
+/** Action type constants for toast state machine */
+type ActionType = {
+  readonly ADD_TOAST: 'ADD_TOAST'
+  readonly UPDATE_TOAST: 'UPDATE_TOAST'
+  readonly DISMISS_TOAST: 'DISMISS_TOAST'
+  readonly REMOVE_TOAST: 'REMOVE_TOAST'
+}
 
 let count = 0
 
@@ -28,8 +29,6 @@ function genId() {
   count = (count + 1) % Number.MAX_SAFE_INTEGER
   return count.toString()
 }
-
-type ActionType = typeof actionTypes
 
 type Action =
   | {

--- a/packages/styrby-web/src/emails/subscription-confirmed.tsx
+++ b/packages/styrby-web/src/emails/subscription-confirmed.tsx
@@ -31,7 +31,7 @@ const tierFeatures = {
   ],
   power: [
     'Everything in Pro',
-    'Team collaboration (coming soon)',
+    'Team collaboration',
     'API access',
     'Custom integrations',
     'Priority support',

--- a/packages/styrby-web/src/hooks/use-toast.ts
+++ b/packages/styrby-web/src/hooks/use-toast.ts
@@ -15,12 +15,13 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: 'ADD_TOAST',
-  UPDATE_TOAST: 'UPDATE_TOAST',
-  DISMISS_TOAST: 'DISMISS_TOAST',
-  REMOVE_TOAST: 'REMOVE_TOAST',
-} as const
+/** Action type constants for toast state machine */
+type ActionType = {
+  readonly ADD_TOAST: 'ADD_TOAST'
+  readonly UPDATE_TOAST: 'UPDATE_TOAST'
+  readonly DISMISS_TOAST: 'DISMISS_TOAST'
+  readonly REMOVE_TOAST: 'REMOVE_TOAST'
+}
 
 let count = 0
 
@@ -28,8 +29,6 @@ function genId() {
   count = (count + 1) % Number.MAX_SAFE_INTEGER
   return count.toString()
 }
-
-type ActionType = typeof actionTypes
 
 type Action =
   | {

--- a/packages/styrby-web/src/middleware/__tests__/api-auth.test.ts
+++ b/packages/styrby-web/src/middleware/__tests__/api-auth.test.ts
@@ -1,0 +1,562 @@
+/**
+ * API Authentication Middleware Tests
+ *
+ * Tests the authenticateApiRequest, withApiAuth, apiAuthError, and
+ * addRateLimitHeaders functions.
+ *
+ * Key behaviors tested:
+ * - Missing/malformed Authorization header
+ * - Invalid API key format
+ * - Database lookup failures
+ * - No matching keys
+ * - Key hash verification (bcrypt)
+ * - Expired key rejection
+ * - Rate limiting (100 req/min per key)
+ * - Successful authentication returns context
+ * - withApiAuth HOF: scope checking, handler invocation
+ * - apiAuthError: correct status codes and error codes
+ * - addRateLimitHeaders: X-RateLimit-* headers
+ *
+ * WHY: The API auth middleware is a security-critical path. Bugs could allow
+ * unauthenticated access, skip rate limits, or expose other users' data.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockRpc = vi.fn();
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn(() => ({
+    rpc: mockRpc,
+  })),
+}));
+
+const mockVerifyApiKey = vi.fn();
+vi.mock('@/lib/api-keys', () => ({
+  verifyApiKey: (...args: unknown[]) => mockVerifyApiKey(...args),
+}));
+
+vi.mock('@styrby/shared', () => ({
+  isValidApiKeyFormat: vi.fn((key: string) => {
+    // Simplified validation: must start with styrby_ and be long enough
+    return (
+      typeof key === 'string' &&
+      key.startsWith('styrby_') &&
+      key.length === 39 // styrby_ (7) + 32 chars
+    );
+  }),
+  extractApiKeyPrefix: vi.fn((key: string) => {
+    if (typeof key === 'string' && key.startsWith('styrby_')) {
+      return 'styrby_';
+    }
+    return null;
+  }),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  getClientIp: vi.fn(() => '203.0.113.1'),
+}));
+
+// Import AFTER mocks are set up
+import {
+  authenticateApiRequest,
+  withApiAuth,
+  apiAuthError,
+  addRateLimitHeaders,
+} from '../api-auth';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Valid-format API key (styrby_ prefix + 32 alphanumeric chars) */
+const VALID_KEY = 'styrby_abcdefghijklmnopqrstuvwxyz123456';
+const VALID_KEY_HASH = '$2b$12$mockedhashvalue';
+
+function createRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost:3000/api/v1/sessions', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-forwarded-for': '203.0.113.1',
+      ...headers,
+    },
+  });
+}
+
+function mockKeyLookupSuccess(
+  keyRecords: Array<{
+    id: string;
+    user_id: string;
+    key_hash: string;
+    scopes: string[];
+    expires_at: string | null;
+  }>
+) {
+  mockRpc.mockImplementation((name: string) => {
+    if (name === 'lookup_api_key') {
+      return Promise.resolve({ data: keyRecords, error: null });
+    }
+    // update_api_key_usage (fire and forget)
+    return Promise.resolve({ data: null, error: null });
+  });
+}
+
+function mockKeyLookupEmpty() {
+  mockRpc.mockImplementation((name: string) => {
+    if (name === 'lookup_api_key') {
+      return Promise.resolve({ data: [], error: null });
+    }
+    return Promise.resolve({ data: null, error: null });
+  });
+}
+
+function mockKeyLookupError() {
+  mockRpc.mockImplementation((name: string) => {
+    if (name === 'lookup_api_key') {
+      return Promise.resolve({
+        data: null,
+        error: { message: 'Database connection failed' },
+      });
+    }
+    return Promise.resolve({ data: null, error: null });
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('authenticateApiRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Authorization header validation', () => {
+    it('returns 401 when Authorization header is missing', async () => {
+      const req = createRequest();
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.status).toBe(401);
+        expect(result.error).toContain('Missing Authorization header');
+      }
+    });
+
+    it('returns 401 for non-Bearer token format', async () => {
+      const req = createRequest({
+        authorization: 'Basic dXNlcjpwYXNz',
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.status).toBe(401);
+        expect(result.error).toContain('Invalid Authorization header format');
+      }
+    });
+
+    it('returns 401 for invalid API key format', async () => {
+      const req = createRequest({
+        authorization: 'Bearer invalid_key_format',
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.status).toBe(401);
+        expect(result.error).toContain('Invalid API key format');
+      }
+    });
+
+    it('returns 401 when key prefix extraction fails', async () => {
+      // A key that passes format validation but has no valid prefix
+      // Our mock of isValidApiKeyFormat requires styrby_ prefix + 32 chars,
+      // so if it somehow passes format but not prefix... we test extractApiKeyPrefix returning null
+      const req = createRequest({
+        authorization: 'Bearer not_styrby_key_but_long_enough_1234',
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.status).toBe(401);
+      }
+    });
+  });
+
+  describe('Database lookup', () => {
+    it('returns 500 when database lookup fails', async () => {
+      mockKeyLookupError();
+      const req = createRequest({
+        authorization: `Bearer ${VALID_KEY}`,
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.status).toBe(500);
+        expect(result.error).toBe('Authentication failed');
+      }
+    });
+
+    it('returns 401 when no keys found for prefix', async () => {
+      mockKeyLookupEmpty();
+      const req = createRequest({
+        authorization: `Bearer ${VALID_KEY}`,
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.status).toBe(401);
+        expect(result.error).toBe('Invalid API key');
+      }
+    });
+
+    it('returns 401 when null keys returned', async () => {
+      mockRpc.mockImplementation((name: string) => {
+        if (name === 'lookup_api_key') {
+          return Promise.resolve({ data: null, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      });
+
+      const req = createRequest({
+        authorization: `Bearer ${VALID_KEY}`,
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.status).toBe(401);
+        expect(result.error).toBe('Invalid API key');
+      }
+    });
+  });
+
+  describe('Key verification', () => {
+    it('returns 401 when no key hash matches', async () => {
+      mockKeyLookupSuccess([
+        {
+          id: 'key-001',
+          user_id: 'user-001',
+          key_hash: VALID_KEY_HASH,
+          scopes: ['read'],
+          expires_at: null,
+        },
+      ]);
+      mockVerifyApiKey.mockResolvedValue(false);
+
+      const req = createRequest({
+        authorization: `Bearer ${VALID_KEY}`,
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.status).toBe(401);
+        expect(result.error).toBe('Invalid API key');
+      }
+    });
+
+    it('tries all candidate keys until a match is found', async () => {
+      mockKeyLookupSuccess([
+        {
+          id: 'key-001',
+          user_id: 'user-001',
+          key_hash: 'hash-1',
+          scopes: ['read'],
+          expires_at: null,
+        },
+        {
+          id: 'key-002',
+          user_id: 'user-001',
+          key_hash: 'hash-2',
+          scopes: ['read', 'write'],
+          expires_at: null,
+        },
+      ]);
+
+      // First key doesn't match, second does
+      mockVerifyApiKey
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+
+      const req = createRequest({
+        authorization: `Bearer ${VALID_KEY}`,
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.context.keyId).toBe('key-002');
+        expect(result.context.scopes).toEqual(['read', 'write']);
+      }
+      expect(mockVerifyApiKey).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns success with correct context on match', async () => {
+      mockKeyLookupSuccess([
+        {
+          id: 'key-001',
+          user_id: 'user-uuid-123',
+          key_hash: VALID_KEY_HASH,
+          scopes: ['read', 'write'],
+          expires_at: null,
+        },
+      ]);
+      mockVerifyApiKey.mockResolvedValue(true);
+
+      const req = createRequest({
+        authorization: `Bearer ${VALID_KEY}`,
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.context.userId).toBe('user-uuid-123');
+        expect(result.context.keyId).toBe('key-001');
+        expect(result.context.scopes).toEqual(['read', 'write']);
+      }
+    });
+  });
+
+  describe('Key expiration', () => {
+    it('returns 401 for expired key', async () => {
+      const pastDate = new Date(Date.now() - 86400000).toISOString(); // Yesterday
+
+      mockKeyLookupSuccess([
+        {
+          id: 'key-001',
+          user_id: 'user-001',
+          key_hash: VALID_KEY_HASH,
+          scopes: ['read'],
+          expires_at: pastDate,
+        },
+      ]);
+      mockVerifyApiKey.mockResolvedValue(true);
+
+      const req = createRequest({
+        authorization: `Bearer ${VALID_KEY}`,
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.status).toBe(401);
+        expect(result.error).toContain('expired');
+      }
+    });
+
+    it('allows non-expired key', async () => {
+      const futureDate = new Date(Date.now() + 86400000).toISOString(); // Tomorrow
+
+      mockKeyLookupSuccess([
+        {
+          id: 'key-001',
+          user_id: 'user-001',
+          key_hash: VALID_KEY_HASH,
+          scopes: ['read'],
+          expires_at: futureDate,
+        },
+      ]);
+      mockVerifyApiKey.mockResolvedValue(true);
+
+      const req = createRequest({
+        authorization: `Bearer ${VALID_KEY}`,
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('allows key with null expiration (no expiry)', async () => {
+      mockKeyLookupSuccess([
+        {
+          id: 'key-001',
+          user_id: 'user-001',
+          key_hash: VALID_KEY_HASH,
+          scopes: ['read'],
+          expires_at: null,
+        },
+      ]);
+      mockVerifyApiKey.mockResolvedValue(true);
+
+      const req = createRequest({
+        authorization: `Bearer ${VALID_KEY}`,
+      });
+      const result = await authenticateApiRequest(req);
+
+      expect(result.success).toBe(true);
+    });
+  });
+});
+
+describe('withApiAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls handler with context on successful auth', async () => {
+    mockKeyLookupSuccess([
+      {
+        id: 'key-001',
+        user_id: 'user-001',
+        key_hash: VALID_KEY_HASH,
+        scopes: ['read'],
+        expires_at: null,
+      },
+    ]);
+    mockVerifyApiKey.mockResolvedValue(true);
+
+    const handler = vi.fn().mockResolvedValue(
+      NextResponse.json({ data: 'test' })
+    );
+
+    const wrappedHandler = withApiAuth(handler);
+    const req = createRequest({
+      authorization: `Bearer ${VALID_KEY}`,
+    });
+    const response = await wrappedHandler(req);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(
+      req,
+      expect.objectContaining({
+        userId: 'user-001',
+        keyId: 'key-001',
+        scopes: ['read'],
+      })
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it('returns 401 when auth fails', async () => {
+    const handler = vi.fn();
+    const wrappedHandler = withApiAuth(handler);
+
+    const req = createRequest(); // No auth header
+    const response = await wrappedHandler(req);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 when required scopes are missing', async () => {
+    mockKeyLookupSuccess([
+      {
+        id: 'key-001',
+        user_id: 'user-001',
+        key_hash: VALID_KEY_HASH,
+        scopes: ['read'], // Only has read
+        expires_at: null,
+      },
+    ]);
+    mockVerifyApiKey.mockResolvedValue(true);
+
+    const handler = vi.fn();
+    const wrappedHandler = withApiAuth(handler, ['write']); // Requires write
+
+    const req = createRequest({
+      authorization: `Bearer ${VALID_KEY}`,
+    });
+    const response = await wrappedHandler(req);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.status).toBe(403);
+
+    const body = await response.json();
+    expect(body.error).toContain('Insufficient permissions');
+    expect(body.code).toBe('ERROR');
+  });
+
+  it('allows request when all required scopes are present', async () => {
+    mockKeyLookupSuccess([
+      {
+        id: 'key-001',
+        user_id: 'user-001',
+        key_hash: VALID_KEY_HASH,
+        scopes: ['read', 'write', 'admin'],
+        expires_at: null,
+      },
+    ]);
+    mockVerifyApiKey.mockResolvedValue(true);
+
+    const handler = vi.fn().mockResolvedValue(
+      NextResponse.json({ ok: true })
+    );
+    const wrappedHandler = withApiAuth(handler, ['read', 'write']);
+
+    const req = createRequest({
+      authorization: `Bearer ${VALID_KEY}`,
+    });
+    const response = await wrappedHandler(req);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(response.status).toBe(200);
+  });
+
+  it('defaults to ["read"] scope requirement', async () => {
+    mockKeyLookupSuccess([
+      {
+        id: 'key-001',
+        user_id: 'user-001',
+        key_hash: VALID_KEY_HASH,
+        scopes: ['read'],
+        expires_at: null,
+      },
+    ]);
+    mockVerifyApiKey.mockResolvedValue(true);
+
+    const handler = vi.fn().mockResolvedValue(
+      NextResponse.json({ ok: true })
+    );
+    const wrappedHandler = withApiAuth(handler); // No scopes specified
+
+    const req = createRequest({
+      authorization: `Bearer ${VALID_KEY}`,
+    });
+    await wrappedHandler(req);
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});
+
+describe('apiAuthError', () => {
+  it('returns UNAUTHORIZED code for 401 status', () => {
+    const response = apiAuthError('Not authenticated', 401);
+    expect(response.status).toBe(401);
+  });
+
+  it('returns RATE_LIMITED code for 429 status', () => {
+    const response = apiAuthError('Rate limited', 429);
+    expect(response.status).toBe(429);
+  });
+
+  it('returns ERROR code for other statuses', () => {
+    const response = apiAuthError('Something went wrong', 500);
+    expect(response.status).toBe(500);
+  });
+
+  it('includes Content-Type header', () => {
+    const response = apiAuthError('Error', 401);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+  });
+});
+
+describe('addRateLimitHeaders', () => {
+  it('returns response unchanged when no rate limit entry exists', () => {
+    const response = NextResponse.json({ data: 'test' });
+    const result = addRateLimitHeaders(response, 'nonexistent-key');
+
+    // Headers should not be set
+    expect(result.headers.get('X-RateLimit-Limit')).toBeNull();
+  });
+});

--- a/packages/styrby-web/vitest.setup.ts
+++ b/packages/styrby-web/vitest.setup.ts
@@ -1,1 +1,10 @@
 import '@testing-library/jest-dom/vitest';
+
+/**
+ * Mock DOM APIs not implemented by jsdom.
+ *
+ * WHY: jsdom doesn't implement scrollIntoView (or many other layout-related APIs)
+ * because it has no visual rendering engine. Tests that render components calling
+ * scrollIntoView would throw "not a function" errors without this stub.
+ */
+Element.prototype.scrollIntoView = () => {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@types/tmp':
         specifier: ^0.2.6
         version: 0.2.6
+      '@vitest/coverage-v8':
+        specifier: 4.0.18
+        version: 4.0.18(vitest@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))
       axios:
         specifier: ^1.13.4
         version: 1.13.4
@@ -12516,6 +12519,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.0.18(vitest@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.18
+      ast-v8-to-istanbul: 0.3.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+
   '@vitest/coverage-v8@4.0.18(vitest@3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -13978,9 +13995,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       eslint: 9.39.2(jiti@1.21.7)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-expo: 0.1.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react-hooks: 4.6.2(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
@@ -13994,8 +14011,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@1.21.7))
@@ -14017,7 +14034,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14028,18 +14045,43 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@1.21.7)
+      get-tsconfig: 4.13.6
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.2(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -14052,7 +14094,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14063,7 +14105,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14081,7 +14123,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14092,7 +14134,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
 
   packages/styrby-web:
     dependencies:
@@ -13995,9 +13998,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       eslint: 9.39.2(jiti@1.21.7)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-expo: 0.1.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react-hooks: 4.6.2(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
@@ -14034,21 +14037,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
-      get-tsconfig: 4.13.6
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -14064,14 +14052,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@1.21.7)
+      get-tsconfig: 4.13.6
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -14094,7 +14097,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14105,7 +14108,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -498,19 +498,6 @@ async function checkNotificationPreferences(
 }
 
 /**
- * Legacy wrapper for backward compatibility.
- * @deprecated Use checkNotificationPreferences instead
- */
-async function shouldSendNotification(
-  supabase: ReturnType<typeof createClient>,
-  userId: string,
-  eventType: NotificationEventType
-): Promise<boolean> {
-  const result = await checkNotificationPreferences(supabase, userId, eventType);
-  return result.shouldSend;
-}
-
-/**
  * Checks whether a specific notification type is enabled in user preferences.
  *
  * Maps each event type to its corresponding preference column.


### PR DESCRIPTION
## Summary
- **Tests**: 214 → 1,097 (5.1x increase) across shared, CLI, and web packages
- **CI**: 3 new test jobs (test-shared, test-cli with ripgrep/difftastic, test-web)
- **Code quality**: 23 ESLint warnings → 0, 2 deprecated functions removed, CLI doctor command + interactive screens added

## Changes

### New Test Suites (14 files, ~5,400 LOC)
- `packages/styrby-shared/tests/` — 210 tests (encryption, api-keys, notification-priority, offline-queue, pairing)
- `packages/styrby-web/src/*/__tests__/` — 155+ tests (template-card, template-form, templates-client, player, controls, use-replay-state, summary-tab, api-auth)

### CI Pipeline (`.github/workflows/ci.yml`)
- Added `test-shared` job for 210 shared package tests
- Updated `test-cli` job: installs ripgrep + difftastic, enables `--coverage`, removed `continue-on-error`
- Added `test-web` job for 629 web unit tests
- Updated `summary` job to gate on all test jobs

### Code Quality Fixes
- Fixed unused props in `calendar.tsx`, type-only `actionTypes` in `use-toast.ts` (both locations)
- Removed unused `useCallback` import in `cookie-consent.tsx`
- Removed deprecated `shouldSendNotification()` and `printOfflineWarning()`
- Removed "(coming soon)" from subscription email

### New CLI Features
- `doctor.ts` — health-check command (Node.js, config, auth, agent detection)
- `interactive.ts` — Recent Sessions and Settings screens (previously disabled)

### Test Infrastructure
- `vitest.setup.ts` — added `scrollIntoView` jsdom mock
- `@vitest/coverage-v8` installed in CLI package

## Test Plan
- [x] All 629 web tests pass locally
- [x] All 210 shared tests pass locally
- [x] All 250 CLI tests pass locally
- [ ] CI pipeline passes with new test jobs
- [ ] Vercel preview deploys successfully

---
🤖 Shipped with [Claude Code](https://claude.com/claude-code)