### PR TITLE
feat(cli): bare styrby command starts session with auto-onboard

### DIFF
--- a/packages/styrby-cli/package.json
+++ b/packages/styrby-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styrby-cli",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "description": "Mobile remote control for AI coding agents. Control Claude Code, Codex, Gemini, and OpenCode from your phone.",
   "author": {
     "name": "Steel Motion LLC",

--- a/packages/styrby-cli/src/commands/onboard.ts
+++ b/packages/styrby-cli/src/commands/onboard.ts
@@ -542,8 +542,8 @@ export async function runOnboard(options: OnboardOptions = {}): Promise<OnboardR
   console.log(chalk.green("  You're all set!"));
   console.log('');
   console.log('  Try these commands:');
-  console.log(chalk.cyan('    styrby              ') + chalk.dim('Interactive mode'));
-  console.log(chalk.cyan('    styrby start        ') + chalk.dim('Start a coding session'));
+  console.log(chalk.cyan('    styrby              ') + chalk.dim('Start a coding session'));
+  console.log(chalk.cyan('    styrby costs        ') + chalk.dim('See token spend'));
   console.log(chalk.cyan('    styrby doctor       ') + chalk.dim('Check system health'));
   console.log('');
 

--- a/packages/styrby-cli/src/index.ts
+++ b/packages/styrby-cli/src/index.ts
@@ -39,22 +39,36 @@ export { AgentRegistry } from './agent/core/AgentRegistry';
 /**
  * CLI version
  */
-export const VERSION = '0.1.0-beta.3';
+export const VERSION = '0.1.0-beta.4';
 
 /**
  * Main CLI entry point.
  *
  * Parses command line arguments and dispatches to appropriate handlers.
- * If no command is given, launches interactive mode.
+ *
+ * WHY bare command starts a session: Every AI coding agent CLI follows
+ * this pattern — `claude`, `codex`, `gemini`, `aider` all start a session
+ * when you type the bare command. Users expect `styrby` to do something
+ * immediately, not show a menu. If not authenticated, we auto-onboard first.
  */
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const command = args[0];
 
-  // Interactive mode if no command given
+  // No command → start a coding session (auto-onboard if needed)
   if (!command || command === undefined) {
-    const { runInteractive } = await import('@/commands/interactive');
-    await runInteractive();
+    const { isAuthenticated } = await import('@/configuration');
+    if (!isAuthenticated()) {
+      // First-time user — run onboard, then start session
+      logger.info(`Styrby CLI v${VERSION}`);
+      const { runOnboard } = await import('@/commands/onboard');
+      const result = await runOnboard({ skipPairing: true });
+      if (!result.success) {
+        process.exit(1);
+      }
+    }
+    // Start session with default agent (claude)
+    await handleStart(args);
     return;
   }
 
@@ -917,16 +931,18 @@ Usage: styrby [command] [options]
 Mobile relay for AI coding agents. Control Claude Code, Codex, Gemini CLI,
 OpenCode, and Aider from your phone. Code stays local — only I/O is relayed.
 
+  styrby                    Start a coding session (auto-setup on first run)
+
 Commands:
 
   Setup
-    onboard                 First-time setup (auth + machine registration + pairing)
-    auth                    Authenticate only (skip pairing)
+    onboard                 Re-run setup wizard (auth + machine registration + pairing)
+    auth                    Re-authenticate only
     pair                    Generate QR code for mobile app pairing
     install <agent>         Install an AI agent (claude, codex, gemini, opencode, aider)
 
   Session
-    start                   Start a coding session
+    start                   Start a coding session (same as bare styrby)
     stop                    Stop running daemon
     status                  Show connection and session status
     logs                    View daemon logs (--follow, --lines N)

--- a/packages/styrby-cli/src/lib.ts
+++ b/packages/styrby-cli/src/lib.ts
@@ -38,7 +38,7 @@ export type {
 /**
  * Version of the Styrby CLI
  */
-export const VERSION = '0.1.0-beta.3';
+export const VERSION = '0.1.0-beta.4';
 
 /**
  * Check if running in development mode


### PR DESCRIPTION
## Summary
- `styrby` (no args) now starts a coding session immediately
- Auto-detects first-time users and runs onboard before starting
- Matches the pattern used by claude, codex, gemini, and aider CLIs
- Updated help text and onboard success message

## Test Plan
- [x] `styrby --help` shows new behavior
- [x] CLI builds clean

---
🤖 Shipped with [Claude Code](https://claude.com/claude-code)