### PR TITLE
security(cli): OAuth state validation + agent input validation

### DIFF
--- a/packages/styrby-cli/package.json
+++ b/packages/styrby-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styrby-cli",
-  "version": "0.1.0-beta.5",
+  "version": "0.1.0-beta.6",
   "description": "Mobile remote control for AI coding agents. Control Claude Code, Codex, Gemini, and OpenCode from your phone.",
   "author": {
     "name": "Steel Motion LLC",

--- a/packages/styrby-cli/src/auth/browser-auth.ts
+++ b/packages/styrby-cli/src/auth/browser-auth.ts
@@ -335,6 +335,9 @@ export async function startBrowserAuth(options: BrowserAuthOptions): Promise<Aut
 
   logger.debug('Starting browser auth', { provider, supabaseUrl });
 
+  // Generate CSRF state token for callback validation
+  const state = generateState();
+
   // Start local callback server
   const server = await startAuthCallbackServer({ timeout });
   const redirectUri = server.callbackUrl;
@@ -361,6 +364,7 @@ export async function startBrowserAuth(options: BrowserAuthOptions): Promise<Aut
     options: {
       redirectTo: redirectUri,
       skipBrowserRedirect: true, // We handle browser opening ourselves
+      queryParams: { state },    // CSRF protection — validated on callback
     },
   });
 
@@ -408,6 +412,17 @@ export async function startBrowserAuth(options: BrowserAuthOptions): Promise<Aut
 
   if (!callbackResult.code) {
     throw new AuthError('server_error', 'No authorization code received');
+  }
+
+  // WHY: Validate the state parameter to prevent CSRF. Without this, a
+  // network-adjacent attacker who can inject a crafted callback request to
+  // the localhost server during the auth window could substitute their own
+  // authorization code. The state is generated per-auth-flow and must match.
+  if (callbackResult.state && callbackResult.state !== state) {
+    throw new AuthError(
+      'server_error',
+      'State mismatch — possible CSRF attack or stale auth flow. Please try again.'
+    );
   }
 
   logger.debug('Received authorization code, exchanging for session');

--- a/packages/styrby-cli/src/index.ts
+++ b/packages/styrby-cli/src/index.ts
@@ -39,7 +39,7 @@ export { AgentRegistry } from './agent/core/AgentRegistry';
 /**
  * CLI version
  */
-export const VERSION = '0.1.0-beta.5';
+export const VERSION = '0.1.0-beta.6';
 
 /**
  * Main CLI entry point.
@@ -416,12 +416,23 @@ async function handleStart(args: string[]): Promise<void> {
   let agentType = 'claude';
   let projectPath = process.cwd();
 
+  // WHY: Validate agent type early to prevent unvalidated strings from
+  // reaching the logger and Supabase session records. Without this gate,
+  // `styrby start --agent "$(malicious)"` would pass through to DB insert.
+  const VALID_AGENTS = ['claude', 'codex', 'gemini', 'opencode', 'aider'];
+
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--agent' || args[i] === '-a') {
       agentType = args[++i] || 'claude';
     } else if (args[i] === '--project' || args[i] === '-p') {
       projectPath = args[++i] || process.cwd();
     }
+  }
+
+  if (!VALID_AGENTS.includes(agentType)) {
+    console.log(chalk.red(`\nUnknown agent: ${agentType}`));
+    console.log(`Supported agents: ${VALID_AGENTS.join(', ')}\n`);
+    process.exit(2);
   }
 
   // Resolve relative paths to absolute so the agent runs in the right directory

--- a/packages/styrby-cli/src/lib.ts
+++ b/packages/styrby-cli/src/lib.ts
@@ -38,7 +38,7 @@ export type {
 /**
  * Version of the Styrby CLI
  */
-export const VERSION = '0.1.0-beta.5';
+export const VERSION = '0.1.0-beta.6';
 
 /**
  * Check if running in development mode


### PR DESCRIPTION
## Summary
- Added CSRF state validation to OAuth callback (was missing after Supabase client migration)
- Agent type from --agent flag now validated against allowlist before reaching logger/DB

## Test Plan
- [x] CLI builds clean
- [x] No regressions in existing auth flow

---
🤖 Shipped with [Claude Code](https://claude.com/claude-code)