### PR TITLE
feat(web): add onboarding flow and support ticket system

### DIFF
--- a/packages/styrby-web/src/app/api/admin/support/[id]/reply/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/reply/route.ts
@@ -1,0 +1,114 @@
+/**
+ * Admin Support Ticket Reply API
+ *
+ * POST /api/admin/support/[id]/reply
+ *
+ * Adds an admin reply to a support ticket and sends an email notification
+ * to the ticket owner via Resend.
+ *
+ * @auth Required - Supabase Auth JWT via cookie (admin only)
+ *
+ * @body { message: string }
+ *
+ * @returns 201 { reply, emailSent: boolean }
+ * @error 400 { error: string }
+ * @error 401 { error: 'Unauthorized' }
+ * @error 403 { error: 'Forbidden' }
+ * @error 404 { error: 'Ticket not found' }
+ * @error 500 { error: string }
+ */
+
+import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { isAdminEmail } from '@/lib/admin';
+import { sendSupportReplyEmail } from '@/lib/resend';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+/** Zod schema for the reply body */
+const ReplySchema = z.object({
+  message: z.string().min(1).max(5000),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // Verify auth and admin status
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!isAdminEmail(user.email)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // Parse and validate body
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const validation = ReplySchema.safeParse(body);
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Message is required (1-5000 characters)' },
+      { status: 400 }
+    );
+  }
+
+  const adminClient = createAdminClient();
+
+  // Verify the ticket exists
+  const { data: ticket, error: ticketError } = await adminClient
+    .from('support_tickets')
+    .select('id, user_id, subject')
+    .eq('id', id)
+    .single();
+
+  if (ticketError || !ticket) {
+    return NextResponse.json({ error: 'Ticket not found' }, { status: 404 });
+  }
+
+  // Insert the admin reply
+  const { data: reply, error: insertError } = await adminClient
+    .from('support_ticket_replies')
+    .insert({
+      ticket_id: id,
+      author_type: 'admin',
+      author_id: user.id,
+      message: validation.data.message,
+    })
+    .select()
+    .single();
+
+  if (insertError) {
+    console.error('[admin/support/reply] Failed to insert reply:', insertError);
+    return NextResponse.json({ error: 'Failed to add reply' }, { status: 500 });
+  }
+
+  // Send email notification to the ticket owner
+  let emailSent = false;
+  const { data: ticketOwner } = await adminClient.auth.admin.getUserById(ticket.user_id);
+
+  if (ticketOwner?.user?.email) {
+    const emailResult = await sendSupportReplyEmail({
+      email: ticketOwner.user.email,
+      subject: ticket.subject,
+      message: validation.data.message,
+      ticketId: ticket.id,
+    });
+    emailSent = emailResult.success;
+  }
+
+  return NextResponse.json({ reply, emailSent }, { status: 201 });
+}

--- a/packages/styrby-web/src/app/api/admin/support/[id]/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/route.ts
@@ -1,0 +1,173 @@
+/**
+ * Admin Single Support Ticket API
+ *
+ * GET /api/admin/support/[id] - Fetch ticket with replies and user info
+ * PATCH /api/admin/support/[id] - Update ticket status or admin notes
+ *
+ * @auth Required - Supabase Auth JWT via cookie (admin only)
+ *
+ * GET @returns 200 { ticket, replies, user }
+ * PATCH @body { status?: string, admin_notes?: string }
+ * PATCH @returns 200 { ticket }
+ *
+ * @error 401 { error: 'Unauthorized' }
+ * @error 403 { error: 'Forbidden' }
+ * @error 404 { error: 'Ticket not found' }
+ * @error 500 { error: string }
+ */
+
+import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { isAdminEmail } from '@/lib/admin';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+/**
+ * Zod schema for PATCH request body validation.
+ * Both fields are optional so admins can update one at a time.
+ */
+const PatchSchema = z.object({
+  status: z.enum(['open', 'in_progress', 'resolved', 'closed']).optional(),
+  admin_notes: z.string().max(10000).optional(),
+});
+
+/**
+ * Verifies the request comes from an authenticated admin user.
+ *
+ * @returns The authenticated user, or a NextResponse error
+ */
+async function verifyAdmin() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  if (!isAdminEmail(user.email)) {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  return { user };
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const result = await verifyAdmin();
+  if ('error' in result && result.error) return result.error;
+
+  const adminClient = createAdminClient();
+
+  // Fetch ticket
+  const { data: ticket, error: ticketError } = await adminClient
+    .from('support_tickets')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (ticketError || !ticket) {
+    return NextResponse.json({ error: 'Ticket not found' }, { status: 404 });
+  }
+
+  // Fetch replies
+  const { data: replies } = await adminClient
+    .from('support_ticket_replies')
+    .select('*')
+    .eq('ticket_id', id)
+    .order('created_at', { ascending: true });
+
+  // Fetch user info
+  const { data: userData } = await adminClient.auth.admin.getUserById(ticket.user_id);
+  const { data: profile } = await adminClient
+    .from('profiles')
+    .select('display_name, avatar_url, created_at')
+    .eq('id', ticket.user_id)
+    .single();
+
+  // Fetch subscription info
+  const { data: subscription } = await adminClient
+    .from('subscriptions')
+    .select('tier, status')
+    .eq('user_id', ticket.user_id)
+    .single();
+
+  // Fetch machine count
+  const { count: machineCount } = await adminClient
+    .from('machines')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', ticket.user_id);
+
+  return NextResponse.json({
+    ticket,
+    replies: replies || [],
+    user: {
+      id: ticket.user_id,
+      email: userData?.user?.email || 'Unknown',
+      display_name: profile?.display_name || null,
+      avatar_url: profile?.avatar_url || null,
+      joined_at: profile?.created_at || null,
+      tier: subscription?.tier || 'free',
+      subscription_status: subscription?.status || null,
+      machines_count: machineCount || 0,
+    },
+  });
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const result = await verifyAdmin();
+  if ('error' in result && result.error) return result.error;
+
+  // Parse and validate body
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const validation = PatchSchema.safeParse(body);
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: 'Invalid request body', details: validation.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const adminClient = createAdminClient();
+
+  // Build update object from validated fields
+  const updates: Record<string, unknown> = {};
+  if (validation.data.status !== undefined) {
+    updates.status = validation.data.status;
+  }
+  if (validation.data.admin_notes !== undefined) {
+    updates.admin_notes = validation.data.admin_notes;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+  }
+
+  const { data: ticket, error } = await adminClient
+    .from('support_tickets')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('[admin/support] Failed to update ticket:', error);
+    return NextResponse.json({ error: 'Failed to update ticket' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ticket });
+}

--- a/packages/styrby-web/src/app/api/admin/support/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/route.ts
@@ -1,0 +1,105 @@
+/**
+ * Admin Support Tickets API
+ *
+ * GET /api/admin/support
+ *
+ * Lists all support tickets with user info for admin management.
+ * Requires the requesting user to be in the admin allowlist.
+ *
+ * @auth Required - Supabase Auth JWT via cookie (admin only)
+ *
+ * @query {
+ *   status?: 'open' | 'in_progress' | 'resolved' | 'closed',
+ *   page?: number (default 1),
+ *   limit?: number (default 50, max 100)
+ * }
+ *
+ * @returns 200 { tickets: Array, total: number }
+ * @error 401 { error: 'Unauthorized' }
+ * @error 403 { error: 'Forbidden' }
+ * @error 500 { error: string }
+ */
+
+import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { isAdminEmail } from '@/lib/admin';
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  // Verify the requesting user is authenticated
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Verify admin access
+  if (!isAdminEmail(user.email)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // Parse query params
+  const url = new URL(request.url);
+  const status = url.searchParams.get('status');
+  const page = Math.max(1, parseInt(url.searchParams.get('page') || '1', 10));
+  const limit = Math.min(100, Math.max(1, parseInt(url.searchParams.get('limit') || '50', 10)));
+  const offset = (page - 1) * limit;
+
+  // Use admin client to bypass RLS and access all tickets
+  const adminClient = createAdminClient();
+
+  // Build the query
+  let query = adminClient
+    .from('support_tickets')
+    .select(
+      `
+      *,
+      profiles!support_tickets_user_id_fkey(
+        display_name,
+        avatar_url
+      )
+    `,
+      { count: 'exact' }
+    )
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (status && ['open', 'in_progress', 'resolved', 'closed'].includes(status)) {
+    query = query.eq('status', status);
+  }
+
+  const { data: tickets, count, error } = await query;
+
+  if (error) {
+    console.error('[admin/support] Failed to fetch tickets:', error);
+    return NextResponse.json({ error: 'Failed to fetch tickets' }, { status: 500 });
+  }
+
+  // Fetch user emails from auth.users via admin client
+  // WHY: profiles table does not store emails; those live in auth.users.
+  // We batch-fetch user data for all unique user_ids in the result set.
+  const userIds = [...new Set((tickets || []).map((t: Record<string, unknown>) => t.user_id as string))];
+
+  const userMap: Record<string, { email: string }> = {};
+
+  for (const uid of userIds) {
+    const { data: userData } = await adminClient.auth.admin.getUserById(uid);
+    if (userData?.user) {
+      userMap[uid] = { email: userData.user.email || '' };
+    }
+  }
+
+  // Enrich tickets with user email
+  const enrichedTickets = (tickets || []).map((ticket: Record<string, unknown>) => ({
+    ...ticket,
+    user_email: userMap[ticket.user_id as string]?.email || 'Unknown',
+  }));
+
+  return NextResponse.json({
+    tickets: enrichedTickets,
+    total: count || 0,
+  });
+}

--- a/packages/styrby-web/src/app/api/onboarding/complete/route.ts
+++ b/packages/styrby-web/src/app/api/onboarding/complete/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Onboarding Completion Route
+ *
+ * Marks the authenticated user's onboarding as complete by setting
+ * the `onboarding_completed_at` timestamp on their profile. Called
+ * automatically when all onboarding steps are finished, or when the
+ * user manually dismisses the onboarding banner.
+ *
+ * POST /api/onboarding/complete
+ *
+ * @auth Required - Supabase Auth JWT via cookie
+ *
+ * @returns 200 { success: true }
+ *
+ * @error 401 { error: 'Unauthorized' }
+ * @error 500 { error: 'Failed to complete onboarding' }
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST() {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({ onboarding_completed_at: new Date().toISOString() })
+      .eq('id', user.id);
+
+    if (updateError) {
+      console.error('Failed to mark onboarding complete:', updateError.message);
+      return NextResponse.json(
+        { error: 'Failed to complete onboarding' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const isDev = process.env.NODE_ENV === 'development';
+    console.error(
+      'Onboarding complete POST error:',
+      isDev ? error : error instanceof Error ? error.message : 'Unknown error'
+    );
+    return NextResponse.json(
+      { error: 'Failed to complete onboarding' },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/page.tsx
@@ -1,0 +1,476 @@
+'use client';
+
+/**
+ * Admin Support Ticket Detail Page
+ *
+ * Shows the full ticket with user info panel, reply thread, admin reply form,
+ * status management dropdown, and internal notes textarea.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft, Send, RefreshCw, User } from 'lucide-react';
+
+/* ──────────────────────────── Types ──────────────────────────── */
+
+interface TicketData {
+  id: string;
+  user_id: string;
+  type: 'bug' | 'feature' | 'question';
+  subject: string;
+  description: string;
+  status: 'open' | 'in_progress' | 'resolved' | 'closed';
+  priority: 'low' | 'medium' | 'high';
+  admin_notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TicketReply {
+  id: string;
+  ticket_id: string;
+  author_type: 'user' | 'admin';
+  author_id: string;
+  message: string;
+  created_at: string;
+}
+
+interface TicketUser {
+  id: string;
+  email: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  joined_at: string | null;
+  tier: string;
+  subscription_status: string | null;
+  machines_count: number;
+}
+
+/* ──────────────────────────── Helpers ────────────────────────── */
+
+/**
+ * Returns a human-readable relative time string.
+ *
+ * @param dateStr - ISO 8601 date string
+ * @returns Relative time string
+ */
+function getRelativeTime(dateStr: string): string {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffDay = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDay > 30) return date.toLocaleDateString();
+  if (diffDay > 0) return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
+  const diffHr = Math.floor(diffMs / (1000 * 60 * 60));
+  if (diffHr > 0) return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`;
+  const diffMin = Math.floor(diffMs / (1000 * 60));
+  if (diffMin > 0) return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`;
+  return 'Just now';
+}
+
+/** Badge styles for ticket types */
+const TYPE_BADGE: Record<string, { bg: string; text: string; label: string }> = {
+  bug: { bg: 'bg-red-500/10', text: 'text-red-400', label: 'Bug Report' },
+  feature: { bg: 'bg-blue-500/10', text: 'text-blue-400', label: 'Feature Request' },
+  question: { bg: 'bg-amber-500/10', text: 'text-amber-400', label: 'General Question' },
+};
+
+/** Badge styles for tier labels */
+const TIER_BADGE: Record<string, { bg: string; text: string; label: string }> = {
+  free: { bg: 'bg-zinc-700/50', text: 'text-zinc-400', label: 'Free' },
+  pro: { bg: 'bg-amber-500/10', text: 'text-amber-400', label: 'Pro' },
+  power: { bg: 'bg-purple-500/10', text: 'text-purple-400', label: 'Power' },
+};
+
+/** All possible ticket statuses for the dropdown */
+const STATUS_OPTIONS = [
+  { value: 'open', label: 'Open' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'closed', label: 'Closed' },
+];
+
+/* ──────────────────────────── Component ──────────────────────── */
+
+export default function AdminTicketDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [ticket, setTicket] = useState<TicketData | null>(null);
+  const [replies, setReplies] = useState<TicketReply[]>([]);
+  const [ticketUser, setTicketUser] = useState<TicketUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Admin reply form
+  const [replyText, setReplyText] = useState('');
+  const [sending, setSending] = useState(false);
+  const [replyError, setReplyError] = useState<string | null>(null);
+  const [replySuccess, setReplySuccess] = useState<string | null>(null);
+
+  // Status update
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+
+  // Admin notes
+  const [adminNotes, setAdminNotes] = useState('');
+  const [notesSaving, setNotesSaving] = useState(false);
+  const [notesSaved, setNotesSaved] = useState(false);
+
+  /**
+   * Fetches the ticket, replies, and user info from the admin API.
+   */
+  const fetchTicket = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/admin/support/${id}`);
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || 'Failed to fetch ticket');
+        setLoading(false);
+        return;
+      }
+
+      const data = await res.json();
+      setTicket(data.ticket);
+      setReplies(data.replies);
+      setTicketUser(data.user);
+      setAdminNotes(data.ticket.admin_notes || '');
+    } catch {
+      setError('Failed to fetch ticket');
+    }
+    setLoading(false);
+  }, [id]);
+
+  useEffect(() => {
+    fetchTicket();
+  }, [fetchTicket]);
+
+  /**
+   * Sends an admin reply and triggers email notification.
+   */
+  const handleSendReply = useCallback(async () => {
+    if (!replyText.trim()) return;
+
+    setSending(true);
+    setReplyError(null);
+    setReplySuccess(null);
+
+    try {
+      const res = await fetch(`/api/admin/support/${id}/reply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: replyText.trim() }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setReplyError(data.error || 'Failed to send reply');
+        setSending(false);
+        return;
+      }
+
+      const data = await res.json();
+      setReplyText('');
+      setReplySuccess(data.emailSent ? 'Reply sent and email delivered.' : 'Reply sent (email delivery skipped).');
+      // Refresh to show the new reply
+      await fetchTicket();
+    } catch {
+      setReplyError('Failed to send reply');
+    }
+    setSending(false);
+  }, [id, replyText, fetchTicket]);
+
+  /**
+   * Updates the ticket status via the admin API.
+   */
+  const handleStatusChange = useCallback(
+    async (newStatus: string) => {
+      setUpdatingStatus(true);
+
+      try {
+        const res = await fetch(`/api/admin/support/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: newStatus }),
+        });
+
+        if (res.ok) {
+          const data = await res.json();
+          setTicket(data.ticket);
+        }
+      } catch {
+        // Silently fail; the dropdown will retain the old value
+      }
+      setUpdatingStatus(false);
+    },
+    [id]
+  );
+
+  /**
+   * Saves admin notes on blur (auto-save pattern).
+   */
+  const handleNotesSave = useCallback(async () => {
+    if (!ticket || adminNotes === (ticket.admin_notes || '')) return;
+
+    setNotesSaving(true);
+    setNotesSaved(false);
+
+    try {
+      const res = await fetch(`/api/admin/support/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ admin_notes: adminNotes }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        setTicket(data.ticket);
+        setNotesSaved(true);
+        setTimeout(() => setNotesSaved(false), 2000);
+      }
+    } catch {
+      // Silently fail
+    }
+    setNotesSaving(false);
+  }, [id, adminNotes, ticket]);
+
+  /* ── Loading / Error states ──────────────────────────────────── */
+
+  if (loading) {
+    return (
+      <div className="py-16 text-center">
+        <RefreshCw className="mx-auto h-8 w-8 animate-spin text-zinc-500" />
+        <p className="mt-4 text-sm text-zinc-500">Loading ticket...</p>
+      </div>
+    );
+  }
+
+  if (error || !ticket) {
+    return (
+      <div className="py-16 text-center">
+        <p className="text-sm text-red-400">{error || 'Ticket not found'}</p>
+        <button
+          onClick={() => router.push('/dashboard/admin/support')}
+          className="mt-4 text-sm text-amber-400 hover:text-amber-300"
+        >
+          Back to tickets
+        </button>
+      </div>
+    );
+  }
+
+  const typeBadge = TYPE_BADGE[ticket.type];
+  const tierBadge = TIER_BADGE[ticketUser?.tier || 'free'] || TIER_BADGE.free;
+
+  return (
+    <div>
+      {/* Back link */}
+      <Link
+        href="/dashboard/admin/support"
+        className="mb-6 inline-flex items-center gap-2 text-sm text-zinc-400 transition-colors hover:text-zinc-100"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to tickets
+      </Link>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Main content: ticket + replies (2/3 width on desktop) */}
+        <div className="lg:col-span-2">
+          {/* Ticket header */}
+          <div className="mb-6 rounded-xl border border-zinc-800 bg-zinc-900 p-6">
+            <div className="mb-4 flex flex-wrap items-center gap-2">
+              <span
+                className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${typeBadge.bg} ${typeBadge.text}`}
+              >
+                {typeBadge.label}
+              </span>
+              {ticket.type === 'bug' && (
+                <span className="inline-flex items-center rounded-full bg-zinc-700/50 px-2.5 py-0.5 text-xs font-medium text-zinc-300">
+                  Priority: {ticket.priority}
+                </span>
+              )}
+              <span className="font-mono text-xs text-zinc-500">{ticket.id.slice(0, 8)}</span>
+            </div>
+
+            <h1 className="mb-2 text-xl font-bold text-zinc-100">{ticket.subject}</h1>
+            <p className="whitespace-pre-wrap text-sm leading-relaxed text-zinc-300">
+              {ticket.description}
+            </p>
+            <p className="mt-4 text-xs text-zinc-500">
+              Submitted {getRelativeTime(ticket.created_at)}
+              {ticket.updated_at !== ticket.created_at && (
+                <> &middot; Updated {getRelativeTime(ticket.updated_at)}</>
+              )}
+            </p>
+          </div>
+
+          {/* Status management */}
+          <div className="mb-6 rounded-xl border border-zinc-800 bg-zinc-900 p-4">
+            <div className="flex items-center justify-between">
+              <label htmlFor="status-select" className="text-sm font-medium text-zinc-300">
+                Status
+              </label>
+              <select
+                id="status-select"
+                value={ticket.status}
+                onChange={(e) => handleStatusChange(e.target.value)}
+                disabled={updatingStatus}
+                className="rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500 disabled:opacity-50"
+              >
+                {STATUS_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Reply thread */}
+          {replies.length > 0 && (
+            <div className="mb-6 space-y-4">
+              <h2 className="text-sm font-semibold text-zinc-400">
+                Replies ({replies.length})
+              </h2>
+              {replies.map((reply) => {
+                const isAdmin = reply.author_type === 'admin';
+                return (
+                  <div
+                    key={reply.id}
+                    className={`flex ${isAdmin ? 'justify-end' : 'justify-start'}`}
+                  >
+                    <div
+                      className={`max-w-[80%] rounded-xl px-4 py-3 ${
+                        isAdmin
+                          ? 'border border-amber-500/20 bg-amber-500/5'
+                          : 'border border-zinc-700 bg-zinc-800'
+                      }`}
+                    >
+                      <p className="mb-1 text-xs font-medium text-zinc-400">
+                        {isAdmin ? 'Admin' : ticketUser?.display_name || ticketUser?.email || 'User'}
+                      </p>
+                      <p className="whitespace-pre-wrap text-sm text-zinc-200">
+                        {reply.message}
+                      </p>
+                      <p className="mt-2 text-xs text-zinc-500">
+                        {getRelativeTime(reply.created_at)}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Admin reply form */}
+          <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4">
+            <label htmlFor="admin-reply" className="mb-2 block text-sm font-medium text-zinc-300">
+              Send Reply
+            </label>
+            <textarea
+              id="admin-reply"
+              value={replyText}
+              onChange={(e) => setReplyText(e.target.value)}
+              placeholder="Type your reply to the user..."
+              rows={4}
+              maxLength={5000}
+              className="mb-3 w-full resize-none rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+            />
+            {replyError && (
+              <p className="mb-3 text-sm text-red-400" role="alert">
+                {replyError}
+              </p>
+            )}
+            {replySuccess && (
+              <p className="mb-3 text-sm text-green-400">{replySuccess}</p>
+            )}
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-zinc-500">
+                Reply will be emailed to {ticketUser?.email || 'the user'}.
+              </p>
+              <button
+                onClick={handleSendReply}
+                disabled={sending || !replyText.trim()}
+                className="inline-flex items-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Send className="h-4 w-4" />
+                {sending ? 'Sending...' : 'Send Reply'}
+              </button>
+            </div>
+          </div>
+
+          {/* Internal notes */}
+          <div className="mt-6 rounded-xl border border-zinc-800 bg-zinc-900 p-4">
+            <div className="mb-2 flex items-center justify-between">
+              <label htmlFor="admin-notes" className="text-sm font-medium text-zinc-300">
+                Internal Notes
+              </label>
+              <span className="text-xs text-zinc-500">
+                {notesSaving ? 'Saving...' : notesSaved ? 'Saved' : 'Auto-saves on blur'}
+              </span>
+            </div>
+            <textarea
+              id="admin-notes"
+              value={adminNotes}
+              onChange={(e) => setAdminNotes(e.target.value)}
+              onBlur={handleNotesSave}
+              placeholder="Private notes about this ticket (not visible to user)..."
+              rows={3}
+              className="w-full resize-none rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600"
+            />
+          </div>
+        </div>
+
+        {/* User info sidebar (1/3 width on desktop) */}
+        <div className="lg:col-span-1">
+          <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-6">
+            <div className="mb-4 flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-zinc-800">
+                <User className="h-5 w-5 text-zinc-400" />
+              </div>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-zinc-100">
+                  {ticketUser?.display_name || 'No display name'}
+                </p>
+                <p className="truncate text-xs text-zinc-500">{ticketUser?.email}</p>
+              </div>
+            </div>
+
+            <div className="space-y-3 border-t border-zinc-800 pt-4">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-zinc-500">Tier</span>
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${tierBadge.bg} ${tierBadge.text}`}
+                >
+                  {tierBadge.label}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-zinc-500">Machines</span>
+                <span className="text-xs text-zinc-300">{ticketUser?.machines_count || 0}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-zinc-500">Account ID</span>
+                <span className="font-mono text-xs text-zinc-500">
+                  {ticketUser?.id?.slice(0, 8) || 'N/A'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-zinc-500">Joined</span>
+                <span className="text-xs text-zinc-300">
+                  {ticketUser?.joined_at
+                    ? new Date(ticketUser.joined_at).toLocaleDateString()
+                    : 'N/A'}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/page.tsx
@@ -146,6 +146,7 @@ export default function AdminTicketDetailPage() {
   }, [id]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchTicket();
   }, [fetchTicket]);
 

--- a/packages/styrby-web/src/app/dashboard/admin/support/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/page.tsx
@@ -1,0 +1,297 @@
+'use client';
+
+/**
+ * Admin Support Tickets Dashboard
+ *
+ * Fetches all support tickets from the admin API and displays them in a
+ * filterable table (desktop) or card list (mobile). Clicking a row navigates
+ * to the ticket detail page.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, RefreshCw } from 'lucide-react';
+
+/* ──────────────────────────── Types ──────────────────────────── */
+
+interface AdminTicket {
+  id: string;
+  user_id: string;
+  type: 'bug' | 'feature' | 'question';
+  subject: string;
+  status: 'open' | 'in_progress' | 'resolved' | 'closed';
+  priority: 'low' | 'medium' | 'high';
+  created_at: string;
+  updated_at: string;
+  user_email: string;
+  profiles?: {
+    display_name: string | null;
+  } | null;
+}
+
+type StatusFilter = 'all' | 'open' | 'in_progress' | 'resolved' | 'closed';
+
+/* ──────────────────────────── Helpers ────────────────────────── */
+
+/**
+ * Returns a human-readable relative time string.
+ *
+ * @param dateStr - ISO 8601 date string
+ * @returns Relative time string
+ */
+function getRelativeTime(dateStr: string): string {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffDay = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDay > 30) return date.toLocaleDateString();
+  if (diffDay > 0) return `${diffDay}d ago`;
+  const diffHr = Math.floor(diffMs / (1000 * 60 * 60));
+  if (diffHr > 0) return `${diffHr}h ago`;
+  const diffMin = Math.floor(diffMs / (1000 * 60));
+  if (diffMin > 0) return `${diffMin}m ago`;
+  return 'Now';
+}
+
+/** Short ID display (first 8 chars of UUID) */
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+/** Badge styles for ticket types */
+const TYPE_BADGE: Record<string, { bg: string; text: string; label: string }> = {
+  bug: { bg: 'bg-red-500/10', text: 'text-red-400', label: 'Bug' },
+  feature: { bg: 'bg-blue-500/10', text: 'text-blue-400', label: 'Feature' },
+  question: { bg: 'bg-amber-500/10', text: 'text-amber-400', label: 'Question' },
+};
+
+/** Badge styles for ticket statuses */
+const STATUS_BADGE: Record<string, { bg: string; text: string; label: string }> = {
+  open: { bg: 'bg-amber-500/10', text: 'text-amber-400', label: 'Open' },
+  in_progress: { bg: 'bg-blue-500/10', text: 'text-blue-400', label: 'In Progress' },
+  resolved: { bg: 'bg-green-500/10', text: 'text-green-400', label: 'Resolved' },
+  closed: { bg: 'bg-zinc-700/50', text: 'text-zinc-400', label: 'Closed' },
+};
+
+/* ──────────────────────────── Component ──────────────────────── */
+
+export default function AdminSupportPage() {
+  const [tickets, setTickets] = useState<AdminTicket[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  /**
+   * Fetches tickets from the admin API with the current status filter.
+   */
+  const fetchTickets = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams();
+    if (statusFilter !== 'all') {
+      params.set('status', statusFilter);
+    }
+
+    try {
+      const res = await fetch(`/api/admin/support?${params.toString()}`);
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || 'Failed to fetch tickets');
+        setLoading(false);
+        return;
+      }
+
+      const data = await res.json();
+      setTickets(data.tickets);
+      setTotal(data.total);
+    } catch {
+      setError('Failed to fetch tickets');
+    }
+    setLoading(false);
+  }, [statusFilter]);
+
+  useEffect(() => {
+    fetchTickets();
+  }, [fetchTickets]);
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6">
+        <Link
+          href="/dashboard"
+          className="mb-4 inline-flex items-center gap-2 text-sm text-zinc-400 transition-colors hover:text-zinc-100"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to dashboard
+        </Link>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">Support Tickets</h1>
+            <p className="mt-1 text-sm text-zinc-400">
+              {total} ticket{total !== 1 ? 's' : ''} total
+            </p>
+          </div>
+          <button
+            onClick={fetchTickets}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-lg border border-zinc-700 px-3 py-2 text-sm text-zinc-300 transition-colors hover:bg-zinc-800 disabled:opacity-50"
+            aria-label="Refresh tickets"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Status filter tabs */}
+      <div className="mb-6 flex flex-wrap gap-2">
+        {(['all', 'open', 'in_progress', 'resolved', 'closed'] as StatusFilter[]).map((status) => (
+          <button
+            key={status}
+            onClick={() => setStatusFilter(status)}
+            className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+              statusFilter === status
+                ? 'bg-amber-500 text-white'
+                : 'border border-zinc-700 text-zinc-400 hover:text-zinc-100'
+            }`}
+          >
+            {status === 'all'
+              ? 'All'
+              : status === 'in_progress'
+                ? 'In Progress'
+                : status.charAt(0).toUpperCase() + status.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div className="mb-6 rounded-xl border border-red-500/30 bg-red-500/5 p-4">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {loading && tickets.length === 0 && (
+        <div className="py-16 text-center">
+          <RefreshCw className="mx-auto h-8 w-8 animate-spin text-zinc-500" />
+          <p className="mt-4 text-sm text-zinc-500">Loading tickets...</p>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && tickets.length === 0 && !error && (
+        <div className="py-16 text-center">
+          <p className="text-sm text-zinc-500">No tickets found.</p>
+        </div>
+      )}
+
+      {/* Desktop table view */}
+      {tickets.length > 0 && (
+        <>
+          <div className="hidden overflow-x-auto rounded-xl border border-zinc-800 md:block">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800 bg-zinc-900/50">
+                  <th className="px-4 py-3 text-left font-medium text-zinc-400">ID</th>
+                  <th className="px-4 py-3 text-left font-medium text-zinc-400">Type</th>
+                  <th className="px-4 py-3 text-left font-medium text-zinc-400">Subject</th>
+                  <th className="px-4 py-3 text-left font-medium text-zinc-400">User</th>
+                  <th className="px-4 py-3 text-left font-medium text-zinc-400">Status</th>
+                  <th className="px-4 py-3 text-left font-medium text-zinc-400">Created</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-800">
+                {tickets.map((ticket) => {
+                  const typeBadge = TYPE_BADGE[ticket.type];
+                  const statusBadge = STATUS_BADGE[ticket.status];
+                  return (
+                    <tr key={ticket.id} className="transition-colors hover:bg-zinc-800/50">
+                      <td className="px-4 py-3">
+                        <Link
+                          href={`/dashboard/admin/support/${ticket.id}`}
+                          className="font-mono text-xs text-zinc-500 hover:text-amber-400"
+                        >
+                          {shortId(ticket.id)}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${typeBadge.bg} ${typeBadge.text}`}
+                        >
+                          {typeBadge.label}
+                        </span>
+                      </td>
+                      <td className="max-w-xs truncate px-4 py-3">
+                        <Link
+                          href={`/dashboard/admin/support/${ticket.id}`}
+                          className="text-zinc-100 hover:text-amber-400"
+                        >
+                          {ticket.subject}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3 text-zinc-400">
+                        {ticket.profiles?.display_name || ticket.user_email}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${statusBadge.bg} ${statusBadge.text}`}
+                        >
+                          {statusBadge.label}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-zinc-500">
+                        {getRelativeTime(ticket.created_at)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile card view */}
+          <div className="space-y-3 md:hidden">
+            {tickets.map((ticket) => {
+              const typeBadge = TYPE_BADGE[ticket.type];
+              const statusBadge = STATUS_BADGE[ticket.status];
+              return (
+                <Link
+                  key={ticket.id}
+                  href={`/dashboard/admin/support/${ticket.id}`}
+                  className="block rounded-xl border border-zinc-800 bg-zinc-900 p-4 transition-colors hover:border-zinc-700"
+                >
+                  <div className="mb-2 flex flex-wrap items-center gap-2">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${typeBadge.bg} ${typeBadge.text}`}
+                    >
+                      {typeBadge.label}
+                    </span>
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${statusBadge.bg} ${statusBadge.text}`}
+                    >
+                      {statusBadge.label}
+                    </span>
+                    <span className="text-xs text-zinc-500">
+                      {getRelativeTime(ticket.created_at)}
+                    </span>
+                  </div>
+                  <p className="truncate text-sm font-medium text-zinc-100">
+                    {ticket.subject}
+                  </p>
+                  <p className="mt-1 text-xs text-zinc-500">
+                    {ticket.profiles?.display_name || ticket.user_email}
+                  </p>
+                </Link>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/admin/support/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/page.tsx
@@ -85,6 +85,7 @@ export default function AdminSupportPage() {
 
   /**
    * Fetches tickets from the admin API with the current status filter.
+   * WHY useCallback: called from useEffect and from the Refresh button onClick.
    */
   const fetchTickets = useCallback(async () => {
     setLoading(true);
@@ -114,6 +115,7 @@ export default function AdminSupportPage() {
   }, [statusFilter]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchTickets();
   }, [fetchTickets]);
 

--- a/packages/styrby-web/src/app/dashboard/dashboard-shell.tsx
+++ b/packages/styrby-web/src/app/dashboard/dashboard-shell.tsx
@@ -5,8 +5,20 @@ import { DashboardTopNav } from '@/components/dashboard/topnav';
 import { DashboardSidebar } from '@/components/dashboard/sidebar';
 import { MobileNav } from '@/components/dashboard/mobile-nav';
 import { CommandPalette } from '@/components/dashboard/command-palette';
+import { OnboardingModal } from '@/components/dashboard/onboarding-modal';
+import { OnboardingBanner } from '@/components/dashboard/onboarding-banner';
 import { cn } from '@/lib/utils';
 import { startConnectivityListener } from '@/lib/offline-sync';
+import type { OnboardingState } from '@/lib/onboarding';
+
+interface DashboardShellProps {
+  children: React.ReactNode;
+  /**
+   * Onboarding state for the current user. Undefined when onboarding
+   * is already complete, in which case no onboarding UI is rendered.
+   */
+  onboardingState?: OnboardingState;
+}
 
 /**
  * Client-side dashboard shell with collapsible sidebar, topnav, and mobile nav.
@@ -15,9 +27,14 @@ import { startConnectivityListener } from '@/lib/offline-sync';
  * default. The sidebar collapse state and mobile nav toggle require useState,
  * which only works in client components. This component handles all interactive
  * chrome while the parent layout.tsx handles auth.
+ *
+ * When onboardingState is provided (user has not completed onboarding), this
+ * component renders the welcome modal on first render and a persistent sidebar
+ * banner until all steps are done.
  */
-export function DashboardShell({ children }: { children: React.ReactNode }) {
+export function DashboardShell({ children, onboardingState }: DashboardShellProps) {
   const [collapsed, setCollapsed] = useState(false);
+  const [showOnboardingModal, setShowOnboardingModal] = useState(!!onboardingState);
 
   // WHY: Start the offline sync connectivity listener when the dashboard
   // mounts. This listens for browser online/offline events and automatically
@@ -32,8 +49,22 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen">
       <DashboardTopNav />
-      <DashboardSidebar collapsed={collapsed} onToggle={() => setCollapsed(!collapsed)} />
+      <DashboardSidebar
+        collapsed={collapsed}
+        onToggle={() => setCollapsed(!collapsed)}
+        onboardingBanner={
+          onboardingState ? <OnboardingBanner onboardingState={onboardingState} /> : undefined
+        }
+      />
       <CommandPalette />
+
+      {/* Onboarding welcome modal, shown once on first render */}
+      {onboardingState && showOnboardingModal && (
+        <OnboardingModal
+          onboardingState={onboardingState}
+          onDismiss={() => setShowOnboardingModal(false)}
+        />
+      )}
 
       <main
         id="main-content"

--- a/packages/styrby-web/src/app/dashboard/layout.tsx
+++ b/packages/styrby-web/src/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import { DashboardShell } from './dashboard-shell';
 import { PlanCheckout } from './plan-checkout';
+import { getOnboardingState } from '@/lib/onboarding';
 
 /**
  * Prevents all dashboard routes from being indexed by search engines.
@@ -45,8 +46,10 @@ export default async function DashboardLayout({
     redirect('/login');
   }
 
+  const onboardingState = await getOnboardingState(supabase, user.id);
+
   return (
-    <DashboardShell>
+    <DashboardShell onboardingState={onboardingState.isComplete ? undefined : onboardingState}>
       <Suspense>
         <PlanCheckout />
       </Suspense>

--- a/packages/styrby-web/src/app/dashboard/settings/settings-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/settings-client.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
 import { ThemeToggle } from '@/components/theme-toggle';
+import { SupportModal } from '@/components/dashboard/support-modal';
 
 /* ──────────────────────────── Types ──────────────────────────── */
 
@@ -112,6 +113,9 @@ export function SettingsClient({
   const [deleteReason, setDeleteReason] = useState('');
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  // Support modal
+  const [showSupportModal, setShowSupportModal] = useState(false);
 
   // Data export
   const [exportLoading, setExportLoading] = useState(false);
@@ -1085,6 +1089,53 @@ export function SettingsClient({
         </div>
       </section>
 
+      {/* Support Section */}
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold text-zinc-100 mb-4">Support</h2>
+        <div className="rounded-xl bg-zinc-900 border border-zinc-800 divide-y divide-zinc-800">
+          <Link
+            href="/dashboard/support"
+            className="px-4 py-4 flex items-center justify-between hover:bg-zinc-800/50 transition-colors"
+          >
+            <div>
+              <p className="text-sm font-medium text-zinc-100">View Your Tickets</p>
+              <p className="text-sm text-zinc-500">
+                Check the status of your support requests
+              </p>
+            </div>
+            <svg
+              className="h-5 w-5 text-zinc-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          </Link>
+          <div className="px-4 py-4 flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-zinc-100">Need Help?</p>
+              <p className="text-sm text-zinc-500">
+                Submit a bug report, feature request, or question
+              </p>
+            </div>
+            <button
+              onClick={() => setShowSupportModal(true)}
+              className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600 transition-colors"
+              aria-label="Submit a new support ticket"
+            >
+              New Ticket
+            </button>
+          </div>
+        </div>
+      </section>
+
       {/* Danger Zone */}
       <section className="mb-8">
         <h2 className="text-lg font-semibold text-red-400 mb-4">
@@ -1172,6 +1223,9 @@ export function SettingsClient({
           </div>
         </div>
       )}
+
+      {/* ── Support Ticket Modal ────────────────────────────── */}
+      <SupportModal open={showSupportModal} onOpenChange={setShowSupportModal} />
 
       {/* ── Delete Account Confirmation Dialog ───────────────── */}
       {showDeleteDialog && (

--- a/packages/styrby-web/src/app/dashboard/support/[id]/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/support/[id]/page.tsx
@@ -1,0 +1,55 @@
+import { createClient } from '@/lib/supabase/server';
+import { redirect, notFound } from 'next/navigation';
+import { TicketDetailClient } from './ticket-detail-client';
+
+/**
+ * Support Ticket Detail Page (User Side)
+ *
+ * Server component that fetches a single ticket and its reply thread.
+ * RLS ensures users can only view their own tickets.
+ *
+ * @param params.id - The ticket UUID from the URL
+ */
+export default async function TicketDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    redirect('/login');
+  }
+
+  // Fetch the ticket (RLS ensures ownership)
+  const { data: ticket } = await supabase
+    .from('support_tickets')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (!ticket) {
+    notFound();
+  }
+
+  // Fetch replies in chronological order
+  const { data: replies } = await supabase
+    .from('support_ticket_replies')
+    .select('*')
+    .eq('ticket_id', id)
+    .order('created_at', { ascending: true });
+
+  return (
+    <TicketDetailClient
+      ticket={ticket}
+      replies={replies || []}
+      userId={user.id}
+    />
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/support/[id]/ticket-detail-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/support/[id]/ticket-detail-client.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+/**
+ * Ticket Detail with Reply Thread (Client Component)
+ *
+ * Shows the full ticket information, a chronological reply thread, and a form
+ * for the user to add replies. User replies appear right-aligned with amber accent,
+ * admin replies appear left-aligned with zinc accent.
+ *
+ * @param props.ticket - The support ticket record
+ * @param props.replies - Array of replies for this ticket
+ * @param props.userId - The authenticated user's ID
+ */
+
+import { useState, useCallback } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Send } from 'lucide-react';
+import { createClient } from '@/lib/supabase/client';
+
+/* ──────────────────────────── Types ──────────────────────────── */
+
+interface SupportTicket {
+  id: string;
+  type: 'bug' | 'feature' | 'question';
+  subject: string;
+  description: string;
+  status: 'open' | 'in_progress' | 'resolved' | 'closed';
+  priority: 'low' | 'medium' | 'high';
+  created_at: string;
+  updated_at: string;
+}
+
+interface TicketReply {
+  id: string;
+  ticket_id: string;
+  author_type: 'user' | 'admin';
+  author_id: string;
+  message: string;
+  created_at: string;
+}
+
+interface TicketDetailClientProps {
+  /** The support ticket record */
+  ticket: SupportTicket;
+  /** Replies for this ticket in chronological order */
+  replies: TicketReply[];
+  /** The authenticated user's UUID */
+  userId: string;
+}
+
+/* ──────────────────────────── Helpers ────────────────────────── */
+
+/**
+ * Returns a human-readable relative time string.
+ *
+ * @param dateStr - ISO 8601 date string
+ * @returns Relative time string
+ */
+function getRelativeTime(dateStr: string): string {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHr = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHr / 24);
+
+  if (diffDay > 30) {
+    return date.toLocaleDateString();
+  }
+  if (diffDay > 0) {
+    return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
+  }
+  if (diffHr > 0) {
+    return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`;
+  }
+  if (diffMin > 0) {
+    return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`;
+  }
+  return 'Just now';
+}
+
+/** Badge styles for ticket types */
+const TYPE_BADGE: Record<SupportTicket['type'], { bg: string; text: string; label: string }> = {
+  bug: { bg: 'bg-red-500/10', text: 'text-red-400', label: 'Bug Report' },
+  feature: { bg: 'bg-blue-500/10', text: 'text-blue-400', label: 'Feature Request' },
+  question: { bg: 'bg-amber-500/10', text: 'text-amber-400', label: 'General Question' },
+};
+
+/** Badge styles for ticket statuses */
+const STATUS_BADGE: Record<SupportTicket['status'], { bg: string; text: string; label: string }> = {
+  open: { bg: 'bg-amber-500/10', text: 'text-amber-400', label: 'Open' },
+  in_progress: { bg: 'bg-blue-500/10', text: 'text-blue-400', label: 'In Progress' },
+  resolved: { bg: 'bg-green-500/10', text: 'text-green-400', label: 'Resolved' },
+  closed: { bg: 'bg-zinc-700/50', text: 'text-zinc-400', label: 'Closed' },
+};
+
+/** Badge styles for priority levels */
+const PRIORITY_BADGE: Record<SupportTicket['priority'], { bg: string; text: string; label: string }> = {
+  low: { bg: 'bg-zinc-700/50', text: 'text-zinc-400', label: 'Low' },
+  medium: { bg: 'bg-amber-500/10', text: 'text-amber-400', label: 'Medium' },
+  high: { bg: 'bg-red-500/10', text: 'text-red-400', label: 'High' },
+};
+
+/* ──────────────────────────── Component ──────────────────────── */
+
+export function TicketDetailClient({ ticket, replies, userId }: TicketDetailClientProps) {
+  const router = useRouter();
+  const supabase = createClient();
+
+  const [replyText, setReplyText] = useState('');
+  const [sending, setSending] = useState(false);
+  const [replyError, setReplyError] = useState<string | null>(null);
+
+  const typeBadge = TYPE_BADGE[ticket.type];
+  const statusBadge = STATUS_BADGE[ticket.status];
+  const priorityBadge = PRIORITY_BADGE[ticket.priority];
+
+  /** Whether the ticket is in a state that accepts new replies */
+  const canReply = ticket.status !== 'closed';
+
+  /**
+   * Inserts a user reply into support_ticket_replies.
+   * RLS verifies ticket ownership and author_type/author_id constraints.
+   */
+  const handleSendReply = useCallback(async () => {
+    if (!replyText.trim()) return;
+    if (replyText.trim().length > 5000) {
+      setReplyError('Reply must be 5,000 characters or fewer.');
+      return;
+    }
+
+    setSending(true);
+    setReplyError(null);
+
+    const { error } = await supabase.from('support_ticket_replies').insert({
+      ticket_id: ticket.id,
+      author_type: 'user',
+      author_id: userId,
+      message: replyText.trim(),
+    });
+
+    if (error) {
+      setReplyError(error.message);
+      setSending(false);
+      return;
+    }
+
+    setReplyText('');
+    setSending(false);
+    router.refresh();
+  }, [supabase, ticket.id, userId, replyText, router]);
+
+  return (
+    <div>
+      {/* Back link */}
+      <Link
+        href="/dashboard/support"
+        className="mb-6 inline-flex items-center gap-2 text-sm text-zinc-400 transition-colors hover:text-zinc-100"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to tickets
+      </Link>
+
+      {/* Ticket header card */}
+      <div className="mb-6 rounded-xl border border-zinc-800 bg-zinc-900 p-6">
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${typeBadge.bg} ${typeBadge.text}`}
+          >
+            {typeBadge.label}
+          </span>
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${statusBadge.bg} ${statusBadge.text}`}
+          >
+            {statusBadge.label}
+          </span>
+          {ticket.type === 'bug' && (
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${priorityBadge.bg} ${priorityBadge.text}`}
+            >
+              Priority: {priorityBadge.label}
+            </span>
+          )}
+        </div>
+
+        <h1 className="mb-2 text-xl font-bold text-zinc-100">{ticket.subject}</h1>
+
+        <p className="whitespace-pre-wrap text-sm leading-relaxed text-zinc-300">
+          {ticket.description}
+        </p>
+
+        <p className="mt-4 text-xs text-zinc-500">
+          Submitted {getRelativeTime(ticket.created_at)}
+        </p>
+      </div>
+
+      {/* Reply thread */}
+      {replies.length > 0 && (
+        <div className="mb-6 space-y-4">
+          <h2 className="text-sm font-semibold text-zinc-400">Replies</h2>
+          {replies.map((reply) => {
+            const isUser = reply.author_type === 'user';
+            return (
+              <div
+                key={reply.id}
+                className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[80%] rounded-xl px-4 py-3 ${
+                    isUser
+                      ? 'border border-amber-500/20 bg-amber-500/5'
+                      : 'border border-zinc-700 bg-zinc-800'
+                  }`}
+                >
+                  <p className="mb-1 text-xs font-medium text-zinc-400">
+                    {isUser ? 'You' : 'Styrby Support'}
+                  </p>
+                  <p className="whitespace-pre-wrap text-sm text-zinc-200">
+                    {reply.message}
+                  </p>
+                  <p className="mt-2 text-xs text-zinc-500">
+                    {getRelativeTime(reply.created_at)}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Reply form */}
+      {canReply ? (
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4">
+          <label htmlFor="reply-message" className="mb-2 block text-sm font-medium text-zinc-300">
+            Add a reply
+          </label>
+          <textarea
+            id="reply-message"
+            value={replyText}
+            onChange={(e) => setReplyText(e.target.value)}
+            placeholder="Type your reply..."
+            rows={3}
+            maxLength={5000}
+            className="mb-3 w-full resize-none rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+          />
+          {replyError && (
+            <p className="mb-3 text-sm text-red-400" role="alert">
+              {replyError}
+            </p>
+          )}
+          <div className="flex justify-end">
+            <button
+              onClick={handleSendReply}
+              disabled={sending || !replyText.trim()}
+              className="inline-flex items-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Send className="h-4 w-4" />
+              {sending ? 'Sending...' : 'Send Reply'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 text-center">
+          <p className="text-sm text-zinc-500">
+            This ticket is closed. If you need further help, please open a new ticket.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/support/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/support/page.tsx
@@ -1,0 +1,32 @@
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import { SupportListClient } from './support-list-client';
+
+/**
+ * Support Tickets List Page (User Side)
+ *
+ * Server component that fetches the authenticated user's support tickets
+ * and delegates rendering to the SupportListClient client component.
+ *
+ * NOTE: Navigation chrome (sidebar, topnav) is handled by dashboard/layout.tsx.
+ */
+export default async function SupportPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    redirect('/login');
+  }
+
+  const { data: tickets } = await supabase
+    .from('support_tickets')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  return <SupportListClient tickets={tickets || []} />;
+}

--- a/packages/styrby-web/src/app/dashboard/support/support-list-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/support/support-list-client.tsx
@@ -100,7 +100,7 @@ export function SupportListClient({ tickets }: SupportListClientProps) {
       {/* Ticket list */}
       {tickets.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-xl border border-zinc-800 bg-zinc-900 py-16">
-          <HelpCircle className="mb-4 h-12 w-12 text-zinc-600" />
+          <HelpCircle className="mb-4 h-12 w-12 text-zinc-400" />
           <p className="text-sm font-medium text-zinc-300">No tickets yet.</p>
           <p className="mt-1 text-sm text-zinc-500">
             Need help? Submit a ticket and we will get back to you.

--- a/packages/styrby-web/src/app/dashboard/support/support-list-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/support/support-list-client.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+/**
+ * Support Tickets List (Client Component)
+ *
+ * Displays the user's support tickets as cards with type badges, status indicators,
+ * and relative timestamps. Includes a "New Ticket" button that opens the SupportModal.
+ *
+ * @param props.tickets - Array of support ticket records from Supabase
+ */
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { HelpCircle, Plus } from 'lucide-react';
+import { SupportModal } from '@/components/dashboard/support-modal';
+
+/* ──────────────────────────── Types ──────────────────────────── */
+
+interface SupportTicket {
+  id: string;
+  type: 'bug' | 'feature' | 'question';
+  subject: string;
+  status: 'open' | 'in_progress' | 'resolved' | 'closed';
+  priority: 'low' | 'medium' | 'high';
+  created_at: string;
+  updated_at: string;
+}
+
+interface SupportListClientProps {
+  /** Pre-fetched tickets from the server component */
+  tickets: SupportTicket[];
+}
+
+/* ──────────────────────────── Helpers ────────────────────────── */
+
+/**
+ * Returns a human-readable relative time string (e.g., "2 days ago").
+ *
+ * @param dateStr - ISO 8601 date string
+ * @returns Relative time string
+ */
+function getRelativeTime(dateStr: string): string {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHr = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHr / 24);
+
+  if (diffDay > 30) {
+    return date.toLocaleDateString();
+  }
+  if (diffDay > 0) {
+    return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
+  }
+  if (diffHr > 0) {
+    return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`;
+  }
+  if (diffMin > 0) {
+    return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`;
+  }
+  return 'Just now';
+}
+
+/** Badge color configuration for ticket types */
+const TYPE_BADGE: Record<SupportTicket['type'], { bg: string; text: string; label: string }> = {
+  bug: { bg: 'bg-red-500/10', text: 'text-red-400', label: 'Bug' },
+  feature: { bg: 'bg-blue-500/10', text: 'text-blue-400', label: 'Feature' },
+  question: { bg: 'bg-amber-500/10', text: 'text-amber-400', label: 'Question' },
+};
+
+/** Badge color configuration for ticket statuses */
+const STATUS_BADGE: Record<SupportTicket['status'], { bg: string; text: string; label: string }> = {
+  open: { bg: 'bg-amber-500/10', text: 'text-amber-400', label: 'Open' },
+  in_progress: { bg: 'bg-blue-500/10', text: 'text-blue-400', label: 'In Progress' },
+  resolved: { bg: 'bg-green-500/10', text: 'text-green-400', label: 'Resolved' },
+  closed: { bg: 'bg-zinc-700/50', text: 'text-zinc-400', label: 'Closed' },
+};
+
+/* ──────────────────────────── Component ──────────────────────── */
+
+export function SupportListClient({ tickets }: SupportListClientProps) {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-8 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-foreground">Support</h1>
+        <button
+          onClick={() => setShowModal(true)}
+          className="inline-flex items-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600"
+        >
+          <Plus className="h-4 w-4" />
+          New Ticket
+        </button>
+      </div>
+
+      {/* Ticket list */}
+      {tickets.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-zinc-800 bg-zinc-900 py-16">
+          <HelpCircle className="mb-4 h-12 w-12 text-zinc-600" />
+          <p className="text-sm font-medium text-zinc-300">No tickets yet.</p>
+          <p className="mt-1 text-sm text-zinc-500">
+            Need help? Submit a ticket and we will get back to you.
+          </p>
+          <button
+            onClick={() => setShowModal(true)}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600"
+          >
+            <Plus className="h-4 w-4" />
+            Submit a Ticket
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {tickets.map((ticket) => {
+            const typeBadge = TYPE_BADGE[ticket.type];
+            const statusBadge = STATUS_BADGE[ticket.status];
+
+            return (
+              <Link
+                key={ticket.id}
+                href={`/dashboard/support/${ticket.id}`}
+                className="block rounded-xl border border-zinc-800 bg-zinc-900 p-4 transition-colors hover:border-zinc-700 hover:bg-zinc-800/50"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${typeBadge.bg} ${typeBadge.text}`}
+                      >
+                        {typeBadge.label}
+                      </span>
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${statusBadge.bg} ${statusBadge.text}`}
+                      >
+                        {statusBadge.label}
+                      </span>
+                    </div>
+                    <p className="truncate text-sm font-medium text-zinc-100">
+                      {ticket.subject}
+                    </p>
+                  </div>
+                  <span className="shrink-0 text-xs text-zinc-500">
+                    {getRelativeTime(ticket.created_at)}
+                  </span>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
+      <SupportModal open={showModal} onOpenChange={setShowModal} />
+    </div>
+  );
+}

--- a/packages/styrby-web/src/components/dashboard/onboarding-banner.tsx
+++ b/packages/styrby-web/src/components/dashboard/onboarding-banner.tsx
@@ -9,7 +9,7 @@
  * API, shows a brief "all set" message, and removes itself.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { CheckCircle2, Circle, ChevronUp, ChevronDown, Sparkles, X } from 'lucide-react';
 import { Progress } from '@/components/ui/progress';
@@ -44,29 +44,21 @@ export function OnboardingBanner({ onboardingState }: OnboardingBannerProps) {
   const [expanded, setExpanded] = useState(false);
   const [dismissed, setDismissed] = useState(false);
   const [allDone, setAllDone] = useState(false);
+  const completionTriggered = useRef(false);
 
   const progressPercent = totalSteps > 0 ? (completedCount / totalSteps) * 100 : 0;
   const allStepsComplete = completedCount === totalSteps;
 
-  /**
-   * When all steps are complete, mark onboarding done and show a brief
-   * "all set" message before auto-dismissing after 2 seconds.
-   */
-  const handleCompletion = useCallback(() => {
-    setAllDone(true);
-    markOnboardingComplete();
-    const timer = setTimeout(() => {
-      setDismissed(true);
-    }, 2000);
-    return () => clearTimeout(timer);
-  }, []);
-
+  // When all steps complete, mark onboarding done and auto-dismiss after 2 seconds
   useEffect(() => {
-    if (allStepsComplete && !allDone) {
-      const cleanup = handleCompletion();
-      return cleanup;
+    if (allStepsComplete && !completionTriggered.current) {
+      completionTriggered.current = true;
+      markOnboardingComplete();
+      const t1 = setTimeout(() => setAllDone(true), 0);
+      const t2 = setTimeout(() => setDismissed(true), 2000);
+      return () => { clearTimeout(t1); clearTimeout(t2); };
     }
-  }, [allStepsComplete, allDone, handleCompletion]);
+  }, [allStepsComplete]);
 
   if (dismissed) return null;
 

--- a/packages/styrby-web/src/components/dashboard/onboarding-banner.tsx
+++ b/packages/styrby-web/src/components/dashboard/onboarding-banner.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+/**
+ * Onboarding Sidebar Banner
+ *
+ * Persistent compact banner displayed at the bottom of the sidebar until
+ * the user completes all onboarding steps. Expands on click to show the
+ * full step checklist. When all steps are done, it calls the completion
+ * API, shows a brief "all set" message, and removes itself.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { CheckCircle2, Circle, ChevronUp, ChevronDown, Sparkles, X } from 'lucide-react';
+import { Progress } from '@/components/ui/progress';
+import type { OnboardingState } from '@/lib/onboarding';
+
+interface OnboardingBannerProps {
+  /** Full onboarding state including steps and completion counts */
+  onboardingState: OnboardingState;
+}
+
+/**
+ * Marks onboarding as complete by calling the server endpoint.
+ * Fire-and-forget; errors are logged but do not block the UI.
+ */
+async function markOnboardingComplete(): Promise<void> {
+  try {
+    await fetch('/api/onboarding/complete', { method: 'POST' });
+  } catch (err) {
+    console.error('Failed to mark onboarding complete:', err);
+  }
+}
+
+/**
+ * Sidebar banner that tracks onboarding progress. Compact by default,
+ * expandable to show the full checklist. Auto-completes and dismisses
+ * when all steps are finished.
+ *
+ * @param onboardingState - Current onboarding progress
+ */
+export function OnboardingBanner({ onboardingState }: OnboardingBannerProps) {
+  const { steps, completedCount, totalSteps } = onboardingState;
+  const [expanded, setExpanded] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [allDone, setAllDone] = useState(false);
+
+  const progressPercent = totalSteps > 0 ? (completedCount / totalSteps) * 100 : 0;
+  const allStepsComplete = completedCount === totalSteps;
+
+  /**
+   * When all steps are complete, mark onboarding done and show a brief
+   * "all set" message before auto-dismissing after 2 seconds.
+   */
+  const handleCompletion = useCallback(() => {
+    setAllDone(true);
+    markOnboardingComplete();
+    const timer = setTimeout(() => {
+      setDismissed(true);
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (allStepsComplete && !allDone) {
+      const cleanup = handleCompletion();
+      return cleanup;
+    }
+  }, [allStepsComplete, allDone, handleCompletion]);
+
+  if (dismissed) return null;
+
+  // Brief completion message
+  if (allDone) {
+    return (
+      <div className="mt-auto border-t border-border/40 pt-4">
+        <div className="rounded-lg bg-emerald-500/10 border border-emerald-500/20 p-3 text-center">
+          <div className="flex items-center justify-center gap-2">
+            <Sparkles className="h-4 w-4 text-emerald-500" />
+            <span className="text-xs font-medium text-emerald-400">
+              You&apos;re all set!
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Compact view (default)
+  if (!expanded) {
+    return (
+      <div className="mt-auto border-t border-border/40 pt-4">
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="w-full rounded-lg bg-amber-500/10 border border-amber-500/20 p-3 text-left transition-colors hover:bg-amber-500/15"
+        >
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-amber-500">
+              Setup: {completedCount}/{totalSteps}
+            </span>
+            <ChevronUp className="h-3.5 w-3.5 text-amber-500" />
+          </div>
+          <Progress
+            value={progressPercent}
+            className="h-1 bg-zinc-800 [&>div]:bg-amber-500"
+          />
+        </button>
+      </div>
+    );
+  }
+
+  // Expanded view
+  return (
+    <div className="mt-auto border-t border-border/40 pt-4">
+      <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-xs font-medium text-amber-500">
+            Setup: {completedCount}/{totalSteps}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              className="rounded p-0.5 text-amber-500/70 transition-colors hover:text-amber-500"
+              aria-label="Collapse onboarding banner"
+            >
+              <ChevronDown className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setDismissed(true)}
+              className="rounded p-0.5 text-amber-500/70 transition-colors hover:text-amber-500"
+              aria-label="Dismiss onboarding banner"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+
+        {/* Progress bar */}
+        <Progress
+          value={progressPercent}
+          className="mb-3 h-1 bg-zinc-800 [&>div]:bg-amber-500"
+        />
+
+        {/* Step list */}
+        <div className="space-y-1.5">
+          {steps.map((step) => (
+            <div key={step.id} className="flex items-center gap-2">
+              {step.completed ? (
+                <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+              ) : (
+                <Circle className="h-3.5 w-3.5 shrink-0 text-amber-500" />
+              )}
+              {step.completed ? (
+                <span className="text-[11px] text-zinc-500 line-through">
+                  {step.label}
+                </span>
+              ) : (
+                <Link
+                  href={step.href}
+                  className="text-[11px] text-zinc-300 transition-colors hover:text-amber-500"
+                >
+                  {step.label}
+                </Link>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/components/dashboard/onboarding-modal.tsx
+++ b/packages/styrby-web/src/components/dashboard/onboarding-modal.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+/**
+ * Welcome Onboarding Modal
+ *
+ * Shown on the user's first visit to the dashboard (when onboarding is
+ * not yet complete). Displays a tier-specific welcome message and a
+ * checklist of setup steps. Uses ResponsiveDialog to render as a
+ * centered dialog on desktop and a bottom sheet on mobile.
+ */
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { CheckCircle2, Circle } from 'lucide-react';
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogFooter,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+} from '@/components/ui/responsive-dialog';
+import { Progress } from '@/components/ui/progress';
+import type { OnboardingState } from '@/lib/onboarding';
+
+interface OnboardingModalProps {
+  /** Full onboarding state including steps and completion counts */
+  onboardingState: OnboardingState;
+  /** Called when the user dismisses the modal */
+  onDismiss: () => void;
+}
+
+/**
+ * Returns a tier-specific welcome headline.
+ *
+ * @param tier - The user's subscription tier
+ * @returns Welcome string like "Welcome to Pro"
+ */
+function getWelcomeTitle(tier: OnboardingState['tier']): string {
+  switch (tier) {
+    case 'pro':
+      return 'Welcome to Pro';
+    case 'power':
+      return 'Welcome to Power';
+    default:
+      return 'Welcome to Styrby';
+  }
+}
+
+/**
+ * Welcome modal shown once when a user first reaches the dashboard.
+ * Renders a setup checklist based on their subscription tier.
+ *
+ * @param onboardingState - Current onboarding progress
+ * @param onDismiss - Callback to close the modal
+ */
+export function OnboardingModal({ onboardingState, onDismiss }: OnboardingModalProps) {
+  const { tier, steps, completedCount, totalSteps } = onboardingState;
+  const progressPercent = totalSteps > 0 ? (completedCount / totalSteps) * 100 : 0;
+
+  return (
+    <ResponsiveDialog open onOpenChange={(open) => !open && onDismiss()}>
+      <ResponsiveDialogContent className="sm:max-w-md border-border/40 bg-zinc-900">
+        <ResponsiveDialogHeader className="items-center text-center">
+          <div className="mx-auto mb-2">
+            <Image
+              src="/logo.png"
+              alt="Styrby"
+              width={48}
+              height={48}
+              className="rounded-xl"
+            />
+          </div>
+          <ResponsiveDialogTitle className="text-xl font-semibold text-zinc-100">
+            {getWelcomeTitle(tier)}
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="text-sm text-zinc-400">
+            Complete these steps to get the most out of your account.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        {/* Progress indicator */}
+        <div className="px-1">
+          <div className="flex items-center justify-between text-xs text-zinc-400 mb-1.5">
+            <span>
+              {completedCount} of {totalSteps} complete
+            </span>
+            <span>{Math.round(progressPercent)}%</span>
+          </div>
+          <Progress
+            value={progressPercent}
+            className="h-1.5 bg-zinc-800 [&>div]:bg-amber-500"
+          />
+        </div>
+
+        {/* Step checklist */}
+        <div className="space-y-1 py-2">
+          {steps.map((step) => (
+            <div
+              key={step.id}
+              className="flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-zinc-800/60"
+            >
+              {step.completed ? (
+                <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500" />
+              ) : (
+                <Circle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+              )}
+              <div className="min-w-0 flex-1">
+                {step.completed ? (
+                  <span className="text-sm font-medium text-zinc-400 line-through">
+                    {step.label}
+                  </span>
+                ) : (
+                  <Link
+                    href={step.href}
+                    onClick={onDismiss}
+                    className="text-sm font-medium text-zinc-100 hover:text-amber-500 transition-colors"
+                  >
+                    {step.label}
+                  </Link>
+                )}
+                <p className="text-xs text-zinc-500 mt-0.5">{step.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <ResponsiveDialogFooter>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="w-full rounded-lg bg-amber-500 px-4 py-2.5 text-sm font-semibold text-zinc-900 transition-colors hover:bg-amber-400"
+          >
+            Get Started
+          </button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/packages/styrby-web/src/components/dashboard/sidebar.tsx
+++ b/packages/styrby-web/src/components/dashboard/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { Home, MessageSquare, BarChart3, Cpu, Settings, PanelLeftClose, PanelLeft } from "lucide-react"
+import { Home, MessageSquare, BarChart3, Cpu, Settings, HelpCircle, PanelLeftClose, PanelLeft } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Progress } from "@/components/ui/progress"
 
@@ -12,14 +12,18 @@ const navItems = [
   { label: "Costs", href: "/dashboard/costs", icon: BarChart3 },
   { label: "Agents", href: "/dashboard/agents", icon: Cpu },
   { label: "Settings", href: "/dashboard/settings", icon: Settings },
+  { label: "Support", href: "/dashboard/support", icon: HelpCircle },
 ]
 
 export function DashboardSidebar({
   collapsed,
   onToggle,
+  onboardingBanner,
 }: {
   collapsed: boolean
   onToggle: () => void
+  /** Optional onboarding banner rendered above the plan badge */
+  onboardingBanner?: React.ReactNode
 }) {
   const pathname = usePathname()
 
@@ -61,6 +65,9 @@ export function DashboardSidebar({
             )
           })}
         </nav>
+
+        {/* Onboarding banner (shown above plan badge when onboarding is incomplete) */}
+        {!collapsed && onboardingBanner}
 
         {/* Plan badge and usage */}
         {!collapsed && (

--- a/packages/styrby-web/src/components/dashboard/support-modal.tsx
+++ b/packages/styrby-web/src/components/dashboard/support-modal.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+/**
+ * Support Ticket Submission Modal
+ *
+ * Allows users to submit bug reports, feature requests, and general questions.
+ * Renders as a centered dialog on desktop and a bottom sheet on mobile via
+ * the ResponsiveDialog component.
+ *
+ * @example
+ * <SupportModal open={showSupport} onOpenChange={setShowSupport} />
+ */
+
+import { useState, useCallback } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+} from '@/components/ui/responsive-dialog';
+
+/* ──────────────────────────── Types ──────────────────────────── */
+
+/** Ticket type options for the submission form */
+type TicketType = 'bug' | 'feature' | 'question';
+
+/** Priority levels available for bug reports */
+type TicketPriority = 'low' | 'medium' | 'high';
+
+interface SupportModalProps {
+  /** Whether the modal is currently visible */
+  open: boolean;
+  /** Callback when the modal open state changes */
+  onOpenChange: (open: boolean) => void;
+}
+
+/* ──────────────────────────── Constants ──────────────────────── */
+
+const TYPE_OPTIONS: { value: TicketType; label: string }[] = [
+  { value: 'bug', label: 'Bug Report' },
+  { value: 'feature', label: 'Feature Request' },
+  { value: 'question', label: 'General Question' },
+];
+
+const PRIORITY_OPTIONS: { value: TicketPriority; label: string }[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+/* ──────────────────────────── Component ──────────────────────── */
+
+/**
+ * Modal form for submitting support tickets.
+ * Inserts directly into the support_tickets table via the Supabase client
+ * (RLS ensures the user can only create tickets for themselves).
+ *
+ * @param props.open - Controls visibility
+ * @param props.onOpenChange - Called when the user closes the modal
+ */
+export function SupportModal({ open, onOpenChange }: SupportModalProps) {
+  const supabase = createClient();
+
+  /* ── Form state ────────────────────────────────────────────── */
+  const [type, setType] = useState<TicketType>('bug');
+  const [subject, setSubject] = useState('');
+  const [description, setDescription] = useState('');
+  const [priority, setPriority] = useState<TicketPriority>('medium');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  /**
+   * Resets all form fields to their default state.
+   * Called after successful submission or when closing the modal.
+   */
+  const resetForm = useCallback(() => {
+    setType('bug');
+    setSubject('');
+    setDescription('');
+    setPriority('medium');
+    setError(null);
+    setSuccess(false);
+  }, []);
+
+  /**
+   * Validates form fields and inserts the ticket into support_tickets.
+   * RLS ensures the user_id matches the authenticated user.
+   */
+  const handleSubmit = useCallback(async () => {
+    // Client-side validation
+    if (subject.trim().length < 3) {
+      setError('Subject must be at least 3 characters.');
+      return;
+    }
+    if (subject.trim().length > 200) {
+      setError('Subject must be 200 characters or fewer.');
+      return;
+    }
+    if (description.trim().length < 10) {
+      setError('Description must be at least 10 characters.');
+      return;
+    }
+    if (description.trim().length > 5000) {
+      setError('Description must be 5,000 characters or fewer.');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    // Get the current user to set user_id
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      setError('You must be signed in to submit a ticket.');
+      setSubmitting(false);
+      return;
+    }
+
+    // TODO: File upload to Supabase Storage is a future enhancement.
+    // For now, screenshot_urls is always an empty array.
+    const { error: insertError } = await supabase
+      .from('support_tickets')
+      .insert({
+        user_id: user.id,
+        type,
+        subject: subject.trim(),
+        description: description.trim(),
+        priority: type === 'bug' ? priority : 'medium',
+        screenshot_urls: [],
+      });
+
+    if (insertError) {
+      setError(insertError.message);
+      setSubmitting(false);
+      return;
+    }
+
+    setSuccess(true);
+    setSubmitting(false);
+
+    // Auto-close after showing success message
+    setTimeout(() => {
+      onOpenChange(false);
+      resetForm();
+    }, 2000);
+  }, [supabase, type, subject, description, priority, onOpenChange, resetForm]);
+
+  /**
+   * Handles modal close: resets form state unless a submission is in progress.
+   */
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen && !submitting) {
+        resetForm();
+      }
+      onOpenChange(nextOpen);
+    },
+    [submitting, resetForm, onOpenChange]
+  );
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+      <ResponsiveDialogContent className="border-zinc-800 bg-zinc-900 sm:max-w-lg">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle className="text-zinc-100">
+            Submit a Support Ticket
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="text-zinc-400">
+            Tell us what you need help with. We typically respond within 24 hours.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        {success ? (
+          <div className="py-8 text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10">
+              <svg
+                className="h-6 w-6 text-green-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <p className="text-sm font-medium text-zinc-100">Ticket submitted.</p>
+            <p className="mt-1 text-sm text-zinc-400">
+              We will respond to your email within 24 hours.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4 px-1">
+            {/* Type selector */}
+            <div>
+              <label
+                htmlFor="ticket-type"
+                className="mb-1 block text-sm font-medium text-zinc-300"
+              >
+                Type
+              </label>
+              <select
+                id="ticket-type"
+                value={type}
+                onChange={(e) => setType(e.target.value as TicketType)}
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+              >
+                {TYPE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Subject */}
+            <div>
+              <label
+                htmlFor="ticket-subject"
+                className="mb-1 block text-sm font-medium text-zinc-300"
+              >
+                Subject
+              </label>
+              <input
+                id="ticket-subject"
+                type="text"
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                placeholder="Brief summary of your issue"
+                maxLength={200}
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+              />
+              <p className="mt-1 text-xs text-zinc-500">
+                {subject.length}/200 characters
+              </p>
+            </div>
+
+            {/* Description */}
+            <div>
+              <label
+                htmlFor="ticket-description"
+                className="mb-1 block text-sm font-medium text-zinc-300"
+              >
+                Description
+              </label>
+              <textarea
+                id="ticket-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Describe your issue in detail. Include steps to reproduce for bugs."
+                rows={5}
+                maxLength={5000}
+                className="w-full resize-none rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+              />
+              <p className="mt-1 text-xs text-zinc-500">
+                {description.length}/5,000 characters
+              </p>
+            </div>
+
+            {/* Priority (only for bug reports) */}
+            {type === 'bug' && (
+              <div>
+                <label
+                  htmlFor="ticket-priority"
+                  className="mb-1 block text-sm font-medium text-zinc-300"
+                >
+                  Priority
+                </label>
+                <select
+                  id="ticket-priority"
+                  value={priority}
+                  onChange={(e) => setPriority(e.target.value as TicketPriority)}
+                  className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+                >
+                  {PRIORITY_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {/* Screenshots placeholder */}
+            <div>
+              <label
+                htmlFor="ticket-screenshots"
+                className="mb-1 block text-sm font-medium text-zinc-300"
+              >
+                Screenshots (optional)
+              </label>
+              <input
+                id="ticket-screenshots"
+                type="file"
+                accept="image/*"
+                multiple
+                disabled
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-500 file:mr-3 file:rounded file:border-0 file:bg-zinc-700 file:px-3 file:py-1 file:text-sm file:text-zinc-300 disabled:opacity-50"
+              />
+              {/* TODO: Implement file upload to Supabase Storage. Max 3 files, 5MB each. */}
+              <p className="mt-1 text-xs text-zinc-500">
+                File upload coming soon. Max 3 images, 5MB each.
+              </p>
+            </div>
+
+            {/* Error message */}
+            {error && (
+              <p className="text-sm text-red-400" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+        )}
+
+        {!success && (
+          <ResponsiveDialogFooter>
+            <button
+              type="button"
+              onClick={() => handleOpenChange(false)}
+              disabled={submitting}
+              className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-400 transition-colors hover:text-zinc-100 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={submitting || !subject.trim() || !description.trim()}
+              className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {submitting ? 'Submitting...' : 'Submit Ticket'}
+            </button>
+          </ResponsiveDialogFooter>
+        )}
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/packages/styrby-web/src/emails/support-reply.tsx
+++ b/packages/styrby-web/src/emails/support-reply.tsx
@@ -1,0 +1,63 @@
+/**
+ * Support Reply Email
+ *
+ * Sent when an admin replies to a user's support ticket.
+ * Includes the ticket subject, the admin's reply, and a link
+ * to view the full ticket in the dashboard.
+ */
+
+import { Section, Text } from '@react-email/components';
+import * as React from 'react';
+import {
+  BaseLayout,
+  Button,
+  Heading,
+  Paragraph,
+  Divider,
+} from './base-layout';
+
+interface SupportReplyEmailProps {
+  /** The original ticket subject */
+  subject: string;
+  /** The admin's reply message */
+  message: string;
+  /** The ticket ID for building the dashboard link */
+  ticketId: string;
+}
+
+export default function SupportReplyEmail({
+  subject,
+  message,
+  ticketId,
+}: SupportReplyEmailProps) {
+  return (
+    <BaseLayout preview={`Re: ${subject}`}>
+      <Heading>Re: {subject}</Heading>
+
+      <Paragraph>We have responded to your support ticket:</Paragraph>
+
+      <Section className="mb-6 rounded-lg bg-zinc-800 p-4">
+        <Text className="m-0 whitespace-pre-wrap text-sm leading-6 text-zinc-200">
+          {message}
+        </Text>
+      </Section>
+
+      <Section className="mb-6 text-center">
+        <Button href={`https://www.styrbyapp.com/dashboard/support/${ticketId}`}>
+          View Ticket
+        </Button>
+      </Section>
+
+      <Divider />
+
+      <Paragraph>
+        You can reply to this ticket directly from your Styrby dashboard.
+        If you need anything else, just open a new ticket.
+      </Paragraph>
+
+      <Text className="m-0 text-sm text-zinc-400">
+        The Styrby Team
+      </Text>
+    </BaseLayout>
+  );
+}

--- a/packages/styrby-web/src/lib/admin.ts
+++ b/packages/styrby-web/src/lib/admin.ts
@@ -1,0 +1,31 @@
+/**
+ * Admin authorization utilities.
+ *
+ * WHY hardcoded emails: Styrby does not yet have a full RBAC system. Rather
+ * than adding an is_admin column to profiles (which would require a migration
+ * and UI for managing admins), we use a simple allowlist of admin email
+ * addresses stored in an environment variable. This is secure because the
+ * check runs server-side only, and the list can be updated via Vercel env
+ * vars without a code deploy.
+ *
+ * Format of ADMIN_EMAILS env var: comma-separated email addresses.
+ * Example: "admin@styrbyapp.com,founder@styrbyapp.com"
+ */
+
+/**
+ * Checks whether the given email belongs to an admin user.
+ *
+ * @param email - The user's email address to check
+ * @returns True if the email is in the admin allowlist
+ */
+export function isAdminEmail(email: string | undefined): boolean {
+  if (!email) return false;
+
+  const adminEmails = process.env.ADMIN_EMAILS?.split(',').map((e) => e.trim().toLowerCase()) || [];
+
+  // Fallback: if ADMIN_EMAILS is not set, no one is an admin.
+  // This prevents accidental admin access in misconfigured environments.
+  if (adminEmails.length === 0) return false;
+
+  return adminEmails.includes(email.toLowerCase());
+}

--- a/packages/styrby-web/src/lib/onboarding.ts
+++ b/packages/styrby-web/src/lib/onboarding.ts
@@ -1,0 +1,240 @@
+/**
+ * Onboarding Configuration and State Detection
+ *
+ * Determines which setup steps a user needs to complete based on their
+ * subscription tier, then checks completion by querying existing tables.
+ * No separate tracking table is needed; the onboarding state is derived
+ * from real data (machines, budget_alerts, device_tokens, etc.).
+ *
+ * Tier-based step requirements:
+ * - Free (1 step): Connect a machine
+ * - Pro (3 steps): Connect a machine, set a budget alert, install mobile app
+ * - Power (5 steps): Connect a machine, set a budget alert, invite a team member,
+ *                     create an API key, install mobile app
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { TierId } from '@/lib/polar';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a single onboarding step with its completion status.
+ */
+export type OnboardingStep = {
+  /** Unique identifier for the step */
+  id: string;
+  /** Short label shown in the checklist */
+  label: string;
+  /** Brief description of what the step accomplishes */
+  description: string;
+  /** Dashboard page where the user completes this step */
+  href: string;
+  /** Whether the user has already completed this step */
+  completed: boolean;
+};
+
+/**
+ * Complete onboarding state for a user, including tier info and all steps.
+ * Used by the welcome modal and sidebar banner to render the setup checklist.
+ */
+export type OnboardingState = {
+  /** The user's current subscription tier */
+  tier: 'free' | 'pro' | 'power';
+  /** Ordered list of onboarding steps for this tier */
+  steps: OnboardingStep[];
+  /** Number of steps the user has completed */
+  completedCount: number;
+  /** Total number of steps required for this tier */
+  totalSteps: number;
+  /** True when all steps are done (or onboarding_completed_at is set) */
+  isComplete: boolean;
+  /** ISO 8601 timestamp when onboarding was marked complete, or null */
+  onboardingCompletedAt: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// Step Definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * All possible onboarding steps. Each tier uses a subset of these.
+ */
+const STEP_DEFINITIONS = {
+  connectMachine: {
+    id: 'connect-machine',
+    label: 'Connect a machine',
+    description: 'Pair your first device using the Styrby CLI.',
+    href: '/dashboard/devices/pair',
+  },
+  setBudgetAlert: {
+    id: 'set-budget-alert',
+    label: 'Set a budget alert',
+    description: 'Get notified before you overspend on AI usage.',
+    href: '/dashboard/costs/budget-alerts',
+  },
+  installMobileApp: {
+    id: 'install-mobile-app',
+    label: 'Install the mobile app',
+    description: 'Monitor sessions and approve permissions on the go.',
+    href: '/dashboard/devices/pair',
+  },
+  inviteTeamMember: {
+    id: 'invite-team-member',
+    label: 'Invite a team member',
+    description: 'Collaborate with your team on shared sessions.',
+    href: '/dashboard/team',
+  },
+  createApiKey: {
+    id: 'create-api-key',
+    label: 'Create an API key',
+    description: 'Integrate Styrby data into your own tools.',
+    href: '/dashboard/settings/api',
+  },
+} as const;
+
+/**
+ * Which steps apply to each subscription tier.
+ *
+ * WHY these specific steps: Free users just need to connect and start using
+ * the product. Pro users benefit from cost awareness and mobile notifications.
+ * Power users have team and API features that drive stickiness.
+ */
+const TIER_STEPS: Record<TierId, (keyof typeof STEP_DEFINITIONS)[]> = {
+  free: ['connectMachine'],
+  pro: ['connectMachine', 'setBudgetAlert', 'installMobileApp'],
+  power: ['connectMachine', 'setBudgetAlert', 'inviteTeamMember', 'createApiKey', 'installMobileApp'],
+};
+
+// ---------------------------------------------------------------------------
+// Server-Side State Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the complete onboarding state for a user by querying existing tables.
+ * Uses Promise.all to run all queries in parallel for speed.
+ *
+ * @param supabase - Authenticated Supabase server client
+ * @param userId - The authenticated user's ID
+ * @returns Full onboarding state with per-step completion status
+ *
+ * @example
+ * const supabase = await createClient();
+ * const state = await getOnboardingState(supabase, user.id);
+ * if (!state.isComplete) {
+ *   // Show onboarding UI
+ * }
+ */
+export async function getOnboardingState(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<OnboardingState> {
+  // First check if onboarding is already complete (fast path)
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('onboarding_completed_at')
+    .eq('id', userId)
+    .single();
+
+  if (profile?.onboarding_completed_at) {
+    // Onboarding was already marked complete. Return minimal state so the
+    // modal and banner are never rendered.
+    return {
+      tier: 'free',
+      steps: [],
+      completedCount: 0,
+      totalSteps: 0,
+      isComplete: true,
+      onboardingCompletedAt: profile.onboarding_completed_at,
+    };
+  }
+
+  // Fetch tier and completion signals in parallel
+  const [subscriptionResult, machinesResult, budgetAlertsResult, deviceTokensResult, teamMembersResult, apiKeysResult] =
+    await Promise.all([
+      // Subscription tier
+      supabase
+        .from('subscriptions')
+        .select('tier')
+        .eq('user_id', userId)
+        .eq('status', 'active')
+        .single(),
+      // Machines count
+      supabase
+        .from('machines')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId),
+      // Budget alerts count
+      supabase
+        .from('budget_alerts')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId),
+      // Device tokens count (indicates mobile app installed)
+      supabase
+        .from('device_tokens')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId),
+      // Team members count (Power tier: user should have invited at least one other person)
+      supabase
+        .from('team_members')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId),
+      // API keys count (Power tier)
+      supabase
+        .from('api_keys')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .is('revoked_at', null),
+    ]);
+
+  const tier: TierId = (subscriptionResult.data?.tier as TierId) || 'free';
+  const hasMachine = (machinesResult.count ?? 0) > 0;
+  const hasBudgetAlert = (budgetAlertsResult.count ?? 0) > 0;
+  const hasDeviceToken = (deviceTokensResult.count ?? 0) > 0;
+  const hasApiKey = (apiKeysResult.count ?? 0) > 0;
+
+  // For team member check: user needs to have invited someone (not just be a member).
+  // We check team_invitations sent by this user, or team_members count > 1 for any
+  // team this user owns. A simpler heuristic: check if there are pending or accepted
+  // invitations sent by this user.
+  let hasInvitedTeamMember = false;
+  if (tier === 'power') {
+    const { count: invitationCount } = await supabase
+      .from('team_invitations')
+      .select('id', { count: 'exact', head: true })
+      .eq('invited_by', userId);
+
+    hasInvitedTeamMember = (invitationCount ?? 0) > 0;
+  }
+
+  // Build completion map
+  const completionMap: Record<string, boolean> = {
+    connectMachine: hasMachine,
+    setBudgetAlert: hasBudgetAlert,
+    installMobileApp: hasDeviceToken,
+    inviteTeamMember: hasInvitedTeamMember,
+    createApiKey: hasApiKey,
+  };
+
+  // Build steps array for this tier
+  const stepKeys = TIER_STEPS[tier];
+  const steps: OnboardingStep[] = stepKeys.map((key) => ({
+    ...STEP_DEFINITIONS[key],
+    completed: completionMap[key] ?? false,
+  }));
+
+  const completedCount = steps.filter((s) => s.completed).length;
+  const totalSteps = steps.length;
+  const isComplete = completedCount === totalSteps;
+
+  return {
+    tier,
+    steps,
+    completedCount,
+    totalSteps,
+    isComplete,
+    onboardingCompletedAt: null,
+  };
+}

--- a/packages/styrby-web/src/lib/resend.ts
+++ b/packages/styrby-web/src/lib/resend.ts
@@ -15,6 +15,7 @@ import SubscriptionCanceledEmail from '@/emails/subscription-canceled';
 import PaymentFailedEmail from '@/emails/payment-failed';
 import BudgetAlertEmail from '@/emails/budget-alert';
 import WeeklySummaryEmail from '@/emails/weekly-summary';
+import SupportReplyEmail from '@/emails/support-reply';
 
 // Lazy-initialize Resend client to avoid build-time errors
 let resendClient: Resend | null = null;
@@ -300,5 +301,33 @@ export async function sendWeeklySummaryEmail({
       agentStats,
       savedWithCache,
     }),
+  });
+}
+
+/**
+ * Send support ticket reply notification to a user.
+ *
+ * @param email - Recipient email address (ticket owner)
+ * @param subject - The original ticket subject
+ * @param message - The admin's reply message
+ * @param ticketId - The ticket UUID for the dashboard link
+ * @returns Result object with `success` boolean and optional `id` or `error`
+ */
+export async function sendSupportReplyEmail({
+  email,
+  subject,
+  message,
+  ticketId,
+}: {
+  email: string;
+  subject: string;
+  message: string;
+  ticketId: string;
+}) {
+  return sendEmail({
+    to: email,
+    subject: `Re: ${subject}`,
+    react: React.createElement(SupportReplyEmail, { subject, message, ticketId }),
+    replyTo: 'support@styrbyapp.com',
   });
 }

--- a/supabase/migrations/012_support_tickets.sql
+++ b/supabase/migrations/012_support_tickets.sql
@@ -1,0 +1,107 @@
+-- ============================================================================
+-- SUPPORT TICKET SYSTEM
+-- ============================================================================
+-- Support ticket system for bug reports, feature requests, and general questions.
+-- Users submit from the dashboard. Admins manage and reply from the admin area.
+--
+-- Tables: support_tickets, support_ticket_replies
+-- Patterns: RLS with (SELECT auth.uid()), partial indexes, timestamp triggers
+-- ============================================================================
+
+-- ============================================================================
+-- SUPPORT TICKETS TABLE
+-- ============================================================================
+
+CREATE TABLE support_tickets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL CHECK (type IN ('bug', 'feature', 'question')),
+  subject TEXT NOT NULL CHECK (char_length(subject) BETWEEN 3 AND 200),
+  description TEXT NOT NULL CHECK (char_length(description) BETWEEN 10 AND 5000),
+  priority TEXT NOT NULL DEFAULT 'medium' CHECK (priority IN ('low', 'medium', 'high')),
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'in_progress', 'resolved', 'closed')),
+  screenshot_urls TEXT[] DEFAULT '{}',
+  admin_notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================================
+-- SUPPORT TICKET REPLIES TABLE
+-- ============================================================================
+
+CREATE TABLE support_ticket_replies (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticket_id UUID NOT NULL REFERENCES support_tickets(id) ON DELETE CASCADE,
+  author_type TEXT NOT NULL CHECK (author_type IN ('user', 'admin')),
+  author_id UUID NOT NULL,
+  message TEXT NOT NULL CHECK (char_length(message) BETWEEN 1 AND 5000),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================================
+-- INDEXES
+-- ============================================================================
+
+-- User's tickets sorted by newest first
+CREATE INDEX idx_support_tickets_user ON support_tickets(user_id, created_at DESC);
+
+-- Admin filtering by status
+CREATE INDEX idx_support_tickets_status ON support_tickets(status, created_at DESC);
+
+-- Replies for a ticket in chronological order
+CREATE INDEX idx_support_ticket_replies_ticket ON support_ticket_replies(ticket_id, created_at ASC);
+
+-- ============================================================================
+-- ROW LEVEL SECURITY
+-- ============================================================================
+
+ALTER TABLE support_tickets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE support_ticket_replies ENABLE ROW LEVEL SECURITY;
+
+-- Users can view their own tickets
+CREATE POLICY "support_tickets_select_own" ON support_tickets
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+-- Users can create their own tickets
+CREATE POLICY "support_tickets_insert_own" ON support_tickets
+  FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));
+
+-- Users can view replies on their own tickets
+CREATE POLICY "support_ticket_replies_select_own" ON support_ticket_replies
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM support_tickets st
+      WHERE st.id = support_ticket_replies.ticket_id
+      AND st.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- Users can add replies to their own tickets
+CREATE POLICY "support_ticket_replies_insert_own" ON support_ticket_replies
+  FOR INSERT WITH CHECK (
+    author_type = 'user'
+    AND author_id = (SELECT auth.uid())
+    AND EXISTS (
+      SELECT 1 FROM support_tickets st
+      WHERE st.id = support_ticket_replies.ticket_id
+      AND st.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- ============================================================================
+-- UPDATED_AT TRIGGER
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION update_support_ticket_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER support_tickets_updated
+  BEFORE UPDATE ON support_tickets
+  FOR EACH ROW
+  EXECUTE FUNCTION update_support_ticket_timestamp();


### PR DESCRIPTION
## Summary

Two new features for the Styrby dashboard: guided onboarding and a support ticket system.

### Onboarding Flow
- Welcome modal on first dashboard visit (ResponsiveDialog, bottom sheet on mobile)
- Tier-specific checklists: Free (1 step), Pro (3 steps), Power (5 steps)
- Steps: connect machine, set budget alert, install mobile app, invite team member, create API key
- Persistent sidebar banner with progress bar until complete
- Detects completion from existing tables (no tracking table needed)
- Sets `profiles.onboarding_completed_at` when all steps done
- POST `/api/onboarding/complete` endpoint

### Support Ticket System
- User submission modal: type (bug/feature/question), subject, description, priority
- Ticket list page (`/dashboard/support`) with type and status badges
- Ticket detail with threaded replies (user right-aligned, admin left-aligned)
- Admin dashboard (`/dashboard/admin/support`): filterable table, status management, internal notes
- Admin reply sends email via Resend from support@styrbyapp.com
- Migration 012: `support_tickets` and `support_ticket_replies` tables with RLS
- Admin auth via `ADMIN_EMAILS` env var

### Files
- 22 files changed, +2,978 lines
- New: onboarding components, support pages, admin dashboard, API routes, migration, email template
- Modified: dashboard shell, layout, sidebar, settings, resend.ts

## Test Plan
- [x] TypeScript typecheck passes
- [ ] CI pipeline
- [ ] Vercel preview deployment

## Env Var Required
`ADMIN_EMAILS` - comma-separated admin email addresses (set in Vercel dashboard)

---
Shipped with [Claude Code](https://claude.com/claude-code)