### PR TITLE
feat(sprint-2): Web Push notifications + mobile onboarding and support tickets

### DIFF
--- a/packages/styrby-mobile/app/(tabs)/index.tsx
+++ b/packages/styrby-mobile/app/(tabs)/index.tsx
@@ -17,8 +17,10 @@ import { router, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useRelay } from '../../src/hooks/useRelay';
 import { useDashboardData } from '../../src/hooks/useDashboardData';
+import { useOnboarding } from '../../src/hooks/useOnboarding';
 import { SessionCarousel, type ActiveSession } from '../../src/components/SessionCarousel';
 import { NotificationStream, type Notification } from '../../src/components/NotificationStream';
+import { OnboardingModal } from '../../src/components/OnboardingModal';
 import type { AgentType } from 'styrby-shared';
 
 /**
@@ -91,7 +93,19 @@ export default function DashboardScreen() {
     refresh: refreshDashboardData,
   } = useDashboardData(lastMessage, connectedDevices);
 
+  const {
+    isComplete: onboardingComplete,
+    isLoading: onboardingLoading,
+    steps: onboardingSteps,
+    completedCount: onboardingCompletedCount,
+    totalCount: onboardingTotalCount,
+    tier: onboardingTier,
+    markComplete: markOnboardingComplete,
+    refresh: refreshOnboarding,
+  } = useOnboarding();
+
   const [refreshing, setRefreshing] = useState(false);
+  const [showOnboardingModal, setShowOnboardingModal] = useState(false);
 
   /**
    * WHY: Notifications need local "read" state that persists during the session
@@ -126,11 +140,12 @@ export default function DashboardScreen() {
       await Promise.all([
         connect(),
         refreshDashboardData(),
+        refreshOnboarding(),
       ]);
     } finally {
       setRefreshing(false);
     }
-  }, [connect, refreshDashboardData]);
+  }, [connect, refreshDashboardData, refreshOnboarding]);
 
   // --------------------------------------------------------------------------
   // Focus Refresh
@@ -359,6 +374,54 @@ export default function DashboardScreen() {
           </View>
         )}
       </View>
+
+      {/* Onboarding Banner */}
+      {/* WHY: Show a persistent setup banner when onboarding is not yet complete.
+          This nudges users to finish their tier-specific checklist without blocking
+          the dashboard. Tapping the banner opens the full checklist modal. */}
+      {!onboardingLoading && !onboardingComplete && (
+        <Pressable
+          onPress={() => setShowOnboardingModal(true)}
+          className="mx-4 mt-4 bg-orange-500/10 rounded-xl px-4 py-3 flex-row items-center justify-between border border-orange-500/20"
+          accessibilityRole="button"
+          accessibilityLabel={`Complete setup, ${onboardingCompletedCount} of ${onboardingTotalCount} steps done`}
+        >
+          <View className="flex-row items-center flex-1">
+            <View className="w-8 h-8 rounded-full bg-brand/20 items-center justify-center mr-3">
+              <Ionicons name="rocket" size={16} color="#f97316" />
+            </View>
+            <View className="flex-1">
+              <Text className="text-zinc-100 font-medium text-sm">
+                Complete setup
+              </Text>
+              <Text className="text-zinc-500 text-xs mt-0.5">
+                {onboardingCompletedCount}/{onboardingTotalCount} steps done
+              </Text>
+            </View>
+          </View>
+          {/* Mini progress bar */}
+          <View className="w-16 h-1.5 bg-zinc-700 rounded-full overflow-hidden ml-3">
+            <View
+              className="h-full bg-brand rounded-full"
+              style={{
+                width: `${onboardingTotalCount > 0 ? (onboardingCompletedCount / onboardingTotalCount) * 100 : 0}%`,
+              }}
+            />
+          </View>
+          <Ionicons name="chevron-forward" size={16} color="#71717a" style={{ marginLeft: 8 }} />
+        </Pressable>
+      )}
+
+      {/* Onboarding Modal */}
+      <OnboardingModal
+        visible={showOnboardingModal}
+        onDismiss={() => setShowOnboardingModal(false)}
+        steps={onboardingSteps}
+        completedCount={onboardingCompletedCount}
+        totalCount={onboardingTotalCount}
+        tier={onboardingTier}
+        onComplete={markOnboardingComplete}
+      />
 
       {/* Active Sessions Carousel */}
       {activeSessions.length > 0 && (

--- a/packages/styrby-mobile/app/(tabs)/settings.tsx
+++ b/packages/styrby-mobile/app/(tabs)/settings.tsx
@@ -1066,6 +1066,13 @@ export default function SettingsScreen() {
       <SectionHeader title="Support" />
       <View className="bg-background-secondary">
         <SettingRow
+          icon="ticket"
+          iconColor="#f97316"
+          title="Support Tickets"
+          subtitle="View or create support tickets"
+          onPress={() => router.push('/support')}
+        />
+        <SettingRow
           icon="help-circle"
           iconColor="#71717a"
           title="Help & FAQ"

--- a/packages/styrby-mobile/app/support/[id].tsx
+++ b/packages/styrby-mobile/app/support/[id].tsx
@@ -1,0 +1,398 @@
+/**
+ * Support Ticket Detail Screen
+ *
+ * Displays a single support ticket with its full description and a threaded
+ * conversation of replies. Users can add new replies via an input field at
+ * the bottom. New replies from admins appear in real-time via Supabase
+ * Realtime subscriptions.
+ *
+ * Route: /support/[id] (expo-router dynamic segment)
+ */
+
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  TextInput,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useLocalSearchParams, Stack } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { z } from 'zod';
+import { useSupport } from '../../src/hooks/useSupport';
+import type { ValidatedSupportTicket, ValidatedSupportTicketReply } from '../../src/lib/schemas';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Status badge colors for the ticket header.
+ */
+const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
+  open: { bg: 'bg-blue-500/15', text: 'text-blue-400' },
+  in_progress: { bg: 'bg-yellow-500/15', text: 'text-yellow-400' },
+  resolved: { bg: 'bg-green-500/15', text: 'text-green-400' },
+  closed: { bg: 'bg-zinc-500/15', text: 'text-zinc-400' },
+};
+
+/**
+ * Display-friendly status labels.
+ */
+const STATUS_LABELS: Record<string, string> = {
+  open: 'Open',
+  in_progress: 'In Progress',
+  resolved: 'Resolved',
+  closed: 'Closed',
+};
+
+/**
+ * Type labels with associated colors.
+ */
+const TYPE_CONFIG: Record<string, { label: string; color: string; icon: keyof typeof Ionicons.glyphMap }> = {
+  bug: { label: 'Bug Report', color: '#ef4444', icon: 'bug' },
+  feature: { label: 'Feature Request', color: '#eab308', icon: 'bulb' },
+  question: { label: 'Question', color: '#3b82f6', icon: 'help-circle' },
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Support ticket detail screen showing ticket info and threaded replies.
+ *
+ * Layout:
+ * 1. Ticket header (type, subject, status, created date)
+ * 2. Original description
+ * 3. Replies thread (user replies aligned right, admin replies aligned left)
+ * 4. Reply input at the bottom (disabled for closed tickets)
+ *
+ * Real-time updates: Subscribes to Supabase Realtime for INSERT events on
+ * the support_ticket_replies table, filtered by ticket_id. New replies appear
+ * immediately in the thread without polling.
+ *
+ * @returns The ticket detail screen JSX
+ */
+export default function TicketDetailScreen() {
+  const { id: rawId } = useLocalSearchParams<{ id: string }>();
+  const { getTicket, replyToTicket, subscribeToReplies } = useSupport();
+
+  // Validate the ticket ID is a valid UUID before using it in queries
+  const parsedId = z.string().uuid().safeParse(rawId);
+  const id = parsedId.success ? parsedId.data : null;
+
+  const [ticket, setTicket] = useState<ValidatedSupportTicket | null>(null);
+  const [replies, setReplies] = useState<ValidatedSupportTicketReply[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [replyText, setReplyText] = useState('');
+  const [isSendingReply, setIsSendingReply] = useState(false);
+  const scrollViewRef = useRef<ScrollView>(null);
+
+  // Show error screen for invalid ticket IDs
+  if (!parsedId.success) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center px-8">
+        <Stack.Screen
+          options={{
+            title: 'Ticket',
+            headerStyle: { backgroundColor: '#09090b' },
+            headerTintColor: '#fff',
+          }}
+        />
+        <Ionicons name="alert-circle" size={48} color="#71717a" />
+        <Text className="text-zinc-400 text-lg mt-4 text-center">
+          Invalid ticket ID
+        </Text>
+      </View>
+    );
+  }
+
+  // --------------------------------------------------------------------------
+  // Data Loading
+  // --------------------------------------------------------------------------
+
+  /**
+   * Fetches the ticket and its replies from Supabase.
+   * Called on mount and can be called to refresh.
+   */
+  const loadTicketData = useCallback(async () => {
+    if (!id) return;
+
+    setIsLoading(true);
+    const result = await getTicket(id);
+    if (result) {
+      setTicket(result.ticket);
+      setReplies(result.replies);
+    }
+    setIsLoading(false);
+  }, [id, getTicket]);
+
+  // Load ticket data on mount
+  useEffect(() => {
+    loadTicketData();
+  }, [loadTicketData]);
+
+  // --------------------------------------------------------------------------
+  // Real-time Subscription
+  // --------------------------------------------------------------------------
+
+  /**
+   * WHY: We subscribe to real-time reply events so that admin responses
+   * appear instantly in the conversation thread. Without this, the user
+   * would need to manually refresh to see new admin replies.
+   */
+  useEffect(() => {
+    if (!id) return;
+
+    const unsubscribe = subscribeToReplies(id, (newReply) => {
+      setReplies((prev) => {
+        // Avoid duplicates (e.g., if the user's own reply is echoed back)
+        if (prev.some((r) => r.id === newReply.id)) return prev;
+        return [...prev, newReply];
+      });
+
+      // Auto-scroll to the new reply
+      setTimeout(() => {
+        scrollViewRef.current?.scrollToEnd({ animated: true });
+      }, 100);
+    });
+
+    return unsubscribe;
+  }, [id, subscribeToReplies]);
+
+  // --------------------------------------------------------------------------
+  // Reply Handler
+  // --------------------------------------------------------------------------
+
+  /**
+   * Submits a new reply to the ticket and adds it to the local reply list.
+   * The reply also arrives via the real-time subscription, so we de-duplicate
+   * in the subscription handler.
+   */
+  const handleSendReply = useCallback(async () => {
+    if (!id || replyText.trim().length === 0) return;
+
+    setIsSendingReply(true);
+    const reply = await replyToTicket(id, replyText.trim());
+    if (reply) {
+      setReplies((prev) => {
+        if (prev.some((r) => r.id === reply.id)) return prev;
+        return [...prev, reply];
+      });
+      setReplyText('');
+
+      // Scroll to the new reply
+      setTimeout(() => {
+        scrollViewRef.current?.scrollToEnd({ animated: true });
+      }, 100);
+    }
+    setIsSendingReply(false);
+  }, [id, replyText, replyToTicket]);
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center">
+        <Stack.Screen
+          options={{
+            title: 'Ticket',
+            headerStyle: { backgroundColor: '#09090b' },
+            headerTintColor: '#fff',
+          }}
+        />
+        <ActivityIndicator size="large" color="#f97316" accessibilityLabel="Loading ticket" />
+      </View>
+    );
+  }
+
+  if (!ticket) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center px-8">
+        <Stack.Screen
+          options={{
+            title: 'Ticket',
+            headerStyle: { backgroundColor: '#09090b' },
+            headerTintColor: '#fff',
+          }}
+        />
+        <Ionicons name="alert-circle" size={48} color="#71717a" />
+        <Text className="text-zinc-400 text-lg mt-4 text-center">
+          Ticket not found
+        </Text>
+      </View>
+    );
+  }
+
+  const statusStyle = STATUS_COLORS[ticket.status] ?? STATUS_COLORS.open;
+  const statusLabel = STATUS_LABELS[ticket.status] ?? ticket.status;
+  const typeConfig = TYPE_CONFIG[ticket.type] ?? TYPE_CONFIG.question;
+  const isClosed = ticket.status === 'closed' || ticket.status === 'resolved';
+  const createdDate = new Date(ticket.created_at).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1 bg-background"
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}
+    >
+      <Stack.Screen
+        options={{
+          title: 'Ticket',
+          headerStyle: { backgroundColor: '#09090b' },
+          headerTintColor: '#fff',
+        }}
+      />
+
+      <ScrollView
+        ref={scrollViewRef}
+        className="flex-1"
+        contentContainerStyle={{ paddingBottom: 16 }}
+      >
+        {/* Ticket Header */}
+        <View className="px-4 pt-4 pb-3 border-b border-zinc-800">
+          <View className="flex-row items-center mb-2">
+            <Ionicons name={typeConfig.icon} size={16} color={typeConfig.color} />
+            <Text className="text-zinc-500 text-xs ml-1.5 mr-3">{typeConfig.label}</Text>
+            <View className={`px-2 py-0.5 rounded-full ${statusStyle.bg}`}>
+              <Text className={`text-xs font-medium ${statusStyle.text}`}>
+                {statusLabel}
+              </Text>
+            </View>
+          </View>
+          <Text className="text-white text-lg font-semibold mb-1">
+            {ticket.subject}
+          </Text>
+          <Text className="text-zinc-600 text-xs">
+            {createdDate}
+          </Text>
+        </View>
+
+        {/* Original Description */}
+        <View className="px-4 py-4 border-b border-zinc-800">
+          <Text className="text-zinc-300 text-sm leading-6">
+            {ticket.description}
+          </Text>
+        </View>
+
+        {/* Replies Thread */}
+        {replies.length > 0 && (
+          <View
+            className="px-4 pt-4"
+            accessibilityRole="list"
+            accessibilityLabel="Ticket replies"
+          >
+            <Text className="text-zinc-500 text-xs font-medium mb-3">REPLIES</Text>
+            {replies.map((reply) => {
+              const isUser = reply.author_type === 'user';
+              const replyDate = new Date(reply.created_at).toLocaleDateString(undefined, {
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+              });
+
+              return (
+                <View
+                  key={reply.id}
+                  className={`mb-3 ${isUser ? 'items-end' : 'items-start'}`}
+                  accessible
+                  accessibilityLabel={`${isUser ? 'Your' : 'Support'} reply`}
+                >
+                  <View
+                    className={`max-w-[85%] rounded-2xl px-4 py-3 ${
+                      isUser
+                        ? 'bg-brand/20 rounded-br-sm'
+                        : 'bg-zinc-800 rounded-bl-sm'
+                    }`}
+                  >
+                    <View className="flex-row items-center mb-1">
+                      <Ionicons
+                        name={isUser ? 'person' : 'shield-checkmark'}
+                        size={12}
+                        color={isUser ? '#f97316' : '#22c55e'}
+                      />
+                      <Text
+                        className={`text-xs font-medium ml-1 ${
+                          isUser ? 'text-orange-400' : 'text-green-400'
+                        }`}
+                      >
+                        {isUser ? 'You' : 'Support'}
+                      </Text>
+                    </View>
+                    <Text className="text-zinc-200 text-sm leading-5">
+                      {reply.message}
+                    </Text>
+                    <Text className="text-zinc-600 text-xs mt-1.5">
+                      {replyDate}
+                    </Text>
+                  </View>
+                </View>
+              );
+            })}
+          </View>
+        )}
+
+        {/* No replies yet */}
+        {replies.length === 0 && (
+          <View className="items-center py-8">
+            <Text className="text-zinc-600 text-sm">No replies yet</Text>
+          </View>
+        )}
+      </ScrollView>
+
+      {/* Reply Input */}
+      {!isClosed ? (
+        <View className="px-4 py-3 border-t border-zinc-800 bg-zinc-900">
+          <View className="flex-row items-end">
+            <TextInput
+              className="flex-1 bg-zinc-800 text-white rounded-xl px-4 py-2.5 text-sm max-h-[100px] mr-2"
+              placeholder="Write a reply..."
+              placeholderTextColor="#71717a"
+              multiline
+              value={replyText}
+              onChangeText={setReplyText}
+              maxLength={5000}
+              accessibilityLabel="Reply message input"
+            />
+            <Pressable
+              onPress={handleSendReply}
+              disabled={replyText.trim().length === 0 || isSendingReply}
+              className={`w-10 h-10 rounded-full items-center justify-center ${
+                replyText.trim().length > 0 && !isSendingReply ? 'bg-brand' : 'bg-zinc-700'
+              }`}
+              accessibilityRole="button"
+              accessibilityLabel="Send reply"
+              accessibilityState={{ disabled: replyText.trim().length === 0 || isSendingReply }}
+            >
+              {isSendingReply ? (
+                <ActivityIndicator size="small" color="white" />
+              ) : (
+                <Ionicons name="send" size={16} color="white" />
+              )}
+            </Pressable>
+          </View>
+        </View>
+      ) : (
+        <View className="px-4 py-3 border-t border-zinc-800 bg-zinc-900 items-center">
+          <Text className="text-zinc-500 text-sm">
+            This ticket is {statusLabel.toLowerCase()}
+          </Text>
+        </View>
+      )}
+    </KeyboardAvoidingView>
+  );
+}

--- a/packages/styrby-mobile/app/support/[id].tsx
+++ b/packages/styrby-mobile/app/support/[id].tsx
@@ -93,25 +93,6 @@ export default function TicketDetailScreen() {
   const [isSendingReply, setIsSendingReply] = useState(false);
   const scrollViewRef = useRef<ScrollView>(null);
 
-  // Show error screen for invalid ticket IDs
-  if (!parsedId.success) {
-    return (
-      <View className="flex-1 bg-background items-center justify-center px-8">
-        <Stack.Screen
-          options={{
-            title: 'Ticket',
-            headerStyle: { backgroundColor: '#09090b' },
-            headerTintColor: '#fff',
-          }}
-        />
-        <Ionicons name="alert-circle" size={48} color="#71717a" />
-        <Text className="text-zinc-400 text-lg mt-4 text-center">
-          Invalid ticket ID
-        </Text>
-      </View>
-    );
-  }
-
   // --------------------------------------------------------------------------
   // Data Loading
   // --------------------------------------------------------------------------
@@ -197,6 +178,26 @@ export default function TicketDetailScreen() {
   // --------------------------------------------------------------------------
   // Render
   // --------------------------------------------------------------------------
+
+  // WHY: Early returns for error/loading states must come after all hooks
+  // to satisfy React's rules-of-hooks (hooks cannot be called conditionally).
+  if (!parsedId.success) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center px-8">
+        <Stack.Screen
+          options={{
+            title: 'Ticket',
+            headerStyle: { backgroundColor: '#09090b' },
+            headerTintColor: '#fff',
+          }}
+        />
+        <Ionicons name="alert-circle" size={48} color="#71717a" />
+        <Text className="text-zinc-400 text-lg mt-4 text-center">
+          Invalid ticket ID
+        </Text>
+      </View>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/packages/styrby-mobile/app/support/index.tsx
+++ b/packages/styrby-mobile/app/support/index.tsx
@@ -1,0 +1,392 @@
+/**
+ * Support Tickets Screen
+ *
+ * Displays the user's existing support tickets in a scrollable list and
+ * provides a floating action button (FAB) to create new tickets. New ticket
+ * creation uses a bottom-sheet modal with a type picker, subject input,
+ * and description textarea.
+ *
+ * Uses the useSupport hook for data fetching and ticket creation.
+ * Navigation to ticket details uses expo-router dynamic routes.
+ */
+
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  TextInput,
+  Modal,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { useState, useCallback } from 'react';
+import { router, Stack } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useSupport } from '../../src/hooks/useSupport';
+import type { CreateTicketInput } from '../../src/lib/schemas';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Support ticket type options with display labels and icons.
+ */
+const TICKET_TYPES: Array<{
+  value: CreateTicketInput['type'];
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  color: string;
+}> = [
+  { value: 'bug', label: 'Bug Report', icon: 'bug', color: '#ef4444' },
+  { value: 'feature', label: 'Feature Request', icon: 'bulb', color: '#eab308' },
+  { value: 'question', label: 'Question', icon: 'help-circle', color: '#3b82f6' },
+];
+
+/**
+ * Status badge colors for ticket status display.
+ */
+const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
+  open: { bg: 'bg-blue-500/15', text: 'text-blue-400' },
+  in_progress: { bg: 'bg-yellow-500/15', text: 'text-yellow-400' },
+  resolved: { bg: 'bg-green-500/15', text: 'text-green-400' },
+  closed: { bg: 'bg-zinc-500/15', text: 'text-zinc-400' },
+};
+
+/**
+ * Display-friendly status labels.
+ */
+const STATUS_LABELS: Record<string, string> = {
+  open: 'Open',
+  in_progress: 'In Progress',
+  resolved: 'Resolved',
+  closed: 'Closed',
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Support tickets list screen with new ticket creation modal.
+ *
+ * Layout:
+ * 1. Screen header with "Support" title
+ * 2. Scrollable list of existing tickets (newest first)
+ * 3. Empty state when no tickets exist
+ * 4. FAB (floating action button) to open new ticket modal
+ * 5. Bottom-sheet modal with ticket creation form
+ *
+ * @returns The support screen JSX
+ */
+export default function SupportScreen() {
+  const {
+    tickets,
+    isLoading,
+    isSubmitting,
+    error,
+    createTicket,
+    refresh,
+  } = useSupport();
+
+  const [showNewTicketModal, setShowNewTicketModal] = useState(false);
+  const [selectedType, setSelectedType] = useState<CreateTicketInput['type']>('bug');
+  const [subject, setSubject] = useState('');
+  const [description, setDescription] = useState('');
+  const [refreshing, setRefreshing] = useState(false);
+
+  // --------------------------------------------------------------------------
+  // Handlers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Handles pull-to-refresh by reloading the ticket list.
+   */
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await refresh();
+    setRefreshing(false);
+  }, [refresh]);
+
+  /**
+   * Submits a new support ticket and resets the form on success.
+   * Validates input through the useSupport hook (which uses Zod).
+   */
+  const handleSubmit = useCallback(async () => {
+    const ticket = await createTicket({
+      type: selectedType,
+      subject: subject.trim(),
+      description: description.trim(),
+    });
+
+    if (ticket) {
+      // Reset form and close modal
+      setSubject('');
+      setDescription('');
+      setSelectedType('bug');
+      setShowNewTicketModal(false);
+    }
+  }, [createTicket, selectedType, subject, description]);
+
+  /**
+   * Navigates to the ticket detail screen.
+   *
+   * @param ticketId - The UUID of the ticket to view
+   */
+  const handleTicketPress = useCallback((ticketId: string) => {
+    router.push(`/support/${ticketId}`);
+  }, []);
+
+  /**
+   * Closes the new ticket modal and resets form state.
+   */
+  const handleCloseModal = useCallback(() => {
+    setShowNewTicketModal(false);
+    setSubject('');
+    setDescription('');
+    setSelectedType('bug');
+  }, []);
+
+  const isFormValid = subject.trim().length >= 3 && description.trim().length >= 10;
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
+  return (
+    <View className="flex-1 bg-background">
+      <Stack.Screen
+        options={{
+          title: 'Support',
+          headerStyle: { backgroundColor: '#09090b' },
+          headerTintColor: '#fff',
+        }}
+      />
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ paddingBottom: 100 }}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor="#f97316"
+            accessibilityLabel="Pull to refresh support tickets"
+          />
+        }
+      >
+        {/* Error banner */}
+        {error && (
+          <View className="mx-4 mt-4 bg-red-500/10 rounded-xl px-4 py-3">
+            <Text className="text-red-400 text-sm">{error}</Text>
+          </View>
+        )}
+
+        {/* Loading state */}
+        {isLoading ? (
+          <View className="items-center py-12">
+            <ActivityIndicator size="large" color="#f97316" accessibilityLabel="Loading tickets" />
+          </View>
+        ) : tickets.length === 0 ? (
+          /* Empty state */
+          <View className="items-center justify-center py-16 px-8">
+            <View className="w-16 h-16 rounded-2xl bg-zinc-800 items-center justify-center mb-4">
+              <Ionicons name="chatbubble-ellipses" size={32} color="#71717a" />
+            </View>
+            <Text className="text-zinc-300 text-lg font-semibold text-center mb-2">
+              No support tickets
+            </Text>
+            <Text className="text-zinc-500 text-sm text-center">
+              Need help? Tap the button below to create a support ticket.
+            </Text>
+          </View>
+        ) : (
+          /* Ticket list */
+          <View className="px-4 pt-4" accessibilityRole="list" accessibilityLabel="Support tickets">
+            {tickets.map((ticket) => {
+              const statusStyle = STATUS_COLORS[ticket.status] ?? STATUS_COLORS.open;
+              const statusLabel = STATUS_LABELS[ticket.status] ?? ticket.status;
+              const typeConfig = TICKET_TYPES.find((t) => t.value === ticket.type);
+              const createdDate = new Date(ticket.created_at).toLocaleDateString();
+
+              return (
+                <Pressable
+                  key={ticket.id}
+                  onPress={() => handleTicketPress(ticket.id)}
+                  className="bg-background-secondary rounded-xl p-4 mb-3 active:opacity-80"
+                  accessibilityRole="button"
+                  accessibilityLabel={`${ticket.subject}, status: ${statusLabel}`}
+                >
+                  <View className="flex-row items-start justify-between mb-2">
+                    <View className="flex-row items-center flex-1">
+                      {typeConfig && (
+                        <Ionicons
+                          name={typeConfig.icon}
+                          size={16}
+                          color={typeConfig.color}
+                          style={{ marginRight: 8 }}
+                        />
+                      )}
+                      <Text className="text-zinc-100 font-medium text-base flex-1" numberOfLines={1}>
+                        {ticket.subject}
+                      </Text>
+                    </View>
+                    <View className={`px-2 py-0.5 rounded-full ml-2 ${statusStyle.bg}`}>
+                      <Text className={`text-xs font-medium ${statusStyle.text}`}>
+                        {statusLabel}
+                      </Text>
+                    </View>
+                  </View>
+                  <Text className="text-zinc-500 text-sm" numberOfLines={2}>
+                    {ticket.description}
+                  </Text>
+                  <Text className="text-zinc-600 text-xs mt-2">
+                    {createdDate}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        )}
+      </ScrollView>
+
+      {/* FAB - New Ticket */}
+      <Pressable
+        onPress={() => setShowNewTicketModal(true)}
+        className="absolute bottom-8 right-6 w-14 h-14 rounded-full bg-brand items-center justify-center shadow-lg active:opacity-80"
+        accessibilityRole="button"
+        accessibilityLabel="Create new support ticket"
+        style={{
+          shadowColor: '#f97316',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 8,
+          elevation: 8,
+        }}
+      >
+        <Ionicons name="add" size={28} color="white" />
+      </Pressable>
+
+      {/* New Ticket Modal */}
+      <Modal
+        visible={showNewTicketModal}
+        animationType="slide"
+        transparent
+        onRequestClose={handleCloseModal}
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          className="flex-1 justify-end"
+        >
+          <Pressable
+            className="flex-1"
+            onPress={handleCloseModal}
+            accessibilityLabel="Close new ticket modal"
+          />
+          <View className="bg-zinc-900 rounded-t-3xl px-6 pt-6 pb-10 border-t border-zinc-800">
+            {/* Drag indicator */}
+            <View className="items-center mb-4">
+              <View className="w-10 h-1 rounded-full bg-zinc-700" />
+            </View>
+
+            {/* Header */}
+            <View className="flex-row items-center justify-between mb-5">
+              <Text className="text-white text-lg font-semibold">New Support Ticket</Text>
+              <Pressable
+                onPress={handleCloseModal}
+                accessibilityRole="button"
+                accessibilityLabel="Close"
+              >
+                <Ionicons name="close" size={24} color="#71717a" />
+              </Pressable>
+            </View>
+
+            {/* Type Picker */}
+            <Text className="text-zinc-400 text-sm font-medium mb-2">TYPE</Text>
+            <View className="flex-row mb-5">
+              {TICKET_TYPES.map((typeOption) => (
+                <Pressable
+                  key={typeOption.value}
+                  onPress={() => setSelectedType(typeOption.value)}
+                  className={`flex-1 py-2.5 mx-1 rounded-lg items-center flex-row justify-center ${
+                    selectedType === typeOption.value ? 'bg-brand/20 border border-brand/40' : 'bg-zinc-800'
+                  }`}
+                  accessibilityRole="radio"
+                  accessibilityLabel={typeOption.label}
+                  accessibilityState={{ selected: selectedType === typeOption.value }}
+                >
+                  <Ionicons
+                    name={typeOption.icon}
+                    size={14}
+                    color={selectedType === typeOption.value ? '#f97316' : '#71717a'}
+                  />
+                  <Text
+                    className={`text-xs font-medium ml-1 ${
+                      selectedType === typeOption.value ? 'text-orange-400' : 'text-zinc-400'
+                    }`}
+                  >
+                    {typeOption.label}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+
+            {/* Subject Input */}
+            <Text className="text-zinc-400 text-sm font-medium mb-2">SUBJECT</Text>
+            <TextInput
+              className="bg-zinc-800 text-white rounded-xl px-4 py-3 text-base mb-4"
+              placeholder="Brief summary of your issue"
+              placeholderTextColor="#71717a"
+              value={subject}
+              onChangeText={setSubject}
+              maxLength={200}
+              accessibilityLabel="Ticket subject"
+            />
+
+            {/* Description Input */}
+            <Text className="text-zinc-400 text-sm font-medium mb-2">DESCRIPTION</Text>
+            <TextInput
+              className="bg-zinc-800 text-white rounded-xl px-4 py-3 text-base mb-1 min-h-[100px]"
+              placeholder="Describe your issue in detail..."
+              placeholderTextColor="#71717a"
+              multiline
+              textAlignVertical="top"
+              value={description}
+              onChangeText={setDescription}
+              maxLength={5000}
+              accessibilityLabel="Ticket description"
+            />
+            <Text className="text-zinc-600 text-xs text-right mb-4">
+              {description.length}/5000
+            </Text>
+
+            {/* Submit Button */}
+            <Pressable
+              onPress={handleSubmit}
+              disabled={!isFormValid || isSubmitting}
+              className={`py-3.5 rounded-xl items-center ${
+                isFormValid && !isSubmitting ? 'bg-brand active:opacity-80' : 'bg-zinc-700'
+              }`}
+              accessibilityRole="button"
+              accessibilityLabel="Submit support ticket"
+              accessibilityState={{ disabled: !isFormValid || isSubmitting }}
+            >
+              {isSubmitting ? (
+                <ActivityIndicator size="small" color="white" />
+              ) : (
+                <Text
+                  className={`font-semibold text-base ${isFormValid ? 'text-white' : 'text-zinc-500'}`}
+                >
+                  Submit Ticket
+                </Text>
+              )}
+            </Pressable>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/components/OnboardingModal.tsx
+++ b/packages/styrby-mobile/src/components/OnboardingModal.tsx
@@ -1,0 +1,279 @@
+/**
+ * Onboarding Checklist Modal
+ *
+ * A bottom-sheet modal that displays tier-specific onboarding steps with
+ * completion status. Appears when the user's onboarding_completed_at is null.
+ * Each step is tappable and navigates to the relevant screen. The modal can
+ * be dismissed (skip) or completed when all steps are done.
+ *
+ * Uses the useOnboarding hook for data and NativeWind for styling.
+ */
+
+import { View, Text, Pressable, Modal, ScrollView, ActivityIndicator } from 'react-native';
+import { useCallback } from 'react';
+import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import type { ChecklistStep } from '../hooks/useOnboarding';
+import type { SubscriptionTier } from 'styrby-shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Props for the OnboardingModal component.
+ */
+interface OnboardingModalProps {
+  /** Whether the modal is currently visible */
+  visible: boolean;
+  /** Callback to close/dismiss the modal */
+  onDismiss: () => void;
+  /** The onboarding checklist steps with completion status */
+  steps: ChecklistStep[];
+  /** Number of completed steps */
+  completedCount: number;
+  /** Total number of steps */
+  totalCount: number;
+  /** The user's subscription tier, displayed in the welcome message */
+  tier: SubscriptionTier;
+  /** Whether a markComplete operation is in progress */
+  isMarkingComplete?: boolean;
+  /** Callback to mark onboarding as complete */
+  onComplete: () => Promise<void>;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Display-friendly tier names for the welcome message.
+ */
+const TIER_DISPLAY_NAMES: Record<SubscriptionTier, string> = {
+  free: 'Free',
+  pro: 'Pro',
+  power: 'Power',
+  team: 'Team',
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Renders a bottom-sheet style modal with the onboarding checklist.
+ *
+ * The modal presents:
+ * 1. A welcome message showing the user's subscription tier
+ * 2. A progress bar indicating how many steps are completed
+ * 3. A list of tappable steps that navigate to relevant screens
+ * 4. A "Skip for now" button to dismiss without completing
+ * 5. A "Complete Setup" button enabled when all steps are done
+ *
+ * @param visible - Controls modal visibility
+ * @param onDismiss - Called when the user dismisses the modal
+ * @param steps - Checklist steps from useOnboarding
+ * @param completedCount - Number of completed steps
+ * @param totalCount - Total step count
+ * @param tier - User's subscription tier
+ * @param isMarkingComplete - Loading state for completion action
+ * @param onComplete - Called when the user completes onboarding
+ * @returns The onboarding modal JSX
+ *
+ * @example
+ * <OnboardingModal
+ *   visible={showModal}
+ *   onDismiss={() => setShowModal(false)}
+ *   steps={steps}
+ *   completedCount={completedCount}
+ *   totalCount={totalCount}
+ *   tier={tier}
+ *   onComplete={markComplete}
+ * />
+ */
+export function OnboardingModal({
+  visible,
+  onDismiss,
+  steps,
+  completedCount,
+  totalCount,
+  tier,
+  isMarkingComplete = false,
+  onComplete,
+}: OnboardingModalProps) {
+  const allComplete = completedCount === totalCount && totalCount > 0;
+  const progressPercent = totalCount > 0 ? (completedCount / totalCount) * 100 : 0;
+
+  /**
+   * Navigates to the route for a specific checklist step and closes the modal.
+   *
+   * WHY: We dismiss the modal before navigating so the user does not see the
+   * modal overlaid on the destination screen when they navigate back.
+   *
+   * @param step - The checklist step to navigate to
+   */
+  const handleStepPress = useCallback(
+    (step: ChecklistStep) => {
+      onDismiss();
+      // Small delay to let modal animation complete before navigation
+      setTimeout(() => {
+        router.push(step.route as never);
+      }, 300);
+    },
+    [onDismiss],
+  );
+
+  /**
+   * Handles the "Complete Setup" button press.
+   * Calls onComplete and then dismisses the modal on success.
+   */
+  const handleComplete = useCallback(async () => {
+    try {
+      await onComplete();
+      onDismiss();
+    } catch {
+      // Error is handled by the hook's error state, modal stays open
+    }
+  }, [onComplete, onDismiss]);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onDismiss}
+    >
+      {/* Backdrop */}
+      <Pressable
+        className="flex-1 bg-black/50"
+        onPress={onDismiss}
+        accessibilityLabel="Close onboarding modal"
+      />
+
+      {/* Bottom sheet content */}
+      <View className="bg-zinc-900 rounded-t-3xl px-6 pt-6 pb-10 border-t border-zinc-800">
+        {/* Drag indicator */}
+        <View className="items-center mb-4">
+          <View className="w-10 h-1 rounded-full bg-zinc-700" />
+        </View>
+
+        {/* Header */}
+        <View className="flex-row items-center justify-between mb-2">
+          <Text className="text-white text-xl font-bold">Welcome to Styrby</Text>
+          <View className="px-2.5 py-1 rounded-full bg-orange-500/15">
+            <Text className="text-xs font-semibold text-orange-400">
+              {TIER_DISPLAY_NAMES[tier]}
+            </Text>
+          </View>
+        </View>
+
+        <Text className="text-zinc-400 text-sm mb-5">
+          Complete these steps to get the most out of your {TIER_DISPLAY_NAMES[tier]} plan.
+        </Text>
+
+        {/* Progress bar */}
+        <View className="mb-5">
+          <View className="flex-row items-center justify-between mb-2">
+            <Text className="text-zinc-500 text-xs font-medium">PROGRESS</Text>
+            <Text className="text-zinc-500 text-xs">
+              {completedCount}/{totalCount} complete
+            </Text>
+          </View>
+          <View className="h-2 bg-zinc-800 rounded-full overflow-hidden">
+            <View
+              className="h-full bg-brand rounded-full"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </View>
+        </View>
+
+        {/* Checklist */}
+        <ScrollView
+          style={{ maxHeight: 280 }}
+          showsVerticalScrollIndicator={false}
+          accessibilityRole="list"
+          accessibilityLabel="Onboarding checklist"
+        >
+          {steps.map((step) => (
+            <Pressable
+              key={step.id}
+              onPress={() => handleStepPress(step)}
+              className={`flex-row items-center py-3.5 px-4 mb-2 rounded-xl ${
+                step.completed ? 'bg-zinc-800/50' : 'bg-zinc-800'
+              }`}
+              accessibilityRole="button"
+              accessibilityLabel={`${step.label}, ${step.completed ? 'completed' : 'not completed'}`}
+              accessibilityState={{ checked: step.completed }}
+            >
+              {/* Completion indicator */}
+              <View
+                className={`w-8 h-8 rounded-full items-center justify-center mr-3 ${
+                  step.completed ? 'bg-green-500/20' : 'bg-zinc-700'
+                }`}
+              >
+                <Ionicons
+                  name={step.completed ? 'checkmark' : (step.icon as keyof typeof Ionicons.glyphMap)}
+                  size={step.completed ? 18 : 16}
+                  color={step.completed ? '#22c55e' : '#a1a1aa'}
+                />
+              </View>
+
+              {/* Step label */}
+              <Text
+                className={`flex-1 text-base ${
+                  step.completed ? 'text-zinc-500 line-through' : 'text-zinc-100'
+                }`}
+              >
+                {step.label}
+              </Text>
+
+              {/* Navigate arrow */}
+              {!step.completed && (
+                <Ionicons name="chevron-forward" size={18} color="#71717a" />
+              )}
+            </Pressable>
+          ))}
+        </ScrollView>
+
+        {/* Action buttons */}
+        <View className="mt-5">
+          {/* Complete button (enabled when all steps are done) */}
+          <Pressable
+            onPress={handleComplete}
+            disabled={!allComplete || isMarkingComplete}
+            className={`py-3.5 rounded-xl items-center mb-3 ${
+              allComplete && !isMarkingComplete
+                ? 'bg-brand active:opacity-80'
+                : 'bg-zinc-700'
+            }`}
+            accessibilityRole="button"
+            accessibilityLabel="Complete onboarding setup"
+            accessibilityState={{ disabled: !allComplete || isMarkingComplete }}
+          >
+            {isMarkingComplete ? (
+              <ActivityIndicator size="small" color="white" />
+            ) : (
+              <Text
+                className={`font-semibold text-base ${
+                  allComplete ? 'text-white' : 'text-zinc-500'
+                }`}
+              >
+                Complete Setup
+              </Text>
+            )}
+          </Pressable>
+
+          {/* Skip button */}
+          <Pressable
+            onPress={onDismiss}
+            className="py-2.5 items-center"
+            accessibilityRole="button"
+            accessibilityLabel="Skip onboarding for now"
+          >
+            <Text className="text-zinc-500 text-sm">Skip for now</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/packages/styrby-mobile/src/components/index.ts
+++ b/packages/styrby-mobile/src/components/index.ts
@@ -44,5 +44,7 @@ export type { TypingIndicatorProps, AgentState } from './TypingIndicator';
 
 export { OnboardingProgress } from './OnboardingProgress';
 
+export { OnboardingModal } from './OnboardingModal';
+
 export { SessionSummary } from './SessionSummary';
 export type { SessionSummaryProps } from './SessionSummary';

--- a/packages/styrby-mobile/src/hooks/useOnboarding.ts
+++ b/packages/styrby-mobile/src/hooks/useOnboarding.ts
@@ -1,0 +1,369 @@
+/**
+ * Onboarding Progress Hook
+ *
+ * Checks the user's onboarding completion state and computes a tier-specific
+ * checklist of setup steps. Each step maps to a table in Supabase that indicates
+ * whether the user has completed a particular action (e.g., pairing a device,
+ * setting a budget alert).
+ *
+ * Tier-based step progression:
+ * - Free: "Pair your first device" (machines table)
+ * - Pro: + "Set a budget alert" (budget_alerts) + "Configure notifications" (notification_preferences or device_tokens)
+ * - Power: + "Create a team" (teams via team_members) + "Generate an API key" (api_keys)
+ *
+ * Uses the same patterns as useSessions and useBudgetAlerts for Supabase queries,
+ * loading states, and error handling.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+import { safeParseSingle, SubscriptionTierRowSchema } from '../lib/schemas';
+import type { SubscriptionTier } from 'styrby-shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Represents a single step in the onboarding checklist.
+ * Each step corresponds to a user action that can be verified by querying
+ * the relevant Supabase table.
+ */
+export interface ChecklistStep {
+  /** Unique identifier for the step */
+  id: string;
+  /** Human-readable label shown in the checklist UI */
+  label: string;
+  /** Whether this step has been completed */
+  completed: boolean;
+  /** The expo-router path to navigate to when the user taps this step */
+  route: string;
+  /** Ionicons icon name for the step */
+  icon: string;
+  /** Minimum subscription tier required for this step to appear */
+  requiredTier: SubscriptionTier;
+}
+
+/**
+ * Return type for the useOnboarding hook.
+ */
+export interface UseOnboardingReturn {
+  /** Whether the full onboarding flow has been marked complete */
+  isComplete: boolean;
+  /** Whether the initial data is being loaded */
+  isLoading: boolean;
+  /** Error message from the most recent operation, or null */
+  error: string | null;
+  /** Tier-filtered checklist steps with completion status */
+  steps: ChecklistStep[];
+  /** Number of steps the user has completed */
+  completedCount: number;
+  /** Total number of steps for the user's tier */
+  totalCount: number;
+  /** The user's current subscription tier */
+  tier: SubscriptionTier;
+  /** Marks onboarding as complete by setting profiles.onboarding_completed_at */
+  markComplete: () => Promise<void>;
+  /** Refreshes onboarding data from Supabase */
+  refresh: () => Promise<void>;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * All possible onboarding steps across all tiers.
+ * Steps are filtered at runtime based on the user's subscription tier.
+ *
+ * WHY: Defining all steps statically makes it easy to add new steps per tier
+ * without modifying the hook logic. The requiredTier field controls visibility.
+ */
+const ALL_STEPS: Omit<ChecklistStep, 'completed'>[] = [
+  {
+    id: 'pair_device',
+    label: 'Pair your first device',
+    route: '/(auth)/scan',
+    icon: 'qr-code',
+    requiredTier: 'free',
+  },
+  {
+    id: 'set_budget_alert',
+    label: 'Set a budget alert',
+    route: '/budget-alerts',
+    icon: 'wallet',
+    requiredTier: 'pro',
+  },
+  {
+    id: 'configure_notifications',
+    label: 'Configure notifications',
+    route: '/(tabs)/settings',
+    icon: 'notifications',
+    requiredTier: 'pro',
+  },
+  {
+    id: 'create_team',
+    label: 'Create a team',
+    route: '/(tabs)/team',
+    icon: 'people',
+    requiredTier: 'power',
+  },
+  {
+    id: 'generate_api_key',
+    label: 'Generate an API key',
+    route: '/(tabs)/settings',
+    icon: 'key',
+    requiredTier: 'power',
+  },
+];
+
+/**
+ * Maps each tier to the set of tiers whose steps should be visible.
+ *
+ * WHY: A power user should see free and pro steps too. This mapping
+ * avoids complex conditional logic in the step-filtering code.
+ */
+const TIER_INCLUDES: Record<SubscriptionTier, SubscriptionTier[]> = {
+  free: ['free'],
+  pro: ['free', 'pro'],
+  power: ['free', 'pro', 'power'],
+  team: ['free', 'pro', 'power', 'team'],
+};
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook for managing onboarding state and computing tier-specific checklist progress.
+ *
+ * Fetches the user's profile (for onboarding_completed_at), subscription tier,
+ * and queries relevant tables to determine which checklist steps are complete.
+ *
+ * @returns Onboarding state, checklist steps, and a markComplete function
+ *
+ * @example
+ * const {
+ *   isComplete, isLoading, steps, completedCount, totalCount,
+ *   tier, markComplete, refresh,
+ * } = useOnboarding();
+ *
+ * if (!isComplete && !isLoading) {
+ *   // Show onboarding banner or modal
+ * }
+ */
+export function useOnboarding(): UseOnboardingReturn {
+  const [isComplete, setIsComplete] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tier, setTier] = useState<SubscriptionTier>('free');
+  const [stepCompletions, setStepCompletions] = useState<Record<string, boolean>>({});
+
+  // --------------------------------------------------------------------------
+  // Data Loading
+  // --------------------------------------------------------------------------
+
+  /**
+   * Fetches onboarding state from Supabase.
+   *
+   * Loads in parallel:
+   * 1. Profile (for onboarding_completed_at)
+   * 2. Subscription tier
+   * 3. Step completion checks (machines, budget_alerts, notification_preferences, team_members, api_keys)
+   *
+   * @throws Sets error state if the user is not authenticated or a query fails
+   */
+  const loadOnboardingState = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setError('You must be signed in to view onboarding status.');
+        setIsLoading(false);
+        return;
+      }
+
+      // Fetch profile, subscription, and all step checks in parallel
+      const [
+        profileResult,
+        subscriptionResult,
+        machinesResult,
+        budgetAlertsResult,
+        notifPrefsResult,
+        deviceTokensResult,
+        teamMembersResult,
+        apiKeysResult,
+      ] = await Promise.all([
+        supabase
+          .from('profiles')
+          .select('onboarding_completed_at')
+          .eq('id', user.id)
+          .single(),
+        supabase
+          .from('subscriptions')
+          .select('tier')
+          .eq('user_id', user.id)
+          .single(),
+        supabase
+          .from('machines')
+          .select('id')
+          .eq('user_id', user.id)
+          .limit(1),
+        supabase
+          .from('budget_alerts')
+          .select('id')
+          .eq('user_id', user.id)
+          .limit(1),
+        supabase
+          .from('notification_preferences')
+          .select('id')
+          .eq('user_id', user.id)
+          .limit(1),
+        supabase
+          .from('device_tokens')
+          .select('id')
+          .eq('user_id', user.id)
+          .limit(1),
+        supabase
+          .from('team_members')
+          .select('id')
+          .eq('user_id', user.id)
+          .limit(1),
+        supabase
+          .from('api_keys')
+          .select('id')
+          .eq('user_id', user.id)
+          .limit(1),
+      ]);
+
+      // Determine onboarding completion
+      if (!profileResult.error && profileResult.data) {
+        setIsComplete(profileResult.data.onboarding_completed_at !== null);
+      }
+
+      // Determine tier (default to free if no subscription row exists)
+      const tierRow = safeParseSingle(
+        SubscriptionTierRowSchema,
+        subscriptionResult.data,
+        'subscription_tier',
+      );
+      const userTier = (tierRow?.tier as SubscriptionTier) ?? 'free';
+      setTier(userTier);
+
+      // Compute step completions based on table row existence
+      // WHY: We check for at least one row in each table rather than a specific
+      // configuration, because the presence of any row means the user has engaged
+      // with that feature.
+      const completions: Record<string, boolean> = {
+        pair_device: !machinesResult.error && (machinesResult.data?.length ?? 0) > 0,
+        set_budget_alert: !budgetAlertsResult.error && (budgetAlertsResult.data?.length ?? 0) > 0,
+        configure_notifications:
+          (!notifPrefsResult.error && (notifPrefsResult.data?.length ?? 0) > 0) ||
+          (!deviceTokensResult.error && (deviceTokensResult.data?.length ?? 0) > 0),
+        create_team: !teamMembersResult.error && (teamMembersResult.data?.length ?? 0) > 0,
+        generate_api_key: !apiKeysResult.error && (apiKeysResult.data?.length ?? 0) > 0,
+      };
+
+      setStepCompletions(completions);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load onboarding state';
+      setError(message);
+      if (__DEV__) {
+        console.error('[useOnboarding] Error loading state:', err);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Load on mount
+  useEffect(() => {
+    loadOnboardingState();
+  }, [loadOnboardingState]);
+
+  // --------------------------------------------------------------------------
+  // Computed Values
+  // --------------------------------------------------------------------------
+
+  /**
+   * Filters the full step list to only include steps relevant to the user's tier,
+   * and attaches the computed completion status for each step.
+   */
+  const visibleTiers = TIER_INCLUDES[tier] ?? TIER_INCLUDES.free;
+  const steps: ChecklistStep[] = ALL_STEPS
+    .filter((step) => visibleTiers.includes(step.requiredTier))
+    .map((step) => ({
+      ...step,
+      completed: stepCompletions[step.id] ?? false,
+    }));
+
+  const completedCount = steps.filter((s) => s.completed).length;
+  const totalCount = steps.length;
+
+  // --------------------------------------------------------------------------
+  // Actions
+  // --------------------------------------------------------------------------
+
+  /**
+   * Marks onboarding as complete by setting profiles.onboarding_completed_at
+   * to the current timestamp. Updates local state immediately for responsive UI.
+   *
+   * @throws Sets error state if the database update fails
+   */
+  const markComplete = useCallback(async () => {
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        const authError = new Error('You must be signed in to complete onboarding.');
+        setError(authError.message);
+        throw authError;
+      }
+
+      const { error: updateError } = await supabase
+        .from('profiles')
+        .update({ onboarding_completed_at: new Date().toISOString() })
+        .eq('id', user.id);
+
+      if (updateError) {
+        setError(updateError.message);
+        if (__DEV__) {
+          console.error('[useOnboarding] Failed to mark complete:', updateError);
+        }
+        throw updateError;
+      }
+
+      setIsComplete(true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to complete onboarding';
+      setError(message);
+      if (__DEV__) {
+        console.error('[useOnboarding] markComplete error:', err);
+      }
+      throw err;
+    }
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Return
+  // --------------------------------------------------------------------------
+
+  return {
+    isComplete,
+    isLoading,
+    error,
+    steps,
+    completedCount,
+    totalCount,
+    tier,
+    markComplete,
+    refresh: loadOnboardingState,
+  };
+}

--- a/packages/styrby-mobile/src/hooks/useSupport.ts
+++ b/packages/styrby-mobile/src/hooks/useSupport.ts
@@ -1,0 +1,455 @@
+/**
+ * Support Tickets Hook
+ *
+ * Provides CRUD operations for support tickets and real-time reply subscriptions.
+ * Users can list their tickets, create new ones, view individual tickets with
+ * threaded replies, and reply to existing tickets.
+ *
+ * Uses the support_tickets and support_ticket_replies tables created in
+ * migration 012_support_tickets.sql. RLS policies restrict access to the
+ * authenticated user's own tickets.
+ *
+ * Real-time subscriptions use Supabase Realtime to receive new replies
+ * on the detail view without polling.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { supabase } from '../lib/supabase';
+import {
+  SupportTicketSchema,
+  SupportTicketReplySchema,
+  CreateTicketInputSchema,
+  safeParseArray,
+  safeParseSingle,
+} from '../lib/schemas';
+import type {
+  ValidatedSupportTicket,
+  ValidatedSupportTicketReply,
+  CreateTicketInput,
+} from '../lib/schemas';
+import type { RealtimeChannel } from '@supabase/supabase-js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Return type for the useSupport hook.
+ */
+export interface UseSupportReturn {
+  /** List of the user's support tickets, sorted by newest first */
+  tickets: ValidatedSupportTicket[];
+  /** Whether the ticket list is currently loading */
+  isLoading: boolean;
+  /** Whether a new ticket is being submitted */
+  isSubmitting: boolean;
+  /** Error message from the most recent operation, or null */
+  error: string | null;
+  /** Fetches a single ticket with its replies by ID */
+  getTicket: (id: string) => Promise<TicketWithReplies | null>;
+  /** Creates a new support ticket */
+  createTicket: (input: CreateTicketInput) => Promise<ValidatedSupportTicket | null>;
+  /** Adds a reply to an existing ticket */
+  replyToTicket: (ticketId: string, message: string) => Promise<ValidatedSupportTicketReply | null>;
+  /** Subscribes to real-time replies for a specific ticket. Returns an unsubscribe function. */
+  subscribeToReplies: (ticketId: string, onNewReply: (reply: ValidatedSupportTicketReply) => void) => () => void;
+  /** Refreshes the ticket list */
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Represents a support ticket along with its threaded replies.
+ * Used by the ticket detail screen.
+ */
+export interface TicketWithReplies {
+  /** The support ticket data */
+  ticket: ValidatedSupportTicket;
+  /** Chronologically ordered replies */
+  replies: ValidatedSupportTicketReply[];
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook for managing support ticket operations.
+ *
+ * Loads the user's ticket list on mount and provides functions for creating
+ * tickets, fetching ticket details with replies, replying to tickets, and
+ * subscribing to real-time reply updates.
+ *
+ * @returns Support ticket data, loading states, and action functions
+ *
+ * @example
+ * const {
+ *   tickets, isLoading, error, createTicket,
+ *   getTicket, replyToTicket, subscribeToReplies,
+ * } = useSupport();
+ *
+ * // Create a new ticket
+ * const ticket = await createTicket({
+ *   type: 'bug',
+ *   subject: 'App crashes on launch',
+ *   description: 'Detailed description of the issue...',
+ * });
+ */
+export function useSupport(): UseSupportReturn {
+  const [tickets, setTickets] = useState<ValidatedSupportTicket[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // WHY: Track active Realtime channels so we can clean up on unmount.
+  // Without cleanup, channels would leak and accumulate WebSocket connections.
+  const activeChannelsRef = useRef<RealtimeChannel[]>([]);
+
+  // --------------------------------------------------------------------------
+  // Ticket List
+  // --------------------------------------------------------------------------
+
+  /**
+   * Fetches all support tickets for the authenticated user.
+   * Tickets are sorted by created_at descending (newest first).
+   * RLS policies ensure only the user's own tickets are returned.
+   *
+   * @throws Sets error state if the user is not authenticated or the query fails
+   */
+  const loadTickets = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setError('You must be signed in to view support tickets.');
+        setIsLoading(false);
+        return;
+      }
+
+      const { data, error: queryError } = await supabase
+        .from('support_tickets')
+        .select('id, user_id, type, subject, description, status, created_at, updated_at')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false });
+
+      if (queryError) {
+        throw new Error(queryError.message);
+      }
+
+      const validated = safeParseArray(SupportTicketSchema, data, 'support_tickets');
+      setTickets(validated);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load support tickets';
+      setError(message);
+      if (__DEV__) {
+        console.error('[useSupport] Error loading tickets:', err);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Load tickets on mount
+  useEffect(() => {
+    loadTickets();
+  }, [loadTickets]);
+
+  // Clean up Realtime channels on unmount
+  useEffect(() => {
+    return () => {
+      for (const channel of activeChannelsRef.current) {
+        supabase.removeChannel(channel);
+      }
+      activeChannelsRef.current = [];
+    };
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Get Single Ticket with Replies
+  // --------------------------------------------------------------------------
+
+  /**
+   * Fetches a single support ticket and its threaded replies.
+   * Replies are ordered chronologically (oldest first) for display
+   * as a conversation thread.
+   *
+   * @param id - The ticket UUID to fetch
+   * @returns The ticket with its replies, or null if not found
+   *
+   * @example
+   * const result = await getTicket('abc-123');
+   * if (result) {
+   *   console.log(result.ticket.subject, result.replies.length);
+   * }
+   */
+  const getTicket = useCallback(async (id: string): Promise<TicketWithReplies | null> => {
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setError('You must be signed in to view a support ticket.');
+        return null;
+      }
+
+      const [ticketResult, repliesResult] = await Promise.all([
+        supabase
+          .from('support_tickets')
+          .select('id, user_id, type, subject, description, status, created_at, updated_at')
+          .eq('id', id)
+          .single(),
+        supabase
+          .from('support_ticket_replies')
+          .select('*')
+          .eq('ticket_id', id)
+          .order('created_at', { ascending: true }),
+      ]);
+
+      if (ticketResult.error) {
+        throw new Error(ticketResult.error.message);
+      }
+
+      const ticket = safeParseSingle(SupportTicketSchema, ticketResult.data, 'support_ticket');
+      if (!ticket) {
+        return null;
+      }
+
+      const replies = safeParseArray(
+        SupportTicketReplySchema,
+        repliesResult.data,
+        'support_ticket_replies',
+      );
+
+      return { ticket, replies };
+    } catch (err) {
+      if (__DEV__) {
+        console.error('[useSupport] Error fetching ticket:', err);
+      }
+      return null;
+    }
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Create Ticket
+  // --------------------------------------------------------------------------
+
+  /**
+   * Creates a new support ticket after validating input with Zod.
+   * Updates the local ticket list on success so the new ticket appears
+   * immediately without a re-fetch.
+   *
+   * @param input - The ticket type, subject, and description
+   * @returns The created ticket, or null on failure
+   * @throws Sets error state with a validation or database error message
+   *
+   * @example
+   * const ticket = await createTicket({
+   *   type: 'feature',
+   *   subject: 'Add dark mode',
+   *   description: 'It would be great to have a dark mode option...',
+   * });
+   */
+  const createTicket = useCallback(async (
+    input: CreateTicketInput,
+  ): Promise<ValidatedSupportTicket | null> => {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      // Validate input with Zod before sending to Supabase
+      const parseResult = CreateTicketInputSchema.safeParse(input);
+      if (!parseResult.success) {
+        const firstIssue = parseResult.error.issues[0];
+        setError(firstIssue?.message ?? 'Invalid ticket data');
+        return null;
+      }
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setError('You must be signed in to create a support ticket.');
+        return null;
+      }
+
+      const { data, error: insertError } = await supabase
+        .from('support_tickets')
+        .insert({
+          user_id: user.id,
+          type: parseResult.data.type,
+          subject: parseResult.data.subject,
+          description: parseResult.data.description,
+          priority: parseResult.data.priority ?? 'medium',
+        })
+        .select('*')
+        .single();
+
+      if (insertError) {
+        throw new Error(insertError.message);
+      }
+
+      const validated = safeParseSingle(SupportTicketSchema, data, 'support_ticket');
+      if (validated) {
+        // Prepend to local list so the new ticket appears immediately
+        setTickets((prev) => [validated, ...prev]);
+      }
+
+      return validated;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create support ticket';
+      setError(message);
+      if (__DEV__) {
+        console.error('[useSupport] Error creating ticket:', err);
+      }
+      return null;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Reply to Ticket
+  // --------------------------------------------------------------------------
+
+  /**
+   * Adds a user reply to an existing support ticket.
+   *
+   * @param ticketId - The ticket UUID to reply to
+   * @param message - The reply message content (1-5000 characters)
+   * @returns The created reply, or null on failure
+   *
+   * @example
+   * const reply = await replyToTicket('ticket-id', 'Thanks for the update!');
+   */
+  const replyToTicket = useCallback(async (
+    ticketId: string,
+    message: string,
+  ): Promise<ValidatedSupportTicketReply | null> => {
+    try {
+      if (message.trim().length === 0) {
+        setError('Reply message cannot be empty.');
+        return null;
+      }
+
+      if (message.length > 5000) {
+        setError('Reply message must be at most 5000 characters.');
+        return null;
+      }
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setError('You must be signed in to reply.');
+        return null;
+      }
+
+      const { data, error: insertError } = await supabase
+        .from('support_ticket_replies')
+        .insert({
+          ticket_id: ticketId,
+          author_type: 'user',
+          author_id: user.id,
+          message: message.trim(),
+        })
+        .select('*')
+        .single();
+
+      if (insertError) {
+        throw new Error(insertError.message);
+      }
+
+      return safeParseSingle(SupportTicketReplySchema, data, 'support_ticket_reply');
+    } catch (err) {
+      const errMessage = err instanceof Error ? err.message : 'Failed to submit reply';
+      setError(errMessage);
+      if (__DEV__) {
+        console.error('[useSupport] Error replying to ticket:', err);
+      }
+      return null;
+    }
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Real-time Subscription
+  // --------------------------------------------------------------------------
+
+  /**
+   * Subscribes to real-time INSERT events on the support_ticket_replies table
+   * for a specific ticket. Calls the provided callback whenever a new reply
+   * is inserted (by the user or an admin).
+   *
+   * WHY: We use Supabase Realtime instead of polling so that admin replies
+   * appear instantly in the user's detail view. The channel is cleaned up
+   * when the returned unsubscribe function is called or on hook unmount.
+   *
+   * @param ticketId - The ticket UUID to subscribe to
+   * @param onNewReply - Callback invoked with the validated new reply data
+   * @returns An unsubscribe function to stop receiving updates
+   *
+   * @example
+   * useEffect(() => {
+   *   const unsub = subscribeToReplies(ticketId, (reply) => {
+   *     setReplies(prev => [...prev, reply]);
+   *   });
+   *   return unsub;
+   * }, [ticketId]);
+   */
+  const subscribeToReplies = useCallback(
+    (ticketId: string, onNewReply: (reply: ValidatedSupportTicketReply) => void): (() => void) => {
+      const channel = supabase
+        .channel(`ticket-replies-${ticketId}`)
+        .on(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'support_ticket_replies',
+            filter: `ticket_id=eq.${ticketId}`,
+          },
+          (payload) => {
+            const validated = safeParseSingle(
+              SupportTicketReplySchema,
+              payload.new,
+              'realtime_reply',
+            );
+            if (validated) {
+              onNewReply(validated);
+            }
+          },
+        )
+        .subscribe();
+
+      activeChannelsRef.current.push(channel);
+
+      return () => {
+        supabase.removeChannel(channel);
+        activeChannelsRef.current = activeChannelsRef.current.filter((c) => c !== channel);
+      };
+    },
+    [],
+  );
+
+  // --------------------------------------------------------------------------
+  // Return
+  // --------------------------------------------------------------------------
+
+  return {
+    tickets,
+    isLoading,
+    isSubmitting,
+    error,
+    getTicket,
+    createTicket,
+    replyToTicket,
+    subscribeToReplies,
+    refresh: loadTickets,
+  };
+}

--- a/packages/styrby-mobile/src/lib/schemas.ts
+++ b/packages/styrby-mobile/src/lib/schemas.ts
@@ -333,6 +333,109 @@ export const SubscriptionTierRowSchema = z.object({
 export type ValidatedSubscriptionTierRow = z.infer<typeof SubscriptionTierRowSchema>;
 
 // ============================================================================
+// Support Ticket Schema
+// ============================================================================
+
+/**
+ * Valid support ticket types.
+ * Matches the CHECK constraint in the support_tickets table.
+ */
+const SupportTicketTypeSchema = z.enum(['bug', 'feature', 'question']);
+
+/**
+ * Valid support ticket priorities.
+ * Matches the CHECK constraint in the support_tickets table.
+ */
+const SupportTicketPrioritySchema = z.enum(['low', 'medium', 'high']);
+
+/**
+ * Valid support ticket statuses.
+ * Matches the CHECK constraint in the support_tickets table.
+ */
+const SupportTicketStatusSchema = z.enum(['open', 'in_progress', 'resolved', 'closed']);
+
+/**
+ * Validates a row from the Supabase `support_tickets` table.
+ *
+ * Support tickets are submitted by users and managed by admins.
+ * Each ticket has a type (bug/feature/question), priority, and status.
+ */
+export const SupportTicketSchema = z.object({
+  /** Primary key (UUID) */
+  id: z.string(),
+  /** Owner of the ticket (UUID) */
+  user_id: z.string(),
+  /** Ticket category */
+  type: SupportTicketTypeSchema,
+  /** Short summary of the issue or request (3-200 characters) */
+  subject: z.string(),
+  /** Detailed description of the issue or request (10-5000 characters) */
+  description: z.string(),
+  /** Ticket priority level */
+  priority: SupportTicketPrioritySchema,
+  /** Current ticket status */
+  status: SupportTicketStatusSchema,
+  /** Optional screenshot URLs attached to the ticket */
+  screenshot_urls: z.array(z.string()).optional().default([]),
+  /** Internal admin notes (null for user-facing queries) */
+  admin_notes: z.string().nullable().optional(),
+  /** ISO timestamp when the ticket was created */
+  created_at: z.string(),
+  /** ISO timestamp when the ticket was last updated */
+  updated_at: z.string(),
+});
+
+/** Inferred TypeScript type for a validated support ticket row. */
+export type ValidatedSupportTicket = z.infer<typeof SupportTicketSchema>;
+
+/**
+ * Valid reply author types.
+ * Matches the CHECK constraint in the support_ticket_replies table.
+ */
+const ReplyAuthorTypeSchema = z.enum(['user', 'admin']);
+
+/**
+ * Validates a row from the Supabase `support_ticket_replies` table.
+ *
+ * Each reply belongs to a ticket and tracks who wrote it (user or admin).
+ */
+export const SupportTicketReplySchema = z.object({
+  /** Primary key (UUID) */
+  id: z.string(),
+  /** Foreign key to the parent ticket */
+  ticket_id: z.string(),
+  /** Whether the reply was written by a user or admin */
+  author_type: ReplyAuthorTypeSchema,
+  /** UUID of the author (matches auth.users.id) */
+  author_id: z.string(),
+  /** Reply message content (1-5000 characters) */
+  message: z.string(),
+  /** ISO timestamp when the reply was created */
+  created_at: z.string(),
+});
+
+/** Inferred TypeScript type for a validated support ticket reply row. */
+export type ValidatedSupportTicketReply = z.infer<typeof SupportTicketReplySchema>;
+
+/**
+ * Zod schema for validating new ticket creation input.
+ * Used to validate user input before sending to Supabase.
+ */
+export const CreateTicketInputSchema = z.object({
+  /** Ticket category */
+  type: SupportTicketTypeSchema,
+  /** Short summary (3-200 characters) */
+  subject: z.string().min(3, 'Subject must be at least 3 characters').max(200, 'Subject must be at most 200 characters'),
+  /** Detailed description (10-5000 characters) */
+  description: z.string().min(10, 'Description must be at least 10 characters').max(5000, 'Description must be at most 5000 characters'),
+  /** Optional priority (defaults to 'medium' in the database) */
+  priority: SupportTicketPrioritySchema.optional(),
+});
+
+/** Inferred TypeScript type for ticket creation input. */
+export type CreateTicketInput = z.infer<typeof CreateTicketInputSchema>;
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 

--- a/packages/styrby-web/.env.example
+++ b/packages/styrby-web/.env.example
@@ -18,3 +18,8 @@ POLAR_PRO_MONTHLY_PRODUCT_ID=your-pro-monthly-product-id
 POLAR_PRO_ANNUAL_PRODUCT_ID=your-pro-annual-product-id
 POLAR_POWER_MONTHLY_PRODUCT_ID=your-power-monthly-product-id
 POLAR_POWER_ANNUAL_PRODUCT_ID=your-power-annual-product-id
+
+# Web Push (VAPID)
+# Generate keys with: npx web-push generate-vapid-keys
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=your-vapid-public-key
+VAPID_PRIVATE_KEY=your-vapid-private-key

--- a/packages/styrby-web/package.json
+++ b/packages/styrby-web/package.json
@@ -74,6 +74,7 @@
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",
     "vaul": "^1.1.2",
+    "web-push": "3.6.7",
     "zod": "^3.24.1"
   },
   "devDependencies": {
@@ -87,6 +88,7 @@
     "@types/node": "^22.10.7",
     "@types/react": "^19.0.7",
     "@types/react-dom": "^19.0.3",
+    "@types/web-push": "3.6.4",
     "@vitejs/plugin-react": "5.1.3",
     "@vitest/coverage-v8": "4.0.18",
     "autoprefixer": "^10.4.20",

--- a/packages/styrby-web/src/app/api/push/subscribe/route.ts
+++ b/packages/styrby-web/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,209 @@
+/**
+ * Web Push Subscription Endpoint
+ *
+ * POST /api/push/subscribe
+ *
+ * Registers a Web Push subscription for the authenticated user. Stores the
+ * subscription in the device_tokens table so the server can send push
+ * notifications to this browser via the Web Push protocol.
+ *
+ * Uses UPSERT on the subscription endpoint to handle re-subscriptions
+ * gracefully (e.g., when the browser refreshes the push subscription).
+ *
+ * @auth Required - Supabase Auth JWT via cookie
+ * @rateLimit 5 requests per minute per IP
+ *
+ * @body {
+ *   endpoint: string,
+ *   keys: { p256dh: string, auth: string },
+ *   expirationTime?: number | null
+ * }
+ *
+ * @returns 201 { success: true }
+ *
+ * @error 400 { error: string } - Validation failure
+ * @error 401 { error: 'Unauthorized' }
+ * @error 429 { error: 'RATE_LIMITED', message: string, retryAfter: number }
+ * @error 500 { error: 'Failed to save push subscription' }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { z } from 'zod';
+import { rateLimit, rateLimitResponse, RATE_LIMITS } from '@/lib/rateLimit';
+
+// ============================================================================
+// Push Service Allowlist
+// ============================================================================
+
+/**
+ * WHY: Without an allowlist, an attacker could supply an arbitrary URL as the
+ * push endpoint, turning our server into an SSRF proxy that sends POST requests
+ * to internal services or third-party targets. By restricting endpoints to known
+ * push service hostnames, we ensure the server only contacts legitimate push
+ * services operated by browser vendors.
+ */
+const ALLOWED_PUSH_HOSTS = [
+  'fcm.googleapis.com',
+  'updates.push.services.mozilla.com',
+  'notify.windows.com',
+  'push.apple.com',
+  'web.push.apple.com',
+];
+
+/**
+ * Checks whether a hostname matches an allowed push service host.
+ * Supports exact matches and subdomain matches (e.g., "foo.push.apple.com").
+ *
+ * @param hostname - The hostname to validate
+ * @returns True if the hostname is an allowed push service
+ */
+function isAllowedPushHost(hostname: string): boolean {
+  return ALLOWED_PUSH_HOSTS.some(
+    (allowed) => hostname === allowed || hostname.endsWith(`.${allowed}`)
+  );
+}
+
+// ============================================================================
+// Zod Schema
+// ============================================================================
+
+/**
+ * Validates a Web Push PushSubscription object.
+ *
+ * WHY: The PushSubscription from the browser contains an endpoint URL and
+ * encryption keys (p256dh for ECDH key exchange, auth for message
+ * authentication). Both keys are required for the web-push library to
+ * encrypt payloads before sending them to the push service.
+ */
+const PushSubscriptionSchema = z.object({
+  /** The push service endpoint URL provided by the browser */
+  endpoint: z
+    .string()
+    .url('Endpoint must be a valid URL')
+    .max(2048, 'Endpoint URL is too long')
+    .refine((url) => {
+      try {
+        const parsed = new URL(url);
+        return isAllowedPushHost(parsed.hostname);
+      } catch {
+        return false;
+      }
+    }, 'Endpoint must be a recognized push service (FCM, Mozilla, Windows, or Apple)'),
+
+  /** Encryption keys for Web Push payload encryption */
+  keys: z.object({
+    /** ECDH public key for Diffie-Hellman key exchange (base64url encoded) */
+    p256dh: z.string().min(1, 'p256dh key is required'),
+    /** Authentication secret for message authentication (base64url encoded) */
+    auth: z.string().min(1, 'auth key is required'),
+  }),
+
+  /** Optional expiration time for the subscription (milliseconds since epoch) */
+  expirationTime: z.number().nullable().optional(),
+});
+
+/**
+ * Rate limit for push subscription operations.
+ * 5 requests per minute prevents abuse while allowing normal usage.
+ */
+const PUSH_RATE_LIMIT = { windowMs: 60_000, maxRequests: 5 } as const;
+
+// ============================================================================
+// POST /api/push/subscribe
+// ============================================================================
+
+/**
+ * Handles POST requests to register a Web Push subscription.
+ *
+ * @param request - The incoming HTTP request containing the PushSubscription JSON
+ * @returns 201 on success, 4xx/5xx on failure
+ *
+ * @example
+ * const response = await fetch('/api/push/subscribe', {
+ *   method: 'POST',
+ *   headers: { 'Content-Type': 'application/json' },
+ *   body: JSON.stringify(pushSubscription.toJSON()),
+ * });
+ */
+export async function POST(request: NextRequest) {
+  // Rate limit check
+  const { allowed, retryAfter } = await rateLimit(
+    request,
+    PUSH_RATE_LIMIT,
+    'push-subscribe'
+  );
+  if (!allowed) {
+    return rateLimitResponse(retryAfter!);
+  }
+
+  try {
+    const supabase = await createClient();
+
+    // Authenticate user
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Parse and validate request body
+    const rawBody = await request.json();
+    const parseResult = PushSubscriptionSchema.safeParse(rawBody);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        {
+          error: parseResult.error.errors
+            .map((e) => e.message)
+            .join(', '),
+        },
+        { status: 400 }
+      );
+    }
+
+    const subscription = parseResult.data;
+
+    // WHY: We use the endpoint URL as the unique token identifier for web push
+    // subscriptions. The endpoint is unique per browser instance and changes
+    // when the subscription is refreshed, making it a reliable dedup key.
+    const { error: upsertError } = await supabase
+      .from('device_tokens')
+      .upsert(
+        {
+          user_id: user.id,
+          token: subscription.endpoint,
+          platform: 'web',
+          web_push_subscription: subscription,
+          is_active: true,
+        },
+        { onConflict: 'user_id,token' }
+      );
+
+    if (upsertError) {
+      console.error(
+        'Failed to save push subscription:',
+        upsertError.message
+      );
+      return NextResponse.json(
+        { error: 'Failed to save push subscription' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch (error) {
+    const isDev = process.env.NODE_ENV === 'development';
+    console.error(
+      'Push subscribe error:',
+      isDev ? error : error instanceof Error ? error.message : 'Unknown error'
+    );
+    return NextResponse.json(
+      { error: 'Failed to save push subscription' },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/styrby-web/src/app/api/push/unsubscribe/route.ts
+++ b/packages/styrby-web/src/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,180 @@
+/**
+ * Web Push Unsubscribe Endpoint
+ *
+ * DELETE /api/push/unsubscribe
+ *
+ * Removes a Web Push subscription for the authenticated user. Deletes the
+ * matching device_tokens row so the server stops sending push notifications
+ * to this browser.
+ *
+ * @auth Required - Supabase Auth JWT via cookie
+ * @rateLimit 5 requests per minute per IP
+ *
+ * @body {
+ *   endpoint: string
+ * }
+ *
+ * @returns 200 { success: true }
+ *
+ * @error 400 { error: string } - Validation failure
+ * @error 401 { error: 'Unauthorized' }
+ * @error 429 { error: 'RATE_LIMITED', message: string, retryAfter: number }
+ * @error 500 { error: 'Failed to remove push subscription' }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { z } from 'zod';
+import { rateLimit, rateLimitResponse } from '@/lib/rateLimit';
+
+// ============================================================================
+// Push Service Allowlist
+// ============================================================================
+
+/**
+ * WHY: Without an allowlist, an attacker could supply an arbitrary URL as the
+ * push endpoint, turning our server into an SSRF proxy that sends POST requests
+ * to internal services or third-party targets. By restricting endpoints to known
+ * push service hostnames, we ensure the server only contacts legitimate push
+ * services operated by browser vendors.
+ */
+const ALLOWED_PUSH_HOSTS = [
+  'fcm.googleapis.com',
+  'updates.push.services.mozilla.com',
+  'notify.windows.com',
+  'push.apple.com',
+  'web.push.apple.com',
+];
+
+/**
+ * Checks whether a hostname matches an allowed push service host.
+ * Supports exact matches and subdomain matches (e.g., "foo.push.apple.com").
+ *
+ * @param hostname - The hostname to validate
+ * @returns True if the hostname is an allowed push service
+ */
+function isAllowedPushHost(hostname: string): boolean {
+  return ALLOWED_PUSH_HOSTS.some(
+    (allowed) => hostname === allowed || hostname.endsWith(`.${allowed}`)
+  );
+}
+
+// ============================================================================
+// Zod Schema
+// ============================================================================
+
+/**
+ * Validates the unsubscribe request body.
+ * Only the push endpoint URL is needed to identify the subscription to remove.
+ */
+const UnsubscribeSchema = z.object({
+  /** The push service endpoint URL that identifies this subscription */
+  endpoint: z
+    .string()
+    .url('Endpoint must be a valid URL')
+    .max(2048, 'Endpoint URL is too long')
+    .refine((url) => {
+      try {
+        const parsed = new URL(url);
+        return isAllowedPushHost(parsed.hostname);
+      } catch {
+        return false;
+      }
+    }, 'Endpoint must be a recognized push service (FCM, Mozilla, Windows, or Apple)'),
+});
+
+/**
+ * Rate limit for push unsubscribe operations.
+ * 5 requests per minute prevents abuse while allowing normal usage.
+ */
+const PUSH_RATE_LIMIT = { windowMs: 60_000, maxRequests: 5 } as const;
+
+// ============================================================================
+// DELETE /api/push/unsubscribe
+// ============================================================================
+
+/**
+ * Handles DELETE requests to remove a Web Push subscription.
+ *
+ * @param request - The incoming HTTP request containing the endpoint to remove
+ * @returns 200 on success, 4xx/5xx on failure
+ *
+ * @example
+ * const response = await fetch('/api/push/unsubscribe', {
+ *   method: 'DELETE',
+ *   headers: { 'Content-Type': 'application/json' },
+ *   body: JSON.stringify({ endpoint: subscription.endpoint }),
+ * });
+ */
+export async function DELETE(request: NextRequest) {
+  // Rate limit check
+  const { allowed, retryAfter } = await rateLimit(
+    request,
+    PUSH_RATE_LIMIT,
+    'push-unsubscribe'
+  );
+  if (!allowed) {
+    return rateLimitResponse(retryAfter!);
+  }
+
+  try {
+    const supabase = await createClient();
+
+    // Authenticate user
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Parse and validate request body
+    const rawBody = await request.json();
+    const parseResult = UnsubscribeSchema.safeParse(rawBody);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        {
+          error: parseResult.error.errors
+            .map((e) => e.message)
+            .join(', '),
+        },
+        { status: 400 }
+      );
+    }
+
+    // WHY: We match on both user_id and token (endpoint) to ensure users
+    // can only delete their own subscriptions. RLS provides a second layer
+    // of defense, but explicit filtering is the primary guard.
+    const { error: deleteError } = await supabase
+      .from('device_tokens')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('token', parseResult.data.endpoint);
+
+    if (deleteError) {
+      console.error(
+        'Failed to remove push subscription:',
+        deleteError.message
+      );
+      return NextResponse.json(
+        { error: 'Failed to remove push subscription' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const isDev = process.env.NODE_ENV === 'development';
+    console.error(
+      'Push unsubscribe error:',
+      isDev ? error : error instanceof Error ? error.message : 'Unknown error'
+    );
+    return NextResponse.json(
+      { error: 'Failed to remove push subscription' },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/styrby-web/src/app/dashboard/settings/settings-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/settings-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
@@ -54,6 +54,30 @@ interface SettingsClientProps {
   notificationPrefs: NotificationPrefs | null;
   /** Per-agent configuration rows */
   agentConfigs: AgentConfig[] | null;
+}
+
+/* ──────────────────────────── Helpers ─────────────────────────── */
+
+/**
+ * Converts a base64url-encoded string to a Uint8Array.
+ *
+ * WHY: The Push API's subscribe() method requires the applicationServerKey
+ * as a Uint8Array, but VAPID public keys are distributed as base64url strings.
+ * This conversion handles the base64url-to-standard-base64 translation and
+ * then decodes into a byte array.
+ *
+ * @param base64String - A base64url-encoded VAPID public key
+ * @returns The decoded key as a Uint8Array for the Push API
+ */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
 }
 
 /* ──────────────────────────── Component ──────────────────────── */
@@ -139,8 +163,44 @@ export function SettingsClient({
   );
   const [prioritySaving, setPrioritySaving] = useState(false);
 
+  // Web Push subscription state
+  const [webPushSupported, setWebPushSupported] = useState(false);
+  const [webPushPermission, setWebPushPermission] = useState<NotificationPermission>('default');
+  const [webPushSubscribed, setWebPushSubscribed] = useState(false);
+  const [webPushLoading, setWebPushLoading] = useState(false);
+  const [webPushError, setWebPushError] = useState<string | null>(null);
+
   /** Whether the user is on a paid tier (Pro+ enables smart notifications) */
   const isPaidTier = subscription?.tier === 'pro' || subscription?.tier === 'power';
+
+  /**
+   * WHY: On mount, we detect browser support for Web Push and check whether
+   * the user already has an active push subscription. This lets the UI show
+   * the correct state (subscribed vs. not subscribed) without a server call.
+   */
+  useEffect(() => {
+    const checkWebPushStatus = async () => {
+      // Check browser support
+      if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+        setWebPushSupported(false);
+        return;
+      }
+      setWebPushSupported(true);
+      setWebPushPermission(Notification.permission);
+
+      // Check if already subscribed
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        const subscription = await registration.pushManager.getSubscription();
+        setWebPushSubscribed(!!subscription);
+      } catch {
+        // Service worker not ready yet, subscription status unknown
+        setWebPushSubscribed(false);
+      }
+    };
+
+    checkWebPushStatus();
+  }, []);
 
   /* ── Handlers ────────────────────────────────────────────────── */
 
@@ -367,6 +427,113 @@ export function SettingsClient({
     },
     [supabase, profile?.id]
   );
+
+  /**
+   * Subscribes the browser to Web Push notifications.
+   * Requests permission if not already granted, creates a push subscription
+   * via the Push API, and saves it to the server.
+   */
+  const handleWebPushSubscribe = useCallback(async () => {
+    setWebPushLoading(true);
+    setWebPushError(null);
+
+    try {
+      // Request notification permission
+      const permission = await Notification.requestPermission();
+      setWebPushPermission(permission);
+
+      if (permission !== 'granted') {
+        setWebPushError(
+          'Notification permission was denied. Please allow notifications in your browser settings.'
+        );
+        setWebPushLoading(false);
+        return;
+      }
+
+      const registration = await navigator.serviceWorker.ready;
+
+      // WHY: The applicationServerKey is the VAPID public key that identifies
+      // our server to the push service. It must match the private key used
+      // to sign push messages on the server side.
+      const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+      if (!vapidPublicKey) {
+        setWebPushError('Push notification configuration is missing. Please contact support.');
+        setWebPushLoading(false);
+        return;
+      }
+
+      // Convert VAPID key from base64url to Uint8Array
+      const applicationServerKey = urlBase64ToUint8Array(vapidPublicKey);
+
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey,
+      });
+
+      // Save subscription to the server
+      const response = await fetch('/api/push/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(subscription.toJSON()),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to save subscription');
+      }
+
+      setWebPushSubscribed(true);
+    } catch (error) {
+      setWebPushError(
+        error instanceof Error ? error.message : 'Failed to enable push notifications'
+      );
+    } finally {
+      setWebPushLoading(false);
+    }
+  }, []);
+
+  /**
+   * Unsubscribes the browser from Web Push notifications.
+   * Removes the push subscription from the browser and the server.
+   */
+  const handleWebPushUnsubscribe = useCallback(async () => {
+    setWebPushLoading(true);
+    setWebPushError(null);
+
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.getSubscription();
+
+      if (subscription) {
+        // Notify the server first (so it stops sending)
+        const response = await fetch('/api/push/unsubscribe', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ endpoint: subscription.endpoint }),
+        });
+
+        // WHY: If the server call fails, we must not unsubscribe locally.
+        // Otherwise the browser loses its subscription reference while the
+        // server still holds the endpoint, causing ghost notifications the
+        // user can never dismiss or re-manage.
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || 'Failed to remove subscription from server');
+        }
+
+        // Then unsubscribe locally
+        await subscription.unsubscribe();
+      }
+
+      setWebPushSubscribed(false);
+    } catch (error) {
+      setWebPushError(
+        error instanceof Error ? error.message : 'Failed to disable push notifications'
+      );
+    } finally {
+      setWebPushLoading(false);
+    }
+  }, []);
 
   /* ── Render ──────────────────────────────────────────────────── */
 
@@ -702,6 +869,62 @@ export function SettingsClient({
               <div className="h-6 w-11 rounded-full bg-zinc-700 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-all peer-checked:bg-orange-500 peer-checked:after:translate-x-full" />
             </label>
           </div>
+
+          {/* Web Push subscription management */}
+          {webPushSupported && (
+            <div className="px-4 py-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-zinc-100">
+                    Browser Push Subscription
+                  </p>
+                  <p className="text-sm text-zinc-500">
+                    {webPushSubscribed
+                      ? 'This browser is receiving push notifications.'
+                      : webPushPermission === 'denied'
+                        ? 'Notifications are blocked in browser settings.'
+                        : 'Enable push notifications for this browser.'}
+                  </p>
+                </div>
+                <div>
+                  {webPushSubscribed ? (
+                    <button
+                      onClick={handleWebPushUnsubscribe}
+                      disabled={webPushLoading}
+                      className="px-3 py-1.5 text-sm font-medium text-zinc-400 bg-zinc-800 border border-zinc-700 rounded-lg hover:bg-zinc-700 hover:text-zinc-200 disabled:opacity-50 transition-colors"
+                      aria-label="Unsubscribe from push notifications"
+                    >
+                      {webPushLoading ? 'Processing...' : 'Unsubscribe'}
+                    </button>
+                  ) : (
+                    <button
+                      onClick={handleWebPushSubscribe}
+                      disabled={webPushLoading || webPushPermission === 'denied'}
+                      className="px-3 py-1.5 text-sm font-medium text-white bg-orange-500 rounded-lg hover:bg-orange-600 disabled:opacity-50 transition-colors"
+                      aria-label="Subscribe to push notifications"
+                    >
+                      {webPushLoading ? 'Processing...' : 'Enable'}
+                    </button>
+                  )}
+                </div>
+              </div>
+              {webPushError && (
+                <p className="mt-2 text-sm text-red-400" role="alert">
+                  {webPushError}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Unsupported browser notice */}
+          {!webPushSupported && (
+            <div className="px-4 py-4">
+              <p className="text-sm text-zinc-500">
+                Your browser does not support Web Push notifications.
+                Try Chrome, Firefox, or Edge for push notification support.
+              </p>
+            </div>
+          )}
 
           {/* Email notifications */}
           <div className="px-4 py-4 flex items-center justify-between">

--- a/packages/styrby-web/src/app/dashboard/settings/settings-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/settings-client.tsx
@@ -463,7 +463,11 @@ export function SettingsClient({
       }
 
       // Convert VAPID key from base64url to Uint8Array
-      const applicationServerKey = urlBase64ToUint8Array(vapidPublicKey);
+      // WHY: Cast to ArrayBuffer because the Push API's subscribe() expects
+      // BufferSource, but Uint8Array's .buffer returns ArrayBufferLike which
+      // includes SharedArrayBuffer. The explicit .buffer access ensures
+      // compatibility with strict TypeScript environments.
+      const applicationServerKey = urlBase64ToUint8Array(vapidPublicKey).buffer as ArrayBuffer;
 
       const subscription = await registration.pushManager.subscribe({
         userVisibleOnly: true,

--- a/packages/styrby-web/src/lib/notifications.ts
+++ b/packages/styrby-web/src/lib/notifications.ts
@@ -1,0 +1,271 @@
+/**
+ * Unified Notification Dispatcher
+ *
+ * Provides a single entry point for sending notifications to users across
+ * all channels (Web Push, and in the future APNs/FCM for mobile). Handles
+ * checking user preferences before dispatching.
+ *
+ * WHY: Without a unified dispatcher, each feature (budget alerts, session
+ * events, team invites) would need to independently check preferences,
+ * resolve channels, and handle failures. This creates duplication and makes
+ * it easy to forget preference checks. A central dispatcher ensures
+ * consistent behavior across all notification sources.
+ *
+ * @module notifications
+ */
+
+import { createAdminClient } from '@/lib/supabase/server';
+import { sendPushToUser, type PushPayload } from '@/lib/web-push';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Notification event types that the dispatcher handles.
+ * Each type maps to a category for preference filtering.
+ */
+export type NotificationType =
+  | 'budget_alert'
+  | 'session_complete'
+  | 'session_error'
+  | 'permission_request'
+  | 'team_invite';
+
+/**
+ * Priority levels for notification filtering.
+ * Maps to the user's priority_threshold setting (1-5 scale).
+ *
+ * WHY: Smart notifications let Pro+ users filter by importance.
+ * Priority 1 = only urgent, 5 = everything. The dispatcher compares
+ * the notification's priority against the user's threshold.
+ */
+type NotificationPriority = 1 | 2 | 3 | 4 | 5;
+
+/**
+ * Payload for dispatching a notification to a user.
+ */
+export interface NotificationPayload {
+  /** Notification title */
+  title: string;
+
+  /** Notification body text */
+  body: string;
+
+  /** Optional icon URL */
+  icon?: string;
+
+  /** Optional URL to navigate to on click */
+  url?: string;
+
+  /** Optional tag for notification grouping/dedup */
+  tag?: string;
+}
+
+/**
+ * Result of a notification dispatch operation.
+ */
+export interface DispatchResult {
+  /** Whether the notification was sent via at least one channel */
+  delivered: boolean;
+
+  /** Channels that were attempted */
+  channels: {
+    webPush?: { sent: number; failed: number; cleaned: number };
+    // Future channels:
+    // apns?: { sent: number; failed: number };
+    // fcm?: { sent: number; failed: number };
+    // email?: { sent: boolean };
+  };
+
+  /** Reason if the notification was skipped entirely */
+  skippedReason?: string;
+}
+
+/**
+ * Shape of the notification_preferences row.
+ */
+interface NotificationPreferences {
+  push_enabled: boolean;
+  email_enabled: boolean;
+  quiet_hours_start: string | null;
+  quiet_hours_end: string | null;
+  priority_threshold: number | null;
+}
+
+// ============================================================================
+// Priority Mapping
+// ============================================================================
+
+/**
+ * Maps notification types to their default priority level.
+ *
+ * WHY: Different event types have inherently different urgency levels.
+ * Budget alerts and permission requests are high-priority because they
+ * require immediate user attention. Session completions are moderate.
+ * Team invites are low because they are not time-sensitive.
+ */
+const TYPE_PRIORITY: Record<NotificationType, NotificationPriority> = {
+  budget_alert: 1,
+  permission_request: 2,
+  session_error: 2,
+  session_complete: 3,
+  team_invite: 4,
+};
+
+// ============================================================================
+// Quiet Hours Check
+// ============================================================================
+
+/**
+ * Checks whether the current time falls within the user's quiet hours.
+ *
+ * WHY: Users configure quiet hours to avoid notifications during sleep or
+ * focus time. We check the user's local time (approximated by UTC for now)
+ * against their configured window.
+ *
+ * @param start - Quiet hours start time in HH:MM format (e.g., "22:00")
+ * @param end - Quiet hours end time in HH:MM format (e.g., "07:00")
+ * @returns True if the current time is within quiet hours
+ *
+ * @example
+ * isWithinQuietHours('22:00', '07:00'); // true at 23:00 UTC
+ * isWithinQuietHours('22:00', '07:00'); // false at 12:00 UTC
+ */
+function isWithinQuietHours(start: string, end: string): boolean {
+  const now = new Date();
+  const currentMinutes = now.getUTCHours() * 60 + now.getUTCMinutes();
+
+  const [startH, startM] = start.split(':').map(Number);
+  const [endH, endM] = end.split(':').map(Number);
+
+  const startMinutes = startH * 60 + startM;
+  const endMinutes = endH * 60 + endM;
+
+  // Handle overnight quiet hours (e.g., 22:00 to 07:00)
+  if (startMinutes > endMinutes) {
+    return currentMinutes >= startMinutes || currentMinutes < endMinutes;
+  }
+
+  return currentMinutes >= startMinutes && currentMinutes < endMinutes;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Dispatches a notification to a user across all eligible channels.
+ *
+ * The dispatch flow:
+ * 1. Fetches the user's notification preferences
+ * 2. Checks if push is enabled
+ * 3. Checks quiet hours (skips if currently in quiet period)
+ * 4. Checks priority threshold (skips if notification is below threshold)
+ * 5. Sends via Web Push to all active browser subscriptions
+ * 6. (Future) Sends via APNs/FCM for mobile devices
+ *
+ * @param userId - The Supabase user ID to notify
+ * @param type - The notification event type (determines default priority)
+ * @param payload - The notification content
+ * @returns Dispatch result with per-channel delivery status
+ *
+ * @example
+ * const result = await dispatchNotification(
+ *   'user-uuid',
+ *   'budget_alert',
+ *   {
+ *     title: 'Budget Warning',
+ *     body: 'You have used 80% of your monthly budget.',
+ *     url: '/dashboard/costs',
+ *     tag: 'budget-warning',
+ *   }
+ * );
+ *
+ * if (result.delivered) {
+ *   console.log('Notification sent to user');
+ * } else {
+ *   console.log('Skipped:', result.skippedReason);
+ * }
+ */
+export async function dispatchNotification(
+  userId: string,
+  type: NotificationType,
+  payload: NotificationPayload
+): Promise<DispatchResult> {
+  const supabase = createAdminClient();
+  const result: DispatchResult = {
+    delivered: false,
+    channels: {},
+  };
+
+  // Fetch user's notification preferences
+  const { data: prefs } = await supabase
+    .from('notification_preferences')
+    .select('push_enabled, email_enabled, quiet_hours_start, quiet_hours_end, priority_threshold')
+    .eq('user_id', userId)
+    .single();
+
+  const preferences = prefs as NotificationPreferences | null;
+
+  // Default to push enabled if no preferences row exists (new users)
+  const pushEnabled = preferences?.push_enabled ?? true;
+
+  if (!pushEnabled) {
+    result.skippedReason = 'Push notifications disabled by user';
+    return result;
+  }
+
+  // Check quiet hours
+  if (
+    preferences?.quiet_hours_start &&
+    preferences?.quiet_hours_end &&
+    isWithinQuietHours(preferences.quiet_hours_start, preferences.quiet_hours_end)
+  ) {
+    // WHY: Budget alerts (priority 1) bypass quiet hours because they
+    // indicate potential cost overruns that need immediate attention.
+    const notifPriority = TYPE_PRIORITY[type];
+    if (notifPriority > 1) {
+      result.skippedReason = 'Quiet hours active';
+      return result;
+    }
+  }
+
+  // Check priority threshold (Pro+ feature)
+  const threshold = preferences?.priority_threshold ?? 5;
+  const notifPriority = TYPE_PRIORITY[type];
+
+  if (notifPriority > threshold) {
+    result.skippedReason = `Notification priority (${notifPriority}) below user threshold (${threshold})`;
+    return result;
+  }
+
+  // Send via Web Push
+  try {
+    const pushPayload: PushPayload = {
+      title: payload.title,
+      body: payload.body,
+      icon: payload.icon,
+      url: payload.url,
+      tag: payload.tag,
+    };
+
+    const pushResult = await sendPushToUser(userId, pushPayload);
+    result.channels.webPush = pushResult;
+
+    if (pushResult.sent > 0) {
+      result.delivered = true;
+    }
+  } catch (error) {
+    console.error(
+      'Web push dispatch failed:',
+      error instanceof Error ? error.message : 'Unknown error'
+    );
+    result.channels.webPush = { sent: 0, failed: 1, cleaned: 0 };
+  }
+
+  // Future: APNs/FCM for mobile push
+  // Future: Email notifications via Resend
+
+  return result;
+}

--- a/packages/styrby-web/src/lib/web-push.ts
+++ b/packages/styrby-web/src/lib/web-push.ts
@@ -1,0 +1,238 @@
+/**
+ * Web Push Server-Side Utility
+ *
+ * Provides functions to send push notifications to users' browsers via the
+ * Web Push protocol. Uses the web-push library with VAPID authentication.
+ *
+ * WHY server-side only: The web-push library uses Node.js crypto APIs to
+ * encrypt notification payloads with the subscriber's public key. It must
+ * never be imported in client components or the browser bundle.
+ *
+ * @module web-push
+ */
+
+import webpush from 'web-push';
+import { createAdminClient } from '@/lib/supabase/server';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Payload for a push notification sent to a user's browser.
+ * Matches the PushPayload interface expected by the service worker.
+ */
+export interface PushPayload {
+  /** Notification title displayed to the user */
+  title: string;
+
+  /** Notification body text */
+  body: string;
+
+  /** Optional icon URL (defaults to app icon in the SW) */
+  icon?: string;
+
+  /** Optional URL to open when the notification is clicked */
+  url?: string;
+
+  /**
+   * Optional tag for notification grouping.
+   * Notifications with the same tag replace each other instead of stacking.
+   */
+  tag?: string;
+}
+
+/**
+ * Result of sending push notifications to a single user.
+ */
+export interface PushSendResult {
+  /** Number of notifications successfully delivered to the push service */
+  sent: number;
+
+  /** Number of notifications that failed to send */
+  failed: number;
+
+  /**
+   * Number of expired/invalid subscriptions that were cleaned up.
+   * A 410 Gone response from the push service means the subscription
+   * has been revoked by the browser.
+   */
+  cleaned: number;
+}
+
+/**
+ * Shape of the web_push_subscription JSONB column in device_tokens.
+ */
+interface StoredSubscription {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+  expirationTime?: number | null;
+}
+
+/**
+ * Row shape returned from the device_tokens query.
+ */
+interface DeviceTokenRow {
+  id: string;
+  token: string;
+  web_push_subscription: StoredSubscription;
+}
+
+// ============================================================================
+// VAPID Configuration
+// ============================================================================
+
+/**
+ * WHY: VAPID (Voluntary Application Server Identification) keys authenticate
+ * the application server to the push service. Without them, push services
+ * reject notification requests. The subject (mailto:) identifies the
+ * application operator for the push service to contact if there are issues.
+ *
+ * Keys are stored in environment variables and never hardcoded.
+ * Generate with: npx web-push generate-vapid-keys
+ */
+const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
+const VAPID_SUBJECT = process.env.NEXT_PUBLIC_APP_URL
+  ? `mailto:support@${new URL(process.env.NEXT_PUBLIC_APP_URL).hostname}`
+  : 'mailto:support@styrby.com';
+
+/** Tracks whether VAPID has been configured on this process. */
+let vapidConfigured = false;
+
+/**
+ * Configures the web-push library with VAPID credentials.
+ * Called lazily on first use to avoid errors during import in environments
+ * where VAPID keys are not set (e.g., CI, local dev without push setup).
+ *
+ * @throws {Error} When VAPID environment variables are missing
+ *
+ * @example
+ * ensureVapidConfigured(); // Throws if keys missing
+ * // Now safe to call webpush.sendNotification(...)
+ */
+function ensureVapidConfigured(): void {
+  if (vapidConfigured) return;
+
+  if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
+    throw new Error(
+      'VAPID keys are not configured. Set NEXT_PUBLIC_VAPID_PUBLIC_KEY and ' +
+        'VAPID_PRIVATE_KEY environment variables. Generate with: ' +
+        'npx web-push generate-vapid-keys'
+    );
+  }
+
+  webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+  vapidConfigured = true;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Sends a push notification to all active web push subscriptions for a user.
+ *
+ * For each subscription:
+ * 1. Encrypts the payload using the subscription's public key
+ * 2. Sends it to the push service endpoint
+ * 3. If the subscription has expired (410 Gone), deletes it from the database
+ *
+ * @param userId - The Supabase user ID to send notifications to
+ * @param payload - The notification content (title, body, icon, url, tag)
+ * @returns Result with counts of sent, failed, and cleaned-up subscriptions
+ * @throws {Error} When VAPID keys are not configured
+ *
+ * @example
+ * const result = await sendPushToUser('user-uuid', {
+ *   title: 'Session Complete',
+ *   body: 'Your Claude session finished. Cost: $2.50',
+ *   url: '/dashboard/sessions/session-uuid',
+ *   tag: 'session-complete',
+ * });
+ * console.log(`Sent: ${result.sent}, Failed: ${result.failed}`);
+ */
+export async function sendPushToUser(
+  userId: string,
+  payload: PushPayload
+): Promise<PushSendResult> {
+  ensureVapidConfigured();
+
+  const supabase = createAdminClient();
+  const result: PushSendResult = { sent: 0, failed: 0, cleaned: 0 };
+
+  // Fetch all active web push subscriptions for this user
+  const { data: tokens, error } = await supabase
+    .from('device_tokens')
+    .select('id, token, web_push_subscription')
+    .eq('user_id', userId)
+    .eq('platform', 'web')
+    .eq('is_active', true);
+
+  if (error) {
+    console.error('Failed to fetch web push subscriptions:', error.message);
+    return result;
+  }
+
+  if (!tokens || tokens.length === 0) {
+    return result;
+  }
+
+  const payloadString = JSON.stringify(payload);
+
+  // WHY: We send to all subscriptions in parallel for speed. A user may have
+  // multiple browsers/devices with web push enabled. Using Promise.allSettled
+  // ensures one failed subscription does not block others.
+  const sendPromises = (tokens as DeviceTokenRow[]).map(async (token) => {
+    const subscription = token.web_push_subscription;
+
+    if (!subscription?.endpoint || !subscription?.keys) {
+      result.failed++;
+      return;
+    }
+
+    try {
+      await webpush.sendNotification(
+        {
+          endpoint: subscription.endpoint,
+          keys: {
+            p256dh: subscription.keys.p256dh,
+            auth: subscription.keys.auth,
+          },
+        },
+        payloadString
+      );
+      result.sent++;
+    } catch (sendError: unknown) {
+      const statusCode =
+        sendError instanceof Error &&
+        'statusCode' in sendError
+          ? (sendError as { statusCode: number }).statusCode
+          : 0;
+
+      if (statusCode === 410 || statusCode === 404) {
+        // WHY: A 410 Gone or 404 Not Found from the push service means the
+        // subscription has been revoked (user unsubscribed via browser
+        // settings, cleared site data, or the subscription expired).
+        // We delete the stale row to avoid retrying on every send.
+        await supabase
+          .from('device_tokens')
+          .delete()
+          .eq('id', token.id);
+        result.cleaned++;
+      } else {
+        console.error(
+          `Failed to send push to subscription ${token.id}:`,
+          sendError instanceof Error ? sendError.message : 'Unknown error'
+        );
+        result.failed++;
+      }
+    }
+  });
+
+  await Promise.allSettled(sendPromises);
+  return result;
+}

--- a/packages/styrby-web/src/sw.ts
+++ b/packages/styrby-web/src/sw.ts
@@ -50,7 +50,13 @@ interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
   __SW_MANIFEST: (PrecacheEntry | string)[] | undefined;
   clients: Clients;
   registration: ServiceWorkerRegistration;
+  location: { origin: string; href: string };
   addEventListener(type: 'sync', listener: (event: SyncEvent) => void): void;
+  addEventListener(type: 'push', listener: (event: PushEvent) => void): void;
+  addEventListener(
+    type: 'notificationclick',
+    listener: (event: NotificationEvent) => void
+  ): void;
   addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
 }
 
@@ -82,6 +88,42 @@ interface ExtendableEvent extends Event {
  */
 interface SyncEvent extends ExtendableEvent {
   readonly tag: string;
+}
+
+/**
+ * PushEvent fires when the service worker receives a push message
+ * from a push service. Contains the encrypted payload sent by the server.
+ */
+interface PushEvent extends ExtendableEvent {
+  readonly data: PushMessageData | null;
+}
+
+/**
+ * Provides methods to extract data from the push message payload.
+ */
+interface PushMessageData {
+  json(): unknown;
+  text(): string;
+}
+
+/**
+ * NotificationEvent fires when the user clicks on a displayed notification.
+ * Provides access to the notification object and its associated data.
+ */
+interface NotificationEvent extends ExtendableEvent {
+  readonly notification: NotificationObject;
+  readonly action: string;
+}
+
+/**
+ * Represents a displayed notification with its properties and methods.
+ */
+interface NotificationObject {
+  readonly title: string;
+  readonly body: string;
+  readonly data: Record<string, unknown>;
+  readonly tag: string;
+  close(): void;
 }
 
 /* eslint-enable @typescript-eslint/no-empty-object-type */
@@ -295,6 +337,131 @@ async function notifyClientsToSync(): Promise<void> {
     client.postMessage({ type: 'SYNC_OFFLINE_QUEUE' });
   }
 }
+
+// ============================================================================
+// Web Push Notification Handlers
+// ============================================================================
+
+/**
+ * Expected shape of the push notification payload sent by the server.
+ * The server sends this JSON via the web-push library.
+ */
+interface PushPayload {
+  /** Notification title displayed to the user */
+  title: string;
+  /** Notification body text */
+  body: string;
+  /** Optional icon URL (defaults to app icon) */
+  icon?: string;
+  /** Optional URL to open when the notification is clicked */
+  url?: string;
+  /** Optional tag for notification grouping/replacement */
+  tag?: string;
+}
+
+/**
+ * WHY: The 'push' event fires when the push service delivers a message to
+ * this service worker. The server encrypts the payload using the VAPID keys
+ * and the subscription's p256dh/auth keys. The browser decrypts it before
+ * delivering it here.
+ *
+ * We display a notification using the Notification API. If the payload is
+ * missing or malformed, we show a generic fallback notification so the user
+ * still knows something happened.
+ */
+self.addEventListener('push', (event: PushEvent) => {
+  const defaultPayload: PushPayload = {
+    title: 'Styrby',
+    body: 'You have a new notification.',
+  };
+
+  let payload: PushPayload = defaultPayload;
+
+  if (event.data) {
+    try {
+      const parsed = event.data.json() as Partial<PushPayload>;
+      payload = {
+        title: parsed.title || defaultPayload.title,
+        body: parsed.body || defaultPayload.body,
+        icon: parsed.icon,
+        url: parsed.url,
+        tag: parsed.tag,
+      };
+    } catch {
+      // WHY: If the payload is not valid JSON, fall back to the text content
+      // as the notification body. This handles edge cases where the server
+      // sends a plain text message instead of structured JSON.
+      payload = {
+        ...defaultPayload,
+        body: event.data.text() || defaultPayload.body,
+      };
+    }
+  }
+
+  const notificationOptions: NotificationOptions = {
+    body: payload.body,
+    icon: payload.icon || '/icons/icon-192x192.png',
+    badge: '/icons/icon-72x72.png',
+    tag: payload.tag || 'styrby-notification',
+    data: { url: payload.url || '/dashboard' },
+  };
+
+  event.waitUntil(
+    self.registration.showNotification(payload.title, notificationOptions)
+  );
+});
+
+/**
+ * WHY: The 'notificationclick' event fires when the user clicks on a
+ * notification displayed by this service worker. We use the data.url
+ * property (set in the push handler above) to navigate the user to the
+ * relevant page in the app.
+ *
+ * We first try to find an existing open tab for the app and focus it.
+ * If no tab is open, we open a new one. This prevents spawning duplicate
+ * tabs every time a notification is clicked.
+ */
+self.addEventListener('notificationclick', (event: NotificationEvent) => {
+  event.notification.close();
+
+  // WHY: Validate that the notification URL is same-origin before navigating.
+  // A malicious push payload could inject an arbitrary URL to redirect users
+  // to a phishing site. By restricting to same-origin paths, we prevent open
+  // redirect attacks via crafted notification data.
+  const rawUrl = (event.notification.data?.url as string) || '/dashboard';
+  let targetUrl: string;
+  try {
+    const parsed = new URL(rawUrl, self.location.origin);
+    targetUrl = parsed.origin === self.location.origin
+      ? parsed.pathname + parsed.search + parsed.hash
+      : '/dashboard';
+  } catch {
+    targetUrl = '/dashboard';
+  }
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: 'window' })
+      .then((clientList: Client[]) => {
+        // WHY: Look for an existing open tab to reuse. Opening a new tab for
+        // every notification click creates tab clutter. We check if any
+        // controlled client is already showing the app and focus it instead.
+        for (const client of clientList) {
+          const windowClient = client as unknown as {
+            url: string;
+            focus(): Promise<unknown>;
+            navigate(url: string): Promise<unknown>;
+          };
+          if (windowClient.url && windowClient.focus) {
+            return windowClient.navigate(targetUrl).then(() => windowClient.focus());
+          }
+        }
+        // No existing tab found, open a new one
+        return (self as unknown as { clients: { openWindow(url: string): Promise<unknown> } })
+          .clients.openWindow(targetUrl);
+      })
+  );
+});
 
 // ============================================================================
 // Activate Serwist Event Listeners

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,6 +472,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      web-push:
+        specifier: 3.6.7
+        version: 3.6.7
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -506,6 +509,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.3
         version: 19.2.3(@types/react@19.2.13)
+      '@types/web-push':
+        specifier: 3.6.4
+        version: 3.6.4
       '@vitejs/plugin-react':
         specifier: 5.1.3
         version: 5.1.3(vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))
@@ -3957,6 +3963,9 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -4455,6 +4464,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
@@ -4625,6 +4637,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -4670,6 +4685,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
@@ -5300,6 +5318,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -6204,6 +6225,10 @@ packages:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -6836,6 +6861,12 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -7192,6 +7223,9 @@ packages:
   mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -9205,6 +9239,11 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -13380,6 +13419,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 22.15.35
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.15.35
@@ -14049,6 +14092,13 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assert@2.1.0:
     dependencies:
       call-bind: 1.0.8
@@ -14260,6 +14310,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bn.js@4.12.3: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -14320,6 +14372,8 @@ snapshots:
       buffer-fill: 1.0.0
 
   buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-fill@1.0.0: {}
 
@@ -14945,6 +14999,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -16177,6 +16235,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -17078,6 +17138,17 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -17506,6 +17577,8 @@ snapshots:
   min-indent@1.0.1: {}
 
   mini-svg-data-uri@1.4.4: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -19777,6 +19850,16 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
## Summary

Sprint 2 of the PWA + Mobile Parity MDMP plan. Two parallel tracks: Web Push notifications for the dashboard, and mobile onboarding + support ticket system.

### Track A: Web Push Notifications
- **Subscribe/unsubscribe API endpoints** with SSRF-hardened endpoint validation (allowlist of known push service hosts), Zod schemas, rate limiting (5 req/min), and auth
- **Service worker push handlers** with same-origin URL validation on notification clicks (prevents open redirect)
- **Server-side notification sender** (`web-push.ts`) with auto-cleanup of expired subscriptions (410 responses)
- **Unified notification dispatcher** (`notifications.ts`) with quiet hours, priority threshold, and multi-channel support (Web Push now, APNs/FCM/email stubs)
- **Dashboard settings UI** for enabling/disabling Web Push with permission status display
- **VAPID key configuration** documented in `.env.example` (keys stored in Vercel env vars, never in code)

### Track B: Mobile Onboarding + Support Tickets
- **Onboarding hook** (`useOnboarding`) queries 6 tables in parallel to compute tier-specific checklist (Free: 1 step, Pro: 3, Power: 5)
- **Onboarding modal** with progress bar, tappable steps that navigate to relevant screens, complete/skip actions
- **Dashboard banner** showing setup progress, auto-dismisses when complete
- **Support ticket system** with full CRUD hook (`useSupport`), Zod-validated schemas, explicit column selects (admin_notes excluded from client)
- **Support screens**: ticket list with status badges, detail view with threaded replies, real-time Supabase Realtime subscription for new replies
- **Settings navigation** entry point to support

## Security Fixes Applied (from code review)
- SSRF prevention: Push endpoint URLs validated against allowlist of known push service hosts
- Open redirect guard: SW notification click validates same-origin before navigation
- Auth guard added to `getTicket` (was missing)
- Ticket ID UUID validation before Realtime filter (prevents filter injection)
- `admin_notes` excluded from client queries (defense in depth)
- Unsubscribe error handling: server failure no longer silently ignored

## Test Plan
- [x] `npx tsc --noEmit` passes with 0 errors (both packages)
- [ ] CI pipeline passes
- [ ] Vercel preview deployment works

---
Shipped with [Claude Code](https://claude.com/claude-code)