### PR TITLE
test(sprint-4): 187 new tests, security validation, and mobile test infra fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ notes/
 # Security audit reports (contain vulnerability details)
 .security-audit.json
 .security-reports/
+.sec-reports/
 
 # Compliance audit reports
 .compliance/

--- a/packages/styrby-mobile/package.json
+++ b/packages/styrby-mobile/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "jest": "^29.7.0",
     "jest-expo": "^52.0.6",
+    "react-native-worklets": "0.8.1",
     "react-test-renderer": "^18.3.1",
     "tailwindcss": "^3.4.0",
     "typescript": "~5.6.0",

--- a/packages/styrby-mobile/src/__tests__/budget-rpc.test.ts
+++ b/packages/styrby-mobile/src/__tests__/budget-rpc.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Budget RPC (checkHardStop) Test Suite
+ *
+ * Tests the check_budget_hard_stop RPC function invoked by useBudgetAlerts.
+ * The RPC uses an advisory lock to atomically check whether the user has
+ * exceeded a hard-stop budget threshold.
+ *
+ * Tests cover:
+ * - checkHardStop returns correct not-blocked result
+ * - checkHardStop returns correct blocked result
+ * - Error handling for RPC failures
+ * - Zod validation of the RPC response
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+// ============================================================================
+// Mock Setup
+// ============================================================================
+
+let mockAuthUser: { id: string } | null = { id: 'test-user-id' };
+let mockRpcResult: { data: unknown; error: unknown } = { data: null, error: null };
+let mockQueryResults: Record<string, { data: unknown; error: unknown }> = {};
+
+jest.mock('@/lib/supabase', () => {
+  const createChain = (table: string) => {
+    const getResult = () =>
+      mockQueryResults[table] || { data: null, error: null };
+
+    const chain: Record<string, unknown> = {};
+    const chainMethods = ['select', 'eq', 'order', 'gte', 'limit', 'insert', 'update', 'delete'];
+    for (const method of chainMethods) {
+      chain[method] = jest.fn(() => chain);
+    }
+    chain.single = jest.fn(() => Promise.resolve(getResult()));
+    chain.maybeSingle = jest.fn(() => Promise.resolve(getResult()));
+    chain.then = (resolve: (v: unknown) => void) =>
+      Promise.resolve(getResult()).then(resolve);
+    return chain;
+  };
+
+  return {
+    supabase: {
+      auth: {
+        getUser: jest.fn(async () => ({
+          data: { user: mockAuthUser },
+          error: null,
+        })),
+      },
+      from: jest.fn((table: string) => createChain(table)),
+      rpc: jest.fn(() => Promise.resolve(mockRpcResult)),
+    },
+  };
+});
+
+jest.mock('styrby-shared', () => ({}));
+
+import { useBudgetAlerts } from '../hooks/useBudgetAlerts';
+import { supabase } from '@/lib/supabase';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('checkHardStop (Budget RPC)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthUser = { id: 'test-user-id' };
+    mockRpcResult = { data: null, error: null };
+    // Default: no alerts, free tier
+    mockQueryResults = {
+      budget_alerts: { data: [], error: null },
+      subscriptions: { data: null, error: null },
+      cost_records: { data: [], error: null },
+    };
+  });
+
+  // --------------------------------------------------------------------------
+  // Not Blocked
+  // --------------------------------------------------------------------------
+
+  it('returns is_blocked=false when no hard-stop alert is triggered', async () => {
+    // RPC returns empty array (no triggered alerts)
+    mockRpcResult = { data: [], error: null };
+
+    const { result } = renderHook(() => useBudgetAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let hardStopResult: unknown = null;
+    await act(async () => {
+      hardStopResult = await result.current.checkHardStop();
+    });
+
+    expect(hardStopResult).toEqual({
+      is_blocked: false,
+      alert_id: null,
+      threshold_usd: null,
+      total_spend: null,
+      period: null,
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Blocked
+  // --------------------------------------------------------------------------
+
+  it('returns is_blocked=true with alert details when threshold exceeded', async () => {
+    mockRpcResult = {
+      data: [
+        {
+          is_blocked: true,
+          alert_id: 'alert-1',
+          threshold_usd: 10.0,
+          total_spend: 12.5,
+          period: 'daily',
+        },
+      ],
+      error: null,
+    };
+
+    const { result } = renderHook(() => useBudgetAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let hardStopResult: unknown = null;
+    await act(async () => {
+      hardStopResult = await result.current.checkHardStop();
+    });
+
+    expect(hardStopResult).toEqual({
+      is_blocked: true,
+      alert_id: 'alert-1',
+      threshold_usd: 10.0,
+      total_spend: 12.5,
+      period: 'daily',
+    });
+  });
+
+  it('handles string numeric values from Postgres (coercion)', async () => {
+    mockRpcResult = {
+      data: [
+        {
+          is_blocked: true,
+          alert_id: 'alert-2',
+          threshold_usd: '25.00', // Postgres numeric may serialize as string
+          total_spend: '30.50',
+          period: 'weekly',
+        },
+      ],
+      error: null,
+    };
+
+    const { result } = renderHook(() => useBudgetAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let hardStopResult: unknown = null;
+    await act(async () => {
+      hardStopResult = await result.current.checkHardStop();
+    });
+
+    expect(hardStopResult).toEqual({
+      is_blocked: true,
+      alert_id: 'alert-2',
+      threshold_usd: 25.0,
+      total_spend: 30.5,
+      period: 'weekly',
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // RPC Errors
+  // --------------------------------------------------------------------------
+
+  it('returns null when RPC call fails', async () => {
+    mockRpcResult = {
+      data: null,
+      error: { message: 'Function not found' },
+    };
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const { result } = renderHook(() => useBudgetAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let hardStopResult: unknown = 'not-null';
+    await act(async () => {
+      hardStopResult = await result.current.checkHardStop();
+    });
+
+    expect(hardStopResult).toBeNull();
+
+    consoleSpy.mockRestore();
+  });
+
+  // --------------------------------------------------------------------------
+  // Auth Check
+  // --------------------------------------------------------------------------
+
+  it('returns null when user is not authenticated', async () => {
+    mockAuthUser = null;
+
+    const { result } = renderHook(() => useBudgetAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let hardStopResult: unknown = 'not-null';
+    await act(async () => {
+      hardStopResult = await result.current.checkHardStop();
+    });
+
+    expect(hardStopResult).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // Zod Validation
+  // --------------------------------------------------------------------------
+
+  it('returns null when RPC response has invalid shape', async () => {
+    mockRpcResult = {
+      data: [
+        {
+          // Missing is_blocked field entirely
+          alert_id: 'alert-1',
+          threshold_usd: 10.0,
+        },
+      ],
+      error: null,
+    };
+
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { result } = renderHook(() => useBudgetAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let hardStopResult: unknown = 'not-null';
+    await act(async () => {
+      hardStopResult = await result.current.checkHardStop();
+    });
+
+    expect(hardStopResult).toBeNull();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles non-array RPC response (single object)', async () => {
+    // Some Postgres RPCs return a single object instead of an array
+    mockRpcResult = {
+      data: {
+        is_blocked: false,
+        alert_id: null,
+        threshold_usd: null,
+        total_spend: null,
+        period: null,
+      },
+      error: null,
+    };
+
+    const { result } = renderHook(() => useBudgetAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let hardStopResult: unknown = null;
+    await act(async () => {
+      hardStopResult = await result.current.checkHardStop();
+    });
+
+    expect(hardStopResult).toEqual({
+      is_blocked: false,
+      alert_id: null,
+      threshold_usd: null,
+      total_spend: null,
+      period: null,
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Integration: RPC call uses correct parameters
+  // --------------------------------------------------------------------------
+
+  it('calls RPC with the authenticated user ID', async () => {
+    mockRpcResult = { data: [], error: null };
+
+    const { result } = renderHook(() => useBudgetAlerts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.checkHardStop();
+    });
+
+    expect(supabase.rpc).toHaveBeenCalledWith('check_budget_hard_stop', {
+      p_user_id: 'test-user-id',
+    });
+  });
+});

--- a/packages/styrby-mobile/src/hooks/__tests__/useCosts.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useCosts.test.ts
@@ -1,0 +1,317 @@
+/**
+ * useCosts Hook Test Suite
+ *
+ * Tests the cost data hook, including:
+ * - Initial fetch and data derivation
+ * - 90-day query range
+ * - Real-time INSERT updates
+ * - Record pruning for memory management
+ * - Utility functions (formatCost, formatTokens)
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+// ============================================================================
+// Mock Setup
+// ============================================================================
+
+let mockAuthUser: { id: string } | null = { id: 'test-user-id' };
+let mockCostRecords: unknown[] = [];
+let mockQueryError: unknown = null;
+
+/** Stores the Realtime event handler so tests can trigger synthetic events. */
+let realtimeCallback: ((payload: { new: unknown }) => void) | null = null;
+
+jest.mock('@/lib/supabase', () => {
+  const createChain = () => {
+    const chain: Record<string, unknown> = {};
+    const chainMethods = ['select', 'eq', 'order', 'gte', 'limit'];
+    for (const method of chainMethods) {
+      chain[method] = jest.fn(() => chain);
+    }
+    chain.single = jest.fn(() =>
+      Promise.resolve({ data: null, error: null }),
+    );
+    chain.then = (resolve: (v: unknown) => void) =>
+      Promise.resolve({
+        data: mockCostRecords,
+        error: mockQueryError,
+      }).then(resolve);
+    return chain;
+  };
+
+  return {
+    supabase: {
+      auth: {
+        getUser: jest.fn(async () => ({
+          data: { user: mockAuthUser },
+          error: null,
+        })),
+      },
+      from: jest.fn(() => createChain()),
+      channel: jest.fn(() => ({
+        on: jest.fn((_event: string, _filter: unknown, callback: (payload: { new: unknown }) => void) => {
+          realtimeCallback = callback;
+          return {
+            on: jest.fn().mockReturnThis(),
+            subscribe: jest.fn(),
+          };
+        }),
+        subscribe: jest.fn(),
+      })),
+      removeChannel: jest.fn(),
+    },
+  };
+});
+
+jest.mock('styrby-shared', () => ({}));
+
+import { useCosts, formatCost, formatTokens } from '../useCosts';
+
+// ============================================================================
+// Test Data
+// ============================================================================
+
+/**
+ * Creates a cost record with the given date and agent type.
+ */
+function makeCostRecord(
+  date: string,
+  agent: string = 'claude',
+  cost: number = 1.0,
+) {
+  return {
+    record_date: date,
+    agent_type: agent,
+    cost_usd: cost,
+    input_tokens: 1000,
+    output_tokens: 500,
+    is_pending: false,
+  };
+}
+
+/**
+ * Returns today's date as YYYY-MM-DD.
+ */
+function todayStr(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+/**
+ * Returns a date N days ago as YYYY-MM-DD.
+ */
+function daysAgoStr(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().split('T')[0];
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useCosts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthUser = { id: 'test-user-id' };
+    mockCostRecords = [];
+    mockQueryError = null;
+    realtimeCallback = null;
+  });
+
+  // --------------------------------------------------------------------------
+  // Initial Fetch
+  // --------------------------------------------------------------------------
+
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useCosts());
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+  });
+
+  it('fetches and derives cost data on mount', async () => {
+    mockCostRecords = [
+      makeCostRecord(todayStr(), 'claude', 2.5),
+      makeCostRecord(todayStr(), 'codex', 1.0),
+      makeCostRecord(daysAgoStr(3), 'gemini', 0.75),
+    ];
+
+    const { result } = renderHook(() => useCosts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.error).toBeNull();
+
+    // Today should include only today's records
+    expect(result.current.data!.today.totalCost).toBeCloseTo(3.5);
+    expect(result.current.data!.today.requestCount).toBe(2);
+
+    // Week should include all 3 records
+    expect(result.current.data!.week.totalCost).toBeCloseTo(4.25);
+    expect(result.current.data!.week.requestCount).toBe(3);
+  });
+
+  it('returns empty data when no records exist', async () => {
+    mockCostRecords = [];
+
+    const { result } = renderHook(() => useCosts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.data!.today.totalCost).toBe(0);
+    expect(result.current.data!.today.requestCount).toBe(0);
+    expect(result.current.data!.byAgent).toHaveLength(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // 90-day Range
+  // --------------------------------------------------------------------------
+
+  it('includes records up to 90 days for quarter summary', async () => {
+    mockCostRecords = [
+      makeCostRecord(todayStr(), 'claude', 1.0),
+      makeCostRecord(daysAgoStr(45), 'claude', 2.0),
+      makeCostRecord(daysAgoStr(85), 'claude', 3.0),
+    ];
+
+    const { result } = renderHook(() => useCosts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data!.quarter.totalCost).toBeCloseTo(6.0);
+    expect(result.current.data!.quarter.requestCount).toBe(3);
+  });
+
+  // --------------------------------------------------------------------------
+  // Agent Breakdown
+  // --------------------------------------------------------------------------
+
+  it('computes agent breakdown with correct percentages', async () => {
+    mockCostRecords = [
+      makeCostRecord(todayStr(), 'claude', 3.0),
+      makeCostRecord(todayStr(), 'codex', 1.0),
+    ];
+
+    const { result } = renderHook(() => useCosts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const { byAgent } = result.current.data!;
+    expect(byAgent).toHaveLength(2);
+
+    const claudeAgent = byAgent.find((a) => a.agent === 'claude');
+    expect(claudeAgent).toBeDefined();
+    expect(claudeAgent!.percentage).toBeCloseTo(75);
+
+    const codexAgent = byAgent.find((a) => a.agent === 'codex');
+    expect(codexAgent).toBeDefined();
+    expect(codexAgent!.percentage).toBeCloseTo(25);
+  });
+
+  // --------------------------------------------------------------------------
+  // Real-time INSERT
+  // --------------------------------------------------------------------------
+
+  it('updates totals when a real-time INSERT is received', async () => {
+    mockCostRecords = [makeCostRecord(todayStr(), 'claude', 1.0)];
+
+    const { result } = renderHook(() => useCosts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data!.today.totalCost).toBeCloseTo(1.0);
+
+    // Simulate a real-time INSERT
+    if (realtimeCallback) {
+      act(() => {
+        realtimeCallback!({
+          new: makeCostRecord(todayStr(), 'codex', 2.0),
+        });
+      });
+    }
+
+    await waitFor(() => {
+      expect(result.current.data!.today.totalCost).toBeCloseTo(3.0);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Error Handling
+  // --------------------------------------------------------------------------
+
+  it('sets error when fetch fails', async () => {
+    mockQueryError = { message: 'Connection timeout' };
+
+    const { result } = renderHook(() => useCosts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // When the query returns an error, fetchQuarterRecords returns []
+    // and deriveAndSetData sets empty data (no error thrown)
+    expect(result.current.data).not.toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // Refresh
+  // --------------------------------------------------------------------------
+
+  it('refresh re-fetches data', async () => {
+    mockCostRecords = [makeCostRecord(todayStr(), 'claude', 1.0)];
+
+    const { result } = renderHook(() => useCosts());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Update mock data for refresh
+    mockCostRecords = [
+      makeCostRecord(todayStr(), 'claude', 1.0),
+      makeCostRecord(todayStr(), 'claude', 5.0),
+    ];
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
+    expect(result.current.data!.today.totalCost).toBeCloseTo(6.0);
+  });
+});
+
+// ============================================================================
+// Utility Function Tests
+// ============================================================================
+
+describe('formatCost', () => {
+  it('formats cost as USD currency string', () => {
+    expect(formatCost(12.34)).toBe('$12.34');
+  });
+
+  it('respects decimal places parameter', () => {
+    expect(formatCost(12.345, 3)).toBe('$12.345');
+    expect(formatCost(12, 0)).toBe('$12');
+  });
+
+  it('handles zero', () => {
+    expect(formatCost(0)).toBe('$0.00');
+  });
+});
+
+describe('formatTokens', () => {
+  it('formats millions with M suffix', () => {
+    expect(formatTokens(1_500_000)).toBe('1.5M');
+  });
+
+  it('formats thousands with K suffix', () => {
+    expect(formatTokens(1_500)).toBe('1.5K');
+  });
+
+  it('returns plain number for small values', () => {
+    expect(formatTokens(500)).toBe('500');
+  });
+
+  it('handles zero', () => {
+    expect(formatTokens(0)).toBe('0');
+  });
+});

--- a/packages/styrby-mobile/src/hooks/__tests__/useOnboarding.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useOnboarding.test.ts
@@ -1,0 +1,282 @@
+/**
+ * useOnboarding Hook Test Suite
+ *
+ * Tests the onboarding progress hook, including:
+ * - Initial loading state
+ * - Checklist computation per subscription tier
+ * - Completion detection from profiles.onboarding_completed_at
+ * - markComplete mutation
+ * - Error handling for unauthenticated users
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+// ============================================================================
+// Mock Setup
+// ============================================================================
+
+/** Mutable state for controlling Supabase mock behavior per test. */
+let mockAuthUser: { id: string } | null = { id: 'test-user-id' };
+
+/**
+ * Mock query results keyed by table name.
+ * Each test can override these to simulate different database states.
+ */
+let mockQueryResults: Record<string, { data: unknown; error: unknown }> = {};
+
+jest.mock('@/lib/supabase', () => {
+  /**
+   * Creates a chainable query builder mock that resolves to the
+   * pre-configured result for the given table.
+   */
+  const createChain = (table: string) => {
+    const getResult = () =>
+      mockQueryResults[table] || { data: null, error: null };
+
+    const chain: Record<string, unknown> = {};
+    const chainMethods = ['select', 'eq', 'limit', 'order', 'gte', 'insert', 'update', 'delete'];
+    for (const method of chainMethods) {
+      chain[method] = jest.fn(() => chain);
+    }
+    chain.single = jest.fn(() => Promise.resolve(getResult()));
+    chain.maybeSingle = jest.fn(() => Promise.resolve(getResult()));
+    // Make the chain itself thenable for queries that do not end in single()
+    chain.then = (resolve: (v: unknown) => void) =>
+      Promise.resolve(getResult()).then(resolve);
+    return chain;
+  };
+
+  return {
+    supabase: {
+      auth: {
+        getUser: jest.fn(async () => ({
+          data: { user: mockAuthUser },
+          error: null,
+        })),
+      },
+      from: jest.fn((table: string) => createChain(table)),
+    },
+  };
+});
+
+jest.mock('styrby-shared', () => ({}));
+
+// Import AFTER mocks
+import { useOnboarding } from '../useOnboarding';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Configures mock query results with sensible defaults for a fully complete
+ * free-tier user (device paired, onboarding not completed).
+ */
+function setupDefaults(overrides: Record<string, { data: unknown; error: unknown }> = {}) {
+  mockQueryResults = {
+    profiles: {
+      data: { onboarding_completed_at: null },
+      error: null,
+    },
+    subscriptions: {
+      data: { tier: 'free' },
+      error: null,
+    },
+    machines: {
+      data: [{ id: 'machine-1' }],
+      error: null,
+    },
+    budget_alerts: { data: [], error: null },
+    notification_preferences: { data: [], error: null },
+    device_tokens: { data: [], error: null },
+    team_members: { data: [], error: null },
+    api_keys: { data: [], error: null },
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useOnboarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthUser = { id: 'test-user-id' };
+    setupDefaults();
+  });
+
+  // --------------------------------------------------------------------------
+  // Loading State
+  // --------------------------------------------------------------------------
+
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('finishes loading after data is fetched', async () => {
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Tier-based Checklist
+  // --------------------------------------------------------------------------
+
+  it('shows 1 step for free tier', async () => {
+    setupDefaults({
+      subscriptions: { data: { tier: 'free' }, error: null },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.tier).toBe('free');
+    expect(result.current.totalCount).toBe(1);
+    expect(result.current.steps[0].id).toBe('pair_device');
+  });
+
+  it('shows 3 steps for pro tier', async () => {
+    setupDefaults({
+      subscriptions: { data: { tier: 'pro' }, error: null },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.tier).toBe('pro');
+    expect(result.current.totalCount).toBe(3);
+    const stepIds = result.current.steps.map((s) => s.id);
+    expect(stepIds).toContain('pair_device');
+    expect(stepIds).toContain('set_budget_alert');
+    expect(stepIds).toContain('configure_notifications');
+  });
+
+  it('shows 5 steps for power tier', async () => {
+    setupDefaults({
+      subscriptions: { data: { tier: 'power' }, error: null },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.tier).toBe('power');
+    expect(result.current.totalCount).toBe(5);
+  });
+
+  it('defaults to free tier when no subscription exists', async () => {
+    setupDefaults({
+      subscriptions: { data: null, error: { message: 'No rows' } },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.tier).toBe('free');
+  });
+
+  // --------------------------------------------------------------------------
+  // Completion Detection
+  // --------------------------------------------------------------------------
+
+  it('reports isComplete=true when onboarding_completed_at is set', async () => {
+    setupDefaults({
+      profiles: {
+        data: { onboarding_completed_at: '2024-01-01T00:00:00Z' },
+        error: null,
+      },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isComplete).toBe(true);
+  });
+
+  it('reports isComplete=false when onboarding_completed_at is null', async () => {
+    setupDefaults();
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isComplete).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
+  // Step Completion
+  // --------------------------------------------------------------------------
+
+  it('marks pair_device as completed when machines exist', async () => {
+    setupDefaults({
+      machines: { data: [{ id: 'machine-1' }], error: null },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const pairStep = result.current.steps.find((s) => s.id === 'pair_device');
+    expect(pairStep?.completed).toBe(true);
+    expect(result.current.completedCount).toBe(1);
+  });
+
+  it('marks pair_device as not completed when no machines exist', async () => {
+    setupDefaults({
+      machines: { data: [], error: null },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const pairStep = result.current.steps.find((s) => s.id === 'pair_device');
+    expect(pairStep?.completed).toBe(false);
+  });
+
+  it('marks configure_notifications as completed if device_tokens exist', async () => {
+    setupDefaults({
+      subscriptions: { data: { tier: 'pro' }, error: null },
+      notification_preferences: { data: [], error: null },
+      device_tokens: { data: [{ id: 'token-1' }], error: null },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const notifStep = result.current.steps.find((s) => s.id === 'configure_notifications');
+    expect(notifStep?.completed).toBe(true);
+  });
+
+  // --------------------------------------------------------------------------
+  // markComplete
+  // --------------------------------------------------------------------------
+
+  it('markComplete sets isComplete to true on success', async () => {
+    setupDefaults();
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isComplete).toBe(false);
+
+    await act(async () => {
+      await result.current.markComplete();
+    });
+
+    expect(result.current.isComplete).toBe(true);
+  });
+
+  // --------------------------------------------------------------------------
+  // Error Handling
+  // --------------------------------------------------------------------------
+
+  it('sets error when user is not authenticated', async () => {
+    mockAuthUser = null;
+
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe('You must be signed in to view onboarding status.');
+  });
+});

--- a/packages/styrby-mobile/src/hooks/__tests__/useSupport.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useSupport.test.ts
@@ -1,0 +1,315 @@
+/**
+ * useSupport Hook Test Suite
+ *
+ * Tests the support ticket management hook, including:
+ * - Fetching ticket list
+ * - Creating new tickets with Zod validation
+ * - Replying to tickets
+ * - getTicket with auth check
+ * - Error handling
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+// ============================================================================
+// Mock Setup
+// ============================================================================
+
+let mockAuthUser: { id: string } | null = { id: 'test-user-id' };
+let mockQueryResults: Record<string, { data: unknown; error: unknown }> = {};
+
+jest.mock('@/lib/supabase', () => {
+  const createChain = (table: string) => {
+    const getResult = () =>
+      mockQueryResults[table] || { data: null, error: null };
+
+    const chain: Record<string, unknown> = {};
+    const chainMethods = ['select', 'eq', 'order', 'insert', 'limit'];
+    for (const method of chainMethods) {
+      chain[method] = jest.fn(() => chain);
+    }
+    chain.single = jest.fn(() => Promise.resolve(getResult()));
+    chain.maybeSingle = jest.fn(() => Promise.resolve(getResult()));
+    chain.then = (resolve: (v: unknown) => void) =>
+      Promise.resolve(getResult()).then(resolve);
+    return chain;
+  };
+
+  return {
+    supabase: {
+      auth: {
+        getUser: jest.fn(async () => ({
+          data: { user: mockAuthUser },
+          error: null,
+        })),
+      },
+      from: jest.fn((table: string) => createChain(table)),
+      channel: jest.fn(() => ({
+        on: jest.fn().mockReturnThis(),
+        subscribe: jest.fn(),
+      })),
+      removeChannel: jest.fn(),
+    },
+  };
+});
+
+jest.mock('styrby-shared', () => ({}));
+
+import { useSupport } from '../useSupport';
+import { supabase } from '@/lib/supabase';
+
+// ============================================================================
+// Test Data
+// ============================================================================
+
+const validTicket = {
+  id: 'ticket-1',
+  user_id: 'test-user-id',
+  type: 'bug',
+  subject: 'App crashes',
+  description: 'The app crashes on launch',
+  priority: 'high',
+  status: 'open',
+  screenshot_urls: [],
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+const validReply = {
+  id: 'reply-1',
+  ticket_id: 'ticket-1',
+  author_type: 'user',
+  author_id: 'test-user-id',
+  message: 'Thanks for looking into this.',
+  created_at: '2024-01-02T00:00:00Z',
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useSupport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthUser = { id: 'test-user-id' };
+    mockQueryResults = {
+      support_tickets: { data: [validTicket], error: null },
+      support_ticket_replies: { data: [validReply], error: null },
+    };
+  });
+
+  // --------------------------------------------------------------------------
+  // Fetch Tickets
+  // --------------------------------------------------------------------------
+
+  it('fetches tickets on mount', async () => {
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.tickets).toHaveLength(1);
+    expect(result.current.tickets[0].id).toBe('ticket-1');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error when user is not authenticated', async () => {
+    mockAuthUser = null;
+
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe('You must be signed in to view support tickets.');
+    expect(result.current.tickets).toHaveLength(0);
+  });
+
+  it('handles query errors gracefully', async () => {
+    mockQueryResults = {
+      support_tickets: {
+        data: null,
+        error: { message: 'Database connection failed' },
+      },
+    };
+
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe('Database connection failed');
+  });
+
+  // --------------------------------------------------------------------------
+  // Create Ticket
+  // --------------------------------------------------------------------------
+
+  it('creates a ticket successfully', async () => {
+    // The hook loads tickets on mount (uses .then/thenable), then createTicket
+    // calls .insert().select().single() which resolves via single().
+    // Our mock returns the same result for both paths on the same table,
+    // so we set it to a single object that works for .single() calls.
+    // The initial load via .then will parse it with safeParseArray,
+    // which handles non-array input by returning [].
+    mockQueryResults = {
+      support_tickets: { data: validTicket, error: null },
+    };
+
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let createdTicket: unknown = null;
+    await act(async () => {
+      createdTicket = await result.current.createTicket({
+        type: 'bug',
+        subject: 'New bug report',
+        description: 'This is a detailed bug description for testing.',
+      });
+    });
+
+    expect(createdTicket).not.toBeNull();
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('rejects ticket with short subject', async () => {
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let createdTicket: unknown = null;
+    await act(async () => {
+      createdTicket = await result.current.createTicket({
+        type: 'bug',
+        subject: 'Hi',
+        description: 'This is a valid description for the ticket.',
+      });
+    });
+
+    expect(createdTicket).toBeNull();
+    expect(result.current.error).toContain('Subject must be at least 3 characters');
+  });
+
+  it('rejects ticket with short description', async () => {
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let createdTicket: unknown = null;
+    await act(async () => {
+      createdTicket = await result.current.createTicket({
+        type: 'bug',
+        subject: 'Valid subject',
+        description: 'Short.',
+      });
+    });
+
+    expect(createdTicket).toBeNull();
+    expect(result.current.error).toContain('Description must be at least 10 characters');
+  });
+
+  // --------------------------------------------------------------------------
+  // Reply to Ticket
+  // --------------------------------------------------------------------------
+
+  it('creates a reply successfully', async () => {
+    mockQueryResults = {
+      support_tickets: { data: [validTicket], error: null },
+      support_ticket_replies: { data: validReply, error: null },
+    };
+
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let reply: unknown = null;
+    await act(async () => {
+      reply = await result.current.replyToTicket('ticket-1', 'Thanks for the update!');
+    });
+
+    expect(reply).not.toBeNull();
+  });
+
+  it('rejects empty reply message', async () => {
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let reply: unknown = null;
+    await act(async () => {
+      reply = await result.current.replyToTicket('ticket-1', '   ');
+    });
+
+    expect(reply).toBeNull();
+    expect(result.current.error).toBe('Reply message cannot be empty.');
+  });
+
+  it('rejects reply message exceeding 5000 characters', async () => {
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let reply: unknown = null;
+    await act(async () => {
+      reply = await result.current.replyToTicket('ticket-1', 'x'.repeat(5001));
+    });
+
+    expect(reply).toBeNull();
+    expect(result.current.error).toBe('Reply message must be at most 5000 characters.');
+  });
+
+  // --------------------------------------------------------------------------
+  // Get Single Ticket
+  // --------------------------------------------------------------------------
+
+  it('returns null when user is not authenticated for getTicket', async () => {
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Switch to unauthenticated after initial load
+    mockAuthUser = null;
+
+    let ticket: unknown = null;
+    await act(async () => {
+      ticket = await result.current.getTicket('ticket-1');
+    });
+
+    expect(ticket).toBeNull();
+  });
+
+  it('fetches ticket with replies successfully', async () => {
+    mockQueryResults = {
+      support_tickets: { data: validTicket, error: null },
+      support_ticket_replies: { data: [validReply], error: null },
+    };
+
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let ticketResult: unknown = null;
+    await act(async () => {
+      ticketResult = await result.current.getTicket('ticket-1');
+    });
+
+    expect(ticketResult).not.toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // Refresh
+  // --------------------------------------------------------------------------
+
+  it('refresh reloads ticket list', async () => {
+    const { result } = renderHook(() => useSupport());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const fromCalls = (supabase.from as jest.Mock).mock.calls.length;
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    // Should have made additional calls to supabase.from
+    expect((supabase.from as jest.Mock).mock.calls.length).toBeGreaterThan(fromCalls);
+  });
+});

--- a/packages/styrby-mobile/src/hooks/__tests__/useTeamManagement.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useTeamManagement.test.ts
@@ -1,0 +1,404 @@
+/**
+ * useTeamManagement Hook Test Suite
+ *
+ * Tests the team management hook, including:
+ * - Team creation
+ * - Member invitation with CSPRNG token generation
+ * - Role changes
+ * - Member removal
+ * - Error handling for unauthenticated users
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+// ============================================================================
+// Mock Setup
+// ============================================================================
+
+let mockAuthUser: { id: string } | null = { id: 'test-user-id' };
+let mockRpcResults: Record<string, { data: unknown; error: unknown }> = {};
+let mockQueryResults: Record<string, { data: unknown; error: unknown }> = {};
+
+jest.mock('expo-crypto', () => ({
+  getRandomBytes: jest.fn(() => new Uint8Array(16).fill(0xab)),
+}));
+
+jest.mock('@/lib/supabase', () => {
+  const createChain = (table: string) => {
+    const getResult = () =>
+      mockQueryResults[table] || { data: null, error: null };
+
+    const chain: Record<string, unknown> = {};
+    const chainMethods = ['select', 'eq', 'order', 'insert', 'update', 'delete', 'limit'];
+    for (const method of chainMethods) {
+      chain[method] = jest.fn(() => chain);
+    }
+    chain.single = jest.fn(() => Promise.resolve(getResult()));
+    chain.maybeSingle = jest.fn(() => Promise.resolve(getResult()));
+    chain.then = (resolve: (v: unknown) => void) =>
+      Promise.resolve(getResult()).then(resolve);
+    return chain;
+  };
+
+  return {
+    supabase: {
+      auth: {
+        getUser: jest.fn(async () => ({
+          data: { user: mockAuthUser },
+          error: null,
+        })),
+      },
+      from: jest.fn((table: string) => createChain(table)),
+      rpc: jest.fn((name: string) => {
+        const result = mockRpcResults[name] || { data: null, error: null };
+        return Promise.resolve(result);
+      }),
+    },
+  };
+});
+
+jest.mock('styrby-shared', () => ({}));
+
+import { useTeamManagement } from '../useTeamManagement';
+import { supabase } from '@/lib/supabase';
+
+// ============================================================================
+// Test Data
+// ============================================================================
+
+const validTeam = {
+  id: 'team-1',
+  name: 'Engineering',
+  description: 'The engineering team',
+  owner_id: 'test-user-id',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+const validTeamMember = {
+  member_id: 'member-1',
+  user_id: 'test-user-id',
+  role: 'owner',
+  display_name: 'Test User',
+  email: 'test@example.com',
+  avatar_url: null,
+  joined_at: '2024-01-01T00:00:00Z',
+};
+
+const validUserTeamRow = {
+  team_id: 'team-1',
+  team_name: 'Engineering',
+  team_description: 'The engineering team',
+  owner_id: 'test-user-id',
+  role: 'owner',
+  member_count: 1,
+  joined_at: '2024-01-01T00:00:00Z',
+};
+
+const validInvitation = {
+  id: 'invite-1',
+  team_id: 'team-1',
+  email: 'newuser@example.com',
+  invited_by: 'test-user-id',
+  role: 'member',
+  token: 'abababababababababababababababab',
+  status: 'pending',
+  expires_at: '2024-02-01T00:00:00Z',
+  created_at: '2024-01-01T00:00:00Z',
+};
+
+/**
+ * Sets up mock responses for a user who has a team.
+ */
+function setupWithTeam() {
+  mockRpcResults = {
+    get_user_teams: { data: [validUserTeamRow], error: null },
+    get_team_members: { data: [validTeamMember], error: null },
+  };
+  mockQueryResults = {
+    teams: { data: validTeam, error: null },
+    team_invitations: { data: [], error: null },
+  };
+}
+
+/**
+ * Sets up mock responses for a user with no team.
+ */
+function setupNoTeam() {
+  mockRpcResults = {
+    get_user_teams: { data: [], error: null },
+    get_team_members: { data: [], error: null },
+  };
+  mockQueryResults = {};
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useTeamManagement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthUser = { id: 'test-user-id' };
+    setupNoTeam();
+  });
+
+  // --------------------------------------------------------------------------
+  // Initial State
+  // --------------------------------------------------------------------------
+
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useTeamManagement());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('loads team data on mount when user has a team', async () => {
+    setupWithTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.team).not.toBeNull();
+    expect(result.current.team?.name).toBe('Engineering');
+    expect(result.current.currentUserRole).toBe('owner');
+    expect(result.current.members).toHaveLength(1);
+  });
+
+  it('sets null team when user has no team', async () => {
+    setupNoTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.team).toBeNull();
+    expect(result.current.currentUserRole).toBeNull();
+    expect(result.current.members).toHaveLength(0);
+  });
+
+  it('sets error when user is not authenticated', async () => {
+    mockAuthUser = null;
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe('You must be signed in to view team data.');
+  });
+
+  // --------------------------------------------------------------------------
+  // Create Team
+  // --------------------------------------------------------------------------
+
+  it('creates a team successfully', async () => {
+    setupNoTeam();
+
+    // After creation, the hook reloads data; set up responses for that reload
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Configure the insert response
+    mockQueryResults = {
+      ...mockQueryResults,
+      teams: { data: validTeam, error: null },
+    };
+
+    // Also set up the reload responses
+    mockRpcResults = {
+      get_user_teams: { data: [validUserTeamRow], error: null },
+      get_team_members: { data: [validTeamMember], error: null },
+    };
+    mockQueryResults.team_invitations = { data: [], error: null };
+
+    let createdTeam: unknown = null;
+    await act(async () => {
+      createdTeam = await result.current.createTeam('Engineering', 'The engineering team');
+    });
+
+    expect(createdTeam).not.toBeNull();
+    expect(result.current.isMutating).toBe(false);
+  });
+
+  it('rejects team creation with empty name', async () => {
+    setupNoTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let createdTeam: unknown = 'not-null';
+    await act(async () => {
+      createdTeam = await result.current.createTeam('');
+    });
+
+    expect(createdTeam).toBeNull();
+    expect(result.current.error).toBe('Team name is required.');
+  });
+
+  it('rejects team creation with name exceeding 100 characters', async () => {
+    setupNoTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let createdTeam: unknown = 'not-null';
+    await act(async () => {
+      createdTeam = await result.current.createTeam('x'.repeat(101));
+    });
+
+    expect(createdTeam).toBeNull();
+    expect(result.current.error).toBe('Team name must be 100 characters or fewer.');
+  });
+
+  // --------------------------------------------------------------------------
+  // Invite Member
+  // --------------------------------------------------------------------------
+
+  it('sends invitation with CSPRNG token', async () => {
+    setupWithTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mockQueryResults = {
+      ...mockQueryResults,
+      team_invitations: { data: validInvitation, error: null },
+    };
+
+    let success = false;
+    await act(async () => {
+      success = await result.current.inviteMember('newuser@example.com', 'member');
+    });
+
+    expect(success).toBe(true);
+
+    // Verify supabase.from was called with 'team_invitations' for the insert
+    const fromCalls = (supabase.from as jest.Mock).mock.calls;
+    const invitationCalls = fromCalls.filter(
+      (call: string[]) => call[0] === 'team_invitations',
+    );
+    expect(invitationCalls.length).toBeGreaterThan(0);
+  });
+
+  it('rejects invitation with invalid email', async () => {
+    setupWithTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let success = true;
+    await act(async () => {
+      success = await result.current.inviteMember('not-an-email', 'member');
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('Please enter a valid email address.');
+  });
+
+  it('rejects invitation when user has no team', async () => {
+    setupNoTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let success = true;
+    await act(async () => {
+      success = await result.current.inviteMember('user@example.com', 'member');
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('You must have a team before inviting members.');
+  });
+
+  // --------------------------------------------------------------------------
+  // Update Member Role
+  // --------------------------------------------------------------------------
+
+  it('updates member role successfully', async () => {
+    setupWithTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mockQueryResults.team_members = { data: null, error: null };
+
+    let success = false;
+    await act(async () => {
+      success = await result.current.updateMemberRole('member-1', 'admin');
+    });
+
+    expect(success).toBe(true);
+    expect(result.current.isMutating).toBe(false);
+  });
+
+  it('handles role update error', async () => {
+    setupWithTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mockQueryResults.team_members = {
+      data: null,
+      error: { message: 'Permission denied' },
+    };
+
+    let success = true;
+    await act(async () => {
+      success = await result.current.updateMemberRole('member-1', 'admin');
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('Permission denied');
+  });
+
+  // --------------------------------------------------------------------------
+  // Remove Member
+  // --------------------------------------------------------------------------
+
+  it('removes member successfully', async () => {
+    setupWithTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mockQueryResults.team_members = { data: null, error: null };
+
+    let success = false;
+    await act(async () => {
+      success = await result.current.removeMember('member-1');
+    });
+
+    expect(success).toBe(true);
+    expect(result.current.isMutating).toBe(false);
+  });
+
+  it('handles removal error', async () => {
+    setupWithTeam();
+
+    const { result } = renderHook(() => useTeamManagement());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mockQueryResults.team_members = {
+      data: null,
+      error: { message: 'Cannot remove owner' },
+    };
+
+    let success = true;
+    await act(async () => {
+      success = await result.current.removeMember('member-1');
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('Cannot remove owner');
+  });
+});

--- a/packages/styrby-mobile/src/lib/__tests__/schemas.test.ts
+++ b/packages/styrby-mobile/src/lib/__tests__/schemas.test.ts
@@ -1,0 +1,881 @@
+/**
+ * Zod Schema Test Suite
+ *
+ * Tests runtime validation schemas for all Supabase table data consumed by
+ * the mobile hooks. Verifies that valid data passes, invalid data is rejected,
+ * and the helper functions (safeParseArray, safeParseSingle) handle edge cases
+ * gracefully.
+ */
+
+import {
+  ProfileSchema,
+  SessionSchema,
+  CostRecordSchema,
+  BudgetAlertSchema,
+  NotificationPreferencesSchema,
+  SupportTicketSchema,
+  SupportTicketReplySchema,
+  CreateTicketInputSchema,
+  TeamSchema,
+  TeamMemberSchema,
+  TeamInvitationSchema,
+  UserTeamRowSchema,
+  DeviceTokenSchema,
+  SubscriptionTierRowSchema,
+  safeParseArray,
+  safeParseSingle,
+} from '../schemas';
+
+// ============================================================================
+// Test Data Factories
+// ============================================================================
+
+/**
+ * Creates a valid profile object for testing.
+ * Override individual fields by passing a partial object.
+ */
+function makeProfile(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'user-123',
+    display_name: 'Test User',
+    avatar_url: null,
+    timezone: 'UTC',
+    referral_code: 'ABC123',
+    tos_accepted_at: '2024-01-01T00:00:00Z',
+    onboarding_completed_at: null,
+    last_active_at: null,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a valid session object for testing.
+ */
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'session-1',
+    user_id: 'user-123',
+    machine_id: 'machine-456',
+    agent_type: 'claude',
+    status: 'running',
+    title: 'Test Session',
+    summary: null,
+    total_input_tokens: 1000,
+    total_output_tokens: 500,
+    total_cost_usd: 0.05,
+    started_at: '2024-01-01T00:00:00Z',
+    ended_at: null,
+    tags: ['test'],
+    updated_at: '2024-01-01T00:10:00Z',
+    message_count: 5,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a valid cost record object for testing.
+ */
+function makeCostRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    record_date: '2024-01-15',
+    agent_type: 'claude',
+    cost_usd: 1.25,
+    input_tokens: 5000,
+    output_tokens: 2000,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a valid budget alert object for testing.
+ */
+function makeBudgetAlert(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'alert-1',
+    user_id: 'user-123',
+    name: 'Daily Limit',
+    threshold_usd: 10.0,
+    period: 'daily',
+    action: 'notify',
+    is_enabled: true,
+    last_triggered_at: null,
+    created_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a valid notification preferences object for testing.
+ */
+function makeNotificationPrefs(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pref-1',
+    user_id: 'user-123',
+    push_enabled: true,
+    email_enabled: false,
+    quiet_hours_enabled: false,
+    quiet_hours_start: null,
+    quiet_hours_end: null,
+    quiet_hours_timezone: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a valid support ticket object for testing.
+ */
+function makeSupportTicket(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ticket-1',
+    user_id: 'user-123',
+    type: 'bug',
+    subject: 'App crashes on launch',
+    description: 'The app crashes every time I open it on iOS 17',
+    priority: 'high',
+    status: 'open',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a valid team object for testing.
+ */
+function makeTeam(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'team-1',
+    name: 'Engineering',
+    description: 'The engineering team',
+    owner_id: 'user-123',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a valid team member object for testing.
+ */
+function makeTeamMember(overrides: Record<string, unknown> = {}) {
+  return {
+    member_id: 'member-1',
+    user_id: 'user-456',
+    role: 'member',
+    display_name: 'Jane Doe',
+    email: 'jane@example.com',
+    avatar_url: null,
+    joined_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a valid team invitation object for testing.
+ */
+function makeTeamInvitation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'invite-1',
+    team_id: 'team-1',
+    email: 'newuser@example.com',
+    invited_by: 'user-123',
+    role: 'member',
+    status: 'pending',
+    expires_at: '2024-02-01T00:00:00Z',
+    created_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// ProfileSchema Tests
+// ============================================================================
+
+describe('ProfileSchema', () => {
+  it('accepts a valid profile', () => {
+    const result = ProfileSchema.safeParse(makeProfile());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a profile with is_admin flag', () => {
+    const result = ProfileSchema.safeParse(makeProfile({ is_admin: true }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.is_admin).toBe(true);
+    }
+  });
+
+  it('accepts a profile without is_admin flag', () => {
+    const profile = makeProfile();
+    const result = ProfileSchema.safeParse(profile);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.is_admin).toBeUndefined();
+    }
+  });
+
+  it('rejects a profile with missing id', () => {
+    const { id, ...noId } = makeProfile();
+    const result = ProfileSchema.safeParse(noId);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a profile with invalid id type', () => {
+    const result = ProfileSchema.safeParse(makeProfile({ id: 123 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts profile with all optional fields omitted', () => {
+    const minimal = {
+      id: 'user-123',
+      display_name: null,
+      avatar_url: null,
+      referral_code: null,
+      tos_accepted_at: null,
+      onboarding_completed_at: null,
+      last_active_at: null,
+      deleted_at: null,
+    };
+    const result = ProfileSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// SessionSchema Tests
+// ============================================================================
+
+describe('SessionSchema', () => {
+  it('accepts a valid session', () => {
+    const result = SessionSchema.safeParse(makeSession());
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a session with missing required fields', () => {
+    const result = SessionSchema.safeParse({ id: 'session-1' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a session with invalid status', () => {
+    const result = SessionSchema.safeParse(makeSession({ status: 'invalid_status' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid status values', () => {
+    const validStatuses = ['starting', 'running', 'idle', 'paused', 'stopped', 'error', 'expired'];
+    for (const status of validStatuses) {
+      const result = SessionSchema.safeParse(makeSession({ status }));
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('accepts session with optional team_id', () => {
+    const result = SessionSchema.safeParse(makeSession({ team_id: 'team-1' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.team_id).toBe('team-1');
+    }
+  });
+
+  it('accepts session with null team_id', () => {
+    const result = SessionSchema.safeParse(makeSession({ team_id: null }));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts any string agent_type for forward-compatibility', () => {
+    const result = SessionSchema.safeParse(makeSession({ agent_type: 'future_agent' }));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects session with non-array tags', () => {
+    const result = SessionSchema.safeParse(makeSession({ tags: 'not-an-array' }));
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// CostRecordSchema Tests
+// ============================================================================
+
+describe('CostRecordSchema', () => {
+  it('accepts a valid cost record', () => {
+    const result = CostRecordSchema.safeParse(makeCostRecord());
+    expect(result.success).toBe(true);
+  });
+
+  it('coerces string cost_usd to number', () => {
+    const result = CostRecordSchema.safeParse(makeCostRecord({ cost_usd: '3.14' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cost_usd).toBe(3.14);
+    }
+  });
+
+  it('accepts null cost_usd', () => {
+    const result = CostRecordSchema.safeParse(makeCostRecord({ cost_usd: null }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cost_usd).toBeNull();
+    }
+  });
+
+  it('accepts any string agent_type', () => {
+    const result = CostRecordSchema.safeParse(makeCostRecord({ agent_type: 'aider' }));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects cost record with missing record_date', () => {
+    const { record_date, ...noDdate } = makeCostRecord();
+    const result = CostRecordSchema.safeParse(noDdate);
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults is_pending to false when missing', () => {
+    const result = CostRecordSchema.safeParse(makeCostRecord());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.is_pending).toBe(false);
+    }
+  });
+
+  it('accepts is_pending when provided', () => {
+    const result = CostRecordSchema.safeParse(makeCostRecord({ is_pending: true }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.is_pending).toBe(true);
+    }
+  });
+});
+
+// ============================================================================
+// BudgetAlertSchema Tests
+// ============================================================================
+
+describe('BudgetAlertSchema', () => {
+  it('accepts a valid budget alert', () => {
+    const result = BudgetAlertSchema.safeParse(makeBudgetAlert());
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid action enum value', () => {
+    const result = BudgetAlertSchema.safeParse(makeBudgetAlert({ action: 'invalid' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts all valid action values', () => {
+    const validActions = ['notify', 'warn_and_slowdown', 'hard_stop'];
+    for (const action of validActions) {
+      const result = BudgetAlertSchema.safeParse(makeBudgetAlert({ action }));
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects invalid period enum value', () => {
+    const result = BudgetAlertSchema.safeParse(makeBudgetAlert({ period: 'yearly' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts all valid period values', () => {
+    const validPeriods = ['daily', 'weekly', 'monthly'];
+    for (const period of validPeriods) {
+      const result = BudgetAlertSchema.safeParse(makeBudgetAlert({ period }));
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('coerces string threshold_usd to number', () => {
+    const result = BudgetAlertSchema.safeParse(makeBudgetAlert({ threshold_usd: '25.50' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.threshold_usd).toBe(25.5);
+    }
+  });
+
+  it('rejects missing required fields', () => {
+    const result = BudgetAlertSchema.safeParse({ id: 'alert-1' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// NotificationPreferencesSchema Tests
+// ============================================================================
+
+describe('NotificationPreferencesSchema', () => {
+  it('accepts valid notification preferences', () => {
+    const result = NotificationPreferencesSchema.safeParse(makeNotificationPrefs());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts notification preferences with quiet hours', () => {
+    const result = NotificationPreferencesSchema.safeParse(
+      makeNotificationPrefs({
+        quiet_hours_enabled: true,
+        quiet_hours_start: '22:00',
+        quiet_hours_end: '08:00',
+        quiet_hours_timezone: 'America/New_York',
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid quiet hours (non-string)', () => {
+    const result = NotificationPreferencesSchema.safeParse(
+      makeNotificationPrefs({ quiet_hours_start: 2200 }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults priority_threshold to 3', () => {
+    const result = NotificationPreferencesSchema.safeParse(makeNotificationPrefs());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.priority_threshold).toBe(3);
+    }
+  });
+
+  it('accepts all optional boolean toggles', () => {
+    const result = NotificationPreferencesSchema.safeParse(
+      makeNotificationPrefs({
+        push_permission_requests: true,
+        push_session_errors: false,
+        push_budget_alerts: true,
+        push_session_complete: false,
+        email_weekly_summary: true,
+        email_budget_alerts: false,
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing required fields', () => {
+    const result = NotificationPreferencesSchema.safeParse({ id: 'pref-1' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// SupportTicketSchema Tests
+// ============================================================================
+
+describe('SupportTicketSchema', () => {
+  it('accepts a valid support ticket', () => {
+    const result = SupportTicketSchema.safeParse(makeSupportTicket());
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid ticket type', () => {
+    const result = SupportTicketSchema.safeParse(makeSupportTicket({ type: 'complaint' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts all valid ticket types', () => {
+    const validTypes = ['bug', 'feature', 'question'];
+    for (const type of validTypes) {
+      const result = SupportTicketSchema.safeParse(makeSupportTicket({ type }));
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects invalid priority', () => {
+    const result = SupportTicketSchema.safeParse(makeSupportTicket({ priority: 'critical' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid status', () => {
+    const result = SupportTicketSchema.safeParse(makeSupportTicket({ status: 'deleted' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts all valid statuses', () => {
+    const validStatuses = ['open', 'in_progress', 'resolved', 'closed'];
+    for (const status of validStatuses) {
+      const result = SupportTicketSchema.safeParse(makeSupportTicket({ status }));
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('defaults screenshot_urls to empty array when missing', () => {
+    const result = SupportTicketSchema.safeParse(makeSupportTicket());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.screenshot_urls).toEqual([]);
+    }
+  });
+});
+
+// ============================================================================
+// SupportTicketReplySchema Tests
+// ============================================================================
+
+describe('SupportTicketReplySchema', () => {
+  it('accepts a valid reply', () => {
+    const result = SupportTicketReplySchema.safeParse({
+      id: 'reply-1',
+      ticket_id: 'ticket-1',
+      author_type: 'user',
+      author_id: 'user-123',
+      message: 'Thanks for looking into this.',
+      created_at: '2024-01-02T00:00:00Z',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts admin author type', () => {
+    const result = SupportTicketReplySchema.safeParse({
+      id: 'reply-2',
+      ticket_id: 'ticket-1',
+      author_type: 'admin',
+      author_id: 'admin-1',
+      message: 'We are investigating this issue.',
+      created_at: '2024-01-02T12:00:00Z',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid author_type', () => {
+    const result = SupportTicketReplySchema.safeParse({
+      id: 'reply-3',
+      ticket_id: 'ticket-1',
+      author_type: 'bot',
+      author_id: 'bot-1',
+      message: 'Auto response.',
+      created_at: '2024-01-02T12:00:00Z',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// CreateTicketInputSchema Tests
+// ============================================================================
+
+describe('CreateTicketInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = CreateTicketInputSchema.safeParse({
+      type: 'bug',
+      subject: 'App crashes',
+      description: 'The app crashes when I tap the settings button.',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects subject shorter than 3 characters', () => {
+    const result = CreateTicketInputSchema.safeParse({
+      type: 'bug',
+      subject: 'Hi',
+      description: 'The app crashes when I tap the settings button.',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects description shorter than 10 characters', () => {
+    const result = CreateTicketInputSchema.safeParse({
+      type: 'feature',
+      subject: 'Dark mode',
+      description: 'Please.',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts optional priority', () => {
+    const result = CreateTicketInputSchema.safeParse({
+      type: 'question',
+      subject: 'How to pair',
+      description: 'How do I pair my device with the CLI tool?',
+      priority: 'low',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.priority).toBe('low');
+    }
+  });
+});
+
+// ============================================================================
+// TeamSchema Tests
+// ============================================================================
+
+describe('TeamSchema', () => {
+  it('accepts a valid team', () => {
+    const result = TeamSchema.safeParse(makeTeam());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts team with null description', () => {
+    const result = TeamSchema.safeParse(makeTeam({ description: null }));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects team with missing name', () => {
+    const { name, ...noName } = makeTeam();
+    const result = TeamSchema.safeParse(noName);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects team with missing owner_id', () => {
+    const { owner_id, ...noOwner } = makeTeam();
+    const result = TeamSchema.safeParse(noOwner);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// TeamMemberSchema Tests
+// ============================================================================
+
+describe('TeamMemberSchema', () => {
+  it('accepts a valid team member', () => {
+    const result = TeamMemberSchema.safeParse(makeTeamMember());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all valid roles', () => {
+    const validRoles = ['owner', 'admin', 'member'];
+    for (const role of validRoles) {
+      const result = TeamMemberSchema.safeParse(makeTeamMember({ role }));
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects invalid role', () => {
+    const result = TeamMemberSchema.safeParse(makeTeamMember({ role: 'superadmin' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts null display_name', () => {
+    const result = TeamMemberSchema.safeParse(makeTeamMember({ display_name: null }));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing email', () => {
+    const { email, ...noEmail } = makeTeamMember();
+    const result = TeamMemberSchema.safeParse(noEmail);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// TeamInvitationSchema Tests
+// ============================================================================
+
+describe('TeamInvitationSchema', () => {
+  it('accepts a valid invitation', () => {
+    const result = TeamInvitationSchema.safeParse(makeTeamInvitation());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all valid invitation statuses', () => {
+    const validStatuses = ['pending', 'accepted', 'declined', 'expired', 'revoked'];
+    for (const status of validStatuses) {
+      const result = TeamInvitationSchema.safeParse(makeTeamInvitation({ status }));
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects invalid status', () => {
+    const result = TeamInvitationSchema.safeParse(makeTeamInvitation({ status: 'cancelled' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts only admin and member roles', () => {
+    expect(TeamInvitationSchema.safeParse(makeTeamInvitation({ role: 'admin' })).success).toBe(true);
+    expect(TeamInvitationSchema.safeParse(makeTeamInvitation({ role: 'member' })).success).toBe(true);
+    expect(TeamInvitationSchema.safeParse(makeTeamInvitation({ role: 'owner' })).success).toBe(false);
+  });
+
+  it('accepts optional token field', () => {
+    const result = TeamInvitationSchema.safeParse(
+      makeTeamInvitation({ token: 'abc123def456' }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.token).toBe('abc123def456');
+    }
+  });
+});
+
+// ============================================================================
+// UserTeamRowSchema Tests
+// ============================================================================
+
+describe('UserTeamRowSchema', () => {
+  it('accepts a valid user team row', () => {
+    const result = UserTeamRowSchema.safeParse({
+      team_id: 'team-1',
+      team_name: 'Engineering',
+      team_description: 'The engineering team',
+      owner_id: 'user-123',
+      role: 'member',
+      member_count: 5,
+      joined_at: '2024-01-01T00:00:00Z',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing team_name', () => {
+    const result = UserTeamRowSchema.safeParse({
+      team_id: 'team-1',
+      team_description: null,
+      owner_id: 'user-123',
+      role: 'member',
+      member_count: 5,
+      joined_at: '2024-01-01T00:00:00Z',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// DeviceTokenSchema Tests
+// ============================================================================
+
+describe('DeviceTokenSchema', () => {
+  it('accepts a valid device token', () => {
+    const result = DeviceTokenSchema.safeParse({
+      id: 'token-1',
+      user_id: 'user-123',
+      token: 'ExponentPushToken[abc123]',
+      platform: 'ios',
+      created_at: '2024-01-01T00:00:00Z',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts optional fields', () => {
+    const result = DeviceTokenSchema.safeParse({
+      id: 'token-1',
+      user_id: 'user-123',
+      token: 'ExponentPushToken[abc123]',
+      platform: 'ios',
+      created_at: '2024-01-01T00:00:00Z',
+      device_name: 'iPhone 15',
+      app_version: '1.0.0',
+      last_used_at: '2024-01-02T00:00:00Z',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// SubscriptionTierRowSchema Tests
+// ============================================================================
+
+describe('SubscriptionTierRowSchema', () => {
+  it('accepts any string tier', () => {
+    const result = SubscriptionTierRowSchema.safeParse({ tier: 'pro' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing tier', () => {
+    const result = SubscriptionTierRowSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-string tier', () => {
+    const result = SubscriptionTierRowSchema.safeParse({ tier: 42 });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// safeParseArray Tests
+// ============================================================================
+
+describe('safeParseArray', () => {
+  it('returns only valid items from mixed array', () => {
+    const data = [
+      makeSession(),
+      { id: 'bad' }, // missing required fields
+      makeSession({ id: 'session-2', status: 'idle' }),
+    ];
+
+    const result = safeParseArray(SessionSchema, data, 'sessions');
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('session-1');
+    expect(result[1].id).toBe('session-2');
+  });
+
+  it('returns empty array for null input', () => {
+    const result = safeParseArray(SessionSchema, null, 'sessions');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for undefined input', () => {
+    const result = safeParseArray(SessionSchema, undefined, 'sessions');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for non-array input', () => {
+    const result = safeParseArray(SessionSchema, 'not-an-array' as unknown as unknown[], 'sessions');
+    expect(result).toEqual([]);
+  });
+
+  it('returns all items when all are valid', () => {
+    const data = [makeSession(), makeSession({ id: 'session-2' })];
+    const result = safeParseArray(SessionSchema, data, 'sessions');
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array when all items are invalid', () => {
+    const data = [{ id: 'bad-1' }, { id: 'bad-2' }];
+    const result = safeParseArray(SessionSchema, data, 'sessions');
+    expect(result).toEqual([]);
+  });
+
+  it('logs invalid items in __DEV__ mode', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    safeParseArray(SessionSchema, [{ id: 'bad' }], 'sessions');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[Zod] Invalid sessions at index 0:'),
+      expect.any(Array),
+    );
+
+    warnSpy.mockRestore();
+  });
+});
+
+// ============================================================================
+// safeParseSingle Tests
+// ============================================================================
+
+describe('safeParseSingle', () => {
+  it('returns validated data for valid input', () => {
+    const result = safeParseSingle(SessionSchema, makeSession(), 'session');
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('session-1');
+  });
+
+  it('returns null for invalid data', () => {
+    const result = safeParseSingle(SessionSchema, { id: 'bad' }, 'session');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for null input', () => {
+    const result = safeParseSingle(SessionSchema, null, 'session');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    const result = safeParseSingle(SessionSchema, undefined, 'session');
+    expect(result).toBeNull();
+  });
+
+  it('logs invalid data in __DEV__ mode', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    safeParseSingle(SessionSchema, { id: 'bad' }, 'session');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[Zod] Invalid session:'),
+      expect.any(Array),
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/styrby-web/src/__tests__/offline.test.tsx
+++ b/packages/styrby-web/src/__tests__/offline.test.tsx
@@ -1,0 +1,383 @@
+/**
+ * Tests for offline-related PWA features.
+ *
+ * Covers:
+ * - Offline fallback page rendering
+ * - usePWAInstall hook states (canInstall, isDismissed, isInstalled)
+ * - Install prompt dismiss persistence via localStorage
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock next/navigation for the offline page (if it uses router).
+ */
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/offline',
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Helper component that renders the usePWAInstall hook output for testing.
+ */
+function createHookTestComponent() {
+  // We import dynamically inside the test to avoid hoisting issues
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let hookModule: any;
+
+  /**
+   * Wrapper component that exposes hook state via data attributes
+   * for easy test assertions.
+   */
+  function HookTestComponent() {
+    const { canInstall, isInstalled, isDismissed, install, dismiss } = hookModule.usePWAInstall();
+
+    return (
+      <div>
+        <span data-testid="canInstall">{String(canInstall)}</span>
+        <span data-testid="isInstalled">{String(isInstalled)}</span>
+        <span data-testid="isDismissed">{String(isDismissed)}</span>
+        <button data-testid="install-btn" onClick={install}>
+          Install
+        </button>
+        <button data-testid="dismiss-btn" onClick={dismiss}>
+          Dismiss
+        </button>
+      </div>
+    );
+  }
+
+  return {
+    HookTestComponent,
+    setModule: (mod: unknown) => {
+      hookModule = mod;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Offline Page Tests
+// ---------------------------------------------------------------------------
+
+describe('Offline fallback page', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the offline message heading', async () => {
+    // The offline page is a server component, but we can still render it
+    // as a regular React component in tests (it does not use server-only APIs).
+    const { default: OfflinePage } = await import('@/app/offline/page');
+
+    render(<OfflinePage />);
+
+    expect(
+      screen.getByRole('heading', { name: /you.re offline/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the main content area with correct id for skip-link targeting', async () => {
+    const { default: OfflinePage } = await import('@/app/offline/page');
+
+    render(<OfflinePage />);
+
+    const main = screen.getByRole('main');
+    expect(main).toHaveAttribute('id', 'main-content');
+  });
+
+  it('renders a link back to the dashboard', async () => {
+    const { default: OfflinePage } = await import('@/app/offline/page');
+
+    render(<OfflinePage />);
+
+    const link = screen.getByRole('link', { name: /back to dashboard/i });
+    expect(link).toHaveAttribute('href', '/dashboard');
+  });
+
+  it('renders a "Try Again" button for refreshing the page', async () => {
+    const { RefreshButton } = await import('@/app/offline/refresh-button');
+
+    render(<RefreshButton />);
+
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('displays a message about queued commands syncing', async () => {
+    const { default: OfflinePage } = await import('@/app/offline/page');
+
+    render(<OfflinePage />);
+
+    expect(
+      screen.getByText(/queued commands will sync automatically/i)
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usePWAInstall Hook Tests
+// ---------------------------------------------------------------------------
+
+describe('usePWAInstall hook', () => {
+  let originalMatchMedia: typeof window.matchMedia;
+  let mockLocalStorage: Record<string, string>;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    mockLocalStorage = {};
+
+    // jsdom localStorage can be unreliable; provide a mock that always works.
+    const storageMock = {
+      getItem: vi.fn((key: string) => mockLocalStorage[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        mockLocalStorage[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete mockLocalStorage[key];
+      }),
+      clear: vi.fn(() => {
+        mockLocalStorage = {};
+      }),
+      get length() {
+        return Object.keys(mockLocalStorage).length;
+      },
+      key: vi.fn((index: number) => Object.keys(mockLocalStorage)[index] ?? null),
+    };
+
+    Object.defineProperty(window, 'localStorage', {
+      value: storageMock,
+      writable: true,
+      configurable: true,
+    });
+
+    // Default: not in standalone mode
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(display-mode: standalone)' ? false : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.3.1: Default states
+  // -----------------------------------------------------------------------
+  it('starts with canInstall=false when no beforeinstallprompt has fired', async () => {
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(await import('@/hooks/usePWAInstall'));
+
+    render(<HookTestComponent />);
+
+    expect(screen.getByTestId('canInstall').textContent).toBe('false');
+  });
+
+  it('starts with isInstalled=false when not in standalone mode', async () => {
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(await import('@/hooks/usePWAInstall'));
+
+    render(<HookTestComponent />);
+
+    expect(screen.getByTestId('isInstalled').textContent).toBe('false');
+  });
+
+  it('starts with isDismissed=false when localStorage has no dismissal', async () => {
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(await import('@/hooks/usePWAInstall'));
+
+    render(<HookTestComponent />);
+
+    expect(screen.getByTestId('isDismissed').textContent).toBe('false');
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.3.2: isInstalled=true when in standalone mode
+  // -----------------------------------------------------------------------
+  it('sets isInstalled=true when display-mode is standalone', async () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(display-mode: standalone)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    // Re-import to pick up the new matchMedia
+    vi.resetModules();
+    const mod = await import('@/hooks/usePWAInstall');
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(mod);
+
+    render(<HookTestComponent />);
+
+    expect(screen.getByTestId('isInstalled').textContent).toBe('true');
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.3.3: isDismissed=true when localStorage has dismissal
+  // -----------------------------------------------------------------------
+  it('sets isDismissed=true when localStorage has pwa-install-dismissed=true', async () => {
+    window.localStorage.setItem('pwa-install-dismissed', 'true');
+
+    vi.resetModules();
+    const mod = await import('@/hooks/usePWAInstall');
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(mod);
+
+    render(<HookTestComponent />);
+
+    expect(screen.getByTestId('isDismissed').textContent).toBe('true');
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.3.4: canInstall becomes true when beforeinstallprompt fires
+  // -----------------------------------------------------------------------
+  it('sets canInstall=true when beforeinstallprompt event fires', async () => {
+    vi.resetModules();
+    const mod = await import('@/hooks/usePWAInstall');
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(mod);
+
+    render(<HookTestComponent />);
+
+    expect(screen.getByTestId('canInstall').textContent).toBe('false');
+
+    // Simulate the browser firing beforeinstallprompt
+    const promptEvent = new Event('beforeinstallprompt', { cancelable: true });
+    Object.assign(promptEvent, {
+      prompt: vi.fn().mockResolvedValue(undefined),
+      userChoice: Promise.resolve({ outcome: 'dismissed' }),
+    });
+
+    await act(async () => {
+      window.dispatchEvent(promptEvent);
+    });
+
+    expect(screen.getByTestId('canInstall').textContent).toBe('true');
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.3.5: dismiss() stores dismissal in localStorage
+  // -----------------------------------------------------------------------
+  it('stores dismissal in localStorage when dismiss() is called', async () => {
+    vi.resetModules();
+    const mod = await import('@/hooks/usePWAInstall');
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(mod);
+
+    const user = userEvent.setup();
+    render(<HookTestComponent />);
+
+    expect(screen.getByTestId('isDismissed').textContent).toBe('false');
+
+    await user.click(screen.getByTestId('dismiss-btn'));
+
+    expect(screen.getByTestId('isDismissed').textContent).toBe('true');
+    expect(window.localStorage.getItem('pwa-install-dismissed')).toBe('true');
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.3.6: install() calls prompt and returns outcome
+  // -----------------------------------------------------------------------
+  it('calls prompt() and sets isInstalled=true when user accepts', async () => {
+    vi.resetModules();
+    const mod = await import('@/hooks/usePWAInstall');
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(mod);
+
+    const user = userEvent.setup();
+    render(<HookTestComponent />);
+
+    // Fire beforeinstallprompt to make canInstall=true
+    const mockPrompt = vi.fn().mockResolvedValue(undefined);
+    const promptEvent = new Event('beforeinstallprompt', { cancelable: true });
+    Object.assign(promptEvent, {
+      prompt: mockPrompt,
+      userChoice: Promise.resolve({ outcome: 'accepted' as const }),
+    });
+
+    await act(async () => {
+      window.dispatchEvent(promptEvent);
+    });
+
+    expect(screen.getByTestId('canInstall').textContent).toBe('true');
+
+    // Click install
+    await user.click(screen.getByTestId('install-btn'));
+
+    expect(mockPrompt).toHaveBeenCalled();
+    expect(screen.getByTestId('isInstalled').textContent).toBe('true');
+    expect(screen.getByTestId('canInstall').textContent).toBe('false');
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.3.7: install() returns false when user dismisses
+  // -----------------------------------------------------------------------
+  it('sets canInstall=false but isInstalled remains false when user dismisses prompt', async () => {
+    vi.resetModules();
+    const mod = await import('@/hooks/usePWAInstall');
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(mod);
+
+    const user = userEvent.setup();
+    render(<HookTestComponent />);
+
+    // Fire beforeinstallprompt
+    const promptEvent = new Event('beforeinstallprompt', { cancelable: true });
+    Object.assign(promptEvent, {
+      prompt: vi.fn().mockResolvedValue(undefined),
+      userChoice: Promise.resolve({ outcome: 'dismissed' as const }),
+    });
+
+    await act(async () => {
+      window.dispatchEvent(promptEvent);
+    });
+
+    await user.click(screen.getByTestId('install-btn'));
+
+    expect(screen.getByTestId('isInstalled').textContent).toBe('false');
+    expect(screen.getByTestId('canInstall').textContent).toBe('false');
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.3.8: appinstalled event sets isInstalled=true
+  // -----------------------------------------------------------------------
+  it('sets isInstalled=true when appinstalled event fires', async () => {
+    vi.resetModules();
+    const mod = await import('@/hooks/usePWAInstall');
+    const { HookTestComponent, setModule } = createHookTestComponent();
+    setModule(mod);
+
+    render(<HookTestComponent />);
+
+    expect(screen.getByTestId('isInstalled').textContent).toBe('false');
+
+    await act(async () => {
+      window.dispatchEvent(new Event('appinstalled'));
+    });
+
+    expect(screen.getByTestId('isInstalled').textContent).toBe('true');
+    expect(screen.getByTestId('canInstall').textContent).toBe('false');
+  });
+});

--- a/packages/styrby-web/src/__tests__/sw-register.test.tsx
+++ b/packages/styrby-web/src/__tests__/sw-register.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * Tests for the SWRegister component.
+ *
+ * Validates the full service worker lifecycle managed by the component:
+ * registration, update detection, SKIP_WAITING message flow, event listener
+ * cleanup on unmount, and graceful degradation when SW is not supported.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import { SWRegister } from '@/components/sw-register';
+
+// ---------------------------------------------------------------------------
+// Mock offlineQueue (imported by sw-register)
+// ---------------------------------------------------------------------------
+/**
+ * The offlineQueue.processQueue() is called with .catch() chained in the
+ * source code, so the mock must return a real Promise (not just a resolved
+ * value). vi.fn().mockResolvedValue handles this correctly since it returns
+ * a proper Promise.
+ */
+vi.mock('@/lib/offlineQueue', () => ({
+  offlineQueue: {
+    processQueue: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers for building mock ServiceWorker / Registration objects
+// ---------------------------------------------------------------------------
+
+type SWStateChangeListener = () => void;
+type EventCallback = (...args: unknown[]) => void;
+
+/**
+ * Creates a mock ServiceWorker object with controllable state.
+ */
+function createMockServiceWorker(
+  initialState: string = 'installing'
+): ServiceWorker & { _stateChangeListeners: SWStateChangeListener[] } {
+  const listeners: SWStateChangeListener[] = [];
+  return {
+    state: initialState,
+    scriptURL: 'http://localhost/sw.js',
+    onstatechange: null,
+    onerror: null,
+    postMessage: vi.fn(),
+    addEventListener: vi.fn((_event: string, cb: EventCallback) => {
+      if (_event === 'statechange') listeners.push(cb as SWStateChangeListener);
+    }),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+    _stateChangeListeners: listeners,
+  } as unknown as ServiceWorker & { _stateChangeListeners: SWStateChangeListener[] };
+}
+
+/**
+ * Creates a mock ServiceWorkerRegistration.
+ */
+function createMockRegistration(overrides: Partial<ServiceWorkerRegistration> = {}) {
+  const listeners = new Map<string, EventCallback[]>();
+  return {
+    scope: '/',
+    active: null,
+    installing: null,
+    waiting: null,
+    navigationPreload: {} as NavigationPreloadManager,
+    pushManager: {} as PushManager,
+    updateViaCache: 'none' as ServiceWorkerUpdateViaCache,
+    onupdatefound: null,
+    unregister: vi.fn(),
+    update: vi.fn(),
+    showNotification: vi.fn(),
+    getNotifications: vi.fn(),
+    addEventListener: vi.fn((type: string, cb: EventCallback) => {
+      const existing = listeners.get(type) || [];
+      existing.push(cb);
+      listeners.set(type, existing);
+    }),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+    _listeners: listeners,
+    ...overrides,
+  } as unknown as ServiceWorkerRegistration & {
+    _listeners: Map<string, EventCallback[]>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock navigator.serviceWorker
+// ---------------------------------------------------------------------------
+
+let swContainerListeners: Map<string, EventCallback[]>;
+let mockRegistration: ReturnType<typeof createMockRegistration>;
+let mockRegisterFn: ReturnType<typeof vi.fn>;
+
+function setupServiceWorkerMock(opts: { supported?: boolean; controller?: boolean } = {}) {
+  const { supported = true, controller = true } = opts;
+  swContainerListeners = new Map();
+  mockRegistration = createMockRegistration();
+  mockRegisterFn = vi.fn().mockResolvedValue(mockRegistration);
+
+  if (!supported) {
+    // Simulate browser without SW support by deleting the property entirely.
+    // The `in` operator checks property existence, so setting to undefined
+    // is not sufficient; we must actually remove it from the prototype chain.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (navigator as any).serviceWorker;
+    return;
+  }
+
+  const swContainer = {
+    register: mockRegisterFn,
+    controller: controller ? { scriptURL: '/sw.js' } : null,
+    ready: Promise.resolve(mockRegistration),
+    oncontrollerchange: null,
+    onmessage: null,
+    onmessageerror: null,
+    startMessages: vi.fn(),
+    addEventListener: vi.fn((type: string, cb: EventCallback) => {
+      const existing = swContainerListeners.get(type) || [];
+      existing.push(cb);
+      swContainerListeners.set(type, existing);
+    }),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+    getRegistration: vi.fn(),
+    getRegistrations: vi.fn(),
+  };
+
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: swContainer,
+    configurable: true,
+    writable: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SWRegister', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    setupServiceWorkerMock();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.1.1: Registers SW on mount
+  // -----------------------------------------------------------------------
+  it('registers the service worker on mount', async () => {
+    await act(async () => {
+      render(<SWRegister />);
+    });
+
+    expect(mockRegisterFn).toHaveBeenCalledWith('/sw.js', {
+      scope: '/',
+      type: 'classic',
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.1.2: Shows update banner when SW update is already waiting
+  // -----------------------------------------------------------------------
+  it('shows update banner when a waiting worker exists on registration', async () => {
+    const waitingWorker = createMockServiceWorker('installed');
+    mockRegistration = createMockRegistration({ waiting: waitingWorker });
+    mockRegisterFn.mockResolvedValue(mockRegistration);
+
+    await act(async () => {
+      render(<SWRegister />);
+    });
+
+    const banner = screen.getByRole('alert');
+    expect(banner).toBeInTheDocument();
+    expect(screen.getByText('A new version of Styrby is available.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update now' })).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.1.3: Shows update banner when updatefound fires and new worker installs
+  // -----------------------------------------------------------------------
+  it('shows update banner when updatefound event detects a new installed worker', async () => {
+    setupServiceWorkerMock({ controller: true });
+
+    await act(async () => {
+      render(<SWRegister />);
+    });
+
+    // No banner initially
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    // Simulate updatefound: the registration gets an installing worker
+    const newWorker = createMockServiceWorker('installing');
+    (mockRegistration as unknown as { installing: ServiceWorker }).installing = newWorker;
+
+    await act(async () => {
+      const updateFoundCbs = mockRegistration._listeners.get('updatefound') || [];
+      for (const cb of updateFoundCbs) cb();
+    });
+
+    // Simulate the new worker transitioning to 'installed'
+    (newWorker as unknown as { state: string }).state = 'installed';
+
+    await act(async () => {
+      for (const cb of newWorker._stateChangeListeners) cb();
+    });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Update now')).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.1.4: SKIP_WAITING message flow
+  // -----------------------------------------------------------------------
+  it('sends SKIP_WAITING to the waiting worker when Update is clicked', async () => {
+    const waitingWorker = createMockServiceWorker('installed');
+    mockRegistration = createMockRegistration({ waiting: waitingWorker });
+    mockRegisterFn.mockResolvedValue(mockRegistration);
+
+    await act(async () => {
+      render(<SWRegister />);
+    });
+
+    const updateButton = screen.getByRole('button', { name: 'Update now' });
+
+    await act(async () => {
+      fireEvent.click(updateButton);
+    });
+
+    expect(waitingWorker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+
+    // Button should show "Updating..." and be disabled
+    expect(screen.getByRole('button', { name: /Updating/i })).toBeDisabled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.1.5: Cleans up event listeners on unmount
+  // -----------------------------------------------------------------------
+  it('removes the message event listener on unmount', async () => {
+    const { unmount } = await act(async () => {
+      return render(<SWRegister />);
+    });
+
+    const swContainer = navigator.serviceWorker!;
+
+    // After mount, a 'message' listener should have been added
+    expect(swContainer.addEventListener).toHaveBeenCalledWith(
+      'message',
+      expect.any(Function)
+    );
+
+    unmount();
+
+    // After unmount, the same listener should be removed
+    expect(swContainer.removeEventListener).toHaveBeenCalledWith(
+      'message',
+      expect.any(Function)
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.1.6: Does nothing when SW not supported
+  // -----------------------------------------------------------------------
+  it('renders nothing and does not throw when serviceWorker is not supported', async () => {
+    setupServiceWorkerMock({ supported: false });
+
+    await act(async () => {
+      render(<SWRegister />);
+    });
+
+    // Should render null (no banner, no errors)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.1.7: Handles SYNC_OFFLINE_QUEUE message from SW
+  // -----------------------------------------------------------------------
+  it('calls offlineQueue.processQueue when SW sends SYNC_OFFLINE_QUEUE message', async () => {
+    const { offlineQueue } = await import('@/lib/offlineQueue');
+
+    await act(async () => {
+      render(<SWRegister />);
+    });
+
+    // Find the message listener that was registered
+    const messageCbs = swContainerListeners.get('message') || [];
+    expect(messageCbs.length).toBeGreaterThan(0);
+
+    // Simulate the SW sending a SYNC_OFFLINE_QUEUE message
+    await act(async () => {
+      for (const cb of messageCbs) {
+        cb({ data: { type: 'SYNC_OFFLINE_QUEUE' } });
+      }
+    });
+
+    expect(offlineQueue.processQueue).toHaveBeenCalled();
+  });
+});

--- a/packages/styrby-web/src/app/api/push/__tests__/subscribe.test.ts
+++ b/packages/styrby-web/src/app/api/push/__tests__/subscribe.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Tests for push subscription and unsubscription API routes.
+ *
+ * Validates authentication, input validation (including SSRF protection),
+ * rate limiting, and database operations for both the subscribe and
+ * unsubscribe endpoints.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ---------------------------------------------------------------------------
+// Mocks (must be declared before imports that use them)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock Supabase client returned by createClient().
+ * Each test can override the behavior of auth.getUser(), from().upsert(), etc.
+ */
+const mockSupabaseClient = {
+  auth: {
+    getUser: vi.fn(),
+  },
+  from: vi.fn(),
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue(mockSupabaseClient),
+}));
+
+/**
+ * Mock rate limiter. Defaults to allowing requests; individual tests override.
+ */
+const mockRateLimit = vi.fn().mockResolvedValue({
+  allowed: true,
+  remaining: 4,
+  resetAt: Date.now() + 60_000,
+});
+
+const mockRateLimitResponse = vi.fn((retryAfter: number) => {
+  return new Response(
+    JSON.stringify({
+      error: 'RATE_LIMITED',
+      message: 'Too many requests. Please try again later.',
+      retryAfter,
+    }),
+    {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': String(retryAfter),
+      },
+    }
+  );
+});
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: (...args: unknown[]) => mockRateLimit(...args),
+  rateLimitResponse: (retryAfter: number) => mockRateLimitResponse(retryAfter),
+  RATE_LIMITS: {
+    standard: { windowMs: 60000, maxRequests: 100 },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_FCM_ENDPOINT = 'https://fcm.googleapis.com/fcm/send/test-subscription-id';
+const VALID_MOZILLA_ENDPOINT = 'https://updates.push.services.mozilla.com/wpush/v2/test-id';
+
+/**
+ * Builds a valid push subscription body for testing.
+ *
+ * @param overrides - Fields to override in the subscription
+ * @returns A JSON-serializable push subscription object
+ */
+function validSubscriptionBody(overrides: Record<string, unknown> = {}) {
+  return {
+    endpoint: VALID_FCM_ENDPOINT,
+    keys: {
+      p256dh: 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8p8REfYJQ',
+      auth: 'tBHItJI5svbpC7htIGjK-g',
+    },
+    expirationTime: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a NextRequest suitable for testing POST /api/push/subscribe.
+ *
+ * @param body - The request body
+ * @returns A NextRequest instance
+ */
+function makeSubscribeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/push/subscribe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Creates a NextRequest suitable for testing DELETE /api/push/unsubscribe.
+ *
+ * @param body - The request body
+ * @returns A NextRequest instance
+ */
+function makeUnsubscribeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/push/unsubscribe', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Sets up the mock Supabase client to return a user for authenticated tests.
+ *
+ * @param userId - The user ID to return
+ */
+function mockAuthenticatedUser(userId: string = 'user-uuid-123') {
+  mockSupabaseClient.auth.getUser.mockResolvedValue({
+    data: { user: { id: userId } },
+    error: null,
+  });
+}
+
+/**
+ * Sets up the mock Supabase client to return an auth error.
+ */
+function mockUnauthenticated() {
+  mockSupabaseClient.auth.getUser.mockResolvedValue({
+    data: { user: null },
+    error: { message: 'Unauthorized' },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Subscribe Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/push/subscribe', () => {
+  let POST: (request: NextRequest) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockRateLimit.mockResolvedValue({ allowed: true, remaining: 4, resetAt: Date.now() + 60000 });
+
+    // Dynamic import to pick up the fresh mocks each time
+    const mod = await import('@/app/api/push/subscribe/route');
+    POST = mod.POST;
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.1: Returns 201 on valid subscription
+  // -----------------------------------------------------------------------
+  it('returns 201 on valid subscription with FCM endpoint', async () => {
+    mockAuthenticatedUser();
+    mockSupabaseClient.from.mockReturnValue({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    });
+
+    const response = await POST(makeSubscribeRequest(validSubscriptionBody()));
+
+    expect(response.status).toBe(201);
+    const json = await response.json();
+    expect(json).toEqual({ success: true });
+  });
+
+  it('returns 201 on valid subscription with Mozilla push endpoint', async () => {
+    mockAuthenticatedUser();
+    mockSupabaseClient.from.mockReturnValue({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    });
+
+    const body = validSubscriptionBody({ endpoint: VALID_MOZILLA_ENDPOINT });
+    const response = await POST(makeSubscribeRequest(body));
+
+    expect(response.status).toBe(201);
+  });
+
+  it('upserts the subscription into device_tokens with correct fields', async () => {
+    mockAuthenticatedUser('user-abc');
+    const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+    mockSupabaseClient.from.mockReturnValue({ upsert: mockUpsert });
+
+    const body = validSubscriptionBody();
+    await POST(makeSubscribeRequest(body));
+
+    expect(mockSupabaseClient.from).toHaveBeenCalledWith('device_tokens');
+    expect(mockUpsert).toHaveBeenCalledWith(
+      {
+        user_id: 'user-abc',
+        token: VALID_FCM_ENDPOINT,
+        platform: 'web',
+        web_push_subscription: body,
+        is_active: true,
+      },
+      { onConflict: 'user_id,token' }
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.2: Returns 401 when unauthenticated
+  // -----------------------------------------------------------------------
+  it('returns 401 when user is not authenticated', async () => {
+    mockUnauthenticated();
+
+    const response = await POST(makeSubscribeRequest(validSubscriptionBody()));
+
+    expect(response.status).toBe(401);
+    const json = await response.json();
+    expect(json).toEqual({ error: 'Unauthorized' });
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.3: Returns 400 on invalid body
+  // -----------------------------------------------------------------------
+  it('returns 400 when endpoint is missing', async () => {
+    mockAuthenticatedUser();
+
+    const body = validSubscriptionBody();
+    delete (body as Record<string, unknown>).endpoint;
+    const response = await POST(makeSubscribeRequest(body));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when keys.p256dh is empty', async () => {
+    mockAuthenticatedUser();
+
+    const body = validSubscriptionBody({ keys: { p256dh: '', auth: 'valid' } });
+    const response = await POST(makeSubscribeRequest(body));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when keys.auth is empty', async () => {
+    mockAuthenticatedUser();
+
+    const body = validSubscriptionBody({ keys: { p256dh: 'valid', auth: '' } });
+    const response = await POST(makeSubscribeRequest(body));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when keys object is missing', async () => {
+    mockAuthenticatedUser();
+
+    const body = validSubscriptionBody();
+    delete (body as Record<string, unknown>).keys;
+    const response = await POST(makeSubscribeRequest(body));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when endpoint is not a valid URL', async () => {
+    mockAuthenticatedUser();
+
+    const body = validSubscriptionBody({ endpoint: 'not-a-url' });
+    const response = await POST(makeSubscribeRequest(body));
+
+    expect(response.status).toBe(400);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.4: SSRF protection - rejects non-push-service endpoints
+  // -----------------------------------------------------------------------
+  it('returns 400 when endpoint is not a recognized push service (SSRF check)', async () => {
+    mockAuthenticatedUser();
+
+    const body = validSubscriptionBody({ endpoint: 'https://evil.example.com/webhook' });
+    const response = await POST(makeSubscribeRequest(body));
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toContain('recognized push service');
+  });
+
+  it('returns 400 for localhost endpoints (SSRF check)', async () => {
+    mockAuthenticatedUser();
+
+    const body = validSubscriptionBody({ endpoint: 'https://localhost:3000/api/internal' });
+    const response = await POST(makeSubscribeRequest(body));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 for internal IP endpoints (SSRF check)', async () => {
+    mockAuthenticatedUser();
+
+    const body = validSubscriptionBody({ endpoint: 'https://192.168.1.1/callback' });
+    const response = await POST(makeSubscribeRequest(body));
+
+    expect(response.status).toBe(400);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.5: Rate limiting
+  // -----------------------------------------------------------------------
+  it('returns 429 when rate limited', async () => {
+    mockRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60000,
+      retryAfter: 30,
+    });
+
+    const response = await POST(makeSubscribeRequest(validSubscriptionBody()));
+
+    expect(response.status).toBe(429);
+    const json = await response.json();
+    expect(json.error).toBe('RATE_LIMITED');
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.6: Database error handling
+  // -----------------------------------------------------------------------
+  it('returns 500 when upsert fails', async () => {
+    mockAuthenticatedUser();
+    mockSupabaseClient.from.mockReturnValue({
+      upsert: vi.fn().mockResolvedValue({ error: { message: 'DB error' } }),
+    });
+
+    const response = await POST(makeSubscribeRequest(validSubscriptionBody()));
+
+    expect(response.status).toBe(500);
+    const json = await response.json();
+    expect(json.error).toBe('Failed to save push subscription');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unsubscribe Tests
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/push/unsubscribe', () => {
+  let DELETE: (request: NextRequest) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockRateLimit.mockResolvedValue({ allowed: true, remaining: 4, resetAt: Date.now() + 60000 });
+
+    const mod = await import('@/app/api/push/unsubscribe/route');
+    DELETE = mod.DELETE;
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.7: Returns 200 on valid unsubscribe
+  // -----------------------------------------------------------------------
+  it('returns 200 on valid unsubscribe', async () => {
+    mockAuthenticatedUser('user-abc');
+
+    const mockDelete = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    });
+    mockSupabaseClient.from.mockReturnValue({ delete: mockDelete });
+
+    const response = await DELETE(
+      makeUnsubscribeRequest({ endpoint: VALID_FCM_ENDPOINT })
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toEqual({ success: true });
+  });
+
+  it('deletes with user_id and token filters', async () => {
+    mockAuthenticatedUser('user-xyz');
+
+    const mockEq2 = vi.fn().mockResolvedValue({ error: null });
+    const mockEq1 = vi.fn().mockReturnValue({ eq: mockEq2 });
+    const mockDeleteFn = vi.fn().mockReturnValue({ eq: mockEq1 });
+    mockSupabaseClient.from.mockReturnValue({ delete: mockDeleteFn });
+
+    await DELETE(
+      makeUnsubscribeRequest({ endpoint: VALID_FCM_ENDPOINT })
+    );
+
+    expect(mockSupabaseClient.from).toHaveBeenCalledWith('device_tokens');
+    expect(mockEq1).toHaveBeenCalledWith('user_id', 'user-xyz');
+    expect(mockEq2).toHaveBeenCalledWith('token', VALID_FCM_ENDPOINT);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.8: Returns 401 when unauthenticated
+  // -----------------------------------------------------------------------
+  it('returns 401 when user is not authenticated', async () => {
+    mockUnauthenticated();
+
+    const response = await DELETE(
+      makeUnsubscribeRequest({ endpoint: VALID_FCM_ENDPOINT })
+    );
+
+    expect(response.status).toBe(401);
+    const json = await response.json();
+    expect(json).toEqual({ error: 'Unauthorized' });
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.9: Returns 400 on invalid endpoint
+  // -----------------------------------------------------------------------
+  it('returns 400 when endpoint is not a valid URL', async () => {
+    mockAuthenticatedUser();
+
+    const response = await DELETE(
+      makeUnsubscribeRequest({ endpoint: 'not-a-url' })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when endpoint is not a recognized push service', async () => {
+    mockAuthenticatedUser();
+
+    const response = await DELETE(
+      makeUnsubscribeRequest({ endpoint: 'https://evil.example.com/callback' })
+    );
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toContain('recognized push service');
+  });
+
+  it('returns 400 when endpoint is missing', async () => {
+    mockAuthenticatedUser();
+
+    const response = await DELETE(makeUnsubscribeRequest({}));
+
+    expect(response.status).toBe(400);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.10: Rate limiting
+  // -----------------------------------------------------------------------
+  it('returns 429 when rate limited', async () => {
+    mockRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60000,
+      retryAfter: 45,
+    });
+
+    const response = await DELETE(
+      makeUnsubscribeRequest({ endpoint: VALID_FCM_ENDPOINT })
+    );
+
+    expect(response.status).toBe(429);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4A.2.11: Database error handling
+  // -----------------------------------------------------------------------
+  it('returns 500 when delete fails', async () => {
+    mockAuthenticatedUser();
+
+    const mockEq2 = vi.fn().mockResolvedValue({ error: { message: 'DB error' } });
+    const mockEq1 = vi.fn().mockReturnValue({ eq: mockEq2 });
+    mockSupabaseClient.from.mockReturnValue({
+      delete: vi.fn().mockReturnValue({ eq: mockEq1 }),
+    });
+
+    const response = await DELETE(
+      makeUnsubscribeRequest({ endpoint: VALID_FCM_ENDPOINT })
+    );
+
+    expect(response.status).toBe(500);
+    const json = await response.json();
+    expect(json.error).toBe('Failed to remove push subscription');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,7 @@ importers:
         version: 0.2.6
       '@vitest/coverage-v8':
         specifier: 4.0.18
-        version: 4.0.18(vitest@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))
+        version: 4.0.18(vitest@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       cross-spawn:
         specifier: ^7.0.6
         version: 7.0.6
@@ -108,7 +108,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/styrby-mobile:
     dependencies:
@@ -174,7 +174,7 @@ importers:
         version: 2.0.1(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       nativewind:
         specifier: ^4.0.0
-        version: 4.2.1(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0))
+        version: 4.2.1(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -236,12 +236,15 @@ importers:
       jest-expo:
         specifier: ^52.0.6
         version: 52.0.6(@babel/core@7.29.0)(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.15.35))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(webpack@5.105.0)
+      react-native-worklets:
+        specifier: 0.8.1
+        version: 0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       react-test-renderer:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^3.4.0
-        version: 3.4.19(tsx@4.21.0)
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
       typescript:
         specifier: ~5.6.0
         version: 5.6.3
@@ -269,7 +272,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/styrby-videos:
     dependencies:
@@ -487,10 +490,10 @@ importers:
         version: 1.58.1
       '@tailwindcss/forms':
         specifier: ^0.5.10
-        version: 0.5.11(tailwindcss@3.4.19(tsx@4.21.0))
+        version: 0.5.11(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@tailwindcss/typography':
         specifier: 0.5.19
-        version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0))
+        version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
@@ -517,10 +520,10 @@ importers:
         version: 3.6.4
       '@vitejs/plugin-react':
         specifier: 5.1.3
-        version: 5.1.3(vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))
+        version: 5.1.3(vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: 4.0.18
-        version: 4.0.18(vitest@3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))
+        version: 4.0.18(vitest@3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.24(postcss@8.5.6)
@@ -538,16 +541,16 @@ importers:
         version: 8.5.6
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19(tsx@4.21.0)
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0))
+        version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -3233,6 +3236,10 @@ packages:
     resolution: {integrity: sha512-vxL/vtDEIYHfWKm5oTaEmwcnNGsua/i9OjIxBDBFiJDu5i5RU3bpmDiXQm/bJxrJNPRp5lW0I0kpGihVhnMAIQ==}
     engines: {node: '>=18'}
 
+  '@react-native/babel-plugin-codegen@0.84.1':
+    resolution: {integrity: sha512-vorvcvptGxtK0qTDCFQb+W3CU6oIhzcX5dduetWRBoAhXdthEQM0MQnF+GTXoXL8/luffKgy7PlZRG/WeI/oRQ==}
+    engines: {node: '>= 20.19.4'}
+
   '@react-native/babel-preset@0.76.0':
     resolution: {integrity: sha512-HgQt4MyuWLcnrIglXn7GNPPVwtzZ4ffX+SUisdhmPtJCHuP8AOU3HsgOKLhqVfEGWTBlE4kbWoTmmLU87IJaOw==}
     engines: {node: '>=18'}
@@ -3242,6 +3249,12 @@ packages:
   '@react-native/babel-preset@0.76.9':
     resolution: {integrity: sha512-TbSeCplCM6WhL3hR2MjC/E1a9cRnMLz7i767T7mP90oWkklEjyPxWl+0GGoVGnJ8FC/jLUupg/HvREKjjif6lw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/core': '*'
+
+  '@react-native/babel-preset@0.84.1':
+    resolution: {integrity: sha512-3GpmCKk21f4oe32bKIdmkdn+WydvhhZL+1nsoFBGi30Qrq9vL16giKu31OcnWshYz139x+mVAvCyoyzgn8RXSw==}
+    engines: {node: '>= 20.19.4'}
     peerDependencies:
       '@babel/core': '*'
 
@@ -3256,6 +3269,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@babel/preset-env': ^7.1.6
+
+  '@react-native/codegen@0.84.1':
+    resolution: {integrity: sha512-n1RIU0QAavgCg1uC5+s53arL7/mpM+16IBhJ3nCFSd/iK5tUmCwxQDcIDC703fuXfpub/ZygeSjVN8bcOWn0gA==}
+    engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/community-cli-plugin@0.76.0':
     resolution: {integrity: sha512-JFU5kmo+lUf5vOsieJ/dGS71Z2+qV3leXbKW6p8cn5aVfupVmtz/uYcFVdGzEGIGJ3juorYOZjpG8Qz91FrUZw==}
@@ -3290,11 +3309,25 @@ packages:
     resolution: {integrity: sha512-0UzEqvg85Bn0BpgNG80wzbiWvNypwdl64sbRs/sEvIDjzgq/tM+u3KoneSD5tP72BCydAqXFfepff3FZgImfbA==}
     engines: {node: '>=18'}
 
+  '@react-native/js-polyfills@0.84.1':
+    resolution: {integrity: sha512-UsTe2AbUugsfyI7XIHMQq4E7xeC8a6GrYwuK+NohMMMJMxmyM3JkzIk+GB9e2il6ScEQNMJNaj+q+i5za8itxQ==}
+    engines: {node: '>= 20.19.4'}
+
   '@react-native/metro-babel-transformer@0.76.0':
     resolution: {integrity: sha512-aq0MrjaOxDitSqQbttBcOt+5tjemCabhEX2gGthy8cNeZokBa2raoHQInDo9iBBN1ePKDCwKGypyC8zKA5dksQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@babel/core': '*'
+
+  '@react-native/metro-babel-transformer@0.84.1':
+    resolution: {integrity: sha512-NswINguTz0eg1Dc0oGO/1dejXSr6iQaz8/NnCRn5HJdA3dGfqadS7zlYv0YjiWpgKgcW6uENaIEgJOQww0KSpw==}
+    engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      '@babel/core': '*'
+
+  '@react-native/metro-config@0.84.1':
+    resolution: {integrity: sha512-KlRawK4aXxRLlR3HYVfZKhfQp7sejQefQ/LttUWUkErhKO0AFt+yznoSLq7xwIrH9K3A3YwImHuFVtUtuDmurA==}
+    engines: {node: '>= 20.19.4'}
 
   '@react-native/normalize-colors@0.76.0':
     resolution: {integrity: sha512-r+pjeIhzehb+bJUUUrztOQb+n6J9DeaLbF6waLgiHa5mFOiwP/4/iWS68inSZnnBtmXHkN2IYiMXzExx8hieWA==}
@@ -4578,6 +4611,9 @@ packages:
 
   babel-plugin-syntax-hermes-parser@0.25.1:
     resolution: {integrity: sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==}
+
+  babel-plugin-syntax-hermes-parser@0.32.0:
+    resolution: {integrity: sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==}
 
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
@@ -6179,11 +6215,23 @@ packages:
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
+  hermes-estree@0.32.0:
+    resolution: {integrity: sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==}
+
+  hermes-estree@0.33.3:
+    resolution: {integrity: sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==}
+
   hermes-parser@0.23.1:
     resolution: {integrity: sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==}
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  hermes-parser@0.32.0:
+    resolution: {integrity: sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==}
+
+  hermes-parser@0.33.3:
+    resolution: {integrity: sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -7137,58 +7185,116 @@ packages:
     resolution: {integrity: sha512-oKCQuajU5srm+ZdDcFg86pG/U8hkSjBlkyFjz380SZ4TTIiI5F+OQB830i53D8hmqmcosa4wR/pnKv8y4Q3dLw==}
     engines: {node: '>=18.18'}
 
+  metro-babel-transformer@0.83.5:
+    resolution: {integrity: sha512-d9FfmgUEVejTiSb7bkQeLRGl6aeno2UpuPm3bo3rCYwxewj03ymvOn8s8vnS4fBqAPQ+cE9iQM40wh7nGXR+eA==}
+    engines: {node: '>=20.19.4'}
+
   metro-cache-key@0.81.5:
     resolution: {integrity: sha512-lGWnGVm1UwO8faRZ+LXQUesZSmP1LOg14OVR+KNPBip8kbMECbQJ8c10nGesw28uQT7AE0lwQThZPXlxDyCLKQ==}
     engines: {node: '>=18.18'}
+
+  metro-cache-key@0.83.5:
+    resolution: {integrity: sha512-Ycl8PBajB7bhbAI7Rt0xEyiF8oJ0RWX8EKkolV1KfCUlC++V/GStMSGpPLwnnBZXZWkCC5edBPzv1Hz1Yi0Euw==}
+    engines: {node: '>=20.19.4'}
 
   metro-cache@0.81.5:
     resolution: {integrity: sha512-wOsXuEgmZMZ5DMPoz1pEDerjJ11AuMy9JifH4yNW7NmWS0ghCRqvDxk13LsElzLshey8C+my/tmXauXZ3OqZgg==}
     engines: {node: '>=18.18'}
 
+  metro-cache@0.83.5:
+    resolution: {integrity: sha512-oH+s4U+IfZyg8J42bne2Skc90rcuESIYf86dYittcdWQtPfcaFXWpByPyTuWk3rR1Zz3Eh5HOrcVImfEhhJLng==}
+    engines: {node: '>=20.19.4'}
+
   metro-config@0.81.5:
     resolution: {integrity: sha512-oDRAzUvj6RNRxratFdcVAqtAsg+T3qcKrGdqGZFUdwzlFJdHGR9Z413sW583uD2ynsuOjA2QB6US8FdwiBdNKg==}
     engines: {node: '>=18.18'}
+
+  metro-config@0.83.5:
+    resolution: {integrity: sha512-JQ/PAASXH7yczgV6OCUSRhZYME+NU8NYjI2RcaG5ga4QfQ3T/XdiLzpSb3awWZYlDCcQb36l4Vl7i0Zw7/Tf9w==}
+    engines: {node: '>=20.19.4'}
 
   metro-core@0.81.5:
     resolution: {integrity: sha512-+2R0c8ByfV2N7CH5wpdIajCWa8escUFd8TukfoXyBq/vb6yTCsznoA25FhNXJ+MC/cz1L447Zj3vdUfCXIZBwg==}
     engines: {node: '>=18.18'}
 
+  metro-core@0.83.5:
+    resolution: {integrity: sha512-YcVcLCrf0ed4mdLa82Qob0VxYqfhmlRxUS8+TO4gosZo/gLwSvtdeOjc/Vt0pe/lvMNrBap9LlmvZM8FIsMgJQ==}
+    engines: {node: '>=20.19.4'}
+
   metro-file-map@0.81.5:
     resolution: {integrity: sha512-mW1PKyiO3qZvjeeVjj1brhkmIotObA3/9jdbY1fQQYvEWM6Ml7bN/oJCRDGn2+bJRlG+J8pwyJ+DgdrM4BsKyg==}
     engines: {node: '>=18.18'}
+
+  metro-file-map@0.83.5:
+    resolution: {integrity: sha512-ZEt8s3a1cnYbn40nyCD+CsZdYSlwtFh2kFym4lo+uvfM+UMMH+r/BsrC6rbNClSrt+B7rU9T+Te/sh/NL8ZZKQ==}
+    engines: {node: '>=20.19.4'}
 
   metro-minify-terser@0.81.5:
     resolution: {integrity: sha512-/mn4AxjANnsSS3/Bb+zA1G5yIS5xygbbz/OuPaJYs0CPcZCaWt66D+65j4Ft/nJkffUxcwE9mk4ubpkl3rjgtw==}
     engines: {node: '>=18.18'}
 
+  metro-minify-terser@0.83.5:
+    resolution: {integrity: sha512-Toe4Md1wS1PBqbvB0cFxBzKEVyyuYTUb0sgifAZh/mSvLH84qA1NAWik9sISWatzvfWf3rOGoUoO5E3f193a3Q==}
+    engines: {node: '>=20.19.4'}
+
   metro-resolver@0.81.5:
     resolution: {integrity: sha512-6BX8Nq3g3go3FxcyXkVbWe7IgctjDTk6D9flq+P201DfHHQ28J+DWFpVelFcrNTn4tIfbP/Bw7u/0g2BGmeXfQ==}
     engines: {node: '>=18.18'}
+
+  metro-resolver@0.83.5:
+    resolution: {integrity: sha512-7p3GtzVUpbAweJeCcUJihJeOQl1bDuimO5ueo1K0BUpUtR41q5EilbQ3klt16UTPPMpA+tISWBtsrqU556mY1A==}
+    engines: {node: '>=20.19.4'}
 
   metro-runtime@0.81.5:
     resolution: {integrity: sha512-M/Gf71ictUKP9+77dV/y8XlAWg7xl76uhU7ggYFUwEdOHHWPG6gLBr1iiK0BmTjPFH8yRo/xyqMli4s3oGorPQ==}
     engines: {node: '>=18.18'}
 
+  metro-runtime@0.83.5:
+    resolution: {integrity: sha512-f+b3ue9AWTVlZe2Xrki6TAoFtKIqw30jwfk7GQ1rDUBQaE0ZQ+NkiMEtb9uwH7uAjJ87U7Tdx1Jg1OJqUfEVlA==}
+    engines: {node: '>=20.19.4'}
+
   metro-source-map@0.81.5:
     resolution: {integrity: sha512-Jz+CjvCKLNbJZYJTBeN3Kq9kIJf6b61MoLBdaOQZJ5Ajhw6Pf95Nn21XwA8BwfUYgajsi6IXsp/dTZsYJbN00Q==}
     engines: {node: '>=18.18'}
+
+  metro-source-map@0.83.5:
+    resolution: {integrity: sha512-VT9bb2KO2/4tWY9Z2yeZqTUao7CicKAOps9LUg2aQzsz+04QyuXL3qgf1cLUVRjA/D6G5u1RJAlN1w9VNHtODQ==}
+    engines: {node: '>=20.19.4'}
 
   metro-symbolicate@0.81.5:
     resolution: {integrity: sha512-X3HV3n3D6FuTE11UWFICqHbFMdTavfO48nXsSpnNGFkUZBexffu0Xd+fYKp+DJLNaQr3S+lAs8q9CgtDTlRRuA==}
     engines: {node: '>=18.18'}
     hasBin: true
 
+  metro-symbolicate@0.83.5:
+    resolution: {integrity: sha512-EMIkrjNRz/hF+p0RDdxoE60+dkaTLPN3vaaGkFmX5lvFdO6HPfHA/Ywznzkev+za0VhPQ5KSdz49/MALBRteHA==}
+    engines: {node: '>=20.19.4'}
+    hasBin: true
+
   metro-transform-plugins@0.81.5:
     resolution: {integrity: sha512-MmHhVx/1dJC94FN7m3oHgv5uOjKH8EX8pBeu1pnPMxbJrx6ZuIejO0k84zTSaQTZ8RxX1wqwzWBpXAWPjEX8mA==}
     engines: {node: '>=18.18'}
+
+  metro-transform-plugins@0.83.5:
+    resolution: {integrity: sha512-KxYKzZL+lt3Os5H2nx7YkbkWVduLZL5kPrE/Yq+Prm/DE1VLhpfnO6HtPs8vimYFKOa58ncl60GpoX0h7Wm0Vw==}
+    engines: {node: '>=20.19.4'}
 
   metro-transform-worker@0.81.5:
     resolution: {integrity: sha512-lUFyWVHa7lZFRSLJEv+m4jH8WrR5gU7VIjUlg4XmxQfV8ngY4V10ARKynLhMYPeQGl7Qvf+Ayg0eCZ272YZ4Mg==}
     engines: {node: '>=18.18'}
 
+  metro-transform-worker@0.83.5:
+    resolution: {integrity: sha512-8N4pjkNXc6ytlP9oAM6MwqkvUepNSW39LKYl9NjUMpRDazBQ7oBpQDc8Sz4aI8jnH6AGhF7s1m/ayxkN1t04yA==}
+    engines: {node: '>=20.19.4'}
+
   metro@0.81.5:
     resolution: {integrity: sha512-YpFF0DDDpDVygeca2mAn7K0+us+XKmiGk4rIYMz/CRdjFoCGqAei/IQSpV0UrGfQbToSugpMQeQJveaWSH88Hg==}
     engines: {node: '>=18.18'}
+    hasBin: true
+
+  metro@0.83.5:
+    resolution: {integrity: sha512-BgsXevY1MBac/3ZYv/RfNFf/4iuW9X7f4H8ZNkiH+r667HD9sVujxcmu4jvEzGCAm4/WyKdZCuyhAcyhTHOucQ==}
+    engines: {node: '>=20.19.4'}
     hasBin: true
 
   micromatch@4.0.8:
@@ -7421,6 +7527,10 @@ packages:
   ob1@0.81.5:
     resolution: {integrity: sha512-iNpbeXPLmaiT9I5g16gFFFjsF3sGxLpYG2EGP3dfFB4z+l9X60mp/yRzStHhMtuNt8qmf7Ww80nOPQHngHhnIQ==}
     engines: {node: '>=18.18'}
+
+  ob1@0.83.5:
+    resolution: {integrity: sha512-vNKPYC8L5ycVANANpF/S+WZHpfnRWKx/F3AYP4QMn6ZJTh+l2HOrId0clNkEmua58NB9vmI9Qh7YOoV/4folYg==}
+    engines: {node: '>=20.19.4'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -8013,6 +8123,14 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-worklets@0.8.1:
+    resolution: {integrity: sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==}
+    peerDependencies:
+      '@babel/core': '*'
+      '@react-native/metro-config': '*'
+      react: '*'
+      react-native: 0.81 - 0.85
 
   react-native@0.76.0:
     resolution: {integrity: sha512-isbLzmY7fhhLdN/oss4jlRHeDmEShuTYsp1Zq93UM0/JssQK4g+2Ub4mHdhxDFm2LN+0ryBgVJK1nO7l93cfsA==}
@@ -9481,6 +9599,11 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -12469,6 +12592,14 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  '@react-native/babel-plugin-codegen@0.84.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@react-native/codegen': 0.84.1(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   '@react-native/babel-preset@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -12571,6 +12702,44 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  '@react-native/babel-preset@0.84.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@react-native/babel-plugin-codegen': 0.84.1(@babel/core@7.29.0)
+      babel-plugin-syntax-hermes-parser: 0.32.0
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@react-native/codegen@0.76.0(@babel/preset-env@7.29.0(@babel/core@7.29.0))':
     dependencies:
       '@babel/parser': 7.29.0
@@ -12598,6 +12767,16 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
+
+  '@react-native/codegen@0.84.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.0
+      hermes-parser: 0.32.0
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      tinyglobby: 0.2.15
+      yargs: 17.7.2
 
   '@react-native/community-cli-plugin@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))':
     dependencies:
@@ -12664,6 +12843,8 @@ snapshots:
 
   '@react-native/js-polyfills@0.76.0': {}
 
+  '@react-native/js-polyfills@0.84.1': {}
+
   '@react-native/metro-babel-transformer@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -12673,6 +12854,27 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
+
+  '@react-native/metro-babel-transformer@0.84.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@react-native/babel-preset': 0.84.1(@babel/core@7.29.0)
+      hermes-parser: 0.32.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/metro-config@0.84.1(@babel/core@7.29.0)':
+    dependencies:
+      '@react-native/js-polyfills': 0.84.1
+      '@react-native/metro-babel-transformer': 0.84.1(@babel/core@7.29.0)
+      metro-config: 0.83.5
+      metro-runtime: 0.83.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.76.0': {}
 
@@ -13209,15 +13411,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/forms@0.5.11(tailwindcss@3.4.19(tsx@4.21.0))':
+  '@tailwindcss/forms@0.5.11(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.19(tsx@4.21.0)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
 
-  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(tsx@4.21.0))':
+  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.19(tsx@4.21.0)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -13700,7 +13902,7 @@ snapshots:
       '@urql/core': 5.2.0
       wonka: 6.3.5
 
-  '@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))':
+  '@vitejs/plugin-react@5.1.3(vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -13708,11 +13910,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.2
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))':
+  '@vitest/coverage-v8@4.0.18(vitest@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -13724,9 +13926,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+      vitest: 3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/coverage-v8@4.0.18(vitest@3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))':
+  '@vitest/coverage-v8@4.0.18(vitest@3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -13738,7 +13940,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+      vitest: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -13748,21 +13950,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -14243,6 +14445,10 @@ snapshots:
   babel-plugin-syntax-hermes-parser@0.25.1:
     dependencies:
       hermes-parser: 0.25.1
+
+  babel-plugin-syntax-hermes-parser@0.32.0:
+    dependencies:
+      hermes-parser: 0.32.0
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.0):
     dependencies:
@@ -15273,7 +15479,7 @@ snapshots:
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@1.21.7))
@@ -15306,7 +15512,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -15384,7 +15590,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -16194,6 +16400,10 @@ snapshots:
 
   hermes-estree@0.25.1: {}
 
+  hermes-estree@0.32.0: {}
+
+  hermes-estree@0.33.3: {}
+
   hermes-parser@0.23.1:
     dependencies:
       hermes-estree: 0.23.1
@@ -16201,6 +16411,14 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hermes-parser@0.32.0:
+    dependencies:
+      hermes-estree: 0.32.0
+
+  hermes-parser@0.33.3:
+    dependencies:
+      hermes-estree: 0.33.3
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -17425,7 +17643,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-babel-transformer@0.83.5:
+    dependencies:
+      '@babel/core': 7.29.0
+      flow-enums-runtime: 0.0.6
+      hermes-parser: 0.33.3
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-cache-key@0.81.5:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-cache-key@0.83.5:
     dependencies:
       flow-enums-runtime: 0.0.6
 
@@ -17434,6 +17665,15 @@ snapshots:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
       metro-core: 0.81.5
+
+  metro-cache@0.83.5:
+    dependencies:
+      exponential-backoff: 3.1.3
+      flow-enums-runtime: 0.0.6
+      https-proxy-agent: 7.0.6
+      metro-core: 0.83.5
+    transitivePeerDependencies:
+      - supports-color
 
   metro-config@0.81.5:
     dependencies:
@@ -17450,15 +17690,50 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-config@0.83.5:
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.83.5
+      metro-cache: 0.83.5
+      metro-core: 0.83.5
+      metro-runtime: 0.83.5
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-core@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
       lodash.throttle: 4.1.1
       metro-resolver: 0.81.5
 
+  metro-core@0.83.5:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      lodash.throttle: 4.1.1
+      metro-resolver: 0.83.5
+
   metro-file-map@0.81.5:
     dependencies:
       debug: 2.6.9
+      fb-watchman: 2.0.2
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      nullthrows: 1.1.1
+      walker: 1.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-file-map@0.83.5:
+    dependencies:
+      debug: 4.4.3
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -17475,11 +17750,25 @@ snapshots:
       flow-enums-runtime: 0.0.6
       terser: 5.46.0
 
+  metro-minify-terser@0.83.5:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      terser: 5.46.0
+
   metro-resolver@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
 
+  metro-resolver@0.83.5:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
   metro-runtime@0.81.5:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      flow-enums-runtime: 0.0.6
+
+  metro-runtime@0.83.5:
     dependencies:
       '@babel/runtime': 7.28.6
       flow-enums-runtime: 0.0.6
@@ -17499,6 +17788,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-source-map@0.83.5:
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-symbolicate: 0.83.5
+      nullthrows: 1.1.1
+      ob1: 0.83.5
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-symbolicate@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -17510,7 +17813,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-symbolicate@0.83.5:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-source-map: 0.83.5
+      nullthrows: 1.1.1
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-transform-plugins@0.81.5:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      flow-enums-runtime: 0.0.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-plugins@0.83.5:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -17535,6 +17860,26 @@ snapshots:
       metro-minify-terser: 0.81.5
       metro-source-map: 0.81.5
       metro-transform-plugins: 0.81.5
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro-transform-worker@0.83.5:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      flow-enums-runtime: 0.0.6
+      metro: 0.83.5
+      metro-babel-transformer: 0.83.5
+      metro-cache: 0.83.5
+      metro-cache-key: 0.83.5
+      metro-minify-terser: 0.83.5
+      metro-source-map: 0.83.5
+      metro-transform-plugins: 0.83.5
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - bufferutil
@@ -17577,6 +17922,53 @@ snapshots:
       metro-transform-plugins: 0.81.5
       metro-transform-worker: 0.81.5
       mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.5:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 2.0.0
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.33.3
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.5
+      metro-cache: 0.83.5
+      metro-cache-key: 0.83.5
+      metro-config: 0.83.5
+      metro-core: 0.83.5
+      metro-file-map: 0.83.5
+      metro-resolver: 0.83.5
+      metro-runtime: 0.83.5
+      metro-source-map: 0.83.5
+      metro-symbolicate: 0.83.5
+      metro-transform-plugins: 0.83.5
+      metro-transform-worker: 0.83.5
+      mime-types: 3.0.2
       nullthrows: 1.1.1
       serialize-error: 2.1.0
       source-map: 0.5.7
@@ -17669,12 +18061,12 @@ snapshots:
 
   napi-postinstall@0.3.4: {}
 
-  nativewind@4.2.1(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)):
+  nativewind@4.2.1(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       comment-json: 4.5.1
       debug: 4.4.3
-      react-native-css-interop: 0.2.1(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0))
-      tailwindcss: 3.4.19(tsx@4.21.0)
+      react-native-css-interop: 0.2.1(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - react
       - react-native
@@ -17773,6 +18165,10 @@ snapshots:
   nwsapi@2.2.23: {}
 
   ob1@0.81.5:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  ob1@0.83.5:
     dependencies:
       flow-enums-runtime: 0.0.6
 
@@ -18047,13 +18443,14 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
       tsx: 4.21.0
+      yaml: 2.8.3
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
     dependencies:
@@ -18275,7 +18672,7 @@ snapshots:
 
   react-is@19.2.4: {}
 
-  react-native-css-interop@0.2.1(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)):
+  react-native-css-interop@0.2.1(react-native-reanimated@3.16.7(@babel/core@7.29.0)(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.12.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native-svg@15.8.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/traverse': 7.29.0
@@ -18286,7 +18683,7 @@ snapshots:
       react-native: 0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
       react-native-reanimated: 3.16.7(@babel/core@7.29.0)(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       semver: 7.7.4
-      tailwindcss: 3.4.19(tsx@4.21.0)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       react-native-safe-area-context: 4.12.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       react-native-svg: 15.8.0(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
@@ -18357,6 +18754,26 @@ snapshots:
       react: 18.3.1
       react-native: 0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
       warn-once: 0.1.1
+
+  react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@react-native/metro-config': 0.84.1(@babel/core@7.29.0)
+      convert-source-map: 2.0.0
+      react: 18.3.1
+      react-native: 0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
 
   react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -19250,11 +19667,11 @@ snapshots:
 
   tailwind-merge@3.4.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      tailwindcss: 3.4.19(tsx@4.21.0)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
 
-  tailwindcss@3.4.19(tsx@4.21.0):
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -19273,7 +19690,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.3)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -19705,13 +20122,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -19726,13 +20143,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -19747,7 +20164,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0):
+  vite@7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -19762,8 +20179,9 @@ snapshots:
       lightningcss: 1.27.0
       terser: 5.46.0
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0):
+  vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -19778,12 +20196,13 @@ snapshots:
       lightningcss: 1.27.0
       terser: 5.46.0
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.15.35)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -19801,8 +20220,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.15.35)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.35
@@ -19821,11 +20240,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -19843,8 +20262,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.9
@@ -20153,6 +20572,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary

Sprint 4 (final sprint) of the PWA + Mobile Parity MDMP plan. Testing, validation, and security hardening.

### Track A: PWA Tests (44 new tests)
- **SW registration tests** (7): Register, update banner, SKIP_WAITING flow, cleanup, offline queue sync
- **Push endpoint tests** (22): Subscribe/unsubscribe with auth, Zod validation, SSRF endpoint rejection, rate limiting, DB error handling
- **Offline + install tests** (15): Offline page rendering, usePWAInstall hook states, localStorage persistence, beforeinstallprompt/appinstalled events

### Track B: Mobile Tests (143 new tests, 307 total)
- **Zod schema tests** (81): All 16 schemas validated for accept/reject behavior, safeParseArray/safeParseSingle helpers
- **useOnboarding tests** (13): Tier-based checklist, completion detection, markComplete
- **useSupport tests** (12): Ticket CRUD, auth check, reply validation
- **useTeamManagement tests** (14): Team CRUD, CSPRNG invite tokens, role management
- **useCosts tests** (15): 90-day range, agent breakdown, real-time INSERT updates
- **Budget RPC tests** (8): checkHardStop blocked/not-blocked, Zod validation, error handling
- **Infra fix**: Added `react-native-worklets` devDependency to resolve pre-existing Babel plugin error (6 test suites were previously failing)

### Track S: Security Validation (PASS)
- No hardcoded secrets found
- All 29 API routes have authentication
- VAPID keys loaded from env vars only
- Push endpoints validated against browser vendor allowlist
- Dashboard routes use NetworkOnly (never cached)
- API routes with Authorization headers excluded from cache
- Periodic sync uses client.postMessage(), not direct cache writes
- Console logging guarded by __DEV__ / NODE_ENV checks
- `.sec-reports/` added to .gitignore

## Test Results
- [x] Web: 744 tests across 44 suites (all passing)
- [x] Mobile: 307 tests across 12 suites (all passing)
- [ ] CI pipeline passes

---
Shipped with [Claude Code](https://claude.com/claude-code)