### PR TITLE
feat(web): E2E NaCl decryption for session messages

### DIFF
--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-thread.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-thread.tsx
@@ -12,6 +12,7 @@ import { useState, useEffect, useRef, useCallback, memo } from 'react';
 import { useRealtimeSubscription } from '@/hooks/useRealtimeSubscription';
 import { PermissionCard } from './permission-card';
 import { cn } from '@/lib/utils';
+import { tryDecryptMessage, registerWebDevice, type DecryptResult } from '@/lib/encryption';
 
 // WHY: Hoisted to module level to avoid re-allocating the RegExp object on every
 // render call. Note: no `g` flag here — we use matchAll() instead, which
@@ -45,6 +46,8 @@ interface Message {
     | 'system';
   /** Encrypted content (E2E encrypted for security) */
   content_encrypted: string | null;
+  /** Base64-encoded nonce used for encryption (null = plaintext) */
+  encryption_nonce: string | null;
   /** Risk level for permission requests */
   risk_level: 'low' | 'medium' | 'high' | null;
   /** Whether permission was granted */
@@ -71,6 +74,8 @@ interface ChatThreadProps {
   initialMessages: Message[];
   /** Whether the session is still active (affects permission cards) */
   isSessionActive: boolean;
+  /** CLI machine ID that created this session (for E2E key lookup) */
+  machineId: string | null;
 }
 
 /* ──────────────────────────── Icons ──────────────────────────── */
@@ -175,15 +180,18 @@ function getSenderLabel(messageType: Message['message_type']): string {
 }
 
 /**
- * Extracts message content from the encrypted field.
- * WHY: For now we display encrypted content directly.
- * Real E2E decryption would happen here using TweetNaCl.
+ * Returns plaintext for unencrypted messages (no nonce).
+ * For encrypted messages, returns null — async decryption is handled
+ * by the useDecryptedMessages hook in the ChatThread component.
  *
  * @param message - Message record
- * @returns Displayable content string
+ * @returns Displayable content string, or null if encrypted
  */
-function getMessageContent(message: Message): string {
-  return message.content_encrypted || '';
+function getMessageContentSync(message: Message): string | null {
+  if (!message.encryption_nonce) {
+    return message.content_encrypted || '';
+  }
+  return null;
 }
 
 /**
@@ -272,6 +280,8 @@ function renderContent(
 interface MessageRowProps {
   /** The message to render */
   message: Message;
+  /** Decrypted content (null if decryption failed or still loading) */
+  decryptedContent: DecryptResult | null;
   /** Which code block ID is currently showing the "Copied" state */
   copiedId: string | null;
   /** Stable callback — parent must wrap in useCallback to preserve referential equality */
@@ -291,8 +301,11 @@ interface MessageRowProps {
  * for unchanged rows), `copiedId` is a string|null (primitive comparison),
  * and `onCopy` must be wrapped in useCallback by the parent.
  */
-const MessageRow = memo(function MessageRow({ message, copiedId, onCopy }: MessageRowProps) {
-  const content = getMessageContent(message);
+const MessageRow = memo(function MessageRow({ message, decryptedContent, copiedId, onCopy }: MessageRowProps) {
+  // Resolve content: use decrypted result, fall back to sync extraction
+  const syncContent = getMessageContentSync(message);
+  const content = syncContent ?? decryptedContent?.content ?? '';
+  const isEncryptedAndUnreadable = !syncContent && decryptedContent?.wasEncrypted && !decryptedContent.content;
 
   return (
     <div
@@ -320,7 +333,16 @@ const MessageRow = memo(function MessageRow({ message, copiedId, onCopy }: Messa
 
       {/* Message content */}
       <div className="whitespace-pre-wrap break-words">
-        {renderContent(content, message.id, copiedId, onCopy)}
+        {isEncryptedAndUnreadable ? (
+          <span className="inline-flex items-center gap-1.5 text-zinc-500 italic">
+            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+            Encrypted — view on paired device
+          </span>
+        ) : (
+          renderContent(content, message.id, copiedId, onCopy)
+        )}
       </div>
 
       {/* Duration for agent responses */}
@@ -349,10 +371,59 @@ export function ChatThread({
   userId: _userId,
   initialMessages,
   isSessionActive,
+  machineId,
 }: ChatThreadProps) {
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  /**
+   * Cached decryption results indexed by message ID.
+   * WHY: Decryption is async (requires Supabase key lookup on first call).
+   * We decrypt all messages on mount and cache results so MessageRow can
+   * render synchronously from the cache.
+   */
+  const [decryptedCache, setDecryptedCache] = useState<Record<string, DecryptResult>>({});
+
+  /**
+   * Decrypt all encrypted messages on mount and when new messages arrive.
+   * Also registers the web device's public key for future E2E support.
+   */
+  useEffect(() => {
+    // Best-effort web device registration (non-blocking)
+    registerWebDevice().catch(() => {});
+
+    const decryptAll = async () => {
+      const newCache: Record<string, DecryptResult> = {};
+      let hasNew = false;
+
+      for (const msg of messages) {
+        // Skip if already cached
+        if (decryptedCache[msg.id]) {
+          newCache[msg.id] = decryptedCache[msg.id];
+          continue;
+        }
+
+        // Only decrypt messages that have a nonce (actually encrypted)
+        if (msg.encryption_nonce) {
+          hasNew = true;
+          const result = await tryDecryptMessage(
+            msg.content_encrypted,
+            msg.encryption_nonce,
+            machineId
+          );
+          newCache[msg.id] = result;
+        }
+      }
+
+      if (hasNew) {
+        setDecryptedCache((prev) => ({ ...prev, ...newCache }));
+      }
+    };
+
+    decryptAll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messages, machineId]);
 
   /**
    * Handles a new message from the real-time subscription.
@@ -451,6 +522,7 @@ export function ChatThread({
                 message={message}
                 sessionId={sessionId}
                 isActive={isSessionActive && message.permission_granted === null}
+                machineId={machineId}
               />
             );
           }
@@ -464,6 +536,7 @@ export function ChatThread({
             <MessageRow
               key={message.id}
               message={message}
+              decryptedContent={decryptedCache[message.id] || null}
               copiedId={copiedId}
               onCopy={copyCode}
             />

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/permission-card.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/permission-card.tsx
@@ -8,8 +8,9 @@
  * determines the card's visual styling.
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
+import { tryDecryptMessage } from '@/lib/encryption';
 
 /* ──────────────────────────── Types ──────────────────────────── */
 
@@ -21,6 +22,8 @@ interface PermissionMessage {
   id: string;
   /** Encrypted content describing the permission request */
   content_encrypted: string | null;
+  /** Base64-encoded nonce (null = plaintext) */
+  encryption_nonce: string | null;
   /** Risk level determines visual styling */
   risk_level: 'low' | 'medium' | 'high' | null;
   /** Whether permission has been granted (null = pending) */
@@ -41,6 +44,8 @@ interface PermissionCardProps {
   sessionId: string;
   /** Whether the card should show action buttons */
   isActive: boolean;
+  /** CLI machine ID for E2E key lookup */
+  machineId: string | null;
 }
 
 /**
@@ -112,7 +117,7 @@ function LoaderIcon({ className }: { className?: string }) {
  *
  * @param props - PermissionCard configuration
  */
-export function PermissionCard({ message, sessionId, isActive }: PermissionCardProps) {
+export function PermissionCard({ message, sessionId, isActive, machineId }: PermissionCardProps) {
   // Track initial state from message
   const initialStatus: ResponseStatus = message.permission_granted === true
     ? 'approved'
@@ -212,8 +217,32 @@ export function PermissionCard({ message, sessionId, isActive }: PermissionCardP
     }
   };
 
-  // Decrypt content (placeholder for E2E encryption)
-  const content = message.content_encrypted || 'Permission request';
+  // Decrypt content — async decryption for E2E encrypted messages
+  const [content, setContent] = useState<string>(
+    // If no nonce, treat as plaintext; otherwise show loading state
+    !message.encryption_nonce
+      ? (message.content_encrypted || 'Permission request')
+      : 'Decrypting...'
+  );
+  const [isEncrypted, setIsEncrypted] = useState(false);
+
+  useEffect(() => {
+    if (!message.encryption_nonce) return; // Already plaintext
+
+    let cancelled = false;
+    tryDecryptMessage(message.content_encrypted, message.encryption_nonce, machineId)
+      .then((result) => {
+        if (cancelled) return;
+        if (result.content) {
+          setContent(result.content);
+        } else {
+          setContent('Permission request');
+          setIsEncrypted(true);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [message.content_encrypted, message.encryption_nonce, machineId]);
 
   return (
     <div
@@ -240,7 +269,16 @@ export function PermissionCard({ message, sessionId, isActive }: PermissionCardP
           </div>
 
           {/* Description */}
-          <p className="text-sm text-zinc-300 mt-1">{content}</p>
+          <p className="text-sm text-zinc-300 mt-1">
+            {isEncrypted && (
+              <span className="inline-flex items-center gap-1 text-zinc-500 mr-1.5">
+                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                </svg>
+              </span>
+            )}
+            {content}
+          </p>
 
           {/* Tool details */}
           <div className="mt-3 rounded-lg bg-zinc-900 border border-zinc-700 p-3">

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/session-view.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/session-view.tsx
@@ -33,6 +33,8 @@ interface Session {
   error_message: string | null;
   summary: string | null;
   summary_generated_at: string | null;
+  /** CLI machine that created this session (used for E2E key lookup) */
+  machine_id: string | null;
 }
 
 /**
@@ -239,6 +241,7 @@ export function SessionView({
             userId={userId}
             initialMessages={messages}
             isSessionActive={isSessionActive}
+            machineId={session.machine_id}
           />
 
           {/* Input (only shown for active sessions) */}

--- a/packages/styrby-web/src/components/session-replay/__tests__/player.test.tsx
+++ b/packages/styrby-web/src/components/session-replay/__tests__/player.test.tsx
@@ -80,6 +80,7 @@ function createMessage(
     sequence_number: parseInt(id.replace('msg-', ''), 10),
     message_type: type,
     content_encrypted: content,
+    encryption_nonce: null,
     risk_level: null,
     permission_granted: null,
     tool_name: null,

--- a/packages/styrby-web/src/components/session-replay/__tests__/use-replay-state.test.ts
+++ b/packages/styrby-web/src/components/session-replay/__tests__/use-replay-state.test.ts
@@ -43,6 +43,7 @@ function createMessage(
     sequence_number: parseInt(id.replace('msg-', ''), 10),
     message_type: type,
     content_encrypted: `Content for ${id}`,
+    encryption_nonce: null,
     risk_level: null,
     permission_granted: null,
     tool_name: null,

--- a/packages/styrby-web/src/components/session-replay/types.ts
+++ b/packages/styrby-web/src/components/session-replay/types.ts
@@ -29,6 +29,8 @@ export interface ReplayMessage {
     | 'system';
   /** Encrypted content (E2E encrypted for security) */
   content_encrypted: string | null;
+  /** Base64-encoded nonce used for encryption (null = plaintext) */
+  encryption_nonce: string | null;
   /** Risk level for permission requests */
   risk_level: 'low' | 'medium' | 'high' | null;
   /** Whether permission was granted */

--- a/packages/styrby-web/src/lib/encryption.ts
+++ b/packages/styrby-web/src/lib/encryption.ts
@@ -1,0 +1,298 @@
+/**
+ * Web Encryption Service
+ *
+ * Manages E2E NaCl box keypairs for the web dashboard and provides
+ * decryption of session messages. Mirrors the mobile encryption service
+ * but uses localStorage instead of SecureStore for key persistence.
+ *
+ * Architecture:
+ * - On first use, generates a NaCl box keypair and stores it in localStorage
+ * - The public key is registered in `machine_keys` so CLIs can encrypt for the web
+ * - For messages encrypted for this web device, decryption succeeds transparently
+ * - For messages encrypted for other devices (e.g., mobile), decryption fails
+ *   gracefully and a "[Encrypted]" fallback is shown
+ *
+ * WHY localStorage: The Web Crypto API with non-exportable keys would be more
+ * secure, but NaCl (TweetNaCl) operates on raw Uint8Arrays, not CryptoKey objects.
+ * localStorage is acceptable here because:
+ * 1. The keys protect session message content, not financial credentials
+ * 2. An attacker with localStorage access already has the auth session cookie
+ * 3. This matches the threat model — E2E encryption protects data in transit
+ *    and at rest on the server, not against local device compromise
+ */
+
+import {
+  generateKeyPair,
+  decryptFromStorage,
+  encodeBase64,
+  decodeBase64,
+  generateFingerprint,
+  type NaClKeyPair,
+} from '@styrby/shared';
+import { createClient } from '@/lib/supabase/client';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * localStorage key for the web device's NaCl box keypair.
+ * Stores a JSON object with base64-encoded publicKey and secretKey.
+ */
+const KEYPAIR_STORAGE_KEY = 'styrby_web_encryption_keypair';
+
+/**
+ * localStorage key for the web device's machine ID in machine_keys.
+ */
+const WEB_MACHINE_ID_KEY = 'styrby_web_machine_id';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * JSON-serializable form of the keypair for localStorage persistence.
+ */
+interface StoredKeyPair {
+  /** Base64-encoded NaCl box public key (32 bytes) */
+  publicKey: string;
+  /** Base64-encoded NaCl box secret key (32 bytes) */
+  secretKey: string;
+}
+
+// ============================================================================
+// In-Memory Cache
+// ============================================================================
+
+/** Cached web keypair (loaded from localStorage on first access) */
+let cachedKeyPair: NaClKeyPair | null = null;
+
+/**
+ * Cached sender public keys indexed by machine ID.
+ * WHY: Avoids repeated Supabase queries for the same CLI's public key
+ * across all messages in a session.
+ */
+const senderKeyCache = new Map<string, Uint8Array>();
+
+// ============================================================================
+// Key Management
+// ============================================================================
+
+/**
+ * Gets or creates the web device's NaCl box keypair.
+ *
+ * On first call, generates a new keypair and stores it in localStorage.
+ * Subsequent calls return the cached keypair without re-reading localStorage.
+ *
+ * @returns The web device's NaCl keypair
+ */
+export function getOrCreateWebKeyPair(): NaClKeyPair {
+  if (cachedKeyPair) return cachedKeyPair;
+
+  // Try to load existing keypair from localStorage
+  const stored = localStorage.getItem(KEYPAIR_STORAGE_KEY);
+  if (stored) {
+    try {
+      const parsed: StoredKeyPair = JSON.parse(stored);
+      cachedKeyPair = {
+        publicKey: decodeBase64(parsed.publicKey),
+        secretKey: decodeBase64(parsed.secretKey),
+      };
+      return cachedKeyPair;
+    } catch {
+      // Corrupted keypair — regenerate
+      localStorage.removeItem(KEYPAIR_STORAGE_KEY);
+    }
+  }
+
+  // Generate new keypair
+  cachedKeyPair = generateKeyPair();
+
+  // Persist to localStorage
+  const toStore: StoredKeyPair = {
+    publicKey: encodeBase64(cachedKeyPair.publicKey),
+    secretKey: encodeBase64(cachedKeyPair.secretKey),
+  };
+  localStorage.setItem(KEYPAIR_STORAGE_KEY, JSON.stringify(toStore));
+
+  return cachedKeyPair;
+}
+
+/**
+ * Registers the web device in the machines and machine_keys tables.
+ *
+ * WHY: Without registration, CLIs don't know the web's public key and
+ * cannot encrypt messages for it. This is called once on first session view.
+ *
+ * Creates a `machines` row (required FK for `machine_keys`) then inserts
+ * the web's NaCl public key into `machine_keys`.
+ *
+ * @returns The web device's machine UUID, or null on failure
+ */
+export async function registerWebDevice(): Promise<string | null> {
+  // Check if already registered
+  const existingId = localStorage.getItem(WEB_MACHINE_ID_KEY);
+  if (existingId) return existingId;
+
+  const keypair = getOrCreateWebKeyPair();
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const fingerprint = await generateFingerprint(keypair.publicKey);
+  const webFingerprint = `web_${fingerprint}`;
+
+  // Step 1: Create a machines row (required FK for machine_keys)
+  // WHY: machine_keys.machine_id references machines(id).
+  // Platform is null since 'web' is not in the CHECK constraint.
+  const { data: machine, error: machineError } = await supabase
+    .from('machines')
+    .upsert(
+      {
+        user_id: user.id,
+        name: 'Web Dashboard',
+        machine_fingerprint: webFingerprint,
+        hostname: typeof window !== 'undefined' ? window.location.hostname : 'web',
+        is_online: true,
+        last_seen_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,machine_fingerprint' }
+    )
+    .select('id')
+    .single();
+
+  if (machineError || !machine) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[Encryption] Failed to register web machine:', machineError?.message);
+    }
+    return null;
+  }
+
+  // Step 2: Insert the public key into machine_keys
+  const { error: keyError } = await supabase
+    .from('machine_keys')
+    .upsert(
+      {
+        machine_id: machine.id,
+        public_key: encodeBase64(keypair.publicKey),
+        fingerprint,
+      },
+      { onConflict: 'machine_id' }
+    );
+
+  if (keyError) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[Encryption] Failed to register web key:', keyError.message);
+    }
+    return null;
+  }
+
+  localStorage.setItem(WEB_MACHINE_ID_KEY, machine.id);
+  return machine.id;
+}
+
+// ============================================================================
+// Key Lookup
+// ============================================================================
+
+/**
+ * Fetches a CLI machine's public key from machine_keys.
+ * Results are cached in memory for the session lifetime.
+ *
+ * @param machineId - The CLI machine's ID
+ * @returns The CLI's public key as Uint8Array, or null if not found
+ */
+async function getSenderPublicKey(machineId: string): Promise<Uint8Array | null> {
+  const cached = senderKeyCache.get(machineId);
+  if (cached) return cached;
+
+  const supabase = createClient();
+  const { data } = await supabase
+    .from('machine_keys')
+    .select('public_key')
+    .eq('machine_id', machineId)
+    .single();
+
+  if (!data?.public_key) return null;
+
+  const publicKey = decodeBase64(data.public_key);
+  senderKeyCache.set(machineId, publicKey);
+  return publicKey;
+}
+
+// ============================================================================
+// Decryption
+// ============================================================================
+
+/**
+ * Result of attempting to decrypt a message.
+ */
+export interface DecryptResult {
+  /** The decrypted plaintext, or null if decryption failed */
+  content: string | null;
+  /** Whether the content was encrypted (had a nonce) */
+  wasEncrypted: boolean;
+}
+
+/**
+ * Attempts to decrypt a session message.
+ *
+ * Three possible outcomes:
+ * 1. Message is unencrypted (no nonce) → returns content_encrypted as plaintext
+ * 2. Message is encrypted and we can decrypt → returns decrypted plaintext
+ * 3. Message is encrypted but not for us → returns null with wasEncrypted=true
+ *
+ * @param contentEncrypted - The content_encrypted field from session_messages
+ * @param encryptionNonce - The encryption_nonce field (null for plaintext messages)
+ * @param machineId - The CLI machine_id that sent this message (from the session)
+ * @returns DecryptResult indicating outcome
+ */
+export async function tryDecryptMessage(
+  contentEncrypted: string | null,
+  encryptionNonce: string | null,
+  machineId: string | null
+): Promise<DecryptResult> {
+  // No content at all
+  if (!contentEncrypted) {
+    return { content: null, wasEncrypted: false };
+  }
+
+  // No nonce means the message is stored as plaintext
+  // WHY: Messages are only encrypted when E2E is active between paired devices.
+  // Many messages (especially early in the product lifecycle) are unencrypted.
+  if (!encryptionNonce) {
+    return { content: contentEncrypted, wasEncrypted: false };
+  }
+
+  // Message is encrypted — attempt decryption
+  if (!machineId) {
+    return { content: null, wasEncrypted: true };
+  }
+
+  try {
+    const keypair = getOrCreateWebKeyPair();
+    const senderPublicKey = await getSenderPublicKey(machineId);
+
+    if (!senderPublicKey) {
+      return { content: null, wasEncrypted: true };
+    }
+
+    const plaintext = decryptFromStorage(
+      contentEncrypted,
+      encryptionNonce,
+      senderPublicKey,
+      keypair.secretKey
+    );
+
+    return { content: plaintext, wasEncrypted: true };
+  } catch {
+    // Decryption failed — message was encrypted for a different device
+    // WHY: This is expected behavior when messages were encrypted for the
+    // mobile device, not the web. NaCl box.open returns null for wrong keys.
+    return { content: null, wasEncrypted: true };
+  }
+}


### PR DESCRIPTION
## Summary
- Adds real E2E NaCl box decryption to the web dashboard, closing the last Phase 1 functional gap
- Creates `lib/encryption.ts` web encryption service with keypair management and device registration
- Replaces placeholder decryption in `permission-card.tsx` and `chat-thread.tsx` with actual `decryptFromStorage()` calls via `@styrby/shared`
- Gracefully degrades with lock icon + "Encrypted — view on paired device" when messages were encrypted for a different device

## Architecture
Messages in `session_messages` are NaCl box encrypted between specific device pairs (CLI → mobile). The web registers its own keypair in `machines` + `machine_keys` so future CLI sessions can encrypt for the web too. For messages encrypted for other devices, decryption fails gracefully.

## Changes
| File | Change |
|------|--------|
| `lib/encryption.ts` (new) | Web encryption service: keypair gen/storage, device registration, tryDecryptMessage() |
| `permission-card.tsx` | Real async decryption with encrypted fallback badge |
| `chat-thread.tsx` | Decrypt cache, web device registration on mount, encrypted message indicator |
| `session-view.tsx` | Thread `machineId` from session to ChatThread |
| `session-replay/types.ts` | Add `encryption_nonce` to ReplayMessage |
| 2 test files | Add `encryption_nonce: null` to test fixtures |

## Test Plan
- [x] Web typecheck passes (0 errors)
- [ ] CI pipeline passes
- [ ] Vercel preview deploys

---
🤖 Shipped with [Claude Code](https://claude.com/claude-code)