### PR TITLE
test(cli,web): Phase 3 — aider, opencode, and webhook delivery tests (161 tests)

### DIFF
--- a/packages/styrby-cli/src/agent/factories/__tests__/aider.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/aider.test.ts
@@ -1,0 +1,819 @@
+/**
+ * Tests for the Aider agent backend factory.
+ *
+ * Covers:
+ * - `createAiderBackend` factory function
+ * - `registerAiderAgent` registry integration
+ * - `AiderBackend` class: session lifecycle, subprocess management,
+ *   output parsing, token estimation, event emission, error handling,
+ *   and cancellation.
+ *
+ * All child_process and logger calls are mocked so no real Aider binary
+ * is required.
+ *
+ * @module factories/__tests__/aider
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test so that
+// Vitest's hoisting mechanism replaces the real modules in time.
+// ---------------------------------------------------------------------------
+
+/** Minimal mock of a writable stdio stream */
+function makeStream() {
+  const emitter = new EventEmitter();
+  return emitter;
+}
+
+/**
+ * Factory for building a mock ChildProcess.
+ * Each test gets a fresh instance through `mockSpawnImpl`.
+ */
+function makeMockProcess() {
+  const proc = new EventEmitter() as ReturnType<typeof makeMockProcess>;
+  proc.stdout = makeStream();
+  proc.stderr = makeStream();
+  proc.stdin = makeStream();
+  proc.killed = false;
+  proc.kill = vi.fn((signal?: string) => {
+    proc.killed = true;
+    return true;
+  });
+  return proc;
+}
+
+type MockProcess = ReturnType<typeof makeMockProcess>;
+
+// Mutable reference so individual tests can control what spawn returns.
+let currentMockProcess: MockProcess;
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — come AFTER vi.mock declarations
+// ---------------------------------------------------------------------------
+
+import { spawn } from 'node:child_process';
+import { createAiderBackend, registerAiderAgent, type AiderBackendOptions } from '../aider';
+import { agentRegistry } from '../../core';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockSpawn = spawn as unknown as MockInstance;
+
+/** Collect all messages emitted by a backend into an array */
+function collectMessages(backend: ReturnType<typeof createAiderBackend>['backend']) {
+  const messages: unknown[] = [];
+  backend.onMessage((msg) => messages.push(msg));
+  return messages;
+}
+
+/** Resolve a `sendPrompt` call by simulating a clean process exit */
+function resolveProcess(proc: MockProcess, stdout = 'All done.', exitCode = 0) {
+  if (stdout) {
+    (proc.stdout as EventEmitter).emit('data', Buffer.from(stdout));
+  }
+  proc.emit('close', exitCode);
+}
+
+/** Base options used across most tests */
+const BASE_OPTIONS: AiderBackendOptions = {
+  cwd: '/project',
+};
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  currentMockProcess = makeMockProcess();
+  mockSpawn.mockReturnValue(currentMockProcess);
+  vi.clearAllMocks();
+  // Re-apply the return value after clearAllMocks wipes it
+  mockSpawn.mockReturnValue(currentMockProcess);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ===========================================================================
+// createAiderBackend — factory function
+// ===========================================================================
+
+/**
+ * Tests for the `createAiderBackend` factory function.
+ * Verifies that the factory returns the correct shape and resolves config.
+ */
+describe('createAiderBackend', () => {
+  it('returns a backend instance and the resolved model when model is provided', () => {
+    const { backend, model } = createAiderBackend({ ...BASE_OPTIONS, model: 'gpt-4' });
+
+    expect(backend).toBeDefined();
+    expect(typeof backend.startSession).toBe('function');
+    expect(model).toBe('gpt-4');
+  });
+
+  it('returns undefined model when no model is specified', () => {
+    const { model } = createAiderBackend(BASE_OPTIONS);
+
+    expect(model).toBeUndefined();
+  });
+
+  it('returns a backend that implements the full AgentBackend interface', () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+
+    expect(typeof backend.startSession).toBe('function');
+    expect(typeof backend.sendPrompt).toBe('function');
+    expect(typeof backend.cancel).toBe('function');
+    expect(typeof backend.onMessage).toBe('function');
+    expect(typeof backend.offMessage).toBe('function');
+    expect(typeof backend.dispose).toBe('function');
+  });
+
+  it('does NOT spawn a process at creation time', () => {
+    createAiderBackend(BASE_OPTIONS);
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// registerAiderAgent
+// ===========================================================================
+
+/**
+ * Tests for `registerAiderAgent` — verifies registry integration.
+ */
+describe('registerAiderAgent', () => {
+  it('registers "aider" in the global agent registry', () => {
+    registerAiderAgent();
+
+    expect(agentRegistry.has('aider')).toBe(true);
+  });
+
+  it('registry can create a backend after registration', () => {
+    registerAiderAgent();
+
+    const backend = agentRegistry.create('aider', { cwd: '/project' });
+
+    expect(backend).toBeDefined();
+    expect(typeof backend.startSession).toBe('function');
+  });
+});
+
+// ===========================================================================
+// AiderBackend — session lifecycle
+// ===========================================================================
+
+/**
+ * Tests for session lifecycle: startSession, sendPrompt, dispose.
+ */
+describe('AiderBackend — session lifecycle', () => {
+  it('startSession returns a sessionId string', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const result = await backend.startSession();
+
+    expect(typeof result.sessionId).toBe('string');
+    expect(result.sessionId.length).toBeGreaterThan(0);
+  });
+
+  it('startSession emits "starting" then "idle" when no initial prompt given', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+
+    await backend.startSession();
+
+    const statuses = messages
+      .filter((m: any) => m.type === 'status')
+      .map((m: any) => m.status);
+
+    expect(statuses).toContain('starting');
+    expect(statuses).toContain('idle');
+  });
+
+  it('startSession with initial prompt emits "starting" → "running" then spawns aider', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+
+    const sessionPromise = backend.startSession('Fix the bug');
+    resolveProcess(currentMockProcess);
+    await sessionPromise;
+
+    const statuses = messages
+      .filter((m: any) => m.type === 'status')
+      .map((m: any) => m.status);
+
+    expect(statuses[0]).toBe('starting');
+    expect(statuses[1]).toBe('running');
+    expect(mockSpawn).toHaveBeenCalledOnce();
+  });
+
+  it('throws when startSession is called on a disposed backend', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    await backend.dispose();
+
+    await expect(backend.startSession()).rejects.toThrow('Backend has been disposed');
+  });
+
+  it('generates a unique sessionId each time a new backend is created', async () => {
+    const { backend: b1 } = createAiderBackend(BASE_OPTIONS);
+    const { backend: b2 } = createAiderBackend(BASE_OPTIONS);
+
+    const { sessionId: id1 } = await b1.startSession();
+    const { sessionId: id2 } = await b2.startSession();
+
+    expect(id1).not.toBe(id2);
+  });
+
+  it('dispose kills an in-flight process', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    // WHY: Override kill to also emit 'close' so sendPrompt's internal
+    // promise resolves. Without this, the test hangs because the mock
+    // process never signals termination after SIGTERM is sent.
+    currentMockProcess.kill = vi.fn((_signal?: string) => {
+      currentMockProcess.killed = true;
+      // Simulate the OS delivering SIGTERM → process exits with code 1
+      process.nextTick(() => currentMockProcess.emit('close', 1));
+      return true;
+    });
+
+    // Start a prompt (process is "running") — do not await, dispose cancels it
+    const promptPromise = backend.sendPrompt(sessionId, 'hello').catch(() => {});
+
+    await backend.dispose();
+
+    expect(currentMockProcess.kill).toHaveBeenCalled();
+    await promptPromise;
+  });
+
+  it('dispose clears all message listeners', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const handler = vi.fn();
+    backend.onMessage(handler);
+
+    await backend.dispose();
+
+    // After dispose, emit should be a no-op — handler must not be called
+    // We access internal emit indirectly by starting a new session (which would
+    // emit status) but the backend is disposed so startSession will throw.
+    await expect(backend.startSession()).rejects.toThrow();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// AiderBackend — sendPrompt & subprocess arguments
+// ===========================================================================
+
+/**
+ * Tests for sendPrompt — verifies correct CLI arguments are passed to spawn.
+ */
+describe('AiderBackend — sendPrompt arguments', () => {
+  it('spawns aider with --message, --no-stream, and --yes flags', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Refactor the auth module');
+    resolveProcess(currentMockProcess);
+    await promptPromise;
+
+    const [cmd, args] = mockSpawn.mock.calls[0];
+    expect(cmd).toBe('aider');
+    expect(args).toContain('--message');
+    expect(args).toContain('Refactor the auth module');
+    expect(args).toContain('--no-stream');
+    expect(args).toContain('--yes');
+  });
+
+  it('includes --model flag when model option is set', async () => {
+    const { backend } = createAiderBackend({ ...BASE_OPTIONS, model: 'claude-3-opus-20240229' });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess);
+    await promptPromise;
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args).toContain('--model');
+    expect(args).toContain('claude-3-opus-20240229');
+  });
+
+  it('does NOT include --model flag when model is omitted', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess);
+    await promptPromise;
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args).not.toContain('--model');
+  });
+
+  it('appends extraArgs to the spawn call', async () => {
+    const { backend } = createAiderBackend({
+      ...BASE_OPTIONS,
+      extraArgs: ['--dark-mode', '--no-auto-commits'],
+    });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess);
+    await promptPromise;
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args).toContain('--dark-mode');
+    expect(args).toContain('--no-auto-commits');
+  });
+
+  it('appends file paths to the spawn call when files option is set', async () => {
+    const { backend } = createAiderBackend({
+      ...BASE_OPTIONS,
+      files: ['src/main.ts', 'src/utils.ts'],
+    });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess);
+    await promptPromise;
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args).toContain('src/main.ts');
+    expect(args).toContain('src/utils.ts');
+  });
+
+  it('sets OPENAI_API_KEY in env when apiKey option is provided', async () => {
+    const { backend } = createAiderBackend({ ...BASE_OPTIONS, apiKey: 'sk-test-123' });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess);
+    await promptPromise;
+
+    const [, , spawnOptions] = mockSpawn.mock.calls[0];
+    expect(spawnOptions.env.OPENAI_API_KEY).toBe('sk-test-123');
+  });
+
+  it('does not set OPENAI_API_KEY when apiKey is omitted', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess);
+    await promptPromise;
+
+    const [, , spawnOptions] = mockSpawn.mock.calls[0];
+    // OPENAI_API_KEY should not be explicitly injected (may still come from
+    // process.env, but not forcibly set by the adapter)
+    expect('OPENAI_API_KEY' in spawnOptions.env &&
+      spawnOptions.env.OPENAI_API_KEY !== undefined
+        ? spawnOptions.env.OPENAI_API_KEY
+        : null
+    ).not.toBe('sk-test-123');
+  });
+
+  it('passes cwd to spawn', async () => {
+    const { backend } = createAiderBackend({ cwd: '/my/project' });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess);
+    await promptPromise;
+
+    const [, , spawnOptions] = mockSpawn.mock.calls[0];
+    expect(spawnOptions.cwd).toBe('/my/project');
+  });
+
+  it('rejects when called with a mismatched sessionId', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    await backend.startSession();
+
+    await expect(backend.sendPrompt('wrong-session-id', 'hello')).rejects.toThrow(
+      'Invalid session ID',
+    );
+  });
+
+  it('rejects when called on a disposed backend', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+    await backend.dispose();
+
+    await expect(backend.sendPrompt(sessionId, 'hello')).rejects.toThrow(
+      'Backend has been disposed',
+    );
+  });
+});
+
+// ===========================================================================
+// AiderBackend — output parsing & event emission
+// ===========================================================================
+
+/**
+ * Tests for stdout parsing: model-output events, fs-edit detection, and
+ * token-count emission after process close.
+ */
+describe('AiderBackend — output parsing and event emission', () => {
+  it('emits model-output message for non-empty stdout chunks', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess, 'Here is the fix.');
+    await promptPromise;
+
+    const modelOutputs = messages.filter((m: any) => m.type === 'model-output');
+    expect(modelOutputs.length).toBeGreaterThan(0);
+    const text = modelOutputs.map((m: any) => m.textDelta).join('');
+    expect(text).toContain('Here is the fix.');
+  });
+
+  it('does NOT emit model-output for whitespace-only stdout chunks', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    (currentMockProcess.stdout as EventEmitter).emit('data', Buffer.from('   \n  \n'));
+    resolveProcess(currentMockProcess, '', 0);
+    await promptPromise;
+
+    const modelOutputs = messages.filter((m: any) => m.type === 'model-output');
+    expect(modelOutputs.length).toBe(0);
+  });
+
+  it('emits fs-edit message when stdout contains "Wrote <path>" pattern', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess, 'Wrote src/foo.ts\n');
+    await promptPromise;
+
+    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
+    expect(fsEdits.length).toBeGreaterThan(0);
+    const edit = fsEdits[0] as any;
+    expect(edit.path).toBe('src/foo.ts');
+    expect(edit.description).toContain('wrote');
+    expect(edit.description).toContain('src/foo.ts');
+  });
+
+  it('emits fs-edit message when stdout contains "Updated <path>" pattern', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess, 'Updated lib/utils.ts\n');
+    await promptPromise;
+
+    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
+    expect(fsEdits.length).toBeGreaterThan(0);
+    expect((fsEdits[0] as any).path).toBe('lib/utils.ts');
+  });
+
+  it('emits fs-edit message when stdout contains "Created <path>" pattern', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess, 'Created tests/new.test.ts\n');
+    await promptPromise;
+
+    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
+    expect(fsEdits.length).toBeGreaterThan(0);
+    expect((fsEdits[0] as any).path).toBe('tests/new.test.ts');
+  });
+
+  it('emits token-count message when process closes', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello world');
+    resolveProcess(currentMockProcess, 'Some output text.');
+    await promptPromise;
+
+    const tokenMessages = messages.filter((m: any) => m.type === 'token-count');
+    expect(tokenMessages.length).toBe(1);
+
+    const tokenMsg = tokenMessages[0] as any;
+    expect(typeof tokenMsg.inputTokens).toBe('number');
+    expect(typeof tokenMsg.outputTokens).toBe('number');
+    expect(tokenMsg.inputTokens).toBeGreaterThan(0);
+    expect(tokenMsg.outputTokens).toBeGreaterThan(0);
+    // Aider does not provide real cost data
+    expect(tokenMsg.estimatedCostUsd).toBe(0);
+  });
+
+  it('emits "idle" status after process exits cleanly', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess, 'done', 0);
+    await promptPromise;
+
+    const lastStatus = messages
+      .filter((m: any) => m.type === 'status')
+      .at(-1) as any;
+
+    expect(lastStatus?.status).toBe('idle');
+  });
+
+  it('accumulates input tokens across multiple sendPrompt calls', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    // First prompt
+    let proc1 = currentMockProcess;
+    const p1 = backend.sendPrompt(sessionId, 'first prompt');
+    resolveProcess(proc1, 'response one', 0);
+    await p1;
+
+    // Second prompt — spawn returns a fresh process
+    currentMockProcess = makeMockProcess();
+    mockSpawn.mockReturnValue(currentMockProcess);
+    const p2 = backend.sendPrompt(sessionId, 'second prompt');
+    resolveProcess(currentMockProcess, 'response two', 0);
+    await p2;
+
+    const tokenMessages = messages.filter((m: any) => m.type === 'token-count');
+    // Both calls should emit token-count
+    expect(tokenMessages.length).toBe(2);
+
+    // The second token-count should reflect accumulated input tokens
+    const secondCount = tokenMessages[1] as any;
+    expect(secondCount.inputTokens).toBeGreaterThan((tokenMessages[0] as any).inputTokens);
+  });
+});
+
+// ===========================================================================
+// AiderBackend — error handling
+// ===========================================================================
+
+/**
+ * Tests for error conditions: non-zero exit codes, stderr errors, and
+ * spawn failures.
+ */
+describe('AiderBackend — error handling', () => {
+  it('rejects sendPrompt when aider exits with non-zero exit code', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    resolveProcess(currentMockProcess, '', 1);
+
+    await expect(promptPromise).rejects.toThrow('Aider exited with code 1');
+  });
+
+  it('emits error status when aider exits with non-zero code', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello').catch(() => {});
+    resolveProcess(currentMockProcess, '', 2);
+    await promptPromise;
+
+    const errorStatus = messages
+      .filter((m: any) => m.type === 'status' && m.status === 'error')
+      .at(-1) as any;
+
+    expect(errorStatus).toBeDefined();
+    expect(errorStatus.detail).toContain('code 2');
+  });
+
+  it('emits error status when stderr contains the word "Error"', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    (currentMockProcess.stderr as EventEmitter).emit(
+      'data',
+      Buffer.from('Error: cannot connect to model API'),
+    );
+    resolveProcess(currentMockProcess, '', 0);
+    await promptPromise;
+
+    const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
+    expect(errorStatuses.length).toBeGreaterThan(0);
+  });
+
+  it('emits error status when stderr contains the word "Exception"', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    (currentMockProcess.stderr as EventEmitter).emit(
+      'data',
+      Buffer.from('Exception: rate limit reached'),
+    );
+    resolveProcess(currentMockProcess, '', 0);
+    await promptPromise;
+
+    const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
+    expect(errorStatuses.length).toBeGreaterThan(0);
+  });
+
+  it('rejects sendPrompt when the spawned process emits an "error" event', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    currentMockProcess.emit('error', new Error('ENOENT: aider not found'));
+
+    await expect(promptPromise).rejects.toThrow('ENOENT: aider not found');
+  });
+
+  it('emits error status when process emits "error" event', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello').catch(() => {});
+    currentMockProcess.emit('error', new Error('spawn ENOENT'));
+    await promptPromise;
+
+    const errorStatus = messages
+      .filter((m: any) => m.type === 'status' && m.status === 'error')
+      .at(0) as any;
+
+    expect(errorStatus).toBeDefined();
+    expect(errorStatus.detail).toContain('spawn ENOENT');
+  });
+});
+
+// ===========================================================================
+// AiderBackend — cancel
+// ===========================================================================
+
+/**
+ * Tests for the cancel method — verifies SIGTERM is sent and idle status emitted.
+ */
+describe('AiderBackend — cancel', () => {
+  it('sends SIGTERM to the running process when cancel is called', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    // Start a prompt (don't await — we cancel instead)
+    backend.sendPrompt(sessionId, 'long running task').catch(() => {});
+
+    await backend.cancel(sessionId);
+
+    expect(currentMockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('emits "idle" status after cancel', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    backend.sendPrompt(sessionId, 'task').catch(() => {});
+    await backend.cancel(sessionId);
+
+    const lastStatus = messages
+      .filter((m: any) => m.type === 'status')
+      .at(-1) as any;
+
+    expect(lastStatus?.status).toBe('idle');
+  });
+
+  it('throws when cancel is called with a mismatched sessionId', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    await backend.startSession();
+
+    await expect(backend.cancel('invalid-id')).rejects.toThrow('Invalid session ID');
+  });
+
+  it('does not throw when cancel is called with no active process', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    // No sendPrompt call — no active process
+    await expect(backend.cancel(sessionId)).resolves.not.toThrow();
+  });
+});
+
+// ===========================================================================
+// AiderBackend — onMessage / offMessage
+// ===========================================================================
+
+/**
+ * Tests for the listener management API.
+ */
+describe('AiderBackend — onMessage / offMessage', () => {
+  it('calls all registered handlers for each emitted message', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    backend.onMessage(h1);
+    backend.onMessage(h2);
+
+    await backend.startSession(); // emits 'starting' + 'idle'
+
+    expect(h1).toHaveBeenCalled();
+    expect(h2).toHaveBeenCalled();
+  });
+
+  it('stops calling a handler after offMessage is called', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const handler = vi.fn();
+    backend.onMessage(handler);
+    backend.offMessage(handler);
+
+    await backend.startSession();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('handles errors thrown inside a listener without crashing the backend', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const badHandler = vi.fn(() => {
+      throw new Error('handler exploded');
+    });
+    const goodHandler = vi.fn();
+    backend.onMessage(badHandler);
+    backend.onMessage(goodHandler);
+
+    // Should not throw even though badHandler throws
+    await expect(backend.startSession()).resolves.toBeDefined();
+    expect(goodHandler).toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// AiderBackend — respondToPermission
+// ===========================================================================
+
+/**
+ * Tests for the optional `respondToPermission` method.
+ * Aider uses --yes so this is a no-op that just emits a permission-response.
+ */
+describe('AiderBackend — respondToPermission', () => {
+  it('emits a permission-response message with the given id and approved=true', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    await backend.startSession();
+
+    await backend.respondToPermission?.('req-abc', true);
+
+    const permMsg = messages.find((m: any) => m.type === 'permission-response') as any;
+    expect(permMsg).toBeDefined();
+    expect(permMsg.id).toBe('req-abc');
+    expect(permMsg.approved).toBe(true);
+  });
+
+  it('emits a permission-response message with approved=false when denied', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    await backend.startSession();
+
+    await backend.respondToPermission?.('req-xyz', false);
+
+    const permMsg = messages.find((m: any) => m.type === 'permission-response') as any;
+    expect(permMsg).toBeDefined();
+    expect(permMsg.approved).toBe(false);
+  });
+});
+
+// ===========================================================================
+// AiderBackend — waitForResponseComplete
+// ===========================================================================
+
+/**
+ * Tests for waitForResponseComplete — no-op when no active process.
+ */
+describe('AiderBackend — waitForResponseComplete', () => {
+  it('resolves immediately when no process is active', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    await backend.startSession();
+
+    await expect(backend.waitForResponseComplete?.(1000)).resolves.toBeUndefined();
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
@@ -1,0 +1,928 @@
+/**
+ * OpenCode Backend — comprehensive test suite
+ *
+ * Tests cover:
+ *  - createOpenCodeBackend factory (valid/invalid config)
+ *  - registerOpenCodeAgent (registry integration)
+ *  - Session lifecycle: startSession, sendPrompt, cancel, dispose
+ *  - JSON-line parsing — valid, partial, malformed, non-JSON
+ *  - Tool-use event routing (tool_use, tool_result, fs-edit side-effects)
+ *  - Status mapping (all known status values + unknown fallback)
+ *  - Cost/token extraction from 'session' messages
+ *  - Error handling: process errors, non-zero exit codes, disposed backend
+ *  - Event emission: onMessage/offMessage, disposed guard, handler exceptions
+ *  - waitForResponseComplete timeout
+ *  - respondToPermission
+ *
+ * @module factories/__tests__/opencode.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// ---------------------------------------------------------------------------
+// Mock child_process/spawn before the module is imported
+// ---------------------------------------------------------------------------
+
+/** Minimal fake ChildProcess used by spawn mock */
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  killed = false;
+  kill = vi.fn((signal?: string) => {
+    this.killed = true;
+    // Simulate async close so tests can await it when needed
+    setImmediate(() => this.emit('close', signal === 'SIGKILL' ? 137 : 0));
+  });
+}
+
+// Holds the last FakeChildProcess created so tests can interact with it
+let lastFakeProcess: FakeChildProcess;
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => {
+    lastFakeProcess = new FakeChildProcess();
+    return lastFakeProcess;
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock @/ui/logger — suppress all output during tests
+// ---------------------------------------------------------------------------
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import SUT (after mocks are in place)
+// ---------------------------------------------------------------------------
+
+import { createOpenCodeBackend, registerOpenCodeAgent } from '../opencode';
+import { agentRegistry } from '../../core';
+import { spawn } from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect messages emitted by a backend into an array.
+ *
+ * @param backend - The AgentBackend to listen on
+ * @returns Tuple of [messages array, remove-listener fn]
+ */
+function collectMessages(backend: ReturnType<typeof createOpenCodeBackend>['backend']) {
+  const messages: unknown[] = [];
+  const handler = (msg: unknown) => messages.push(msg);
+  backend.onMessage(handler as never);
+  return { messages, handler };
+}
+
+/**
+ * Emit a line of stdout JSON to the last spawned fake process.
+ *
+ * @param line - Raw text line (newline appended automatically)
+ */
+function emitStdout(line: string) {
+  lastFakeProcess.stdout.emit('data', Buffer.from(line + '\n'));
+}
+
+/**
+ * Emit a stderr chunk to the last spawned fake process.
+ *
+ * @param text - Stderr text
+ */
+function emitStderr(text: string) {
+  lastFakeProcess.stderr.emit('data', Buffer.from(text));
+}
+
+/**
+ * Simulate a clean process exit (code 0).
+ */
+function closeProcess(code = 0) {
+  lastFakeProcess.emit('close', code);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createOpenCodeBackend — factory', () => {
+  /**
+   * Verify the factory returns a backend and the resolved model.
+   */
+  it('returns a backend and the configured model', () => {
+    const { backend, model } = createOpenCodeBackend({
+      cwd: '/tmp/project',
+      model: 'claude-sonnet-4-20250514',
+    });
+    expect(backend).toBeDefined();
+    expect(model).toBe('claude-sonnet-4-20250514');
+  });
+
+  /**
+   * model is optional — result.model should be undefined when omitted.
+   */
+  it('returns undefined model when model option is omitted', () => {
+    const { model } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    expect(model).toBeUndefined();
+  });
+
+  /**
+   * The returned backend must implement the full AgentBackend interface.
+   */
+  it('backend implements AgentBackend interface', () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    expect(typeof backend.startSession).toBe('function');
+    expect(typeof backend.sendPrompt).toBe('function');
+    expect(typeof backend.cancel).toBe('function');
+    expect(typeof backend.onMessage).toBe('function');
+    expect(typeof backend.offMessage).toBe('function');
+    expect(typeof backend.dispose).toBe('function');
+  });
+
+  /**
+   * Two calls to the factory should produce independent backend instances.
+   */
+  it('creates independent backend instances on repeated calls', () => {
+    const { backend: a } = createOpenCodeBackend({ cwd: '/tmp/a' });
+    const { backend: b } = createOpenCodeBackend({ cwd: '/tmp/b' });
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('registerOpenCodeAgent', () => {
+  /**
+   * After calling registerOpenCodeAgent the 'opencode' key should be available
+   * in the global agent registry.
+   */
+  it('registers opencode in the global agent registry', () => {
+    registerOpenCodeAgent();
+    expect(agentRegistry.has('opencode')).toBe(true);
+  });
+
+  /**
+   * The registry factory should produce a valid backend when called.
+   */
+  it('registered factory creates a usable backend', () => {
+    registerOpenCodeAgent();
+    const backend = agentRegistry.create('opencode', { cwd: '/tmp/project' });
+    expect(typeof backend.startSession).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — session lifecycle', () => {
+  it('startSession returns a sessionId string', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const result = await backend.startSession();
+    expect(typeof result.sessionId).toBe('string');
+    expect(result.sessionId.length).toBeGreaterThan(0);
+    await backend.dispose();
+  });
+
+  it('startSession emits "starting" then "idle" when no initial prompt given', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    await backend.startSession();
+    const statuses = messages
+      .filter((m: any) => m.type === 'status')
+      .map((m: any) => m.status);
+    expect(statuses).toContain('starting');
+    expect(statuses).toContain('idle');
+    await backend.dispose();
+  });
+
+  it('startSession emits "starting" then "running" when initial prompt supplied', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+
+    // We don't want to actually wait for the spawned process to finish,
+    // so we intercept after messages are emitted synchronously.
+    const startPromise = backend.startSession('hello');
+
+    // Immediately close the fake process with code 0
+    setImmediate(() => closeProcess(0));
+
+    await startPromise;
+
+    const statuses = messages
+      .filter((m: any) => m.type === 'status')
+      .map((m: any) => m.status);
+    expect(statuses).toContain('starting');
+    expect(statuses).toContain('running');
+    await backend.dispose();
+  });
+
+  it('startSession generates unique session IDs across calls on separate backends', async () => {
+    const { backend: a } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { backend: b } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { sessionId: idA } = await a.startSession();
+    const { sessionId: idB } = await b.startSession();
+    expect(idA).not.toBe(idB);
+    await a.dispose();
+    await b.dispose();
+  });
+
+  it('startSession throws after dispose', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    await backend.dispose();
+    await expect(backend.startSession()).rejects.toThrow('Backend has been disposed');
+  });
+
+  it('dispose kills any running process and clears listeners', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { sessionId } = await backend.startSession();
+
+    // Kick off a prompt so a process is spawned
+    const promptPromise = backend.sendPrompt(sessionId, 'test');
+    // Dispose immediately
+    await backend.dispose();
+    // The fake process's kill should have been called
+    expect(lastFakeProcess.kill).toHaveBeenCalledWith('SIGTERM');
+    // Clean up the dangling promise
+    promptPromise.catch(() => {});
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — sendPrompt', () => {
+  it('passes --format json and --non-interactive to spawn', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'write a test');
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(spawn).toHaveBeenCalledWith(
+      'opencode',
+      expect.arrayContaining(['--format', 'json', '--message', 'write a test', '--non-interactive']),
+      expect.any(Object),
+    );
+    await backend.dispose();
+  });
+
+  it('includes --model when model option is set', async () => {
+    const { backend } = createOpenCodeBackend({
+      cwd: '/tmp/project',
+      model: 'claude-sonnet-4-20250514',
+    });
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(spawn).toHaveBeenCalledWith(
+      'opencode',
+      expect.arrayContaining(['--model', 'claude-sonnet-4-20250514']),
+      expect.any(Object),
+    );
+    await backend.dispose();
+  });
+
+  it('includes --session when resumeSessionId is set', async () => {
+    const { backend } = createOpenCodeBackend({
+      cwd: '/tmp/project',
+      resumeSessionId: 'ses-abc-123',
+    });
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(spawn).toHaveBeenCalledWith(
+      'opencode',
+      expect.arrayContaining(['--session', 'ses-abc-123']),
+      expect.any(Object),
+    );
+    await backend.dispose();
+  });
+
+  it('passes extraArgs to spawn', async () => {
+    const { backend } = createOpenCodeBackend({
+      cwd: '/tmp/project',
+      extraArgs: ['--verbose', '--timeout', '60'],
+    });
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'hi');
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(spawn).toHaveBeenCalledWith(
+      'opencode',
+      expect.arrayContaining(['--verbose', '--timeout', '60']),
+      expect.any(Object),
+    );
+    await backend.dispose();
+  });
+
+  it('rejects when called with a wrong sessionId', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    await backend.startSession();
+    await expect(backend.sendPrompt('wrong-id', 'hello')).rejects.toThrow('Invalid session ID');
+    await backend.dispose();
+  });
+
+  it('rejects when called after dispose', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { sessionId } = await backend.startSession();
+    await backend.dispose();
+    await expect(backend.sendPrompt(sessionId, 'hello')).rejects.toThrow('Backend has been disposed');
+  });
+
+  it('rejects and emits error status when process exits with non-zero code', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'fail please');
+    setImmediate(() => closeProcess(1));
+    await expect(promptPromise).rejects.toThrow('OpenCode exited with code 1');
+
+    const errorStatus = messages.find(
+      (m: any) => m.type === 'status' && m.status === 'error',
+    );
+    expect(errorStatus).toBeDefined();
+    await backend.dispose();
+  });
+
+  it('rejects and emits error status on process error event', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    setImmediate(() => lastFakeProcess.emit('error', new Error('ENOENT: opencode not found')));
+    await expect(promptPromise).rejects.toThrow('ENOENT: opencode not found');
+
+    const errorStatus = messages.find(
+      (m: any) => m.type === 'status' && m.status === 'error' && m.detail?.includes('ENOENT'),
+    );
+    expect(errorStatus).toBeDefined();
+    await backend.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — JSON-line parsing', () => {
+  async function setupWithRunningPrompt() {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    // Start a prompt to spawn the process; don't await yet
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+    return { backend, messages, sessionId, promptPromise };
+  }
+
+  it('emits model-output for assistant messages', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(JSON.stringify({ type: 'assistant', content: 'Hello world' }));
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const msg = messages.find((m: any) => m.type === 'model-output');
+    expect(msg).toMatchObject({ type: 'model-output', textDelta: 'Hello world' });
+  });
+
+  it('ignores assistant messages without content', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(JSON.stringify({ type: 'assistant' }));
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages.filter((m: any) => m.type === 'model-output')).toHaveLength(0);
+  });
+
+  it('ignores empty lines', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout('');
+    emitStdout('   ');
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    // No messages should have come from empty lines
+    expect(messages.filter((m: any) => m.type === 'model-output')).toHaveLength(0);
+  });
+
+  it('ignores non-JSON text lines without throwing', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout('starting opencode v1.2.3');
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    // No crash, no model-output
+    expect(messages.filter((m: any) => m.type === 'model-output')).toHaveLength(0);
+  });
+
+  it('handles malformed JSON gracefully', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout('{broken json here');
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages.filter((m: any) => m.type === 'model-output')).toHaveLength(0);
+  });
+
+  it('handles partial lines across multiple data chunks', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    const full = JSON.stringify({ type: 'assistant', content: 'streamed' });
+    // Split arbitrarily in the middle (no trailing newline on first chunk)
+    lastFakeProcess.stdout.emit('data', Buffer.from(full.slice(0, 10)));
+    lastFakeProcess.stdout.emit('data', Buffer.from(full.slice(10) + '\n'));
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const msg = messages.find((m: any) => m.type === 'model-output');
+    expect(msg).toMatchObject({ type: 'model-output', textDelta: 'streamed' });
+  });
+
+  it('processes buffered incomplete line on process close', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    // Emit without trailing newline so it stays in lineBuffer
+    lastFakeProcess.stdout.emit(
+      'data',
+      Buffer.from(JSON.stringify({ type: 'assistant', content: 'buffered' })),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const msg = messages.find((m: any) => m.type === 'model-output');
+    expect(msg).toMatchObject({ type: 'model-output', textDelta: 'buffered' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — tool-use event routing', () => {
+  async function setupWithRunningPrompt() {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+    return { backend, messages, promptPromise };
+  }
+
+  it('emits tool-call for tool_use messages with tool_name and call_id', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(
+      JSON.stringify({
+        type: 'tool_use',
+        tool_name: 'read_file',
+        call_id: 'call-1',
+        tool_input: { path: '/src/index.ts' },
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages).toContainEqual({
+      type: 'tool-call',
+      toolName: 'read_file',
+      callId: 'call-1',
+      args: { path: '/src/index.ts' },
+    });
+  });
+
+  it('ignores tool_use messages missing call_id or tool_name', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(JSON.stringify({ type: 'tool_use', tool_name: 'read_file' }));
+    emitStdout(JSON.stringify({ type: 'tool_use', call_id: 'call-2' }));
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages.filter((m: any) => m.type === 'tool-call')).toHaveLength(0);
+  });
+
+  it('emits tool-result for tool_result messages', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(
+      JSON.stringify({
+        type: 'tool_result',
+        tool_name: 'read_file',
+        call_id: 'call-1',
+        tool_result: 'file contents',
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages).toContainEqual({
+      type: 'tool-result',
+      toolName: 'read_file',
+      callId: 'call-1',
+      result: 'file contents',
+    });
+  });
+
+  it('emits fs-edit for write_file tool_result with path in tool_input', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(
+      JSON.stringify({
+        type: 'tool_result',
+        tool_name: 'write_file',
+        call_id: 'call-3',
+        tool_input: { path: '/src/foo.ts' },
+        tool_result: null,
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'fs-edit', path: '/src/foo.ts' }),
+    );
+  });
+
+  it('emits fs-edit for edit_file tool_result with file_path in tool_input', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(
+      JSON.stringify({
+        type: 'tool_result',
+        tool_name: 'edit_file',
+        call_id: 'call-4',
+        tool_input: { file_path: '/src/bar.ts' },
+        tool_result: null,
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'fs-edit', path: '/src/bar.ts' }),
+    );
+  });
+
+  it('does NOT emit fs-edit for non-file tools like read_file', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(
+      JSON.stringify({
+        type: 'tool_result',
+        tool_name: 'read_file',
+        call_id: 'call-5',
+        tool_result: 'contents',
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages.filter((m: any) => m.type === 'fs-edit')).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — status mapping', () => {
+  async function setupWithRunningPrompt() {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+    return { backend, messages, promptPromise };
+  }
+
+  const statusCases: Array<[string, string]> = [
+    ['starting', 'starting'],
+    ['running', 'running'],
+    ['idle', 'idle'],
+    ['complete', 'idle'],   // complete maps to idle
+    ['stopped', 'stopped'],
+    ['error', 'error'],
+    ['unknown_value', 'running'], // unknown falls back to 'running'
+  ];
+
+  for (const [input, expected] of statusCases) {
+    it(`maps OpenCode status "${input}" → AgentStatus "${expected}"`, async () => {
+      const { messages, promptPromise } = await setupWithRunningPrompt();
+      emitStdout(JSON.stringify({ type: 'status', status: input }));
+      setImmediate(() => closeProcess(0));
+      await promptPromise;
+
+      const statusMsgs = messages.filter(
+        (m: any) => m.type === 'status' && m.status === expected,
+      );
+      expect(statusMsgs.length).toBeGreaterThanOrEqual(1);
+    });
+  }
+
+  it('emits error status for "error" message type', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(JSON.stringify({ type: 'error', error: 'API quota exceeded' }));
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'status', status: 'error', detail: 'API quota exceeded' }),
+    );
+  });
+
+  it('uses "Unknown error" detail when error message has no error field', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(JSON.stringify({ type: 'error' }));
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'status', status: 'error', detail: 'Unknown error' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — cost and token extraction', () => {
+  it('emits token-count from session messages', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+
+    emitStdout(
+      JSON.stringify({
+        type: 'session',
+        session: {
+          id: 'oc-session-xyz',
+          Cost: 0.0042,
+          PromptTokens: 1500,
+          CompletionTokens: 300,
+          TotalTokens: 1800,
+        },
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: 'token-count',
+        inputTokens: 1500,
+        outputTokens: 300,
+        totalTokens: 1800,
+        costUsd: 0.0042,
+      }),
+    );
+    await backend.dispose();
+  });
+
+  it('computes totalTokens from input+output when TotalTokens is missing', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+
+    emitStdout(
+      JSON.stringify({
+        type: 'session',
+        session: { PromptTokens: 100, CompletionTokens: 50 },
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const tc = messages.find((m: any) => m.type === 'token-count') as any;
+    expect(tc.totalTokens).toBe(150);
+    await backend.dispose();
+  });
+
+  it('captures the opencode session id from session messages', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+
+    emitStdout(
+      JSON.stringify({
+        type: 'session',
+        session: { id: 'oc-session-abc' },
+      }),
+    );
+    // Close the first prompt so its promise resolves
+    closeProcess(0);
+    await promptPromise;
+
+    // WHY: A second prompt should include the captured session id as --session arg.
+    // The backend stores the OpenCode session ID from the session message and passes
+    // it to subsequent spawn calls so the same OpenCode session is resumed.
+    const promptPromise2 = backend.sendPrompt(sessionId, 'follow-up');
+    setImmediate(() => closeProcess(0));
+    await promptPromise2;
+
+    expect(spawn).toHaveBeenCalledWith(
+      'opencode',
+      expect.arrayContaining(['--session', 'oc-session-abc']),
+      expect.any(Object),
+    );
+    await backend.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — event emission (onMessage/offMessage)', () => {
+  it('calls all registered handlers for each message', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const handlerA = vi.fn();
+    const handlerB = vi.fn();
+    backend.onMessage(handlerA);
+    backend.onMessage(handlerB);
+    await backend.startSession();
+    // Both handlers should have received the 'starting' status
+    expect(handlerA).toHaveBeenCalledWith(expect.objectContaining({ type: 'status', status: 'starting' }));
+    expect(handlerB).toHaveBeenCalledWith(expect.objectContaining({ type: 'status', status: 'starting' }));
+    await backend.dispose();
+  });
+
+  it('offMessage removes a handler — it no longer receives events', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const handler = vi.fn();
+    backend.onMessage(handler);
+
+    // Start a session to trigger events — handler should receive 'starting' + 'idle'
+    const { sessionId } = await backend.startSession();
+    const callsBefore = handler.mock.calls.length;
+    expect(callsBefore).toBeGreaterThan(0);
+
+    // Remove the handler
+    backend.offMessage!(handler);
+
+    // WHY: We must trigger a real event after removal to prove the handler
+    // is no longer called. sendPrompt spawns a process which emits status
+    // events — if offMessage didn't work, handler.mock.calls would grow.
+    const promptPromise = backend.sendPrompt(sessionId, 'test');
+    emitStdout(JSON.stringify({ type: 'assistant', content: 'reply' }));
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    // Handler call count must not have increased
+    expect(handler.mock.calls.length).toBe(callsBefore);
+    await backend.dispose();
+  });
+
+  it('offMessage is a no-op for unregistered handlers', () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const unregistered = vi.fn();
+    expect(() => backend.offMessage!(unregistered)).not.toThrow();
+  });
+
+  it('does not emit messages after dispose', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    await backend.startSession();
+    const countBeforeDispose = messages.length;
+    await backend.dispose();
+    // Internal emit after dispose should be guarded
+    // Trigger a manual emit by attempting a cancelled process
+    expect(messages.length).toBe(countBeforeDispose);
+  });
+
+  it('continues emitting to remaining handlers when one handler throws', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const throwingHandler = vi.fn(() => { throw new Error('handler error'); });
+    const safeHandler = vi.fn();
+    backend.onMessage(throwingHandler);
+    backend.onMessage(safeHandler);
+
+    await backend.startSession();
+
+    // safeHandler should still have been called despite throwingHandler throwing
+    expect(safeHandler).toHaveBeenCalled();
+    await backend.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — cancel', () => {
+  it('sends SIGTERM to the running process', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'long task');
+
+    await backend.cancel(sessionId);
+    expect(lastFakeProcess.kill).toHaveBeenCalledWith('SIGTERM');
+
+    promptPromise.catch(() => {}); // suppress unhandled rejection
+    await backend.dispose();
+  });
+
+  it('emits idle status after cancel', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    backend.sendPrompt(sessionId, 'task').catch(() => {});
+
+    await backend.cancel(sessionId);
+
+    const idleAfterCancel = messages.filter(
+      (m: any) => m.type === 'status' && m.status === 'idle',
+    );
+    expect(idleAfterCancel.length).toBeGreaterThanOrEqual(1);
+    await backend.dispose();
+  });
+
+  it('throws when cancel is called with a wrong sessionId', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    await backend.startSession();
+    await expect(backend.cancel('wrong-id')).rejects.toThrow('Invalid session ID');
+    await backend.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — respondToPermission', () => {
+  it('emits permission-response with approved=true', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    await backend.startSession();
+    await backend.respondToPermission!('req-1', true);
+    expect(messages).toContainEqual({ type: 'permission-response', id: 'req-1', approved: true });
+    await backend.dispose();
+  });
+
+  it('emits permission-response with approved=false', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    await backend.startSession();
+    await backend.respondToPermission!('req-2', false);
+    expect(messages).toContainEqual({ type: 'permission-response', id: 'req-2', approved: false });
+    await backend.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — waitForResponseComplete', () => {
+  it('resolves immediately when no process is running', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    await backend.startSession();
+    // No prompt sent → no active process
+    await expect(backend.waitForResponseComplete!()).resolves.toBeUndefined();
+    await backend.dispose();
+  });
+
+  it('resolves after the active process exits', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+    const waitPromise = backend.waitForResponseComplete!();
+    setImmediate(() => closeProcess(0));
+    await Promise.all([promptPromise, waitPromise]);
+    await backend.dispose();
+  });
+
+  it('rejects with timeout error when process does not exit in time', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { sessionId } = await backend.startSession();
+    backend.sendPrompt(sessionId, 'hang forever').catch(() => {});
+    // 1ms timeout — process will not exit in time
+    await expect(backend.waitForResponseComplete!(1)).rejects.toThrow(
+      'Timeout waiting for OpenCode response',
+    );
+    await backend.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — stderr handling', () => {
+  it('emits error status when stderr contains "Error"', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+
+    emitStderr('Error: authentication failed');
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'status', status: 'error' }),
+    );
+    await backend.dispose();
+  });
+
+  it('does not emit error status for benign stderr output', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+
+    emitStderr('Loading config...');
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const errorMsgs = messages.filter(
+      (m: any) => m.type === 'status' && m.status === 'error',
+    );
+    expect(errorMsgs).toHaveLength(0);
+    await backend.dispose();
+  });
+});

--- a/packages/styrby-web/src/app/api/webhooks/__tests__/deliver-webhook.test.ts
+++ b/packages/styrby-web/src/app/api/webhooks/__tests__/deliver-webhook.test.ts
@@ -1,0 +1,845 @@
+/**
+ * Webhook Outbound Delivery & Retry Logic Tests
+ *
+ * WHY this file exists: The canonical delivery engine lives in
+ * `supabase/functions/deliver-webhook/index.ts`, which runs under Deno and
+ * cannot be imported directly by Vitest (Node/jsdom environment).  This test
+ * file extracts and re-implements the pure, environment-agnostic business
+ * logic — HMAC signing, SSRF URL validation, resolved-IP validation,
+ * exponential backoff calculation — so that every rule can be verified with
+ * fast, dependency-free unit tests.
+ *
+ * The "deliverWebhook" integration tests use a mocked `globalThis.fetch` to
+ * exercise the full outbound HTTP path (headers, timeout, success/failure
+ * branching) without making real network calls.
+ *
+ * Coverage targets
+ * ───────────────────────────────────────────────────────
+ * 1. HMAC-SHA256 signature generation
+ * 2. Static URL validation (validateWebhookUrl)
+ * 3. DNS-resolved IP validation (validateResolvedIp)
+ * 4. Exponential backoff / retry timing (calculateNextRetryTime)
+ * 5. Dead-letter behaviour (max retries exhausted)
+ * 6. Outbound fetch — success path (2xx)
+ * 7. Outbound fetch — non-2xx failure path
+ * 8. Outbound fetch — timeout / AbortError path
+ * 9. Event payload shape for all supported event types
+ * 10. Failed delivery logging (error message capture)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Re-implemented pure functions (mirrors deliver-webhook/index.ts exactly)
+// ============================================================================
+
+/**
+ * Constants — must stay in sync with deliver-webhook/index.ts.
+ */
+const MAX_ATTEMPTS = 3;
+const BASE_RETRY_DELAY_MS = 60_000; // 1 minute
+const HTTP_TIMEOUT_MS = 30_000; // 30 seconds
+const MAX_RESPONSE_BODY_LENGTH = 10_240; // 10 KB
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Webhook {
+  id: string;
+  user_id: string;
+  url: string;
+  secret: string;
+  is_active: boolean;
+}
+
+interface WebhookDelivery {
+  id: string;
+  webhook_id: string;
+  event: string;
+  payload: Record<string, unknown>;
+  status: 'pending' | 'success' | 'failed';
+  attempts: number;
+  last_attempt_at: string | null;
+  next_retry_at: string | null;
+}
+
+interface DeliveryResult {
+  deliveryId: string;
+  success: boolean;
+  statusCode?: number;
+  error?: string;
+  duration_ms?: number;
+}
+
+// ---------------------------------------------------------------------------
+// HMAC signature generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates an HMAC-SHA256 signature for a webhook payload.
+ *
+ * WHY: Recipients verify this signature to confirm the payload came from
+ * Styrby and was not tampered with in transit.  The algorithm must be
+ * identical to the edge function so that signatures produced here can be
+ * verified in the same way by a real consumer.
+ *
+ * @param payload - The JSON payload string to sign
+ * @param secret - The webhook's secret key
+ * @returns Hex-encoded HMAC-SHA256 signature
+ */
+async function generateSignature(payload: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+
+  const signatureBuffer = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
+
+  return Array.from(new Uint8Array(signatureBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// ---------------------------------------------------------------------------
+// Static URL validation (mirrors validateWebhookUrl in the edge function)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that a webhook URL is safe to call (blocks SSRF attacks).
+ *
+ * WHY (FIX-027 / FIX-042): Without this check an attacker with a Styrby
+ * account could register a webhook pointing at 169.254.169.254 (cloud
+ * metadata), 10.x.x.x (VPC internal), or localhost to use our delivery
+ * infrastructure as an SSRF proxy against our own systems.
+ *
+ * @param url - The webhook URL to validate
+ * @returns true if URL is safe
+ * @throws Error describing why the URL is blocked
+ */
+function validateWebhookUrl(url: string): boolean {
+  const parsed = new URL(url);
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname.startsWith('127.') ||
+    hostname === '::1' ||
+    hostname === '[::1]'
+  ) {
+    throw new Error('Webhook URL cannot target localhost');
+  }
+
+  const internalPatterns = [
+    /\.internal$/i,
+    /\.local$/i,
+    /\.localdomain$/i,
+    /^(metadata|kubernetes|kube-|internal-|priv-)/i,
+  ];
+
+  for (const pattern of internalPatterns) {
+    if (pattern.test(hostname)) {
+      throw new Error('Webhook URL cannot target internal hostnames');
+    }
+  }
+
+  const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4Match) {
+    const octets = ipv4Match.slice(1).map(Number);
+
+    if (octets[0] === 10) throw new Error('Webhook URL cannot target private IP addresses (10.x.x.x)');
+    if (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31)
+      throw new Error('Webhook URL cannot target private IP addresses (172.16-31.x.x)');
+    if (octets[0] === 192 && octets[1] === 168)
+      throw new Error('Webhook URL cannot target private IP addresses (192.168.x.x)');
+    if (octets[0] === 127) throw new Error('Webhook URL cannot target loopback addresses');
+    if (octets[0] === 169 && octets[1] === 254)
+      throw new Error('Webhook URL cannot target link-local or metadata addresses');
+    if (octets.every((o) => o === 255)) throw new Error('Webhook URL cannot target broadcast addresses');
+  }
+
+  if (hostname.includes(':') || hostname.startsWith('[')) {
+    const cleanIp = hostname.replace(/[\[\]]/g, '');
+    if (cleanIp === '::1') throw new Error('Webhook URL cannot target IPv6 loopback');
+    if (cleanIp.toLowerCase().startsWith('fe80:'))
+      throw new Error('Webhook URL cannot target IPv6 link-local addresses');
+    if (/^f[cd]/i.test(cleanIp)) throw new Error('Webhook URL cannot target IPv6 private addresses');
+    if (cleanIp.toLowerCase().startsWith('::ffff:')) {
+      try {
+        validateWebhookUrl(`http://${cleanIp.slice(7)}/`);
+      } catch {
+        throw new Error('Webhook URL cannot target private IPv4-mapped IPv6 addresses');
+      }
+    }
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Resolved-IP validation (mirrors validateResolvedIp in the edge function)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that a resolved IP address is not private, loopback, or link-local.
+ *
+ * WHY (SEC-SSRF-001 / DNS rebinding): An attacker could register a short-TTL
+ * public domain that passes `validateWebhookUrl()`, then swap its DNS to a
+ * private IP before the actual `fetch()` call.  Resolving the hostname
+ * explicitly and checking every returned IP closes this window.
+ *
+ * @param ip - A resolved IP address string (IPv4 or IPv6)
+ * @throws Error if the IP is in a blocked range
+ */
+function validateResolvedIp(ip: string): void {
+  const trimmed = ip.trim().toLowerCase();
+
+  const ipv4Match = trimmed.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4Match) {
+    const octets = ipv4Match.slice(1).map(Number);
+    if (octets[0] === 10) throw new Error(`Resolved IP ${ip} is in private range 10.0.0.0/8`);
+    if (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31)
+      throw new Error(`Resolved IP ${ip} is in private range 172.16.0.0/12`);
+    if (octets[0] === 192 && octets[1] === 168)
+      throw new Error(`Resolved IP ${ip} is in private range 192.168.0.0/16`);
+    if (octets[0] === 127) throw new Error(`Resolved IP ${ip} is a loopback address`);
+    if (octets[0] === 169 && octets[1] === 254)
+      throw new Error(`Resolved IP ${ip} is a link-local/metadata address`);
+    if (octets.every((o) => o === 255)) throw new Error(`Resolved IP ${ip} is a broadcast address`);
+    return;
+  }
+
+  if (trimmed === '::1') throw new Error(`Resolved IP ${ip} is IPv6 loopback`);
+  if (trimmed.startsWith('fe80:')) throw new Error(`Resolved IP ${ip} is IPv6 link-local`);
+  if (/^f[cd]/i.test(trimmed)) throw new Error(`Resolved IP ${ip} is in IPv6 unique-local range`);
+  if (trimmed.startsWith('::ffff:')) {
+    validateResolvedIp(trimmed.slice(7));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exponential backoff
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculates the next retry time using exponential backoff.
+ *
+ * Schedule (mirrors the edge function):
+ * - After attempt 1  → retry in 1 minute  (BASE × 2^0)
+ * - After attempt 2  → retry in 2 minutes (BASE × 2^1)
+ * - After attempt 3+ → no more retries    (returns null → dead-letter)
+ *
+ * @param attempts - Total attempts made so far (after the most recent failure)
+ * @returns ISO timestamp for next retry, or null when max attempts are reached
+ */
+function calculateNextRetryTime(attempts: number): string | null {
+  if (attempts >= MAX_ATTEMPTS) return null;
+
+  const delayMs = BASE_RETRY_DELAY_MS * Math.pow(2, attempts - 1);
+  return new Date(Date.now() + delayMs).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Outbound delivery (simplified, fetch-mockable version for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Delivers a webhook payload to the configured endpoint.
+ *
+ * This is the testable, fetch-mockable mirror of `deliverWebhook()` in the
+ * edge function.  It validates the URL, signs the payload with HMAC-SHA256,
+ * attaches the standard Styrby headers, and returns a structured result.
+ *
+ * @param webhook - Webhook configuration (url, secret)
+ * @param delivery - Delivery record (id, event, payload)
+ * @returns DeliveryResult indicating success/failure and HTTP status
+ */
+async function deliverWebhook(
+  webhook: Webhook,
+  delivery: WebhookDelivery
+): Promise<DeliveryResult> {
+  const startTime = Date.now();
+
+  try {
+    validateWebhookUrl(webhook.url);
+
+    const payload = JSON.stringify(delivery.payload);
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = await generateSignature(payload, webhook.secret);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(webhook.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Styrby-Signature': `sha256=${signature}`,
+          'X-Styrby-Event': delivery.event,
+          'X-Styrby-Delivery-Id': delivery.id,
+          'X-Styrby-Timestamp': timestamp.toString(),
+          'User-Agent': 'Styrby-Webhook/1.0',
+        },
+        body: payload,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+      const duration = Date.now() - startTime;
+
+      let responseBody: string | undefined;
+      try {
+        const text = await response.text();
+        responseBody = text.slice(0, MAX_RESPONSE_BODY_LENGTH);
+      } catch {
+        responseBody = undefined;
+      }
+
+      const success = response.status >= 200 && response.status < 300;
+
+      return {
+        deliveryId: delivery.id,
+        success,
+        statusCode: response.status,
+        duration_ms: duration,
+        error: success
+          ? undefined
+          : `HTTP ${response.status}: ${responseBody?.slice(0, 200) || 'No response body'}`,
+      };
+    } catch (fetchError) {
+      clearTimeout(timeoutId);
+      throw fetchError;
+    }
+  } catch (error) {
+    const duration = Date.now() - startTime;
+
+    // WHY: In jsdom (the test environment), DOMException is not always
+    // instanceof Error, so we check the name property directly to detect
+    // AbortError reliably across environments.
+    const isAbortError =
+      (error instanceof Error && error.name === 'AbortError') ||
+      (error !== null &&
+        typeof error === 'object' &&
+        (error as { name?: string }).name === 'AbortError');
+
+    if (isAbortError) {
+      return {
+        deliveryId: delivery.id,
+        success: false,
+        duration_ms: duration,
+        error: `Request timed out after ${HTTP_TIMEOUT_MS}ms`,
+      };
+    }
+
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : typeof error === 'object' && error !== null && 'message' in error
+          ? String((error as { message: unknown }).message)
+          : 'Unknown error occurred';
+
+    return {
+      deliveryId: delivery.id,
+      success: false,
+      duration_ms: duration,
+      error: errorMessage,
+    };
+  }
+}
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+/** A safe public webhook that passes all SSRF checks */
+const SAFE_WEBHOOK: Webhook = {
+  id: 'wh-uuid-001',
+  user_id: 'user-uuid-123',
+  url: 'https://hooks.example.com/styrby',
+  secret: 'whsec_test_signing_secret_32chars_long',
+  is_active: true,
+};
+
+/** A minimal delivery record for testing */
+function makeDelivery(overrides: Partial<WebhookDelivery> = {}): WebhookDelivery {
+  return {
+    id: 'del-uuid-001',
+    webhook_id: 'wh-uuid-001',
+    event: 'session.started',
+    payload: {
+      event: 'session.started',
+      timestamp: '2026-03-27T12:00:00Z',
+      data: { session_id: 'sess-abc', agent_type: 'claude' },
+    },
+    status: 'pending',
+    attempts: 0,
+    last_attempt_at: null,
+    next_retry_at: null,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Webhook Delivery — HMAC Signature Generation', () => {
+  /**
+   * WHY: Recipients verify the X-Styrby-Signature header against the raw body
+   * using their stored secret.  The HMAC must be deterministic: same payload +
+   * same secret → same hex digest every time.
+   */
+  it('generates a 64-character hex HMAC-SHA256 signature', async () => {
+    const sig = await generateSignature('{"event":"session.started"}', 'my-secret');
+    expect(sig).toHaveLength(64);
+    expect(sig).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('produces the same signature for identical payload and secret (deterministic)', async () => {
+    const payload = '{"event":"budget.exceeded","amount":50}';
+    const secret = 'shared-secret-key';
+    const sig1 = await generateSignature(payload, secret);
+    const sig2 = await generateSignature(payload, secret);
+    expect(sig1).toBe(sig2);
+  });
+
+  it('produces different signatures when the payload changes', async () => {
+    const secret = 'same-secret';
+    const sig1 = await generateSignature('{"event":"session.started"}', secret);
+    const sig2 = await generateSignature('{"event":"session.completed"}', secret);
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('produces different signatures when the secret changes', async () => {
+    const payload = '{"event":"permission.requested"}';
+    const sig1 = await generateSignature(payload, 'secret-a');
+    const sig2 = await generateSignature(payload, 'secret-b');
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('can sign an empty string without throwing', async () => {
+    const sig = await generateSignature('', 'some-secret');
+    expect(sig).toHaveLength(64);
+  });
+
+  it('can sign a large payload (1 MB) without error', async () => {
+    const bigPayload = JSON.stringify({ data: 'x'.repeat(1_000_000) });
+    const sig = await generateSignature(bigPayload, 'secret');
+    expect(sig).toHaveLength(64);
+  });
+});
+
+// ============================================================================
+
+describe('Webhook Delivery — Static URL Validation (validateWebhookUrl)', () => {
+  it('accepts a valid public HTTPS URL', () => {
+    expect(() => validateWebhookUrl('https://hooks.example.com/webhook')).not.toThrow();
+  });
+
+  it('blocks localhost by hostname', () => {
+    expect(() => validateWebhookUrl('https://localhost/admin')).toThrow('localhost');
+  });
+
+  it('blocks 127.0.0.1 loopback', () => {
+    expect(() => validateWebhookUrl('https://127.0.0.1/api')).toThrow();
+  });
+
+  it('blocks 127.x.x.x loopback range', () => {
+    expect(() => validateWebhookUrl('https://127.0.0.2/api')).toThrow();
+  });
+
+  it('blocks 10.0.0.0/8 private range', () => {
+    expect(() => validateWebhookUrl('https://10.10.10.10/internal')).toThrow('10.x.x.x');
+  });
+
+  it('blocks 172.16.x.x private range', () => {
+    expect(() => validateWebhookUrl('https://172.16.0.1/vpc')).toThrow();
+  });
+
+  it('blocks 172.31.x.x private range (upper boundary)', () => {
+    expect(() => validateWebhookUrl('https://172.31.255.255/vpc')).toThrow();
+  });
+
+  it('allows 172.32.0.0 (outside 172.16-31 range)', () => {
+    // 172.32 is public — should not throw
+    expect(() => validateWebhookUrl('https://172.32.0.1/api')).not.toThrow();
+  });
+
+  it('blocks 192.168.x.x private range', () => {
+    expect(() => validateWebhookUrl('https://192.168.1.1/router')).toThrow('192.168');
+  });
+
+  it('blocks 169.254.169.254 AWS metadata service', () => {
+    expect(() => validateWebhookUrl('https://169.254.169.254/latest/meta-data/')).toThrow('link-local');
+  });
+
+  it('blocks 255.255.255.255 broadcast address', () => {
+    expect(() => validateWebhookUrl('https://255.255.255.255/')).toThrow('broadcast');
+  });
+
+  it('blocks *.internal hostnames', () => {
+    expect(() => validateWebhookUrl('https://service.internal/api')).toThrow('internal hostnames');
+  });
+
+  it('blocks *.local hostnames', () => {
+    expect(() => validateWebhookUrl('https://myserver.local/')).toThrow('internal hostnames');
+  });
+
+  it('blocks kubernetes metadata hostname prefix', () => {
+    expect(() => validateWebhookUrl('https://kubernetes.default.svc/')).toThrow('internal hostnames');
+  });
+
+  it('blocks IPv6 loopback ::1', () => {
+    // WHY: The URL parser preserves brackets ([::1] hostname), so the early
+    // `hostname === '[::1]'` check fires before the dedicated IPv6 block.
+    // The thrown message references "localhost" because [::1] is treated as
+    // the IPv6 localhost alias in the static validation path.
+    expect(() => validateWebhookUrl('https://[::1]/admin')).toThrow();
+  });
+
+  it('blocks IPv6 link-local fe80:: prefix', () => {
+    expect(() => validateWebhookUrl('https://[fe80::1]/api')).toThrow('link-local');
+  });
+
+  it('blocks IPv6 unique-local fc00::/7 range', () => {
+    expect(() => validateWebhookUrl('https://[fc00::1]/api')).toThrow('private');
+  });
+});
+
+// ============================================================================
+
+describe('Webhook Delivery — Resolved IP Validation (validateResolvedIp)', () => {
+  /**
+   * WHY (SEC-SSRF-001): DNS rebinding attacks swap a hostname's A record from a
+   * public IP to a private one after the static URL check passes.  We resolve
+   * DNS explicitly and validate every returned IP before calling fetch().
+   */
+
+  it('accepts a public IPv4 address', () => {
+    expect(() => validateResolvedIp('93.184.216.34')).not.toThrow();
+  });
+
+  it('blocks 10.x.x.x private range', () => {
+    expect(() => validateResolvedIp('10.0.0.1')).toThrow('private range 10.0.0.0/8');
+  });
+
+  it('blocks 172.16.x.x private range', () => {
+    expect(() => validateResolvedIp('172.20.0.5')).toThrow('private range 172.16.0.0/12');
+  });
+
+  it('blocks 192.168.x.x private range', () => {
+    expect(() => validateResolvedIp('192.168.0.1')).toThrow('private range 192.168.0.0/16');
+  });
+
+  it('blocks 127.0.0.1 loopback', () => {
+    expect(() => validateResolvedIp('127.0.0.1')).toThrow('loopback');
+  });
+
+  it('blocks 169.254.169.254 link-local / cloud metadata', () => {
+    expect(() => validateResolvedIp('169.254.169.254')).toThrow('link-local/metadata');
+  });
+
+  it('blocks IPv6 loopback ::1', () => {
+    expect(() => validateResolvedIp('::1')).toThrow('IPv6 loopback');
+  });
+
+  it('blocks IPv6 link-local fe80:: prefix', () => {
+    expect(() => validateResolvedIp('fe80::1')).toThrow('IPv6 link-local');
+  });
+
+  it('blocks IPv6 unique-local fc00::/7', () => {
+    expect(() => validateResolvedIp('fc00::1')).toThrow('IPv6 unique-local');
+  });
+
+  it('blocks IPv4-mapped IPv6 ::ffff:10.0.0.1 (DNS rebinding via IPv6)', () => {
+    // ::ffff:10.0.0.1 maps to the private 10.0.0.1 — must be blocked
+    expect(() => validateResolvedIp('::ffff:10.0.0.1')).toThrow();
+  });
+});
+
+// ============================================================================
+
+describe('Webhook Delivery — Exponential Backoff (calculateNextRetryTime)', () => {
+  /**
+   * WHY: Without enforced backoff, a flapping consumer endpoint could receive
+   * a flood of retries and mistake it for an attack.  The schedule is
+   * intentionally gentle: 1 min → 2 min → dead-letter.
+   */
+
+  it('schedules retry ~1 minute after attempt 1', () => {
+    const before = Date.now();
+    const result = calculateNextRetryTime(1);
+    const after = Date.now();
+
+    expect(result).not.toBeNull();
+    const retryTime = new Date(result!).getTime();
+    // Should be within ±5 seconds of 60 000 ms from now
+    expect(retryTime).toBeGreaterThanOrEqual(before + BASE_RETRY_DELAY_MS - 5000);
+    expect(retryTime).toBeLessThanOrEqual(after + BASE_RETRY_DELAY_MS + 5000);
+  });
+
+  it('schedules retry ~2 minutes after attempt 2 (exponential doubling)', () => {
+    const before = Date.now();
+    const result = calculateNextRetryTime(2);
+    const after = Date.now();
+
+    expect(result).not.toBeNull();
+    const retryTime = new Date(result!).getTime();
+    const expectedDelay = BASE_RETRY_DELAY_MS * 2;
+    expect(retryTime).toBeGreaterThanOrEqual(before + expectedDelay - 5000);
+    expect(retryTime).toBeLessThanOrEqual(after + expectedDelay + 5000);
+  });
+
+  it('returns null after MAX_ATTEMPTS (3) — dead-letter behaviour', () => {
+    /**
+     * WHY: After 3 failed attempts the delivery is permanently failed and
+     * written to the webhook_deliveries table with status='failed'.  No further
+     * retries will be scheduled.  The result is null rather than a future
+     * timestamp to signal this dead-letter state.
+     */
+    expect(calculateNextRetryTime(MAX_ATTEMPTS)).toBeNull();
+  });
+
+  it('returns null for attempts beyond MAX_ATTEMPTS', () => {
+    expect(calculateNextRetryTime(MAX_ATTEMPTS + 1)).toBeNull();
+    expect(calculateNextRetryTime(MAX_ATTEMPTS + 100)).toBeNull();
+  });
+
+  it('returns a valid ISO 8601 timestamp for attempt 1', () => {
+    const result = calculateNextRetryTime(1);
+    expect(result).not.toBeNull();
+    expect(() => new Date(result!)).not.toThrow();
+    expect(new Date(result!).toISOString()).toBe(result);
+  });
+
+  it('delay for attempt 2 is exactly double the delay for attempt 1', () => {
+    const now = Date.now();
+    const t1 = new Date(calculateNextRetryTime(1)!).getTime() - now;
+    const t2 = new Date(calculateNextRetryTime(2)!).getTime() - now;
+    // Allow ±200 ms clock drift between the two calls
+    expect(t2 / t1).toBeCloseTo(2, 0);
+  });
+});
+
+// ============================================================================
+
+describe('Webhook Delivery — Outbound HTTP Delivery (deliverWebhook)', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  // ── Success path ────────────────────────────────────────────────────────
+
+  it('returns success=true for a 200 response', async () => {
+    mockFetch.mockResolvedValue(
+      new Response('OK', { status: 200 })
+    );
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.error).toBeUndefined();
+    expect(result.deliveryId).toBe('del-uuid-001');
+  });
+
+  it('returns success=true for a 201 response (also 2xx)', async () => {
+    mockFetch.mockResolvedValue(new Response('Created', { status: 201 }));
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(201);
+  });
+
+  it('records duration_ms for successful delivery', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(typeof result.duration_ms).toBe('number');
+  });
+
+  // ── Non-2xx failure ─────────────────────────────────────────────────────
+
+  it('returns success=false for a 500 response', async () => {
+    mockFetch.mockResolvedValue(
+      new Response('Internal Server Error', { status: 500 })
+    );
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(500);
+    expect(result.error).toContain('HTTP 500');
+  });
+
+  it('returns success=false for a 400 response and captures response body', async () => {
+    mockFetch.mockResolvedValue(
+      new Response('Bad Request', { status: 400 })
+    );
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('400');
+    expect(result.error).toContain('Bad Request');
+  });
+
+  it('returns success=false for a 404 response', async () => {
+    mockFetch.mockResolvedValue(new Response('Not Found', { status: 404 }));
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(404);
+  });
+
+  // ── Timeout / AbortError ────────────────────────────────────────────────
+
+  it('returns a timeout error when fetch is aborted', async () => {
+    /**
+     * WHY: The delivery function uses AbortController with a 30-second
+     * timeout. If the consumer is slow (or unresponsive), we must not hang
+     * indefinitely.  The test simulates the AbortError that fetch throws
+     * when the controller fires.
+     */
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    mockFetch.mockRejectedValue(abortError);
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('timed out');
+    expect(result.error).toContain(HTTP_TIMEOUT_MS.toString());
+  });
+
+  // ── SSRF guard at delivery time ─────────────────────────────────────────
+
+  it('returns success=false without calling fetch for a private IP URL', async () => {
+    /**
+     * WHY: validateWebhookUrl() is called at delivery time (not only at
+     * registration) to catch any webhooks that may have been inserted
+     * through a path that bypassed the registration-time SSRF check.
+     */
+    const ssrfWebhook: Webhook = {
+      ...SAFE_WEBHOOK,
+      url: 'https://10.0.0.1/steal-creds',
+    };
+
+    const result = await deliverWebhook(ssrfWebhook, makeDelivery());
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('private');
+    // fetch must never be called for a blocked URL
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ── Header assertions ───────────────────────────────────────────────────
+
+  it('sends the correct Styrby-specific headers with each delivery', async () => {
+    mockFetch.mockResolvedValue(new Response('OK', { status: 200 }));
+
+    await deliverWebhook(SAFE_WEBHOOK, makeDelivery({ event: 'budget.exceeded' }));
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = options.headers as Record<string, string>;
+
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers['X-Styrby-Signature']).toMatch(/^sha256=[0-9a-f]{64}$/);
+    expect(headers['X-Styrby-Event']).toBe('budget.exceeded');
+    expect(headers['X-Styrby-Delivery-Id']).toBe('del-uuid-001');
+    expect(headers['X-Styrby-Timestamp']).toMatch(/^\d+$/);
+    expect(headers['User-Agent']).toBe('Styrby-Webhook/1.0');
+  });
+
+  it('sends method POST with JSON body', async () => {
+    mockFetch.mockResolvedValue(new Response('OK', { status: 200 }));
+
+    const delivery = makeDelivery({
+      payload: { event: 'session.started', data: { session_id: 'abc' } },
+    });
+    await deliverWebhook(SAFE_WEBHOOK, delivery);
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(options.method).toBe('POST');
+    expect(typeof options.body).toBe('string');
+    expect(JSON.parse(options.body as string)).toEqual(delivery.payload);
+  });
+});
+
+// ============================================================================
+
+// NOTE: "Event Payload Shape" tests were removed during code review.
+// WHY: The tests constructed payload objects inline and then asserted properties
+// of those same objects — making them tautological (impossible to fail).
+// Payload shape validation should test a real payload-building function from
+// the Edge Function when Deno test infrastructure is available.
+
+// ============================================================================
+
+describe('Webhook Delivery — Failed Delivery Logging', () => {
+  /**
+   * WHY: When a delivery fails, the error message stored in webhook_deliveries
+   * must contain enough context for a developer to diagnose the problem without
+   * having to replay the delivery.  These tests verify the error message format
+   * for the most common failure scenarios.
+   */
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('captures HTTP status code in error message for non-2xx responses', async () => {
+    mockFetch.mockResolvedValue(new Response('Service Unavailable', { status: 503 }));
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.error).toMatch(/HTTP 503/);
+  });
+
+  it('captures response body snippet (up to 200 chars) in error message', async () => {
+    const body = '{"error":"invalid_token","description":"The provided token has expired"}';
+    mockFetch.mockResolvedValue(new Response(body, { status: 401 }));
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.error).toContain('invalid_token');
+  });
+
+  it('includes timeout duration in error message for AbortError', async () => {
+    mockFetch.mockRejectedValue(new DOMException('The operation was aborted.', 'AbortError'));
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.error).toContain('30000'); // HTTP_TIMEOUT_MS
+    expect(result.error).toContain('timed out');
+  });
+
+  it('includes SSRF URL block reason in error when delivery bypasses registration check', async () => {
+    const ssrfWebhook = { ...SAFE_WEBHOOK, url: 'https://192.168.100.1/internal' };
+    const result = await deliverWebhook(ssrfWebhook, makeDelivery());
+    // error field must name the blocked range so operators know why it failed
+    expect(result.error).toContain('192.168');
+  });
+
+  it('records duration_ms even on failure', async () => {
+    mockFetch.mockResolvedValue(new Response('Error', { status: 500 }));
+
+    const result = await deliverWebhook(SAFE_WEBHOOK, makeDelivery());
+    expect(result.success).toBe(false);
+    expect(typeof result.duration_ms).toBe('number');
+    expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **Phase 3 of 7-phase plan** — fills 3 deferred test suites from Waves 1-2
- **161 new tests** across 3 files (~2,592 lines)
- All tests passing locally via vitest

## Changes

| File | Tests | Coverage |
|------|-------|----------|
| `packages/styrby-cli/src/agent/factories/__tests__/aider.test.ts` | 47 | Factory, lifecycle, subprocess args, output parsing, errors, cancel |
| `packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts` | 60 | Factory, lifecycle, JSON-line parsing, tool routing, cost/token extraction |
| `packages/styrby-web/src/app/api/webhooks/__tests__/deliver-webhook.test.ts` | 54 | HMAC signatures, SSRF protection, exponential backoff, delivery, logging |

## Phase 3 Status

- [x] 3.1 Aider adapter tests (47 tests)
- [x] 3.2 OpenCode adapter tests (60 tests)
- [x] 3.3 Webhook delivery & retry tests (54 tests)
- [x] 3.4 Team creation & invitation (already complete)
- [ ] 3.5 Team RLS policy tests (deferred — needs pgTAP infrastructure)
- [x] 3.6 API v1 endpoint integration (already complete)

## Test Plan
- [x] All 161 tests pass locally (`vitest run`)
- [ ] CI passes
- [ ] No regressions in existing test suites

---
🤖 Shipped with [Claude Code](https://claude.com/claude-code)