### PR TITLE
docs(web): full documentation site — OTEL, agents, voice, 12 guide pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,9 @@ notes/
 CLAUDE.md
 
 # Local docs (planning, marketing, audits — never pushed)
-docs/
+# WHY leading slash: /docs/ only matches the root docs/ directory.
+# Without it, git also ignores packages/styrby-web/src/app/docs/ (the web docs route).
+/docs/
 
 # IDE & editor
 .idea/
@@ -104,7 +106,7 @@ next-env.d.ts
 # ============================================
 CLAUDE.md
 ARCHITECTURE.md
-docs/
+/docs/
 
 # All markdown files (notes, plans, strategy)
 *.md

--- a/packages/styrby-web/src/app/docs/agents/page.tsx
+++ b/packages/styrby-web/src/app/docs/agents/page.tsx
@@ -1,0 +1,450 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "Agent Setup",
+  description:
+    "Install and connect all 11 supported AI coding agents to Styrby. Includes install commands, verification steps, and how auto-detection works.",
+};
+
+/**
+ * Agent Setup documentation page.
+ *
+ * Covers all 11 supported CLI coding agents grouped by tier availability.
+ * Each agent section includes install command, verify command, and detection notes.
+ */
+export default function AgentSetupPage() {
+  const { prev, next } = getPrevNext("/docs/agents");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Agent Setup
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        Styrby supports 11 CLI coding agents. Install any agent on your machine
+        and Styrby auto-detects it the next time the CLI starts. No extra
+        configuration is needed for detection to work. The agent just needs to
+        be on your PATH.
+      </p>
+      <p className="mt-3 text-zinc-400">
+        Free tier supports 1 agent at a time. Pro and Power tiers support all 11
+        simultaneously. Agents you do not have installed are simply skipped
+        during detection.
+      </p>
+
+      {/* Free agents */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Available on All Tiers
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        These five agents are available on the Free tier and above. Free tier
+        users may activate one agent at a time.
+      </p>
+
+      {/* Claude Code */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Claude Code</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Anthropic&apos;s official CLI coding agent with deep code understanding
+        and agentic tool-use via the Model Context Protocol. Detected via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          claude
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install
+npm install -g @anthropic-ai/claude-code
+
+# Verify
+claude --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Styrby detects Claude Code by checking for{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          claude
+        </code>{" "}
+        in your PATH. Configure auto-approve rules under{" "}
+        <strong className="text-zinc-400">Agents &gt; Claude Code &gt; Permissions</strong>{" "}
+        in the dashboard.
+      </p>
+
+      {/* Codex */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Codex</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        OpenAI&apos;s CLI coding agent for code generation and understanding,
+        using GPT-4o and reasoning models. Detected via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          codex
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install
+npm install -g @openai/codex
+
+# Verify
+codex --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Styrby tracks token usage by intercepting Codex session output. Set your{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          OPENAI_API_KEY
+        </code>{" "}
+        environment variable before starting a session.
+      </p>
+
+      {/* Gemini CLI */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Gemini CLI</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Google&apos;s CLI for multimodal AI coding assistance using Gemini 2.0
+        and 2.5 models. Detected via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          gemini
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install
+npm install -g @google/gemini-cli
+
+# Verify
+gemini --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Requires a Google account and Gemini API key. Authenticate by running{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          gemini auth
+        </code>{" "}
+        before your first session.
+      </p>
+
+      {/* OpenCode */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">OpenCode</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        A terminal-based AI coding assistant with multi-provider support, JSON
+        output, and session persistence. Detected via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          opencode
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install
+npm install -g opencode-ai
+
+# Verify
+opencode --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        OpenCode supports multiple model providers. Styrby tracks whichever
+        model is active in the running session. Check{" "}
+        <strong className="text-zinc-400">opencode.ai</strong> for the latest
+        install instructions.
+      </p>
+
+      {/* Aider */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Aider</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        AI pair programming in your terminal that works with many LLM providers
+        and integrates directly with Git. Detected via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          aider
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install via pip (recommended)
+pip install aider-chat
+
+# Or via pipx (isolated environment)
+pipx install aider-chat
+
+# Verify
+aider --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Aider requires Python 3.9 or later. It supports Claude, GPT-4o, Gemini,
+        and many other LLM backends. Set the appropriate API key environment
+        variable for your chosen model provider.
+      </p>
+
+      {/* Pro and Power agents */}
+      <h2 className="mt-12 text-xl font-semibold text-zinc-100">
+        Pro and Power Tier Agents
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        These six agents are available on the Pro tier and above. All 11 agents
+        can run simultaneously on Pro and Power plans with no session limits.
+      </p>
+
+      {/* Goose */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Goose</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        An open-source AI coding agent by Block (formerly Square) that uses the
+        Model Context Protocol for extensible tool integrations. Detected via
+        the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          goose
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install via Homebrew (macOS)
+brew install block/tap/goose
+
+# Or via pip
+pip install goose-ai
+
+# Verify
+goose --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Goose is Apache 2.0 licensed. Config lives at{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          ~/.config/goose/config.yaml
+        </code>
+        . Check{" "}
+        <strong className="text-zinc-400">github.com/block/goose</strong> for
+        the latest install instructions.
+      </p>
+
+      {/* Amp */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Amp</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Sourcegraph&apos;s AI coding agent with a &quot;deep mode&quot; that
+        parallelizes code analysis across multiple sub-agents for accurate edits
+        on large codebases. Detected via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          amp
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install via npm
+npm install -g @sourcegraph/amp
+
+# Verify
+amp --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Config lives at{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          ~/.config/amp/config.json
+        </code>
+        . Check{" "}
+        <strong className="text-zinc-400">ampcode.com</strong> for the latest
+        install instructions and account setup.
+      </p>
+
+      {/* Crush */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Crush</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Charmbracelet&apos;s terminal-native AI coding agent with ACP-compatible
+        communication and rich ANSI terminal output. Detected via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          crush
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install via Homebrew (macOS/Linux)
+brew install charmbracelet/tap/crush
+
+# Verify
+crush --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Config lives at{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          ~/.config/crush/config.yaml
+        </code>
+        . Check{" "}
+        <strong className="text-zinc-400">github.com/charmbracelet/crush</strong>{" "}
+        for the latest install instructions.
+      </p>
+
+      {/* Kilo */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Kilo</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        A community-driven AI coding agent with support for 500+ models and a
+        Memory Bank feature that persists structured project knowledge across
+        sessions. Detected via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          kilo
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install via npm
+npm install -g kilo-code
+
+# Verify
+kilo --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Config lives at{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          ~/.config/kilo/config.json
+        </code>
+        . Kilo supports any OpenAI-compatible API endpoint as a backend. Check
+        the agent&apos;s official site for the latest install instructions.
+      </p>
+
+      {/* Kiro */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Kiro</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        AWS&apos;s AI coding agent with per-prompt credit billing and deep
+        integration with IAM, CodeWhisperer, and Amazon Q Developer. Detected
+        via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          kiro
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install via npm
+npm install -g @aws/kiro
+
+# Or download directly from kiro.dev
+# Check the official site for platform-specific installers
+
+# Verify
+kiro --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Kiro uses a credit-based billing model. Styrby converts credits to a USD
+        equivalent (1 credit = $0.01) for unified cost tracking. Check{" "}
+        <strong className="text-zinc-400">kiro.dev</strong> for the latest
+        install instructions.
+      </p>
+
+      {/* Droid */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">Droid</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        A Bring Your Own Key (BYOK) AI coding agent that routes to multiple LLM
+        backends through LiteLLM, so you can use Anthropic, OpenAI, Google,
+        Mistral, or on-prem models with your own API keys. Detected via the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          droid
+        </code>{" "}
+        binary.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Install via npm
+npm install -g @droid-ai/cli
+
+# Verify
+droid --version`}
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Config lives at{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          ~/.config/droid/config.yaml
+        </code>
+        . Styrby uses LiteLLM pricing tables to estimate costs when the backend
+        does not report token usage directly. Check{" "}
+        <strong className="text-zinc-400">droid-ai.dev</strong> for the latest
+        install instructions.
+      </p>
+
+      {/* How detection works */}
+      <h2 className="mt-12 text-xl font-semibold text-zinc-100">
+        How Detection Works
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        When the Styrby CLI starts, it checks your PATH for each of the 11 agent
+        binaries in order:
+      </p>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full text-sm text-left text-zinc-400">
+          <thead className="text-xs uppercase text-zinc-500 border-b border-zinc-800">
+            <tr>
+              <th className="py-2 pr-4">Agent</th>
+              <th className="py-2 pr-4">Binary</th>
+              <th className="py-2">Config File</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-800">
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Claude Code</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">claude</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.claude/</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Codex</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">codex</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.openai/</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Gemini CLI</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">gemini</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.config/gemini/</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">OpenCode</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">opencode</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.config/opencode/</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Aider</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">aider</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.aider/</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Goose</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">goose</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.config/goose/config.yaml</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Amp</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">amp</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.config/amp/config.json</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Crush</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">crush</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.config/crush/config.yaml</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Kilo</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">kilo</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.config/kilo/config.json</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Kiro</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">kiro</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.config/kiro/config.json</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Droid</td>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">droid</td>
+              <td className="py-2 font-mono text-xs text-zinc-500">~/.config/droid/config.yaml</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-4 text-zinc-400">
+        Detected agents appear in the{" "}
+        <strong className="text-zinc-300">Agents</strong> section of your
+        dashboard. Agents not found in PATH are shown as{" "}
+        <span className="text-zinc-300">Not Installed</span> with a link to
+        these docs.
+      </p>
+      <p className="mt-3 text-zinc-400">
+        If an agent is installed but not detected, confirm its binary is on your
+        PATH:
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Check PATH for a binary (replace 'claude' with your agent)
+which claude
+
+# If not found, confirm the install location and add it to PATH
+export PATH="$HOME/.local/bin:$PATH"   # Example for pip installs`}
+      </pre>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/api/page.tsx
+++ b/packages/styrby-web/src/app/docs/api/page.tsx
@@ -1,0 +1,364 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "API Reference",
+  description: "Styrby REST API: authentication, endpoints, request/response examples, and rate limits.",
+};
+
+/**
+ * API Reference page. Covers auth, endpoints, examples, rate limits, errors.
+ */
+export default function APIReferencePage() {
+  const { prev, next } = getPrevNext("/docs/api");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        API Reference
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        Programmatic access to your Styrby data. Available on the Power tier.
+      </p>
+
+      {/* Auth */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Authentication
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Generate an API key in the dashboard under Settings &gt; API Keys. Pass
+        it as a Bearer token in the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">Authorization</code>{" "}
+        header.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`Authorization: Bearer styrby_abc123...`}</code>
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        API keys are prefixed with{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby_</code>.
+        They are hashed with bcrypt (cost factor 12) before storage. Styrby
+        cannot retrieve your key after creation. Store it securely. Keys can
+        optionally expire; set an expiration in days when creating the key.
+      </p>
+
+      {/* Base URL */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">Base URL</h2>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>https://styrbyapp.com/api/v1</code>
+      </pre>
+
+      {/* GET /sessions */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        GET /sessions
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Returns a paginated list of your sessions, newest first. Archived
+        sessions are excluded by default.
+      </p>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">Query Parameters</h3>
+      <div className="mt-2 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Param</th>
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Type</th>
+              <th className="pb-2 font-medium text-zinc-300">Description</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">agent_type</td>
+              <td className="py-2 pr-4 text-xs">string</td>
+              <td className="py-2 text-xs">Filter by agent type: claude, codex, gemini, opencode, or aider.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">status</td>
+              <td className="py-2 pr-4 text-xs">string</td>
+              <td className="py-2 text-xs">Filter by status: starting, running, idle, paused, stopped, error, expired.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">limit</td>
+              <td className="py-2 pr-4 text-xs">number</td>
+              <td className="py-2 text-xs">Results per page. Default 20, max 100.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">offset</td>
+              <td className="py-2 pr-4 text-xs">number</td>
+              <td className="py-2 text-xs">Pagination offset. Default 0.</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">archived</td>
+              <td className="py-2 pr-4 text-xs">boolean</td>
+              <td className="py-2 text-xs">Include archived sessions. Default false.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <pre className="mt-4 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`curl -H "Authorization: Bearer styrby_abc123" \\
+  "https://styrbyapp.com/api/v1/sessions?agent_type=claude&limit=5"
+
+# Response
+{
+  "sessions": [
+    {
+      "id": "ses_8f3k2m9x",
+      "agent_type": "claude",
+      "model": "claude-sonnet-4-20250514",
+      "title": "Refactor auth module",
+      "status": "stopped",
+      "total_input_tokens": 12840,
+      "total_output_tokens": 3210,
+      "total_cache_tokens": 8400,
+      "total_cost_usd": 0.042,
+      "started_at": "2026-03-22T14:30:00Z",
+      "ended_at": "2026-03-22T14:45:12Z",
+      "created_at": "2026-03-22T14:30:00Z"
+    }
+  ],
+  "pagination": {
+    "total": 142,
+    "limit": 5,
+    "offset": 0,
+    "hasMore": true
+  }
+}`}</code>
+      </pre>
+
+      {/* GET /costs */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        GET /costs
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Returns aggregated cost data for a time period. Choose daily (last 30
+        days), weekly (last 12 weeks), or monthly (last 12 months) aggregation.
+      </p>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">Query Parameters</h3>
+      <div className="mt-2 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Param</th>
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Type</th>
+              <th className="pb-2 font-medium text-zinc-300">Description</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">period</td>
+              <td className="py-2 pr-4 text-xs">string</td>
+              <td className="py-2 text-xs">Aggregation period: daily, weekly, or monthly. Default monthly.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`curl -H "Authorization: Bearer styrby_abc123" \\
+  "https://styrbyapp.com/api/v1/costs?period=daily"
+
+# Response
+{
+  "summary": {
+    "period": "daily",
+    "totalCostUsd": 18.73,
+    "totalInputTokens": 284000,
+    "totalOutputTokens": 62000,
+    "totalCacheTokens": 190000,
+    "sessionCount": 47
+  },
+  "breakdown": [
+    {
+      "date": "2026-03-22",
+      "costUsd": 2.14,
+      "inputTokens": 34000,
+      "outputTokens": 8000,
+      "cacheTokens": 22000
+    }
+  ]
+}`}</code>
+      </pre>
+
+      {/* GET /costs/breakdown */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        GET /costs/breakdown
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Returns cost breakdown grouped by agent type for a trailing window.
+      </p>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">Query Parameters</h3>
+      <div className="mt-2 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Param</th>
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Type</th>
+              <th className="pb-2 font-medium text-zinc-300">Description</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">days</td>
+              <td className="py-2 pr-4 text-xs">number</td>
+              <td className="py-2 text-xs">Trailing days to include. Default 30, max 365.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`curl -H "Authorization: Bearer styrby_abc123" \\
+  "https://styrbyapp.com/api/v1/costs/breakdown?days=30"
+
+# Response
+{
+  "breakdown": [
+    {
+      "agentType": "claude",
+      "costUsd": 15.42,
+      "inputTokens": 220000,
+      "outputTokens": 48000,
+      "cacheTokens": 160000,
+      "sessionCount": 38,
+      "percentage": 82.3
+    },
+    {
+      "agentType": "codex",
+      "costUsd": 3.31,
+      "inputTokens": 64000,
+      "outputTokens": 14000,
+      "cacheTokens": 30000,
+      "sessionCount": 9,
+      "percentage": 17.7
+    }
+  ],
+  "total": {
+    "costUsd": 18.73,
+    "inputTokens": 284000,
+    "outputTokens": 62000,
+    "cacheTokens": 190000,
+    "sessionCount": 47
+  }
+}`}</code>
+      </pre>
+
+      {/* GET /machines */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        GET /machines
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Returns all paired machines for your account.
+      </p>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">Query Parameters</h3>
+      <div className="mt-2 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Param</th>
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Type</th>
+              <th className="pb-2 font-medium text-zinc-300">Description</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">online_only</td>
+              <td className="py-2 pr-4 text-xs">boolean</td>
+              <td className="py-2 text-xs">Filter to only currently online machines. Default false.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`curl -H "Authorization: Bearer styrby_abc123" \\
+  "https://styrbyapp.com/api/v1/machines"
+
+# Response
+{
+  "machines": [
+    {
+      "id": "mch_abc123",
+      "name": "macbook-pro",
+      "platform": "darwin",
+      "hostname": "macbook-pro.local",
+      "cliVersion": "0.1.0-beta.7",
+      "isOnline": true,
+      "lastSeenAt": "2026-03-22T15:42:00Z",
+      "createdAt": "2026-03-10T09:00:00Z"
+    }
+  ],
+  "count": 1
+}`}</code>
+      </pre>
+
+      {/* Rate Limits */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Rate Limits
+      </h2>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Endpoint group</th>
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Limit</th>
+              <th className="pb-2 font-medium text-zinc-300">Window</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr>
+              <td className="py-2 pr-4 text-xs">All v1 endpoints</td>
+              <td className="py-2 pr-4 text-xs">100 requests</td>
+              <td className="py-2 text-xs">Per minute, per API key</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Error Codes */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Error Codes
+      </h2>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">HTTP</th>
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Description</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">400</td>
+              <td className="py-2 text-xs">Missing or malformed query parameters.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">401</td>
+              <td className="py-2 text-xs">Missing or invalid API key.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">403</td>
+              <td className="py-2 text-xs">API access requires Power tier.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">429</td>
+              <td className="py-2 text-xs">Too many requests. Retry after the indicated delay.</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-xs">500</td>
+              <td className="py-2 text-xs">Server error. Retry with exponential backoff.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-sm text-zinc-400">
+        All error responses use the same shape:
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`{
+  "error": "Rate limit exceeded. Try again in 42 seconds."
+}`}</code>
+      </pre>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/cli/page.tsx
+++ b/packages/styrby-web/src/app/docs/cli/page.tsx
@@ -1,0 +1,295 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "CLI Reference",
+  description: "Styrby CLI commands, configuration, environment variables, and system requirements.",
+};
+
+/**
+ * CLI Reference page. Covers all commands, config, and requirements.
+ */
+export default function CLIReferencePage() {
+  const { prev, next } = getPrevNext("/docs/cli");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        CLI Reference
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        The Styrby CLI runs on your development machine, detects active AI
+        agents, and streams session data to the dashboard.
+      </p>
+
+      {/* Requirements */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        System Requirements
+      </h2>
+      <ul className="mt-3 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>Node.js 20 or later</li>
+        <li>macOS, Linux, or WSL2 on Windows</li>
+        <li>Outbound HTTPS (port 443) to styrbyapp.com and supabase.co</li>
+      </ul>
+
+      {/* Installation */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Installation
+      </h2>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`npm install -g styrby-cli
+
+# Or with your preferred package manager
+pnpm add -g styrby-cli
+yarn global add styrby-cli`}</code>
+      </pre>
+
+      {/* Commands */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">Commands</h2>
+
+      {/* onboard */}
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby onboard</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Interactive setup wizard. Handles GitHub OAuth authentication, machine
+        registration, and mobile QR code pairing. Run this once on a new machine.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby onboard
+# --skip-pairing    Skip the mobile QR code step
+# --force           Re-authenticate even if already logged in`}</code>
+      </pre>
+
+      {/* pair */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby pair</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Generates a new QR code for pairing a mobile device. Use this when you
+        get a new phone or want to add another device after initial setup.
+        Requires prior authentication via{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby onboard</code>.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby pair
+# Scan the QR code with the Styrby mobile app
+# Waiting for mobile app to connect...`}</code>
+      </pre>
+
+      {/* start */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby start</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Starts a session with a specific agent. Agent shorthands are also
+        supported as a faster alternative.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby start --agent claude
+styrby start --agent codex
+
+# Agent shorthand (equivalent)
+styrby claude
+styrby codex
+styrby gemini
+styrby opencode
+styrby aider
+
+# Bare command uses your default agent
+styrby`}</code>
+      </pre>
+
+      {/* status */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby status</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Shows the current state of the CLI: pairing status, detected agents,
+        active sessions, and connection health.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby status
+# Machine: paired (abc123)
+# Agents:  2 active (claude, codex)
+# Session: ses_8f3k2... (running, 4,218 tokens)
+# Session: ses_9g4m1... (idle, 890 tokens)`}</code>
+      </pre>
+
+      {/* stop */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby stop</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Stops the running Styrby daemon process.
+      </p>
+
+      {/* doctor */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby doctor</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Runs health checks: Node.js version, configuration file, authentication
+        status, and installed agent detection. Use this to diagnose problems.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby doctor
+#   ✓ [PASS] Node.js version — 20.x.x (>= 18 required)
+#   ✓ [PASS] Configuration — Config file loaded successfully
+#   ✓ [PASS] Authentication — Authenticated
+#   ✓ [PASS] AI Agents — 2 agent(s) found: Claude Code, Codex`}</code>
+      </pre>
+
+      {/* install */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby install</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Installs an AI coding agent via npm. Supported agents: claude, codex,
+        gemini, opencode.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby install claude
+styrby install codex
+styrby install gemini
+styrby install opencode
+styrby install --all    # Install all agents`}</code>
+      </pre>
+
+      {/* costs */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby costs</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Displays token usage and cost data for recent sessions.
+      </p>
+
+      {/* logs */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby logs</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        View daemon logs.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby logs
+styrby logs --follow    # Stream logs in real time`}</code>
+      </pre>
+
+      {/* upgrade */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby upgrade</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Checks for and installs CLI updates from npm.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby upgrade           # Check and install update
+styrby upgrade --check   # Check only, do not install`}</code>
+      </pre>
+
+      {/* daemon */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby daemon</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Manages CLI auto-start on boot. On macOS uses a LaunchAgent plist; on
+        Linux uses a systemd user service.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby daemon install    # Set up auto-start on login
+styrby daemon uninstall  # Remove auto-start
+styrby daemon status     # Check auto-start status`}</code>
+      </pre>
+
+      {/* template */}
+      <h3 className="mt-8 text-lg font-medium text-zinc-200">
+        <code className="rounded bg-zinc-800 px-2 py-0.5 text-amber-500">styrby template</code>
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Manage reusable prompt templates.
+      </p>
+
+      {/* Environment Variables */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Environment Variables
+      </h2>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Variable</th>
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Default</th>
+              <th className="pb-2 font-medium text-zinc-300">Description</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">STYRBY_API_URL</td>
+              <td className="py-2 pr-4 text-xs">https://api.styrbyapp.com</td>
+              <td className="py-2 text-xs">API base URL. Override for staging.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">STYRBY_LOG_LEVEL</td>
+              <td className="py-2 pr-4 text-xs">info</td>
+              <td className="py-2 text-xs">Logging verbosity: debug, info, warn, error.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">STYRBY_ENV</td>
+              <td className="py-2 pr-4 text-xs">production</td>
+              <td className="py-2 text-xs">Set to development to use local Supabase.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">SUPABASE_URL</td>
+              <td className="py-2 pr-4 text-xs">(built-in)</td>
+              <td className="py-2 text-xs">Override Supabase project URL (dev/self-hosted).</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">SUPABASE_ANON_KEY</td>
+              <td className="py-2 pr-4 text-xs">(built-in)</td>
+              <td className="py-2 text-xs">Override Supabase anon key (dev/self-hosted).</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-sm text-zinc-500">
+        Config is stored in{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          ~/.styrby/config.json
+        </code>
+        . The Supabase URL and anon key are embedded in the CLI binary and
+        require no setup for the default (hosted) Styrby service.
+      </p>
+
+      {/* Agent Detection */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Agent Detection
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        The CLI monitors the local process list for known agent binaries. When
+        it detects one, it hooks into the agent&apos;s stdio streams to capture
+        session data. No agent modification required.
+      </p>
+      <p className="mt-2 text-sm text-zinc-400">
+        Detected agents:
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li><strong className="text-zinc-300">Claude Code</strong> (claude)</li>
+        <li><strong className="text-zinc-300">Codex</strong> (codex)</li>
+        <li><strong className="text-zinc-300">Gemini CLI</strong> (gemini)</li>
+        <li><strong className="text-zinc-300">OpenCode</strong> (opencode)</li>
+        <li><strong className="text-zinc-300">Aider</strong> (aider)</li>
+      </ul>
+      <p className="mt-2 text-sm text-zinc-500">
+        Use{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          styrby doctor
+        </code>{" "}
+        to check which agents are installed and configured on your machine.
+      </p>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/dashboard/page.tsx
+++ b/packages/styrby-web/src/app/docs/dashboard/page.tsx
@@ -1,0 +1,203 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "Dashboard Guide",
+  description: "Navigate the Styrby dashboard: costs, sessions, agent status, and settings.",
+};
+
+/**
+ * Dashboard Guide page. Overview of all dashboard sections.
+ */
+export default function DashboardGuidePage() {
+  const { prev, next } = getPrevNext("/docs/dashboard");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Dashboard Guide
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        The web dashboard at{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          styrbyapp.com/dashboard
+        </code>{" "}
+        is your control center for all connected agents and machines.
+      </p>
+
+      {/* Overview */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">Overview</h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        The main dashboard shows a live summary of your account:
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>Active agents across all paired machines</li>
+        <li>Today&apos;s total cost and token usage</li>
+        <li>Recent sessions with status indicators</li>
+        <li>Budget alert status (if configured)</li>
+      </ul>
+      <p className="mt-2 text-sm text-zinc-400">
+        Agent status and session feeds update in real time via Supabase
+        Realtime subscriptions. Cost charts and analytics refresh on each
+        page load from materialized views.
+      </p>
+
+      {/* Cost Analytics */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Cost Analytics
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Navigate to <strong className="text-zinc-300">Costs</strong> in the sidebar.
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">Daily cost chart:</strong> Bar chart of spending
+          over the last 30 days. Powered by the{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            mv_daily_cost_summary
+          </code>{" "}
+          materialized view for fast loads.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Cost by agent:</strong> Pie chart breaking down
+          spend per agent type.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Cost table:</strong> Detailed per-session cost
+          records with input, output, and cache token counts.
+        </li>
+      </ul>
+
+      <h3 className="mt-6 text-base font-medium text-zinc-200">Cost by Tag</h3>
+      <p className="mt-1 text-sm text-zinc-400">
+        Sessions can carry freeform tags (e.g., a client name or project identifier).
+        The <strong className="text-zinc-300">Cost by Tag</strong> section on the Cost Analytics
+        page aggregates spending across all sessions that share a tag.
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">Add tags:</strong> Open any session detail page and
+          use the tag editor in the header. Type a tag name and press Enter.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Filter by tag:</strong> On the Sessions list, use the
+          tag dropdown to narrow sessions to a specific client or project.
+        </li>
+        <li>
+          <strong className="text-zinc-300">View cost breakdown:</strong> Navigate to Costs. The
+          Cost by Tag section shows total spend and session count for each tag,
+          sorted by highest cost first.
+        </li>
+      </ul>
+      <p className="mt-2 text-sm text-zinc-400">
+        This is designed for freelancers and agencies who bill multiple clients.
+        Tag sessions with client names, then reference the Cost by Tag breakdown
+        when generating invoices.
+      </p>
+
+      <h3 className="mt-6 text-base font-medium text-zinc-200">Budget Alerts</h3>
+      <p className="mt-1 text-sm text-zinc-400">
+        Set spending thresholds under Costs &gt; Budget Alerts. Three action
+        types:
+      </p>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Action</th>
+              <th className="pb-2 font-medium text-zinc-300">Behavior</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs font-mono text-zinc-300">notify</td>
+              <td className="py-2 text-xs">Push notification and email when threshold hit.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs font-mono text-zinc-300">slowdown</td>
+              <td className="py-2 text-xs">Rate-limits agent API calls to reduce burn rate.</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-xs font-mono text-zinc-300">stop</td>
+              <td className="py-2 text-xs">Halts all agent sessions until you manually resume.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Sessions */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">Sessions</h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        The Sessions page lists all agent sessions, sortable by date, agent,
+        cost, or status.
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">Filter by agent:</strong> Click any agent badge to
+          filter the list.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Filter by status:</strong> Active, completed, or
+          errored sessions.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Session detail:</strong> Click a session to see
+          the full encrypted chat thread, token timeline, and a summary tab
+          with key metrics.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Bookmarks:</strong> Star important sessions for
+          quick access later.
+        </li>
+      </ul>
+
+      {/* Agent Status */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Agent Status Cards
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        The Agents page shows a card for each detected agent across all your
+        machines. Each card displays:
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>Current status (active, idle, error, disconnected)</li>
+        <li>Machine name and last seen timestamp</li>
+        <li>Current session ID and token count</li>
+        <li>Auto-approve and blocked tool configuration</li>
+      </ul>
+
+      {/* Settings */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Settings
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Access from the sidebar under Settings. Sections include:
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">Profile:</strong> Display name, email, referral
+          code.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Notifications:</strong> Push and email preferences,
+          quiet hours.
+        </li>
+        <li>
+          <strong className="text-zinc-300">API Keys:</strong> Generate and manage API keys
+          (Power tier).
+        </li>
+        <li>
+          <strong className="text-zinc-300">Webhooks:</strong> Configure webhook endpoints and
+          event subscriptions.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Prompt Templates:</strong> Create and manage
+          reusable prompt templates for your agents.
+        </li>
+      </ul>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/docs-sidebar.tsx
+++ b/packages/styrby-web/src/app/docs/docs-sidebar.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { docsNav } from "./nav";
+
+/**
+ * Sidebar navigation for the documentation section.
+ *
+ * Persistent on desktop (>=768px). On mobile, toggled via a hamburger button
+ * fixed to the bottom-right corner of the viewport.
+ */
+export function DocsSidebar() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      {/* Mobile toggle button */}
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-zinc-800 text-zinc-300 shadow-lg ring-1 ring-zinc-700 md:hidden"
+        aria-label={open ? "Close docs menu" : "Open docs menu"}
+        aria-expanded={open}
+      >
+        {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+      </button>
+
+      {/* Backdrop for mobile */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60 md:hidden"
+          onClick={() => setOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        className={cn(
+          "fixed top-16 z-40 h-[calc(100vh-4rem)] w-60 shrink-0 overflow-y-auto border-r border-zinc-800 bg-zinc-950 px-4 py-6 transition-transform duration-200 md:sticky md:translate-x-0",
+          open ? "translate-x-0" : "-translate-x-full"
+        )}
+      >
+        <nav aria-label="Documentation">
+          <ul className="space-y-1">
+            {docsNav.map((item) => {
+              const active = pathname === item.href;
+              return (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    onClick={() => setOpen(false)}
+                    className={cn(
+                      "block rounded-md px-3 py-2 text-sm transition-colors",
+                      active
+                        ? "bg-amber-500/10 font-medium text-amber-500"
+                        : "text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-200"
+                    )}
+                    aria-current={active ? "page" : undefined}
+                  >
+                    {item.title}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </aside>
+    </>
+  );
+}

--- a/packages/styrby-web/src/app/docs/getting-started/page.tsx
+++ b/packages/styrby-web/src/app/docs/getting-started/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "Getting Started",
+  description: "Install the Styrby CLI, pair your machine, and monitor your first AI agent session.",
+};
+
+/**
+ * Getting Started guide. Walks through install, pairing, and first session.
+ */
+export default function GettingStartedPage() {
+  const { prev, next } = getPrevNext("/docs/getting-started");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Getting Started
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        From zero to monitoring your first AI agent session in under five minutes.
+      </p>
+
+      {/* Step 1 */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        1. Install the CLI
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Requires Node.js 20 or later.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>npm install -g styrby-cli</code>
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Verify the install:
+      </p>
+      <pre className="mt-2 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>styrby --version</code>
+      </pre>
+
+      {/* Step 2 */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        2. Create an account
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Sign up at{" "}
+        <a
+          href="https://styrbyapp.com/signup"
+          className="text-amber-500 underline underline-offset-2 hover:text-amber-400"
+        >
+          styrbyapp.com
+        </a>
+        . Free tier includes one machine and full session monitoring.
+      </p>
+
+      {/* Step 3 */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        3. Run the setup wizard
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Run the onboard command. It handles GitHub authentication, machine
+        registration, and mobile pairing in one flow.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>styrby onboard</code>
+      </pre>
+      <p className="mt-2 text-sm text-zinc-400">
+        The wizard opens your browser for GitHub OAuth, registers your machine,
+        then displays a QR code. Open Styrby on your phone and tap{" "}
+        <strong className="text-zinc-300">Add Machine</strong> to scan it.
+      </p>
+      <p className="mt-3 text-sm text-zinc-500">
+        Pairing generates a TweetNaCl keypair on your machine. The public key is
+        sent to Styrby; the private key never leaves your device. All session
+        data is end-to-end encrypted from this point.
+      </p>
+      <p className="mt-2 text-sm text-zinc-500">
+        To re-pair later (new phone, lost device), run{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs">styrby pair</code>.
+      </p>
+
+      {/* Step 4 */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        4. Start an AI agent
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Launch any supported agent. The CLI auto-detects the agent process and
+        begins streaming session data.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`# Use agent shorthand to start a session:
+styrby claude     # or: styrby codex, styrby gemini, styrby opencode, styrby aider
+
+# Or let Styrby use your default agent:
+styrby`}</code>
+      </pre>
+      <p className="mt-2 text-sm text-zinc-400">
+        Within seconds, the session appears in your dashboard and mobile app.
+        You can see token usage, approve permission requests, and review the
+        conversation in real time.
+      </p>
+
+      {/* Step 5 */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        5. Verify everything works
+      </h2>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby status
+# Output:
+# Machine: paired (abc123)
+# Agents:  1 active (claude)
+# Session: ses_8f3k2... (running, 142 tokens)`}</code>
+      </pre>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/layout.tsx
+++ b/packages/styrby-web/src/app/docs/layout.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { Navbar } from "@/components/landing/navbar";
+import { Footer } from "@/components/landing/footer";
+import { DocsSidebar } from "./docs-sidebar";
+
+export const metadata: Metadata = {
+  title: "Documentation",
+  description:
+    "Styrby developer documentation: CLI reference, API docs, agent setup guides, security architecture, and troubleshooting.",
+  openGraph: {
+    title: "Styrby Documentation",
+    description:
+      "Styrby developer documentation: CLI reference, API docs, agent setup guides, security architecture, and troubleshooting.",
+    type: "website",
+    url: "https://styrbyapp.com/docs",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Styrby Documentation",
+    description:
+      "Styrby developer documentation: CLI reference, API docs, agent setup guides, security architecture, and troubleshooting.",
+  },
+};
+
+/**
+ * Layout for all /docs/* pages.
+ *
+ * Renders the landing Navbar at the top, a persistent sidebar on the left
+ * (collapsible on mobile), the doc content in the center, and the Footer
+ * at the bottom.
+ */
+export default function DocsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col bg-zinc-950 text-zinc-100">
+      <Navbar />
+
+      {/* Spacer for the fixed navbar */}
+      <div className="h-16" />
+
+      <div className="mx-auto flex w-full max-w-7xl flex-1">
+        <DocsSidebar />
+
+        <main
+          id="main-content"
+          className="min-w-0 flex-1 px-6 py-10 md:px-12 lg:px-16"
+        >
+          <div className="mx-auto max-w-3xl">{children}</div>
+        </main>
+      </div>
+
+      <Footer />
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/docs/mobile/page.tsx
+++ b/packages/styrby-web/src/app/docs/mobile/page.tsx
@@ -1,0 +1,169 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "Mobile App",
+  description: "Styrby mobile app: setup, push notifications, offline mode, and permission approvals.",
+};
+
+/**
+ * Mobile App documentation page.
+ */
+export default function MobileAppPage() {
+  const { prev, next } = getPrevNext("/docs/mobile");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Mobile App
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        Monitor and control your AI agents from your phone. Available for iOS
+        and Android.
+      </p>
+
+      {/* Download */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Download and Setup
+      </h2>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">iOS:</strong> App Store, search
+          &quot;Styrby&quot;. Requires iOS 17+.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Android:</strong> Google Play Store,
+          search &quot;Styrby&quot;. Requires Android 14+.
+        </li>
+      </ul>
+      <p className="mt-2 text-sm text-zinc-400">
+        Sign in with the same GitHub account you used on the web dashboard.
+      </p>
+
+      {/* Pairing */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Pairing with Your Machine
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        After signing in, tap &quot;Add Machine&quot; and scan the QR code
+        displayed by{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          styrby onboard
+        </code>{" "}
+        or{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          styrby pair
+        </code>{" "}
+        in your terminal. The QR code encodes a signed pairing token with an
+        expiration time. The app generates its own TweetNaCl keypair for
+        decrypting session data on the phone.
+      </p>
+
+      {/* Push Notifications */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Push Notifications
+      </h2>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">
+        What triggers a notification
+      </h3>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">Permission request:</strong> An agent
+          needs approval for a tool call.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Session error:</strong> An agent
+          session crashed or hit an unrecoverable error.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Budget alert:</strong> A spending
+          threshold was reached.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Machine disconnected:</strong> A
+          paired machine went offline.
+        </li>
+      </ul>
+      <p className="mt-3 text-sm text-zinc-500">
+        Push tokens are registered with APNs (iOS) and FCM (Android). Token
+        registration happens automatically on sign-in.
+      </p>
+
+      <h3 className="mt-4 text-base font-medium text-zinc-200">
+        Configuration
+      </h3>
+      <p className="mt-1 text-sm text-zinc-400">
+        Fine-tune notifications in the app under Settings &gt; Notifications.
+        Toggle each event type on or off. You can also configure these from the
+        web dashboard.
+      </p>
+
+      {/* Quiet Hours */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Quiet Hours
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Suppress non-critical notifications during set hours. Permission
+        requests are still delivered (they block agent progress), but
+        informational alerts like session completions are held until quiet hours
+        end.
+      </p>
+      <p className="mt-2 text-sm text-zinc-400">
+        Configure quiet hours in the mobile app under Settings &gt; Notifications
+        &gt; Quiet Hours, or from the web dashboard under Settings &gt;
+        Notifications.
+      </p>
+
+      {/* Offline Mode */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Offline Mode
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        The mobile app works offline using a local SQLite queue. When you
+        approve a permission, change a setting, or perform any action while
+        offline, the command is queued locally on-device.
+      </p>
+      <p className="mt-2 text-sm text-zinc-400">
+        When connectivity returns, the queue syncs automatically in order.
+        A badge shows the number of pending queued commands.
+      </p>
+      <p className="mt-2 text-sm text-zinc-500">
+        Processed commands are also synced to the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          offline_command_queue
+        </code>{" "}
+        table in Supabase for audit purposes.
+      </p>
+
+      {/* Permission Workflow */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Permission Approval Workflow
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        When an agent requests a tool call that is not auto-approved:
+      </p>
+      <ol className="mt-2 list-decimal space-y-2 pl-6 text-sm text-zinc-400">
+        <li>Push notification arrives on your phone.</li>
+        <li>
+          Tap the notification to see the request detail: tool name, arguments,
+          and a description of what it will do.
+        </li>
+        <li>
+          Tap <strong className="text-zinc-300">Approve</strong> or{" "}
+          <strong className="text-zinc-300">Deny</strong>.
+        </li>
+        <li>
+          The decision is sent to the CLI in real time via Supabase Realtime.
+          The agent continues or retries based on your response.
+        </li>
+      </ol>
+      <p className="mt-3 text-sm text-zinc-500">
+        You can also approve or deny from the web dashboard. The first response
+        wins; duplicate approvals are ignored.
+      </p>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/nav.ts
+++ b/packages/styrby-web/src/app/docs/nav.ts
@@ -1,0 +1,94 @@
+/**
+ * Documentation navigation structure.
+ *
+ * Single source of truth for sidebar links and prev/next computation.
+ * Add new pages here; the layout and prev/next links update automatically.
+ */
+export interface DocNavItem {
+  /** Display label in the sidebar */
+  title: string;
+  /** Route path relative to /docs */
+  href: string;
+  /** Short description shown on the index page */
+  description: string;
+}
+
+export const docsNav: DocNavItem[] = [
+  {
+    title: 'Getting Started',
+    href: '/docs/getting-started',
+    description: 'Install the CLI, pair your machine, and see your first session.',
+  },
+  {
+    title: 'CLI Reference',
+    href: '/docs/cli',
+    description: 'Commands, configuration, and supported agents.',
+  },
+  {
+    title: 'Agent Setup',
+    href: '/docs/agents',
+    description: 'Install and connect all 11 supported CLI coding agents.',
+  },
+  {
+    title: 'Dashboard Guide',
+    href: '/docs/dashboard',
+    description: 'Costs, sessions, agent status, and settings.',
+  },
+  {
+    title: 'API Reference',
+    href: '/docs/api',
+    description: 'REST API for programmatic access (Power tier).',
+  },
+  {
+    title: 'Webhooks',
+    href: '/docs/webhooks',
+    description: 'HTTP event delivery to your endpoints.',
+  },
+  {
+    title: 'Security',
+    href: '/docs/security',
+    description: 'E2E encryption, zero-knowledge architecture, audit logging.',
+  },
+  {
+    title: 'Mobile App',
+    href: '/docs/mobile',
+    description: 'Push notifications, offline mode, permission approvals.',
+  },
+  {
+    title: 'Team Management',
+    href: '/docs/teams',
+    description: 'Roles, shared visibility, and member management (Pro and Power tiers).',
+  },
+  {
+    title: 'OTEL Metrics Export',
+    href: '/docs/otel',
+    description: 'Export metrics to Grafana, Datadog, Honeycomb, or New Relic (Power tier).',
+  },
+  {
+    title: 'Voice Input',
+    href: '/docs/voice',
+    description: 'Send voice commands to your agents from the mobile app (Power tier).',
+  },
+  {
+    title: 'Troubleshooting',
+    href: '/docs/troubleshooting',
+    description: 'Common issues and how to fix them.',
+  },
+];
+
+/**
+ * Returns the previous and next nav items for a given path.
+ *
+ * @param currentPath - The current page path (e.g. "/docs/cli")
+ * @returns Object with prev and next items, or null if at the boundary
+ */
+export function getPrevNext(currentPath: string): {
+  prev: DocNavItem | null;
+  next: DocNavItem | null;
+} {
+  const index = docsNav.findIndex((item) => item.href === currentPath);
+  return {
+    prev: index > 0 ? docsNav[index - 1] : null,
+    next: index < docsNav.length - 1 ? docsNav[index + 1] : null,
+  };
+}

--- a/packages/styrby-web/src/app/docs/otel/page.tsx
+++ b/packages/styrby-web/src/app/docs/otel/page.tsx
@@ -1,0 +1,295 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "OTEL Metrics Export",
+  description:
+    "Export Styrby session metrics to Grafana Cloud, Datadog, Honeycomb, or New Relic via OpenTelemetry.",
+};
+
+/**
+ * OTEL Metrics Export documentation page.
+ *
+ * Covers setup for all four supported providers plus custom OTLP endpoints.
+ * Power tier feature.
+ */
+export default function OtelDocsPage() {
+  const { prev, next } = getPrevNext("/docs/otel");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        OTEL Metrics Export
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        Export session metrics to your existing observability platform.
+        Styrby sends data using the OpenTelemetry OTLP/HTTP protocol, so it
+        works with any OTLP-compatible backend. Power tier feature.
+      </p>
+
+      {/* What gets exported */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Exported Metrics
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        After each session, Styrby exports these 7 metrics to your configured
+        endpoint:
+      </p>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full text-sm text-left text-zinc-400">
+          <thead className="text-xs uppercase text-zinc-500 border-b border-zinc-800">
+            <tr>
+              <th className="py-2 pr-4">Metric</th>
+              <th className="py-2 pr-4">Type</th>
+              <th className="py-2">Attributes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-800">
+            <tr><td className="py-2 pr-4 font-mono text-zinc-300">styrby.session.duration_ms</td><td className="py-2 pr-4">Gauge</td><td className="py-2">agent, model, status</td></tr>
+            <tr><td className="py-2 pr-4 font-mono text-zinc-300">styrby.tokens.input</td><td className="py-2 pr-4">Sum</td><td className="py-2">agent, model</td></tr>
+            <tr><td className="py-2 pr-4 font-mono text-zinc-300">styrby.tokens.output</td><td className="py-2 pr-4">Sum</td><td className="py-2">agent, model</td></tr>
+            <tr><td className="py-2 pr-4 font-mono text-zinc-300">styrby.tokens.cache_read</td><td className="py-2 pr-4">Sum</td><td className="py-2">agent, model</td></tr>
+            <tr><td className="py-2 pr-4 font-mono text-zinc-300">styrby.tokens.cache_write</td><td className="py-2 pr-4">Sum</td><td className="py-2">agent, model</td></tr>
+            <tr><td className="py-2 pr-4 font-mono text-zinc-300">styrby.cost.usd</td><td className="py-2 pr-4">Sum</td><td className="py-2">agent, model</td></tr>
+            <tr><td className="py-2 pr-4 font-mono text-zinc-300">styrby.errors.count</td><td className="py-2 pr-4">Sum</td><td className="py-2">agent, error_source</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-zinc-500 text-sm">
+        All metrics include{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          service.name
+        </code>{" "}
+        as a resource attribute (defaults to &quot;styrby-cli&quot;).
+      </p>
+
+      {/* Two ways to configure */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Configuration
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        There are two ways to configure OTEL export. Both produce the same
+        result.
+      </p>
+
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Option A: Web Dashboard (recommended)
+      </h3>
+      <ol className="mt-3 list-decimal list-inside space-y-2 text-zinc-400">
+        <li>Go to <strong className="text-zinc-300">Settings</strong> in the web dashboard</li>
+        <li>Scroll to the <strong className="text-zinc-300">OTEL Metrics Export</strong> section</li>
+        <li>Select your provider preset (Grafana Cloud, Datadog, Honeycomb, New Relic, or Custom)</li>
+        <li>Paste your endpoint URL and authentication credentials</li>
+        <li>Click <strong className="text-zinc-300">Save</strong></li>
+        <li>Copy the generated environment variables from the preview panel</li>
+        <li>Add them to your shell profile (<code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">~/.zshrc</code> or <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">~/.bashrc</code>)</li>
+      </ol>
+
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Option B: Environment Variables (direct)
+      </h3>
+      <p className="mt-3 text-zinc-400">
+        Set these in your shell profile or{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">.env</code>{" "}
+        file:
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`export STYRBY_OTEL_ENABLED=true
+export STYRBY_OTEL_ENDPOINT="https://your-endpoint/v1/metrics"
+export STYRBY_OTEL_HEADERS='{"Authorization":"Bearer your-key"}'
+export STYRBY_OTEL_SERVICE="styrby-cli"
+export STYRBY_OTEL_TIMEOUT_MS="5000"`}
+      </pre>
+
+      {/* Grafana Cloud */}
+      <h2 className="mt-12 text-xl font-semibold text-zinc-100">
+        Grafana Cloud
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        Grafana Cloud accepts OTLP/HTTP data at a per-stack gateway endpoint.
+        You need your stack&apos;s instance ID and an API token with the
+        &quot;metrics:write&quot; scope.
+      </p>
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">Steps</h3>
+      <ol className="mt-3 list-decimal list-inside space-y-2 text-zinc-400">
+        <li>Sign in at <strong className="text-zinc-300">grafana.com</strong> and open your stack</li>
+        <li>Go to <strong className="text-zinc-300">My Account &rarr; Access Policies</strong> (left sidebar under Security)</li>
+        <li>Click <strong className="text-zinc-300">Create access policy</strong></li>
+        <li>Give it a name like &quot;Styrby Metrics&quot;, select the <strong className="text-zinc-300">metrics:write</strong> scope, and choose your Grafana Cloud stack</li>
+        <li>Click <strong className="text-zinc-300">Create</strong>, then <strong className="text-zinc-300">Add token</strong></li>
+        <li>Copy the token (you will not see it again)</li>
+        <li>Note your <strong className="text-zinc-300">Instance ID</strong> (shown at the top of the Access Policies page, or under your stack details)</li>
+        <li>Create the Base64 credentials: <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">echo -n &quot;INSTANCE_ID:API_TOKEN&quot; | base64</code></li>
+        <li>Find your OTLP gateway zone from your stack URL (e.g., <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">prod-us-east-0</code>)</li>
+      </ol>
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Environment Variables
+      </h3>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`export STYRBY_OTEL_ENABLED=true
+export STYRBY_OTEL_ENDPOINT="https://otlp-gateway-prod-us-east-0.grafana.net/otlp/v1/metrics"
+export STYRBY_OTEL_HEADERS='{"Authorization":"Basic <BASE64_INSTANCE_ID:API_TOKEN>"}'`}
+      </pre>
+      <p className="mt-3 text-zinc-500 text-sm">
+        Replace the zone (<code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">prod-us-east-0</code>) with your
+        stack&apos;s zone, and the Base64 string with the value from step 8.
+      </p>
+
+      {/* Datadog */}
+      <h2 className="mt-12 text-xl font-semibold text-zinc-100">Datadog</h2>
+      <p className="mt-3 text-zinc-400">
+        Datadog accepts OTLP metrics directly at their intake API. No Datadog
+        Agent or Collector required. You need a Datadog API key.
+      </p>
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">Steps</h3>
+      <ol className="mt-3 list-decimal list-inside space-y-2 text-zinc-400">
+        <li>Sign in at <strong className="text-zinc-300">app.datadoghq.com</strong></li>
+        <li>Go to <strong className="text-zinc-300">Organization Settings &rarr; API Keys</strong> (bottom of the left sidebar)</li>
+        <li>Click <strong className="text-zinc-300">New Key</strong>, name it &quot;Styrby Metrics&quot;</li>
+        <li>Copy the key value</li>
+        <li>Note your Datadog site domain (e.g., <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">datadoghq.com</code> for US1, <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">datadoghq.eu</code> for EU, <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">us3.datadoghq.com</code> for US3, etc.)</li>
+      </ol>
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Environment Variables
+      </h3>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`export STYRBY_OTEL_ENABLED=true
+export STYRBY_OTEL_ENDPOINT="https://api.datadoghq.com/api/intake/otlp/v1/metrics"
+export STYRBY_OTEL_HEADERS='{"DD-API-KEY":"<YOUR_DATADOG_API_KEY>"}'`}
+      </pre>
+      <p className="mt-3 text-zinc-500 text-sm">
+        If your Datadog account is in EU, replace{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">api.datadoghq.com</code> with{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">api.datadoghq.eu</code>. For US3, use{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">api.us3.datadoghq.com</code>. For US5, use{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">api.us5.datadoghq.com</code>.
+      </p>
+
+      {/* Honeycomb */}
+      <h2 className="mt-12 text-xl font-semibold text-zinc-100">Honeycomb</h2>
+      <p className="mt-3 text-zinc-400">
+        Honeycomb accepts OTLP metrics natively. You need a Honeycomb Ingest API
+        key. Metrics appear under the dataset you specify (or default to
+        &quot;styrby-cli&quot;).
+      </p>
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">Steps</h3>
+      <ol className="mt-3 list-decimal list-inside space-y-2 text-zinc-400">
+        <li>Sign in at <strong className="text-zinc-300">ui.honeycomb.io</strong></li>
+        <li>Click the gear icon in the lower-left corner to open <strong className="text-zinc-300">Environment Settings</strong></li>
+        <li>Go to <strong className="text-zinc-300">API Keys</strong></li>
+        <li>Click <strong className="text-zinc-300">Create API Key</strong></li>
+        <li>Name it &quot;Styrby Metrics&quot; and check <strong className="text-zinc-300">Can create datasets</strong></li>
+        <li>Copy the key (you will not see it again after this page)</li>
+      </ol>
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Environment Variables
+      </h3>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`export STYRBY_OTEL_ENABLED=true
+export STYRBY_OTEL_ENDPOINT="https://api.honeycomb.io/v1/metrics"
+export STYRBY_OTEL_HEADERS='{"X-Honeycomb-Team":"<YOUR_API_KEY>"}'`}
+      </pre>
+      <p className="mt-3 text-zinc-500 text-sm">
+        For EU accounts, replace{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">api.honeycomb.io</code> with{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">api.eu1.honeycomb.io</code>.
+        To set a custom dataset name, add{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">&quot;X-Honeycomb-Dataset&quot;:&quot;your-dataset&quot;</code>{" "}
+        to the headers JSON.
+      </p>
+
+      {/* New Relic */}
+      <h2 className="mt-12 text-xl font-semibold text-zinc-100">New Relic</h2>
+      <p className="mt-3 text-zinc-400">
+        New Relic accepts OTLP/HTTP at their dedicated ingest endpoint. You
+        need your account&apos;s <strong className="text-zinc-300">license key</strong> (not the
+        REST API key or User API key).
+      </p>
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">Steps</h3>
+      <ol className="mt-3 list-decimal list-inside space-y-2 text-zinc-400">
+        <li>Sign in at <strong className="text-zinc-300">one.newrelic.com</strong></li>
+        <li>Click your account name in the bottom-left corner</li>
+        <li>Go to <strong className="text-zinc-300">Administration &rarr; API Keys</strong></li>
+        <li>Find your <strong className="text-zinc-300">INGEST - LICENSE</strong> key (or click <strong className="text-zinc-300">Create a key</strong> with type &quot;Ingest - License&quot;)</li>
+        <li>Click the three-dot menu next to the key and select <strong className="text-zinc-300">Copy key</strong></li>
+      </ol>
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Environment Variables
+      </h3>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`export STYRBY_OTEL_ENABLED=true
+export STYRBY_OTEL_ENDPOINT="https://otlp.nr-data.net/v1/metrics"
+export STYRBY_OTEL_HEADERS='{"api-key":"<YOUR_LICENSE_KEY>"}'`}
+      </pre>
+      <p className="mt-3 text-zinc-500 text-sm">
+        For EU accounts, replace{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">otlp.nr-data.net</code> with{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">otlp.eu01.nr-data.net</code>.
+        Use the <strong>license key</strong> (starts with a long hex string), not the User or REST API key.
+      </p>
+
+      {/* Custom endpoint */}
+      <h2 className="mt-12 text-xl font-semibold text-zinc-100">
+        Custom OTLP Endpoint
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        Any backend that accepts OTLP/HTTP JSON at a{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">/v1/metrics</code>{" "}
+        path will work. This includes self-hosted OpenTelemetry Collectors,
+        Prometheus with the OTLP receiver, Jaeger, SigNoz, and others.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`export STYRBY_OTEL_ENABLED=true
+export STYRBY_OTEL_ENDPOINT="https://your-collector:4318/v1/metrics"
+export STYRBY_OTEL_HEADERS='{"Authorization":"Bearer your-token"}'`}
+      </pre>
+
+      {/* Verification */}
+      <h2 className="mt-12 text-xl font-semibold text-zinc-100">
+        Verifying the Integration
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        After adding the environment variables to your shell profile:
+      </p>
+      <ol className="mt-3 list-decimal list-inside space-y-2 text-zinc-400">
+        <li>Open a new terminal (or run <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">source ~/.zshrc</code>)</li>
+        <li>Start a Styrby session: <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby</code></li>
+        <li>Send a prompt, wait for the agent to respond, then stop the session</li>
+        <li>Check your observability platform for metrics with <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">service.name = styrby-cli</code></li>
+      </ol>
+      <p className="mt-3 text-zinc-400">
+        If metrics do not appear, check for warnings in the Styrby CLI output.
+        The exporter logs connection errors but does not interrupt your session.
+        Common issues:
+      </p>
+      <ul className="mt-3 list-disc list-inside space-y-2 text-zinc-400">
+        <li><strong className="text-zinc-300">401 Unauthorized</strong> - Check that your API key or token is correct and has write permissions</li>
+        <li><strong className="text-zinc-300">Connection timeout</strong> - Verify the endpoint URL is reachable from your machine. Increase <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">STYRBY_OTEL_TIMEOUT_MS</code> if behind a slow proxy</li>
+        <li><strong className="text-zinc-300">No data in dashboard</strong> - It can take 1-2 minutes for metrics to appear. Check that you are looking at the correct service name and time range</li>
+      </ul>
+
+      {/* Building dashboards */}
+      <h2 className="mt-12 text-xl font-semibold text-zinc-100">
+        Building a Dashboard
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        Once metrics are flowing, create a dashboard with panels for:
+      </p>
+      <ul className="mt-3 list-disc list-inside space-y-2 text-zinc-400">
+        <li><strong className="text-zinc-300">Daily AI spend</strong> - Sum of <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby.cost.usd</code> grouped by day</li>
+        <li><strong className="text-zinc-300">Token usage by agent</strong> - <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby.tokens.input</code> + <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby.tokens.output</code> grouped by <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">agent</code> attribute</li>
+        <li><strong className="text-zinc-300">Session duration trend</strong> - Average of <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby.session.duration_ms</code> over time</li>
+        <li><strong className="text-zinc-300">Cache hit ratio</strong> - <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby.tokens.cache_read</code> / (<code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby.tokens.input</code> + <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby.tokens.cache_read</code>)</li>
+        <li><strong className="text-zinc-300">Error rate</strong> - <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby.errors.count</code> as a time series, alert when it spikes</li>
+      </ul>
+      <p className="mt-3 text-zinc-400">
+        Set alerts on <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">styrby.cost.usd</code> to get paged
+        when daily spend exceeds your threshold. This works alongside
+        Styrby&apos;s built-in budget alerts for defense-in-depth cost control.
+      </p>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/page.tsx
+++ b/packages/styrby-web/src/app/docs/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { docsNav } from "./nav";
+
+export const metadata: Metadata = {
+  title: "Documentation",
+  description:
+    "Styrby documentation hub. Get started with the CLI, connect your AI agents, and explore the full API reference.",
+};
+
+/**
+ * Documentation index page. Lists all doc sections with descriptions.
+ */
+export default function DocsIndexPage() {
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Documentation
+      </h1>
+      <p className="mt-3 text-lg text-zinc-400">
+        Everything you need to set up Styrby, connect your AI coding agents, and
+        control them from anywhere.
+      </p>
+
+      <div className="mt-10 grid gap-4 sm:grid-cols-2">
+        {docsNav.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="group rounded-lg border border-zinc-800 bg-zinc-900/50 p-5 transition-colors hover:border-amber-500/40 hover:bg-zinc-900"
+          >
+            <h2 className="flex items-center gap-2 text-base font-semibold text-zinc-100 group-hover:text-amber-500">
+              {item.title}
+              <ArrowRight className="h-4 w-4 opacity-0 transition-all group-hover:translate-x-1 group-hover:opacity-100" />
+            </h2>
+            <p className="mt-1.5 text-sm text-zinc-500">{item.description}</p>
+          </Link>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/prev-next.tsx
+++ b/packages/styrby-web/src/app/docs/prev-next.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { DocNavItem } from "./nav";
+
+/**
+ * Previous/Next navigation links rendered at the bottom of each doc page.
+ *
+ * @param prev - The previous page in the docs nav, or null
+ * @param next - The next page in the docs nav, or null
+ */
+export function PrevNext({
+  prev,
+  next,
+}: {
+  prev: DocNavItem | null;
+  next: DocNavItem | null;
+}) {
+  return (
+    <div className="mt-16 flex items-center justify-between border-t border-zinc-800 pt-6">
+      {prev ? (
+        <Link
+          href={prev.href}
+          className="group flex items-center gap-2 text-sm text-zinc-400 transition-colors hover:text-amber-500"
+        >
+          <ChevronLeft className="h-4 w-4 transition-transform group-hover:-translate-x-0.5" />
+          {prev.title}
+        </Link>
+      ) : (
+        <span />
+      )}
+      {next ? (
+        <Link
+          href={next.href}
+          className="group flex items-center gap-2 text-sm text-zinc-400 transition-colors hover:text-amber-500"
+        >
+          {next.title}
+          <ChevronRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+        </Link>
+      ) : (
+        <span />
+      )}
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/docs/security/page.tsx
+++ b/packages/styrby-web/src/app/docs/security/page.tsx
@@ -1,0 +1,210 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "Security",
+  description: "Styrby security architecture: E2E encryption, zero-knowledge design, key management, audit logging.",
+};
+
+/**
+ * Security documentation page.
+ */
+export default function SecurityPage() {
+  const { prev, next } = getPrevNext("/docs/security");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Security
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        Styrby is built on a zero-knowledge architecture. Your code and
+        conversations are end-to-end encrypted. We cannot read them.
+      </p>
+
+      {/* E2E Encryption */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        End-to-End Encryption
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        All session messages are encrypted with TweetNaCl{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">box</code>{" "}
+        (Curve25519 key exchange, XSalsa20 encryption, Poly1305 authentication)
+        before leaving your machine.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`# Encryption flow:
+1. CLI generates a 32-byte NaCl keypair during "styrby onboard"
+2. Public key uploaded to Styrby and stored in the machine_keys table
+3. Private key stored locally in ~/.styrby/config.json
+4. Each message encrypted: nacl.box(msg, nonce, recipientPub, senderPriv)
+   - nonce: 24 random bytes, unique per message
+5. Server stores only the ciphertext
+6. Dashboard and mobile decrypt locally using the device's private key`}</code>
+      </pre>
+
+      {/* Zero-Knowledge */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Zero-Knowledge Architecture
+      </h2>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">
+        What Styrby can see
+      </h3>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>Token counts (input, output, cache) for cost tracking</li>
+        <li>Agent type and model name</li>
+        <li>Session timestamps and duration</li>
+        <li>Machine connection status</li>
+      </ul>
+
+      <h3 className="mt-4 text-base font-medium text-zinc-200">
+        What Styrby cannot see
+      </h3>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>Message content (prompts and responses)</li>
+        <li>File contents or diffs</li>
+        <li>Tool call arguments</li>
+        <li>Your source code</li>
+      </ul>
+      <p className="mt-3 text-sm text-zinc-500">
+        Even if Styrby servers were compromised, attackers would only get
+        encrypted blobs. The decryption keys exist only on your devices.
+      </p>
+
+      {/* Key Management */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Key Management
+      </h2>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">Generation</h3>
+      <p className="mt-1 text-sm text-zinc-400">
+        Keys are generated using{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          nacl.box.keyPair()
+        </code>{" "}
+        during the onboarding process. This produces a 32-byte public key and a
+        32-byte secret key. The entropy source is the OS cryptographic random
+        number generator.
+      </p>
+
+      <h3 className="mt-4 text-base font-medium text-zinc-200">Storage</h3>
+      <p className="mt-1 text-sm text-zinc-400">
+        The CLI stores the private key in{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          ~/.styrby/config.json
+        </code>{" "}
+        with 0600 file permissions (owner read/write only). On mobile, the key
+        is stored in the device keychain (iOS Keychain / Android Keystore).
+      </p>
+
+      <h3 className="mt-4 text-base font-medium text-zinc-200">Re-pairing</h3>
+      <p className="mt-1 text-sm text-zinc-400">
+        If you lose your private key (cleared browser storage, corrupted config,
+        or new machine), run{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          styrby onboard --force
+        </code>{" "}
+        to generate a new keypair and re-register. Sessions encrypted with the
+        old key will no longer be decryptable on the new device.
+      </p>
+
+      {/* API Key Hashing */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        API Key Hashing
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        API keys are prefixed with{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          styrby_
+        </code>{" "}
+        and hashed with bcrypt (cost factor 12) before storage. When you make
+        an API request, Styrby hashes the provided key and compares it against
+        the stored hash. The raw key is never persisted. The plaintext key is
+        returned only once at creation time.
+      </p>
+
+      {/* Rate Limiting */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Rate Limiting
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        All API endpoints are rate-limited using Upstash Redis with a sliding
+        window algorithm. Limits are applied per user (authenticated routes)
+        and per IP (public routes like login).
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>Authentication endpoints: 10 requests per minute per IP</li>
+        <li>API v1 endpoints: 100 requests per minute per API key</li>
+        <li>Webhook management: 30 requests per minute per user</li>
+      </ul>
+
+      {/* Webhook Security */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Webhook Security
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Webhook URLs must use HTTPS and must not target internal or private
+        network addresses. The following are blocked:
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>localhost and 127.0.0.1</li>
+        <li>RFC 1918 private IPs (10.x.x.x, 172.16-31.x.x, 192.168.x.x)</li>
+        <li>Link-local (169.254.x.x) and cloud metadata services</li>
+      </ul>
+      <p className="mt-2 text-sm text-zinc-500">
+        This prevents SSRF attacks where a webhook could be used to make
+        requests against internal infrastructure.
+      </p>
+
+      {/* Audit Logging */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Audit Logging
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Security-relevant events are recorded in the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">audit_log</code>{" "}
+        table with BRIN indexing for efficient time-range queries. Logged events
+        include:
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>Login attempts (success and failure)</li>
+        <li>Machine pairing and unpairing</li>
+        <li>API key creation and revocation</li>
+        <li>Webhook endpoint changes</li>
+        <li>Permission approvals and denials</li>
+        <li>Team member additions and removals</li>
+        <li>Budget alert triggers</li>
+      </ul>
+
+      {/* Data Residency */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Data Residency and Compliance
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Styrby infrastructure runs on Supabase (AWS) and Vercel. Database and
+        auth are in the Supabase project region. Encrypted session data at rest
+        uses AES-256 (Supabase default). In transit, all connections use TLS
+        1.3.
+      </p>
+      <p className="mt-2 text-sm text-zinc-400">
+        For compliance details, data processing agreements, and security
+        certifications, see the{" "}
+        <a
+          href="/dpa"
+          className="text-amber-500 underline underline-offset-2 hover:text-amber-400"
+        >
+          Data Processing Agreement
+        </a>{" "}
+        and{" "}
+        <a
+          href="/security"
+          className="text-amber-500 underline underline-offset-2 hover:text-amber-400"
+        >
+          Security page
+        </a>.
+      </p>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/teams/page.tsx
+++ b/packages/styrby-web/src/app/docs/teams/page.tsx
@@ -1,0 +1,169 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "Team Management",
+  description: "Create teams, invite members, manage roles, and control data visibility in Styrby.",
+};
+
+/**
+ * Team Management documentation page.
+ */
+export default function TeamsPage() {
+  const { prev, next } = getPrevNext("/docs/teams");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Team Management
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        Share cost visibility and agent management across your team. Available
+        on the Power tier. Power includes up to 3 team members.
+      </p>
+
+      {/* Creating a Team */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Creating a Team
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Go to Dashboard &gt; Team and click &quot;Create Team&quot;. You
+        become the Owner. One team per account; the Owner&apos;s Power
+        subscription covers the team.
+      </p>
+
+      {/* Inviting Members */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Inviting Members
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Invite by email from the Team page. The invitee receives an email with
+        an invite link. They must create a Styrby account (any tier) to accept.
+        Invite links expire after 7 days.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`# Invite link format:
+https://styrbyapp.com/invite/<token>
+
+# Token expires after 7 days
+# Resend from Dashboard > Team > Pending Invites`}</code>
+      </pre>
+      <p className="mt-2 text-sm text-zinc-500">
+        Invites are tied to the recipient&apos;s email address. An invitation
+        addressed to one email cannot be accepted by a different account.
+      </p>
+
+      {/* Roles */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">Roles</h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Three roles are available: owner, admin, and member. Roles are assigned
+        per team and enforced by row-level security in the database.
+      </p>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Permission</th>
+              <th className="pb-2 pr-4 font-medium text-zinc-300 text-center">Owner</th>
+              <th className="pb-2 pr-4 font-medium text-zinc-300 text-center">Admin</th>
+              <th className="pb-2 font-medium text-zinc-300 text-center">Member</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">View own sessions and costs</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 text-xs text-center">Yes</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">View team aggregate costs</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 text-xs text-center">Yes</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">View other members&apos; sessions</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 text-xs text-center">No</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">Invite members</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 text-xs text-center">No</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">Remove regular members</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 text-xs text-center">No</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">Manage team budget alerts</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 text-xs text-center">No</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">Manage API keys and webhooks</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 text-xs text-center">No</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 text-xs">Change member roles</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 pr-4 text-xs text-center">No</td>
+              <td className="py-2 text-xs text-center">No</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-xs">Delete team</td>
+              <td className="py-2 pr-4 text-xs text-center">Yes</td>
+              <td className="py-2 pr-4 text-xs text-center">No</td>
+              <td className="py-2 text-xs text-center">No</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-sm text-zinc-500">
+        Admins can remove regular members but cannot remove other admins or the
+        owner. Admins cannot promote themselves to owner. Any member can remove
+        themselves (leave the team).
+      </p>
+
+      {/* Data Visibility */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Data Visibility
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Session message content is always encrypted per-user. Even Owners and
+        Admins cannot read other members&apos; session messages. What is shared:
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>Session metadata: agent, model, duration, token counts, cost</li>
+        <li>Aggregate cost data: team total, per-member breakdown</li>
+        <li>Agent status: which agents are active on which machines</li>
+      </ul>
+      <p className="mt-2 text-sm text-zinc-500">
+        This design ensures cost accountability across the team while
+        preserving individual code privacy.
+      </p>
+
+      {/* Removing Members */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Removing Members
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Owners can remove any member. Admins can remove regular members only,
+        not other admins or the owner. Removal takes effect immediately. The
+        removed member keeps their individual Styrby account and data, but
+        loses access to team views.
+      </p>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/troubleshooting/page.tsx
+++ b/packages/styrby-web/src/app/docs/troubleshooting/page.tsx
@@ -1,0 +1,220 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "Troubleshooting",
+  description: "Fix common Styrby issues: CLI connection, agent detection, push notifications, and more.",
+};
+
+/**
+ * Troubleshooting page. Common issues and their solutions.
+ */
+export default function TroubleshootingPage() {
+  const { prev, next } = getPrevNext("/docs/troubleshooting");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Troubleshooting
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        Common issues and how to fix them. If your problem is not listed here,
+        reach out at{" "}
+        <a
+          href="mailto:support@styrbyapp.com"
+          className="text-amber-500 underline underline-offset-2 hover:text-amber-400"
+        >
+          support@styrbyapp.com
+        </a>.
+      </p>
+
+      {/* CLI won't connect */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        CLI won&apos;t connect
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        The CLI needs outbound HTTPS (port 443) to styrbyapp.com and
+        supabase.co.
+      </p>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">
+        Check connectivity
+      </h3>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`curl -I https://styrbyapp.com/api/health
+# Should return HTTP 200
+
+curl -I https://supabase.co
+# Should return HTTP 200`}</code>
+      </pre>
+
+      <h3 className="mt-4 text-base font-medium text-zinc-200">
+        Firewall or proxy
+      </h3>
+      <p className="mt-1 text-sm text-zinc-400">
+        If you are behind a corporate firewall or proxy, set the standard proxy
+        environment variables:
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`export HTTPS_PROXY=http://proxy.corp.com:8080
+export NO_PROXY=localhost,127.0.0.1`}</code>
+      </pre>
+
+      <h3 className="mt-4 text-base font-medium text-zinc-200">VPN issues</h3>
+      <p className="mt-1 text-sm text-zinc-400">
+        Some VPNs intercept WebSocket connections. If{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          styrby status
+        </code>{" "}
+        shows &quot;connecting&quot; indefinitely, try disconnecting your VPN
+        temporarily to confirm.
+      </p>
+
+      {/* Not authenticated */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        &quot;Not authenticated&quot; error
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Run the full setup wizard to authenticate and register your machine:
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`styrby onboard
+# Use --force to re-authenticate if already set up
+styrby onboard --force`}</code>
+      </pre>
+
+      {/* Agent not appearing */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Agent not appearing in the dashboard
+      </h2>
+      <ol className="mt-2 list-decimal space-y-2 pl-6 text-sm text-zinc-400">
+        <li>
+          Run the health check to see if your agent is detected:{" "}
+          <pre className="mt-2 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+            <code>styrby doctor</code>
+          </pre>
+        </li>
+        <li>
+          If the agent shows as &quot;not installed&quot;, install it:
+          <pre className="mt-2 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+            <code>styrby install claude</code>
+          </pre>
+        </li>
+        <li>
+          Confirm the CLI is running and connected:
+          <pre className="mt-2 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+            <code>styrby status</code>
+          </pre>
+        </li>
+        <li>
+          Start the agent via Styrby (not directly):
+          <pre className="mt-2 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+            <code>styrby claude</code>
+          </pre>
+        </li>
+        <li>
+          Check CLI logs for errors:
+          <pre className="mt-2 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+            <code>{`STYRBY_LOG_LEVEL=debug styrby status`}</code>
+          </pre>
+        </li>
+      </ol>
+
+      {/* Push notifications */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Push notifications not working
+      </h2>
+      <ul className="mt-2 list-disc space-y-2 pl-6 text-sm text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">Check OS permissions:</strong> Make sure
+          the Styrby app has notification permission in your phone&apos;s settings.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Check quiet hours:</strong> Notifications
+          are suppressed during quiet hours (except permission requests). Verify
+          your quiet hours config in Settings &gt; Notifications.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Token registration:</strong> Force a
+          token refresh by signing out of the mobile app and signing back in.
+          This re-registers the push token (APNs or FCM).
+        </li>
+        <li>
+          <strong className="text-zinc-300">Check event types:</strong> Make sure
+          the specific event type is enabled in your notification preferences.
+        </li>
+      </ul>
+
+      {/* Cost data delayed */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Cost data delayed or missing
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        The daily cost chart uses a materialized view (
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          mv_daily_cost_summary
+        </code>
+        ) that refreshes periodically for performance. If you just finished a
+        session:
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>
+          Near real-time cost data appears in session detail views and
+          the cost ticker.
+        </li>
+        <li>
+          The daily aggregate chart updates within 5 minutes when the
+          materialized view refreshes.
+        </li>
+        <li>
+          If data is still missing after 10 minutes, check your machine
+          connection status. Cost records require the CLI to be online to report.
+        </li>
+      </ul>
+
+      {/* Session replay blank */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Session replay shows blank messages
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Session messages are end-to-end encrypted. Blank messages mean the
+        decryption key on your current device does not match the key used to
+        encrypt the session.
+      </p>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">Common causes</h3>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">Different device:</strong> You are
+          viewing from a device that was not paired when the session was
+          recorded. Each device has its own keypair.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Re-onboarded:</strong> If you ran{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            styrby onboard --force
+          </code>{" "}
+          after the session was recorded, a new keypair was generated. Sessions
+          encrypted with the old key are no longer decryptable on this machine.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Cleared config:</strong> If{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            ~/.styrby/config.json
+          </code>{" "}
+          was deleted, the private key was lost along with it.
+        </li>
+      </ul>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">Fix</h3>
+      <p className="mt-1 text-sm text-zinc-400">
+        Open the session from the original machine where the agent ran. That
+        machine has the private key in{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          ~/.styrby/config.json
+        </code>{" "}
+        and can decrypt the session.
+      </p>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/voice/page.tsx
+++ b/packages/styrby-web/src/app/docs/voice/page.tsx
@@ -1,0 +1,417 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "Voice Input",
+  description:
+    "Send voice commands to your AI coding agents from the Styrby mobile app. Power tier, mobile only. Requires a transcription endpoint you provide.",
+};
+
+/**
+ * Voice Input documentation page.
+ *
+ * Covers setup for OpenAI Whisper and self-hosted alternatives,
+ * hold-to-talk vs toggle mode, and troubleshooting.
+ * Power tier feature, mobile only.
+ */
+export default function VoiceDocsPage() {
+  const { prev, next } = getPrevNext("/docs/voice");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Voice Input
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        Speak to your AI coding agent instead of typing. Styrby captures audio
+        on the mobile app, sends it to a transcription service you configure,
+        then delivers the transcribed text to your agent as a normal message.
+        Power tier feature. Mobile only.
+      </p>
+      <p className="mt-3 text-zinc-400">
+        Styrby does not include a transcription service and never processes or
+        stores your audio. Audio goes directly from your phone to whichever
+        transcription endpoint you configure. Your code conversations stay
+        private.
+      </p>
+
+      {/* Overview */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">Overview</h2>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full text-sm text-left text-zinc-400">
+          <thead className="text-xs uppercase text-zinc-500 border-b border-zinc-800">
+            <tr>
+              <th className="py-2 pr-4">Property</th>
+              <th className="py-2">Value</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-800">
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Tier requirement</td>
+              <td className="py-2">Power tier</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Platform</td>
+              <td className="py-2">iOS and Android (mobile only)</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Audio storage</td>
+              <td className="py-2">Never stored by Styrby</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Audio routing</td>
+              <td className="py-2">Phone to your transcription endpoint directly</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Transcription service</td>
+              <td className="py-2">Provided by you (not included in Styrby)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Requirements */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Requirements
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        To use Voice Input you need two things:
+      </p>
+      <ul className="mt-3 list-disc list-inside space-y-2 text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">A transcription endpoint</strong>{" "}
+          that accepts audio and returns text. The endpoint must accept{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            multipart/form-data
+          </code>{" "}
+          POST requests with an{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            audio
+          </code>{" "}
+          field and return a JSON response with a{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            text
+          </code>{" "}
+          field. The OpenAI Whisper API format is the default.
+        </li>
+        <li>
+          <strong className="text-zinc-300">An API key or access token</strong>{" "}
+          for that service, if required.
+        </li>
+      </ul>
+      <p className="mt-3 text-zinc-400">
+        The recommended service is the{" "}
+        <strong className="text-zinc-300">OpenAI Whisper API</strong> at
+        $0.006 per minute. A two-minute voice command costs less than two cents.
+        Self-hosted alternatives are also supported for teams with stricter
+        privacy requirements.
+      </p>
+
+      {/* OpenAI Whisper setup */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Setting Up with OpenAI Whisper
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        OpenAI&apos;s Whisper API is the easiest way to get started. It requires
+        an OpenAI account and a few minutes of setup.
+      </p>
+      <ol className="mt-3 list-decimal list-inside space-y-2 text-zinc-400">
+        <li>
+          Sign in at{" "}
+          <strong className="text-zinc-300">platform.openai.com</strong>
+        </li>
+        <li>
+          Go to{" "}
+          <strong className="text-zinc-300">
+            API Keys
+          </strong>{" "}
+          in the left sidebar
+        </li>
+        <li>
+          Click <strong className="text-zinc-300">Create new secret key</strong>,
+          name it &quot;Styrby Voice&quot;, and copy the key
+        </li>
+        <li>
+          Open the Styrby mobile app and go to{" "}
+          <strong className="text-zinc-300">Settings &gt; Voice Input</strong>
+        </li>
+        <li>
+          Set <strong className="text-zinc-300">Transcription Endpoint</strong>{" "}
+          to:
+          <pre className="mt-2 overflow-x-auto rounded-lg bg-zinc-900 p-3 text-sm text-zinc-300 border border-zinc-800">
+{`https://api.openai.com/v1/audio/transcriptions`}
+          </pre>
+        </li>
+        <li>
+          Set <strong className="text-zinc-300">API Key</strong> to the key you
+          copied in step 3
+        </li>
+        <li>
+          Set <strong className="text-zinc-300">Model</strong> to{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            whisper-1
+          </code>
+        </li>
+        <li>
+          Tap <strong className="text-zinc-300">Save</strong> and then{" "}
+          <strong className="text-zinc-300">Test Microphone</strong> to confirm
+          transcription works
+        </li>
+      </ol>
+      <p className="mt-3 text-zinc-500 text-sm">
+        The API key is stored securely in your device keychain. It is never sent
+        to Styrby servers.
+      </p>
+
+      {/* Self-hosted */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Self-Hosted Transcription
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        If you prefer not to send audio to a third-party cloud service, you can
+        run a local Whisper server. Two popular options:
+      </p>
+
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Whisper.cpp (fastest on Apple Silicon)
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Whisper.cpp is a C++ port of OpenAI Whisper that runs a local HTTP
+        server. It is the fastest self-hosted option on Apple Silicon Macs.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Clone and build
+git clone https://github.com/ggerganov/whisper.cpp
+cd whisper.cpp
+make
+
+# Download a model (base is fast and accurate enough for voice commands)
+bash ./models/download-ggml-model.sh base.en
+
+# Start the server on port 8080
+./server -m models/ggml-base.en.bin --port 8080`}
+      </pre>
+      <p className="mt-3 text-zinc-400">
+        Then in Styrby mobile Settings &gt; Voice Input, set:
+      </p>
+      <ul className="mt-2 space-y-1 text-zinc-400 text-sm list-disc list-inside">
+        <li>
+          <strong className="text-zinc-300">Transcription Endpoint:</strong>{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            http://your-mac-ip:8080/inference
+          </code>
+        </li>
+        <li>
+          <strong className="text-zinc-300">API Key:</strong> leave blank (no
+          auth required for local server)
+        </li>
+      </ul>
+      <p className="mt-2 text-zinc-500 text-sm">
+        Your phone and Mac must be on the same network for a local server to be
+        reachable from the mobile app.
+      </p>
+
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Faster Whisper (Docker)
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Faster Whisper uses CTranslate2 for significantly faster inference than
+        the original Whisper model, and is easy to run with Docker.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-300 border border-zinc-800">
+{`# Run Faster Whisper with the whisper-asr-webservice image
+docker run -d -p 9000:9000 \
+  -e ASR_MODEL=base \
+  onerahmet/openai-whisper-asr-webservice:latest`}
+      </pre>
+      <p className="mt-3 text-zinc-400">
+        In Styrby mobile Settings &gt; Voice Input, set the endpoint to:
+      </p>
+      <pre className="mt-2 overflow-x-auto rounded-lg bg-zinc-900 p-3 text-sm text-zinc-300 border border-zinc-800">
+{`http://your-server-ip:9000/asr`}
+      </pre>
+
+      {/* Configuration options */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Configuration Options
+      </h2>
+      <p className="mt-3 text-zinc-400">
+        All voice settings are under{" "}
+        <strong className="text-zinc-300">Settings &gt; Voice Input</strong> in
+        the Styrby mobile app.
+      </p>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full text-sm text-left text-zinc-400">
+          <thead className="text-xs uppercase text-zinc-500 border-b border-zinc-800">
+            <tr>
+              <th className="py-2 pr-4">Setting</th>
+              <th className="py-2 pr-4">Options</th>
+              <th className="py-2">Notes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-800">
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Input mode</td>
+              <td className="py-2 pr-4">Hold to talk / Toggle</td>
+              <td className="py-2 text-xs">
+                Hold to talk: press and hold the mic button while speaking, release to
+                transcribe. Toggle: tap once to start, tap again to stop.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Transcription endpoint</td>
+              <td className="py-2 pr-4">URL string</td>
+              <td className="py-2 text-xs">
+                Must accept{" "}
+                <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs text-zinc-300">
+                  multipart/form-data
+                </code>{" "}
+                with an{" "}
+                <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs text-zinc-300">
+                  audio
+                </code>{" "}
+                field and return{" "}
+                <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs text-zinc-300">
+                  {"{ text: string }"}
+                </code>
+                .
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">API key</td>
+              <td className="py-2 pr-4">String</td>
+              <td className="py-2 text-xs">
+                Sent as{" "}
+                <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs text-zinc-300">
+                  Authorization: Bearer &lt;key&gt;
+                </code>
+                . Leave blank for unauthenticated local servers.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Model</td>
+              <td className="py-2 pr-4">String</td>
+              <td className="py-2 text-xs">
+                Passed as the{" "}
+                <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs text-zinc-300">
+                  model
+                </code>{" "}
+                field in the form data. Use{" "}
+                <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs text-zinc-300">
+                  whisper-1
+                </code>{" "}
+                for the OpenAI API.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Language</td>
+              <td className="py-2 pr-4">Auto / ISO 639-1 code</td>
+              <td className="py-2 text-xs">
+                Auto-detect is recommended. Set a specific language code (e.g.,{" "}
+                <code className="rounded bg-zinc-800 px-1 py-0.5 text-xs text-zinc-300">
+                  en
+                </code>
+                ) to improve accuracy for short technical phrases.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 text-zinc-300">Request timeout</td>
+              <td className="py-2 pr-4">5 to 30 seconds</td>
+              <td className="py-2 text-xs">
+                Increase if transcription requests fail on slow connections or
+                for longer recordings.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Troubleshooting */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Troubleshooting
+      </h2>
+
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        No transcription returned
+      </h3>
+      <ul className="mt-2 list-disc list-inside space-y-2 text-zinc-400">
+        <li>
+          Confirm the endpoint URL is correct and reachable from your phone.
+          Open a browser on the same network and navigate to the URL to check
+          connectivity.
+        </li>
+        <li>
+          Check that the API key is valid. For OpenAI, verify the key has not
+          been revoked in the API Keys dashboard.
+        </li>
+        <li>
+          Confirm microphone permission is granted to the Styrby app in your
+          phone&apos;s system settings (Settings &gt; Styrby &gt; Microphone).
+        </li>
+      </ul>
+
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Garbled or inaccurate transcription
+      </h3>
+      <ul className="mt-2 list-disc list-inside space-y-2 text-zinc-400">
+        <li>
+          Speak clearly and at a moderate pace. Background noise significantly
+          reduces accuracy.
+        </li>
+        <li>
+          Set a specific language code in Settings &gt; Voice Input &gt;
+          Language instead of using auto-detect. Technical jargon like variable
+          names and framework names transcribes more accurately with a known
+          language hint.
+        </li>
+        <li>
+          If using a self-hosted model, try a larger model variant (e.g.,{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            small
+          </code>{" "}
+          or{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            medium
+          </code>{" "}
+          instead of{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            base
+          </code>
+          ).
+        </li>
+      </ul>
+
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Request timeout
+      </h3>
+      <ul className="mt-2 list-disc list-inside space-y-2 text-zinc-400">
+        <li>
+          Increase the timeout in Settings &gt; Voice Input &gt; Request
+          Timeout. A 10-second timeout is usually enough for cloud services.
+          Self-hosted servers on first load may need up to 20 seconds while the
+          model warms up.
+        </li>
+        <li>
+          For self-hosted servers, confirm the server is running and not
+          sleeping. Containers on low-memory hosts sometimes get killed under
+          load.
+        </li>
+      </ul>
+
+      <h3 className="mt-6 text-lg font-medium text-zinc-200">
+        Voice Input option not available
+      </h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Voice Input requires the Power tier. If the setting is grayed out,
+        upgrade your plan from{" "}
+        <strong className="text-zinc-300">Settings &gt; Plan</strong> in the
+        mobile app or from the{" "}
+        <strong className="text-zinc-300">Pricing</strong> page on the web
+        dashboard.
+      </p>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/app/docs/webhooks/page.tsx
+++ b/packages/styrby-web/src/app/docs/webhooks/page.tsx
@@ -1,0 +1,236 @@
+import type { Metadata } from "next";
+import { PrevNext } from "../prev-next";
+import { getPrevNext } from "../nav";
+
+export const metadata: Metadata = {
+  title: "Webhooks",
+  description: "Styrby webhook events, payload format, signature verification, and retry policy.",
+};
+
+/**
+ * Webhooks documentation page.
+ */
+export default function WebhooksPage() {
+  const { prev, next } = getPrevNext("/docs/webhooks");
+
+  return (
+    <article>
+      <h1 className="text-3xl font-bold tracking-tight text-zinc-50">
+        Webhooks
+      </h1>
+      <p className="mt-3 text-zinc-400">
+        Get HTTP event callbacks when events happen in your Styrby account.
+        Available on Pro (3 webhooks) and Power (10 webhooks) tiers. Not
+        available on Free.
+      </p>
+
+      {/* Available Events */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Available Events
+      </h2>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left">
+              <th className="pb-2 pr-4 font-medium text-zinc-300">Event</th>
+              <th className="pb-2 font-medium text-zinc-300">Fired when</th>
+            </tr>
+          </thead>
+          <tbody className="text-zinc-400">
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">session.started</td>
+              <td className="py-2 text-xs">An agent session begins.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">session.completed</td>
+              <td className="py-2 text-xs">An agent session transitions to stopped, error, or expired.</td>
+            </tr>
+            <tr className="border-b border-zinc-800/50">
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">budget.exceeded</td>
+              <td className="py-2 text-xs">A budget alert threshold is crossed.</td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 font-mono text-xs text-zinc-300">permission.requested</td>
+              <td className="py-2 text-xs">An agent requests a tool call that needs approval.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Setup */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Setting Up a Webhook
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Go to Settings &gt; Webhooks in the dashboard. Click &quot;Add
+        Endpoint&quot; and provide:
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>
+          <strong className="text-zinc-300">Name:</strong> A label for this
+          webhook (max 100 characters).
+        </li>
+        <li>
+          <strong className="text-zinc-300">URL:</strong> Your HTTPS endpoint.
+          Must return 2xx within 10 seconds. Internal IPs and localhost are
+          blocked.
+        </li>
+        <li>
+          <strong className="text-zinc-300">Events:</strong> Select which events
+          to subscribe to (at least one required).
+        </li>
+      </ul>
+      <p className="mt-2 text-sm text-zinc-400">
+        After creation, the signing secret is shown once. Store it securely; it
+        cannot be retrieved again. If lost, delete and recreate the webhook.
+      </p>
+
+      {/* Payload Format */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Payload Format
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        All webhook payloads are JSON. The shape of the{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">data</code>{" "}
+        object varies by event type.
+      </p>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">session.started</h3>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`{
+  "event": "session.started",
+  "timestamp": "2026-03-22T14:30:00Z",
+  "data": {
+    "session_id": "ses_8f3k2m9x",
+    "agent_type": "claude",
+    "model": "claude-sonnet-4-20250514",
+    "project_path": "/home/user/my-project",
+    "machine_id": "mch_abc123",
+    "started_at": "2026-03-22T14:30:00Z"
+  }
+}`}</code>
+      </pre>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">session.completed</h3>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`{
+  "event": "session.completed",
+  "timestamp": "2026-03-22T14:45:12Z",
+  "data": {
+    "session_id": "ses_8f3k2m9x",
+    "agent_type": "claude",
+    "model": "claude-sonnet-4-20250514",
+    "status": "stopped",
+    "started_at": "2026-03-22T14:30:00Z",
+    "ended_at": "2026-03-22T14:45:12Z",
+    "total_cost_usd": 0.042,
+    "total_input_tokens": 12840,
+    "total_output_tokens": 3210,
+    "message_count": 24
+  }
+}`}</code>
+      </pre>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">budget.exceeded</h3>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`{
+  "event": "budget.exceeded",
+  "timestamp": "2026-03-22T14:45:12Z",
+  "data": {
+    "alert_id": "bgt_xyz789",
+    "alert_name": "Daily $10 limit",
+    "current_spend_usd": 10.23,
+    "threshold_usd": 10.00,
+    "period": "daily",
+    "action": "notify",
+    "percentage_used": 102.3
+  }
+}`}</code>
+      </pre>
+      <h3 className="mt-4 text-base font-medium text-zinc-200">permission.requested</h3>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`{
+  "event": "permission.requested",
+  "timestamp": "2026-03-22T14:32:00Z",
+  "data": {
+    "session_id": "ses_8f3k2m9x",
+    "message_id": "msg_abc999",
+    "agent_type": "claude",
+    "model": "claude-sonnet-4-20250514",
+    "project_path": "/home/user/my-project",
+    "risk_level": "high",
+    "tool_name": "Bash",
+    "created_at": "2026-03-22T14:32:00Z"
+  }
+}`}</code>
+      </pre>
+
+      {/* Signature Verification */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Signature Verification
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        Every webhook request includes a{" "}
+        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          X-Styrby-Signature
+        </code>{" "}
+        header. Verify it using HMAC-SHA256 with your signing secret.
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm font-mono text-zinc-300 ring-1 ring-zinc-800">
+        <code>{`import crypto from "crypto";
+
+function verifyWebhook(
+  payload: string,
+  signature: string,
+  secret: string
+): boolean {
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(payload)
+    .digest("hex");
+  return crypto.timingSafeEqual(
+    Buffer.from(signature),
+    Buffer.from(expected)
+  );
+}
+
+// In your endpoint handler:
+const isValid = verifyWebhook(
+  rawBody,
+  req.headers["x-styrby-signature"],
+  process.env.STYRBY_WEBHOOK_SECRET
+);
+
+if (!isValid) {
+  return res.status(401).json({ error: "Invalid signature" });
+}`}</code>
+      </pre>
+
+      {/* Retry Policy */}
+      <h2 className="mt-10 text-xl font-semibold text-zinc-100">
+        Retry Policy
+      </h2>
+      <p className="mt-2 text-sm text-zinc-400">
+        If your endpoint returns a non-2xx status or times out (10 seconds),
+        Styrby retries up to 4 more times with exponential backoff (5 total
+        attempts):
+      </p>
+      <ul className="mt-2 list-disc space-y-1 pl-6 text-sm text-zinc-400">
+        <li>Retry 1: after 30 seconds</li>
+        <li>Retry 2: after 2 minutes</li>
+        <li>Retry 3: after 10 minutes</li>
+        <li>Retry 4: after 1 hour (final attempt)</li>
+      </ul>
+      <p className="mt-2 text-sm text-zinc-400">
+        After 5 total failed attempts, the delivery is marked as failed. You
+        can view delivery history and retry failed events from the webhook
+        detail page in Settings &gt; Webhooks.
+      </p>
+      <p className="mt-2 text-sm text-zinc-500">
+        A webhook that accumulates 10 consecutive complete failures (5 attempts
+        each) is automatically disabled to prevent ongoing delivery attempts to
+        unreachable endpoints. Re-enable it from the dashboard after fixing the
+        endpoint.
+      </p>
+
+      <PrevNext prev={prev} next={next} />
+    </article>
+  );
+}

--- a/packages/styrby-web/src/components/landing/social-proof.tsx
+++ b/packages/styrby-web/src/components/landing/social-proof.tsx
@@ -133,11 +133,11 @@ export function SocialProof() {
         <p className="mb-6 text-center text-sm text-muted-foreground">
           Works with 11 CLI coding agents you already use
         </p>
-        <div className="flex flex-wrap items-center justify-center gap-8 md:gap-12">
+        <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-4 lg:flex-nowrap lg:gap-x-6">
           {agents.map((agent) => (
-            <div key={agent.name} className="flex items-center gap-2.5">
-              <agent.Logo className={`h-5 w-5 ${agent.color}`} />
-              <span className={`text-sm font-medium tracking-tight ${agent.color}`}>
+            <div key={agent.name} className="flex items-center gap-1.5 shrink-0">
+              <agent.Logo className={`h-4 w-4 ${agent.color}`} />
+              <span className={`text-xs font-medium tracking-tight whitespace-nowrap ${agent.color}`}>
                 {agent.name}
               </span>
             </div>


### PR DESCRIPTION
## Summary
Adds the complete documentation site to production. Previously, all `/docs/*` pages were gitignored by accident (the `docs/` pattern in `.gitignore` matched nested paths).

### Root Cause Fix
`.gitignore` had `docs/` (no leading slash) which matched both:
- `/docs/` (local planning docs — should be ignored)
- `packages/styrby-web/src/app/docs/` (web docs route — should NOT be ignored)

Fixed to `/docs/` (leading slash = root-only match).

### Documentation Pages (17 files)
| Page | Route | Content |
|------|-------|---------|
| Index | `/docs` | Overview with links to all guides |
| Getting Started | `/docs/getting-started` | Install, pair, first session |
| CLI Reference | `/docs/cli` | All commands including checkpoint, cloud, export |
| **Agent Setup** | `/docs/agents` | Install guides for all 11 agents |
| Dashboard Guide | `/docs/dashboard` | Costs, sessions, activity graph |
| API Reference | `/docs/api` | REST API docs |
| Webhooks | `/docs/webhooks` | HTTP event delivery |
| Security | `/docs/security` | E2E encryption, zero-knowledge |
| Mobile App | `/docs/mobile` | Push, offline, permissions |
| Teams | `/docs/teams` | Roles, management (Pro+) |
| **OTEL Export** | `/docs/otel` | Grafana, Datadog, Honeycomb, New Relic setup |
| **Voice Input** | `/docs/voice` | Whisper API, self-hosted, config |
| Troubleshooting | `/docs/troubleshooting` | Common issues |

### Also Fixed
- Social proof section: all 11 agents on one line at desktop (`lg:flex-nowrap`, tighter spacing)

## Test Plan
- [ ] CI passes
- [ ] `/docs` loads on Vercel preview (was 404 before)
- [ ] All 12 nav links work
- [ ] Social proof shows 11 agents on one line

---
🤖 Shipped with [Claude Code](https://claude.com/claude-code)