### PR TITLE
fix(web): correct misleading how-it-works copy

### DIFF
--- a/packages/styrby-web/src/components/landing/how-it-works.tsx
+++ b/packages/styrby-web/src/components/landing/how-it-works.tsx
@@ -10,8 +10,8 @@ const steps = [
   },
   {
     number: "02",
-    title: "Scan the QR Code",
-    description: "Pair your phone or browser to your machine. No account forms, no email verification. Just scan and go.",
+    title: "Sign In and Pair",
+    description: "Sign in with GitHub or email, then scan the QR code to connect your phone. The CLI walks you through it.",
     icon: QrCode,
     code: null,
   },


### PR DESCRIPTION
## Summary
- Step 2 on the homepage claimed "No account forms, no email verification. Just scan and go."
- In reality, users sign in with GitHub or email before QR pairing
- Updated to honest but still simple copy: "Sign in with GitHub or email, then scan the QR code to connect your phone."

## Test Plan
- [ ] CI passes
- [ ] Homepage step 2 reads correctly on preview

---
🤖 Shipped with [Claude Code](https://claude.com/claude-code)