### PR TITLE
design(web): radical homepage redesign — premium dark UI, logo fix, narrative shift

### DIFF
--- a/packages/styrby-web/src/app/dashboard/settings/api/docs/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/api/docs/page.tsx
@@ -1,0 +1,530 @@
+/**
+ * API Documentation Page
+ *
+ * Static documentation for the Styrby API v1.
+ * Covers authentication, rate limits, endpoints, and error handling.
+ */
+
+import Link from 'next/link';
+
+// ---------------------------------------------------------------------------
+// Code Block Component
+// ---------------------------------------------------------------------------
+
+function CodeBlock({ language, code }: { language: string; code: string }) {
+  return (
+    <div className="relative rounded-lg bg-zinc-800 border border-zinc-700 overflow-hidden">
+      <div className="absolute top-0 right-0 px-2 py-1 text-xs text-zinc-500">
+        {language}
+      </div>
+      <pre className="p-4 overflow-x-auto text-sm text-zinc-300">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section Component
+// ---------------------------------------------------------------------------
+
+function Section({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="mb-12">
+      <h2 className="text-xl font-semibold text-zinc-100 mb-4 scroll-mt-8">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint Component
+// ---------------------------------------------------------------------------
+
+function Endpoint({
+  method,
+  path,
+  description,
+  params,
+  response,
+}: {
+  method: 'GET' | 'POST' | 'DELETE';
+  path: string;
+  description: string;
+  params?: { name: string; type: string; description: string; required?: boolean }[];
+  response: string;
+}) {
+  const methodColors = {
+    GET: 'bg-green-500/10 text-green-400',
+    POST: 'bg-blue-500/10 text-blue-400',
+    DELETE: 'bg-red-500/10 text-red-400',
+  };
+
+  return (
+    <div className="rounded-xl bg-zinc-900 border border-zinc-800 overflow-hidden mb-6">
+      <div className="px-4 py-3 border-b border-zinc-800 flex items-center gap-3">
+        <span
+          className={`px-2 py-0.5 rounded text-xs font-semibold ${methodColors[method]}`}
+        >
+          {method}
+        </span>
+        <code className="text-sm text-zinc-300">{path}</code>
+      </div>
+      <div className="p-4">
+        <p className="text-sm text-zinc-400 mb-4">{description}</p>
+
+        {params && params.length > 0 && (
+          <div className="mb-4">
+            <h4 className="text-sm font-medium text-zinc-300 mb-2">Parameters</h4>
+            <div className="space-y-2">
+              {params.map((param) => (
+                <div key={param.name} className="flex items-start gap-2">
+                  <code className="text-xs bg-zinc-800 px-1.5 py-0.5 rounded text-orange-400">
+                    {param.name}
+                  </code>
+                  <span className="text-xs text-zinc-500">{param.type}</span>
+                  {param.required && (
+                    <span className="text-xs text-red-400">required</span>
+                  )}
+                  <span className="text-xs text-zinc-400">{param.description}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <h4 className="text-sm font-medium text-zinc-300 mb-2">Response</h4>
+          <CodeBlock language="json" code={response} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page Component
+// ---------------------------------------------------------------------------
+
+export default function ApiDocsPage() {
+  return (
+    <div className="min-h-screen bg-zinc-950">
+      {/* Header */}
+      <header className="border-b border-zinc-800 bg-zinc-900/50">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex h-16 items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Link href="/dashboard" className="flex items-center gap-2">
+                <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-orange-500 to-orange-600 flex items-center justify-center">
+                  <span className="text-lg font-bold text-white">S</span>
+                </div>
+                <span className="font-semibold text-zinc-100">Styrby</span>
+              </Link>
+            </div>
+
+            <nav className="flex items-center gap-6">
+              <Link
+                href="/dashboard"
+                className="text-sm font-medium text-zinc-400 hover:text-zinc-100 transition-colors"
+              >
+                Dashboard
+              </Link>
+              <Link
+                href="/sessions"
+                className="text-sm font-medium text-zinc-400 hover:text-zinc-100 transition-colors"
+              >
+                Sessions
+              </Link>
+              <Link
+                href="/costs"
+                className="text-sm font-medium text-zinc-400 hover:text-zinc-100 transition-colors"
+              >
+                Costs
+              </Link>
+              <Link href="/settings" className="text-sm font-medium text-orange-500">
+                Settings
+              </Link>
+            </nav>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex items-center gap-3 mb-2">
+          <Link
+            href="/settings"
+            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            Settings
+          </Link>
+          <span className="text-zinc-500">/</span>
+          <Link
+            href="/settings/api"
+            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            API Keys
+          </Link>
+          <span className="text-zinc-500">/</span>
+          <span className="text-sm text-zinc-300">Documentation</span>
+        </div>
+        <h1 className="text-2xl font-bold text-zinc-100 mb-2">API Documentation</h1>
+        <p className="text-zinc-400 mb-8">
+          The Styrby API provides read-only access to your sessions, costs, and machines.
+        </p>
+
+        {/* Table of Contents */}
+        <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4 mb-8">
+          <h3 className="text-sm font-medium text-zinc-300 mb-3">Contents</h3>
+          <nav className="space-y-1">
+            <a href="#authentication" className="block text-sm text-orange-400 hover:text-orange-300">
+              Authentication
+            </a>
+            <a href="#rate-limits" className="block text-sm text-orange-400 hover:text-orange-300">
+              Rate Limits
+            </a>
+            <a href="#errors" className="block text-sm text-orange-400 hover:text-orange-300">
+              Error Handling
+            </a>
+            <a href="#sessions" className="block text-sm text-orange-400 hover:text-orange-300">
+              Sessions Endpoints
+            </a>
+            <a href="#costs" className="block text-sm text-orange-400 hover:text-orange-300">
+              Costs Endpoints
+            </a>
+            <a href="#machines" className="block text-sm text-orange-400 hover:text-orange-300">
+              Machines Endpoints
+            </a>
+          </nav>
+        </div>
+
+        {/* Authentication */}
+        <Section id="authentication" title="Authentication">
+          <p className="text-sm text-zinc-400 mb-4">
+            All API requests require authentication using an API key. Include your key in the
+            Authorization header:
+          </p>
+          <CodeBlock
+            language="bash"
+            code={`curl -H "Authorization: Bearer sk_live_your_api_key_here" \\
+  https://styrby.app/api/v1/sessions`}
+          />
+          <div className="mt-4 rounded-lg bg-yellow-500/10 border border-yellow-500/30 px-4 py-3">
+            <p className="text-sm text-yellow-400">
+              Keep your API key secret. Do not expose it in client-side code or public
+              repositories. If compromised, revoke it immediately and create a new one.
+            </p>
+          </div>
+        </Section>
+
+        {/* Rate Limits */}
+        <Section id="rate-limits" title="Rate Limits">
+          <p className="text-sm text-zinc-400 mb-4">
+            API requests are rate limited to 100 requests per minute per API key. Rate limit
+            information is included in response headers:
+          </p>
+          <div className="rounded-lg bg-zinc-800 border border-zinc-700 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-700">
+                  <th className="px-4 py-2 text-left text-zinc-300">Header</th>
+                  <th className="px-4 py-2 text-left text-zinc-300">Description</th>
+                </tr>
+              </thead>
+              <tbody className="text-zinc-400">
+                <tr className="border-b border-zinc-700">
+                  <td className="px-4 py-2 font-mono text-xs">X-RateLimit-Limit</td>
+                  <td className="px-4 py-2">Maximum requests per window (100)</td>
+                </tr>
+                <tr className="border-b border-zinc-700">
+                  <td className="px-4 py-2 font-mono text-xs">X-RateLimit-Remaining</td>
+                  <td className="px-4 py-2">Remaining requests in current window</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2 font-mono text-xs">X-RateLimit-Reset</td>
+                  <td className="px-4 py-2">Unix timestamp when the window resets</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </Section>
+
+        {/* Errors */}
+        <Section id="errors" title="Error Handling">
+          <p className="text-sm text-zinc-400 mb-4">
+            The API uses standard HTTP status codes and returns JSON error responses:
+          </p>
+          <div className="rounded-lg bg-zinc-800 border border-zinc-700 overflow-hidden mb-4">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-700">
+                  <th className="px-4 py-2 text-left text-zinc-300">Status</th>
+                  <th className="px-4 py-2 text-left text-zinc-300">Description</th>
+                </tr>
+              </thead>
+              <tbody className="text-zinc-400">
+                <tr className="border-b border-zinc-700">
+                  <td className="px-4 py-2 font-mono text-xs">200</td>
+                  <td className="px-4 py-2">Success</td>
+                </tr>
+                <tr className="border-b border-zinc-700">
+                  <td className="px-4 py-2 font-mono text-xs">400</td>
+                  <td className="px-4 py-2">Bad request (invalid parameters)</td>
+                </tr>
+                <tr className="border-b border-zinc-700">
+                  <td className="px-4 py-2 font-mono text-xs">401</td>
+                  <td className="px-4 py-2">Unauthorized (invalid or missing API key)</td>
+                </tr>
+                <tr className="border-b border-zinc-700">
+                  <td className="px-4 py-2 font-mono text-xs">403</td>
+                  <td className="px-4 py-2">Forbidden (insufficient permissions)</td>
+                </tr>
+                <tr className="border-b border-zinc-700">
+                  <td className="px-4 py-2 font-mono text-xs">404</td>
+                  <td className="px-4 py-2">Not found</td>
+                </tr>
+                <tr className="border-b border-zinc-700">
+                  <td className="px-4 py-2 font-mono text-xs">429</td>
+                  <td className="px-4 py-2">Rate limit exceeded</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2 font-mono text-xs">500</td>
+                  <td className="px-4 py-2">Internal server error</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <CodeBlock
+            language="json"
+            code={`{
+  "error": "Invalid API key",
+  "code": "UNAUTHORIZED"
+}`}
+          />
+        </Section>
+
+        {/* Sessions Endpoints */}
+        <Section id="sessions" title="Sessions Endpoints">
+          <Endpoint
+            method="GET"
+            path="/api/v1/sessions"
+            description="List sessions for your account. Supports pagination and filtering."
+            params={[
+              { name: 'limit', type: 'number', description: 'Max results (1-100, default: 20)' },
+              { name: 'offset', type: 'number', description: 'Skip N results (default: 0)' },
+              { name: 'status', type: 'string', description: 'Filter by status (running, stopped, etc.)' },
+              { name: 'agent_type', type: 'string', description: 'Filter by agent (claude, codex, gemini)' },
+              { name: 'archived', type: 'boolean', description: 'Include archived sessions (default: false)' },
+            ]}
+            response={`{
+  "sessions": [
+    {
+      "id": "uuid",
+      "agent_type": "claude",
+      "model": "claude-sonnet-4",
+      "title": "Refactoring auth module",
+      "status": "stopped",
+      "total_cost_usd": 0.023456,
+      "message_count": 42,
+      "created_at": "2026-02-01T10:00:00Z"
+    }
+  ],
+  "pagination": {
+    "total": 156,
+    "limit": 20,
+    "offset": 0,
+    "hasMore": true
+  }
+}`}
+          />
+
+          <Endpoint
+            method="GET"
+            path="/api/v1/sessions/:id"
+            description="Get details for a single session."
+            response={`{
+  "session": {
+    "id": "uuid",
+    "agent_type": "claude",
+    "model": "claude-sonnet-4",
+    "title": "Refactoring auth module",
+    "summary": "Refactored authentication...",
+    "project_path": "/path/to/project",
+    "git_branch": "main",
+    "status": "stopped",
+    "total_cost_usd": 0.023456,
+    "total_input_tokens": 15000,
+    "total_output_tokens": 5000,
+    "message_count": 42,
+    "created_at": "2026-02-01T10:00:00Z"
+  }
+}`}
+          />
+
+          <Endpoint
+            method="GET"
+            path="/api/v1/sessions/:id/messages"
+            description="List messages for a session. Note: Message content is E2E encrypted."
+            params={[
+              { name: 'limit', type: 'number', description: 'Max results (1-200, default: 50)' },
+              { name: 'offset', type: 'number', description: 'Skip N results (default: 0)' },
+              { name: 'type', type: 'string', description: 'Filter by message type' },
+            ]}
+            response={`{
+  "messages": [
+    {
+      "id": "uuid",
+      "sequence_number": 1,
+      "message_type": "user_prompt",
+      "content_encrypted": "base64...",
+      "encryption_nonce": "base64...",
+      "input_tokens": 100,
+      "output_tokens": 0,
+      "created_at": "2026-02-01T10:00:00Z"
+    }
+  ],
+  "pagination": {
+    "total": 42,
+    "limit": 50,
+    "offset": 0,
+    "hasMore": false
+  }
+}`}
+          />
+        </Section>
+
+        {/* Costs Endpoints */}
+        <Section id="costs" title="Costs Endpoints">
+          <Endpoint
+            method="GET"
+            path="/api/v1/costs"
+            description="Get cost summary aggregated by period (daily, weekly, or monthly)."
+            params={[
+              {
+                name: 'period',
+                type: 'string',
+                description: 'Aggregation period: daily, weekly, monthly (default: monthly)',
+              },
+            ]}
+            response={`{
+  "summary": {
+    "period": "monthly",
+    "totalCostUsd": 45.67,
+    "totalInputTokens": 1500000,
+    "totalOutputTokens": 500000,
+    "totalCacheTokens": 200000,
+    "sessionCount": 156
+  },
+  "breakdown": [
+    {
+      "date": "2026-01",
+      "costUsd": 23.45,
+      "inputTokens": 750000,
+      "outputTokens": 250000,
+      "cacheTokens": 100000
+    }
+  ]
+}`}
+          />
+
+          <Endpoint
+            method="GET"
+            path="/api/v1/costs/breakdown"
+            description="Get cost breakdown by agent type."
+            params={[
+              { name: 'days', type: 'number', description: 'Look back N days (1-365, default: 30)' },
+            ]}
+            response={`{
+  "breakdown": [
+    {
+      "agentType": "claude",
+      "costUsd": 35.50,
+      "inputTokens": 1200000,
+      "outputTokens": 400000,
+      "cacheTokens": 150000,
+      "sessionCount": 120,
+      "percentage": 77.5
+    },
+    {
+      "agentType": "codex",
+      "costUsd": 10.17,
+      "inputTokens": 300000,
+      "outputTokens": 100000,
+      "cacheTokens": 50000,
+      "sessionCount": 36,
+      "percentage": 22.5
+    }
+  ],
+  "total": {
+    "costUsd": 45.67,
+    "inputTokens": 1500000,
+    "outputTokens": 500000,
+    "cacheTokens": 200000,
+    "sessionCount": 156
+  },
+  "period": {
+    "days": 30,
+    "startDate": "2026-01-07",
+    "endDate": "2026-02-06"
+  }
+}`}
+          />
+        </Section>
+
+        {/* Machines Endpoints */}
+        <Section id="machines" title="Machines Endpoints">
+          <Endpoint
+            method="GET"
+            path="/api/v1/machines"
+            description="List connected machines (CLI instances)."
+            params={[
+              {
+                name: 'online_only',
+                type: 'boolean',
+                description: 'Filter to only online machines (default: false)',
+              },
+            ]}
+            response={`{
+  "machines": [
+    {
+      "id": "uuid",
+      "name": "MacBook Pro",
+      "platform": "darwin",
+      "platformVersion": "14.0.0",
+      "architecture": "arm64",
+      "hostname": "macbook.local",
+      "cliVersion": "1.2.3",
+      "isOnline": true,
+      "lastSeenAt": "2026-02-06T10:00:00Z",
+      "createdAt": "2025-12-01T10:00:00Z"
+    }
+  ],
+  "count": 3
+}`}
+          />
+        </Section>
+
+        {/* Back link */}
+        <div className="mt-12 pt-8 border-t border-zinc-800">
+          <Link
+            href="/settings/api"
+            className="inline-flex items-center gap-2 text-sm text-orange-400 hover:text-orange-300 transition-colors"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to API Keys
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/docs/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/docs/page.tsx
@@ -1,0 +1,466 @@
+/**
+ * Webhook Documentation Page
+ *
+ * Provides comprehensive documentation for webhook integration including:
+ * - Event payload schemas
+ * - Signature verification examples
+ * - Best practices
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+
+export default async function WebhookDocsPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-950">
+      {/* Header */}
+      <header className="border-b border-zinc-800 bg-zinc-900/50">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex h-16 items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Link href="/dashboard" className="flex items-center gap-2">
+                <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-orange-500 to-orange-600 flex items-center justify-center">
+                  <span className="text-lg font-bold text-white">S</span>
+                </div>
+                <span className="font-semibold text-zinc-100">Styrby</span>
+              </Link>
+            </div>
+
+            <nav className="flex items-center gap-6">
+              <Link
+                href="/dashboard"
+                className="text-sm font-medium text-zinc-400 hover:text-zinc-100 transition-colors"
+              >
+                Dashboard
+              </Link>
+              <Link
+                href="/sessions"
+                className="text-sm font-medium text-zinc-400 hover:text-zinc-100 transition-colors"
+              >
+                Sessions
+              </Link>
+              <Link
+                href="/costs"
+                className="text-sm font-medium text-zinc-400 hover:text-zinc-100 transition-colors"
+              >
+                Costs
+              </Link>
+              <Link href="/settings" className="text-sm font-medium text-orange-500">
+                Settings
+              </Link>
+            </nav>
+
+            <div className="flex items-center gap-4">
+              <span className="text-sm text-zinc-400">{user.email}</span>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-8">
+        {/* Breadcrumb */}
+        <div className="flex items-center gap-3 mb-2">
+          <Link
+            href="/settings"
+            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            Settings
+          </Link>
+          <span className="text-zinc-500">/</span>
+          <Link
+            href="/settings/webhooks"
+            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            Webhooks
+          </Link>
+          <span className="text-zinc-500">/</span>
+          <span className="text-sm text-zinc-300">Documentation</span>
+        </div>
+
+        <h1 className="text-2xl font-bold text-zinc-100 mb-8">Webhook Documentation</h1>
+
+        <div className="space-y-12">
+          {/* Overview */}
+          <section>
+            <h2 className="text-lg font-semibold text-zinc-100 mb-4">Overview</h2>
+            <div className="prose prose-invert max-w-none">
+              <p className="text-zinc-400">
+                Styrby webhooks allow you to receive real-time notifications when events occur
+                in your account. You can use webhooks to integrate Styrby with Slack, Discord,
+                custom monitoring systems, or any HTTP endpoint.
+              </p>
+              <p className="text-zinc-400 mt-3">
+                When an event occurs, Styrby sends an HTTP POST request to your configured URL
+                with a JSON payload containing event details.
+              </p>
+            </div>
+          </section>
+
+          {/* Event Types */}
+          <section>
+            <h2 className="text-lg font-semibold text-zinc-100 mb-4">Event Types</h2>
+            <div className="space-y-6">
+              {/* session.started */}
+              <EventDocBlock
+                event="session.started"
+                description="Triggered when a new agent session begins."
+                payload={{
+                  event: 'session.started',
+                  timestamp: '2025-02-06T10:30:00.000Z',
+                  data: {
+                    session_id: 'uuid-xxxx-xxxx-xxxx',
+                    agent_type: 'claude',
+                    model: 'claude-sonnet-4',
+                    project_path: '/home/user/my-project',
+                    machine_id: 'uuid-machine-id',
+                    started_at: '2025-02-06T10:30:00.000Z',
+                  },
+                }}
+              />
+
+              {/* session.completed */}
+              <EventDocBlock
+                event="session.completed"
+                description="Triggered when a session ends (stopped, error, or expired)."
+                payload={{
+                  event: 'session.completed',
+                  timestamp: '2025-02-06T12:45:00.000Z',
+                  data: {
+                    session_id: 'uuid-xxxx-xxxx-xxxx',
+                    agent_type: 'claude',
+                    model: 'claude-sonnet-4',
+                    status: 'stopped',
+                    error_code: null,
+                    error_message: null,
+                    started_at: '2025-02-06T10:30:00.000Z',
+                    ended_at: '2025-02-06T12:45:00.000Z',
+                    total_cost_usd: 2.45,
+                    total_input_tokens: 150000,
+                    total_output_tokens: 25000,
+                    message_count: 42,
+                  },
+                }}
+              />
+
+              {/* budget.exceeded */}
+              <EventDocBlock
+                event="budget.exceeded"
+                description="Triggered when a budget alert threshold is crossed."
+                payload={{
+                  event: 'budget.exceeded',
+                  timestamp: '2025-02-06T14:00:00.000Z',
+                  data: {
+                    alert_id: 'uuid-alert-id',
+                    alert_name: 'Daily Claude Limit',
+                    current_spend_usd: 10.50,
+                    threshold_usd: 10.00,
+                    period: 'daily',
+                    action: 'notify',
+                    percentage_used: 105.00,
+                  },
+                }}
+              />
+
+              {/* permission.requested */}
+              <EventDocBlock
+                event="permission.requested"
+                description="Triggered when an agent requests permission for a sensitive action."
+                payload={{
+                  event: 'permission.requested',
+                  timestamp: '2025-02-06T11:15:00.000Z',
+                  data: {
+                    session_id: 'uuid-xxxx-xxxx-xxxx',
+                    message_id: 'uuid-message-id',
+                    agent_type: 'claude',
+                    model: 'claude-sonnet-4',
+                    project_path: '/home/user/my-project',
+                    risk_level: 'high',
+                    tool_name: 'bash',
+                    created_at: '2025-02-06T11:15:00.000Z',
+                  },
+                }}
+              />
+            </div>
+          </section>
+
+          {/* Request Headers */}
+          <section>
+            <h2 className="text-lg font-semibold text-zinc-100 mb-4">Request Headers</h2>
+            <div className="rounded-xl bg-zinc-900 border border-zinc-800 overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-zinc-800">
+                    <th className="px-4 py-3 text-left text-zinc-400 font-medium">Header</th>
+                    <th className="px-4 py-3 text-left text-zinc-400 font-medium">Description</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-800">
+                  <tr>
+                    <td className="px-4 py-3 font-mono text-orange-400">X-Styrby-Signature</td>
+                    <td className="px-4 py-3 text-zinc-300">
+                      HMAC-SHA256 signature of the payload, prefixed with <code className="bg-zinc-800 px-1 rounded">sha256=</code>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="px-4 py-3 font-mono text-orange-400">X-Styrby-Event</td>
+                    <td className="px-4 py-3 text-zinc-300">
+                      The event type (e.g., <code className="bg-zinc-800 px-1 rounded">session.started</code>)
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="px-4 py-3 font-mono text-orange-400">X-Styrby-Delivery-Id</td>
+                    <td className="px-4 py-3 text-zinc-300">Unique identifier for this delivery attempt</td>
+                  </tr>
+                  <tr>
+                    <td className="px-4 py-3 font-mono text-orange-400">X-Styrby-Timestamp</td>
+                    <td className="px-4 py-3 text-zinc-300">Unix timestamp when the request was sent</td>
+                  </tr>
+                  <tr>
+                    <td className="px-4 py-3 font-mono text-orange-400">Content-Type</td>
+                    <td className="px-4 py-3 text-zinc-300">
+                      Always <code className="bg-zinc-800 px-1 rounded">application/json</code>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* Signature Verification */}
+          <section>
+            <h2 className="text-lg font-semibold text-zinc-100 mb-4">Signature Verification</h2>
+            <p className="text-zinc-400 mb-4">
+              To verify that a webhook request came from Styrby, compute an HMAC-SHA256 signature
+              of the raw request body using your webhook secret, and compare it to the signature
+              in the <code className="bg-zinc-800 px-1 rounded">X-Styrby-Signature</code> header.
+            </p>
+
+            {/* Node.js Example */}
+            <div className="mb-6">
+              <h3 className="text-sm font-medium text-zinc-300 mb-2">Node.js / Express</h3>
+              <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4 overflow-x-auto">
+                <pre className="text-sm text-zinc-300 font-mono whitespace-pre">{`import crypto from 'crypto';
+import express from 'express';
+
+const app = express();
+
+// Use raw body parser to get the exact payload
+app.use('/webhook', express.raw({ type: 'application/json' }));
+
+app.post('/webhook', (req, res) => {
+  const signature = req.headers['x-styrby-signature'];
+  const secret = process.env.STYRBY_WEBHOOK_SECRET;
+
+  // Compute expected signature
+  const expectedSignature = 'sha256=' + crypto
+    .createHmac('sha256', secret)
+    .update(req.body)
+    .digest('hex');
+
+  // Constant-time comparison to prevent timing attacks
+  const isValid = crypto.timingSafeEqual(
+    Buffer.from(signature),
+    Buffer.from(expectedSignature)
+  );
+
+  if (!isValid) {
+    return res.status(401).send('Invalid signature');
+  }
+
+  // Parse and process the event
+  const event = JSON.parse(req.body);
+  console.log('Received event:', event.event);
+
+  res.status(200).send('OK');
+});`}</pre>
+              </div>
+            </div>
+
+            {/* Python Example */}
+            <div className="mb-6">
+              <h3 className="text-sm font-medium text-zinc-300 mb-2">Python / Flask</h3>
+              <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4 overflow-x-auto">
+                <pre className="text-sm text-zinc-300 font-mono whitespace-pre">{`import hmac
+import hashlib
+import os
+from flask import Flask, request, abort
+
+app = Flask(__name__)
+
+@app.route('/webhook', methods=['POST'])
+def webhook():
+    signature = request.headers.get('X-Styrby-Signature')
+    secret = os.environ.get('STYRBY_WEBHOOK_SECRET')
+
+    # Compute expected signature
+    expected = 'sha256=' + hmac.new(
+        secret.encode('utf-8'),
+        request.data,
+        hashlib.sha256
+    ).hexdigest()
+
+    # Constant-time comparison
+    if not hmac.compare_digest(signature, expected):
+        abort(401, 'Invalid signature')
+
+    # Process the event
+    event = request.get_json()
+    print(f"Received event: {event['event']}")
+
+    return 'OK', 200`}</pre>
+              </div>
+            </div>
+
+            {/* Go Example */}
+            <div>
+              <h3 className="text-sm font-medium text-zinc-300 mb-2">Go</h3>
+              <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4 overflow-x-auto">
+                <pre className="text-sm text-zinc-300 font-mono whitespace-pre">{`package main
+
+import (
+    "crypto/hmac"
+    "crypto/sha256"
+    "encoding/hex"
+    "io"
+    "net/http"
+    "os"
+)
+
+func webhookHandler(w http.ResponseWriter, r *http.Request) {
+    signature := r.Header.Get("X-Styrby-Signature")
+    secret := os.Getenv("STYRBY_WEBHOOK_SECRET")
+
+    // Read body
+    body, _ := io.ReadAll(r.Body)
+
+    // Compute expected signature
+    mac := hmac.New(sha256.New, []byte(secret))
+    mac.Write(body)
+    expected := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+    // Constant-time comparison
+    if !hmac.Equal([]byte(signature), []byte(expected)) {
+        http.Error(w, "Invalid signature", http.StatusUnauthorized)
+        return
+    }
+
+    // Process event...
+    w.WriteHeader(http.StatusOK)
+}`}</pre>
+              </div>
+            </div>
+          </section>
+
+          {/* Best Practices */}
+          <section>
+            <h2 className="text-lg font-semibold text-zinc-100 mb-4">Best Practices</h2>
+            <div className="space-y-4">
+              <BestPracticeItem
+                title="Always verify signatures"
+                description="Never trust webhook payloads without verifying the signature. This prevents attackers from spoofing events."
+              />
+              <BestPracticeItem
+                title="Respond quickly"
+                description="Return a 2xx response within 30 seconds. Process events asynchronously if needed. Webhook delivery times out after 30 seconds."
+              />
+              <BestPracticeItem
+                title="Handle retries gracefully"
+                description="Styrby retries failed deliveries up to 3 times with exponential backoff. Use the X-Styrby-Delivery-Id header to deduplicate events."
+              />
+              <BestPracticeItem
+                title="Use HTTPS endpoints"
+                description="Always use HTTPS URLs for production webhooks. HTTP is only allowed for local development."
+              />
+              <BestPracticeItem
+                title="Keep secrets secure"
+                description="Store your webhook secret in environment variables. Never commit it to source control or expose it in client-side code."
+              />
+            </div>
+          </section>
+
+          {/* Retry Policy */}
+          <section>
+            <h2 className="text-lg font-semibold text-zinc-100 mb-4">Retry Policy</h2>
+            <p className="text-zinc-400 mb-4">
+              If your endpoint returns a non-2xx response or times out, Styrby will retry the delivery:
+            </p>
+            <ul className="list-disc list-inside text-zinc-400 space-y-2">
+              <li>1st retry: 1 minute after initial failure</li>
+              <li>2nd retry: 2 minutes after 1st retry</li>
+              <li>3rd retry: 4 minutes after 2nd retry</li>
+            </ul>
+            <p className="text-zinc-400 mt-4">
+              After 3 failed retries, the delivery is marked as failed. Webhooks with 10+ consecutive
+              failed deliveries are automatically disabled to prevent excessive retries.
+            </p>
+          </section>
+
+          {/* Back link */}
+          <div className="pt-8 border-t border-zinc-800">
+            <Link
+              href="/settings/webhooks"
+              className="text-orange-400 hover:text-orange-300 transition-colors text-sm font-medium"
+            >
+              Back to Webhooks
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper Components
+// ---------------------------------------------------------------------------
+
+interface EventDocBlockProps {
+  event: string;
+  description: string;
+  payload: Record<string, unknown>;
+}
+
+function EventDocBlock({ event, description, payload }: EventDocBlockProps) {
+  return (
+    <div className="rounded-xl bg-zinc-900 border border-zinc-800 overflow-hidden">
+      <div className="px-4 py-3 border-b border-zinc-800">
+        <h3 className="text-sm font-semibold text-zinc-100">
+          <code className="text-orange-400">{event}</code>
+        </h3>
+        <p className="text-sm text-zinc-400 mt-1">{description}</p>
+      </div>
+      <div className="p-4 overflow-x-auto">
+        <pre className="text-xs text-zinc-300 font-mono whitespace-pre">
+          {JSON.stringify(payload, null, 2)}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+interface BestPracticeItemProps {
+  title: string;
+  description: string;
+}
+
+function BestPracticeItem({ title, description }: BestPracticeItemProps) {
+  return (
+    <div className="rounded-lg bg-zinc-900 border border-zinc-800 p-4">
+      <h4 className="text-sm font-medium text-zinc-100 mb-1">{title}</h4>
+      <p className="text-sm text-zinc-400">{description}</p>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/globals.css
+++ b/packages/styrby-web/src/app/globals.css
@@ -97,8 +97,9 @@
 }
 
 /* ── Amber glow ── */
+/* Used on the Pro pricing card and other highlighted elements */
 .amber-glow {
-  box-shadow: 0 0 80px rgba(245, 158, 11, 0.08), 0 0 160px rgba(245, 158, 11, 0.04);
+  box-shadow: 0 0 60px rgba(245, 158, 11, 0.12), 0 0 120px rgba(245, 158, 11, 0.06);
 }
 
 /* ── Pulse animation for live indicators ── */

--- a/packages/styrby-web/src/app/layout.tsx
+++ b/packages/styrby-web/src/app/layout.tsx
@@ -1,14 +1,19 @@
 import type { Metadata, Viewport } from 'next';
-import { Space_Grotesk, JetBrains_Mono } from 'next/font/google';
+import { Outfit, JetBrains_Mono } from 'next/font/google';
 import { Toaster } from 'sonner';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { CookieConsent } from '@/components/cookie-consent';
 import { SWRegister } from '@/components/sw-register';
 
-const spaceGrotesk = Space_Grotesk({
+/**
+ * WHY Outfit: geometric sans-serif with tight tracking and optical weight that
+ * reads as premium at large display sizes. Space Grotesk was too neutral for
+ * the luxury-developer positioning; Outfit has stronger personality at 8xl+.
+ */
+const outfit = Outfit({
   subsets: ['latin'],
-  variable: '--font-space-grotesk',
+  variable: '--font-outfit',
 });
 
 const jetbrainsMono = JetBrains_Mono({
@@ -102,7 +107,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark scroll-smooth" suppressHydrationWarning>
       <body
-        className={`${spaceGrotesk.variable} ${jetbrainsMono.variable} font-sans antialiased noise-bg`}
+        className={`${outfit.variable} ${jetbrainsMono.variable} font-sans antialiased noise-bg`}
       >
         <a
           href="#main-content"

--- a/packages/styrby-web/src/app/page.tsx
+++ b/packages/styrby-web/src/app/page.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from 'next';
 import { Navbar } from '@/components/landing/navbar';
 import { Hero } from '@/components/landing/hero';
 import { SocialProof } from '@/components/landing/social-proof';
+import { ProblemSection } from '@/components/landing/problem-section';
 import { FeaturesSection } from '@/components/landing/features-section';
 import { MobileShowcase } from '@/components/landing/mobile-showcase';
+import { CostSavings } from '@/components/landing/cost-savings';
 import { HowItWorks } from '@/components/landing/how-it-works';
 import { PricingCTA } from '@/components/landing/pricing-cta';
 import { FAQSection } from '@/components/landing/faq-section';
@@ -165,13 +167,17 @@ const faqPageJsonLd = {
 /**
  * Marketing landing page - composed from modular section components.
  *
- * WHY this order: Hero establishes the value prop. Social proof builds
- * trust. Features shows the top 3 capabilities (full list on /features).
- * How It Works removes friction. Pricing drives action. FAQ handles
- * objections. Final CTA closes.
- *
- * Removed from homepage (moved to /features): ProblemSection, UseCases,
- * CostSavings. These added depth but created a wall-of-text effect.
+ * WHY this order:
+ * 1. Hero — establishes the remote control value prop
+ * 2. SocialProof — builds trust before asking for attention
+ * 3. ProblemSection — names the pain (no unified view, surprise bills, desk-tethered)
+ * 4. FeaturesSection — bento grid showing how Styrby solves each problem
+ * 5. MobileShowcase — makes the phone experience concrete: permission, voice, diff
+ * 6. CostSavings — supporting benefit positioned as "oh, and it does this too"
+ * 7. HowItWorks — removes setup friction with staggered timeline + CSS mockups
+ * 8. PricingCTA — drives plan selection after full value is established
+ * 9. FAQSection — handles remaining objections
+ * 10. CTABanner + Footer — closes
  */
 export default function LandingPage() {
   return (
@@ -189,8 +195,10 @@ export default function LandingPage() {
       <Navbar />
       <Hero />
       <SocialProof />
+      <ProblemSection />
       <FeaturesSection />
       <MobileShowcase />
+      <CostSavings />
       <HowItWorks />
       <PricingCTA />
       <FAQSection />

--- a/packages/styrby-web/src/app/pricing/page.tsx
+++ b/packages/styrby-web/src/app/pricing/page.tsx
@@ -2,17 +2,11 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { Check, Minus, ArrowRight } from 'lucide-react';
+import { Check, X, Minus, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Navbar } from '@/components/landing/navbar';
 import { Footer } from '@/components/landing/footer';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
 
 /**
  * Public pricing page with plan comparison, feature table, and FAQ.
@@ -21,6 +15,10 @@ import {
  * lets prospective users compare plans before signing up. This reduces friction
  * in the acquisition funnel — users can see exactly what they get before
  * creating an account.
+ *
+ * WHY decoy layout: Pro is visually highlighted as the recommended choice, but
+ * Power is close enough in price that informed buyers self-select into it. Free
+ * anchors the low end so $24/mo feels reasonable.
  */
 
 const plans = [
@@ -32,8 +30,8 @@ const plans = [
     savings: null,
     popular: false,
     cta: 'Get Started',
-    ctaVariant: 'outline' as const,
-    features: [
+    ctaVariant: 'ghost' as const,
+    included: [
       '1 connected machine',
       '3 agents: Claude Code, Codex, Gemini CLI',
       '7-day session history',
@@ -45,6 +43,12 @@ const plans = [
       'Offline queue',
       'Device pairing',
     ],
+    notIncluded: [
+      'Per-message cost tracking',
+      'Session checkpoints',
+      'Team management',
+      'Voice commands',
+    ],
   },
   {
     name: 'Pro',
@@ -54,23 +58,24 @@ const plans = [
     savings: 48,
     popular: true,
     cta: 'Sign Up for Pro',
-    ctaVariant: 'default' as const,
-    features: [
+    ctaVariant: 'amber' as const,
+    included: [
       '3 connected machines',
-      '8 agents (adds OpenCode, Aider, Goose, Amp, Crush, Kilo)',
+      '8 agents (+ OpenCode, Aider, Goose, Amp, Crush, Kilo)',
       '90-day session history',
       '25,000 messages/month',
       'Full cost dashboard',
       'Per-message cost tracking',
+      'Context breakdown by file',
       'Session checkpoints',
       'Session sharing',
       'Export and import',
-      'Per-file context breakdown',
       'Activity graph',
-      'Team management (3 members)',
+      'Team management — 3 members',
       '3 budget alerts',
       'Email support',
     ],
+    notIncluded: [],
   },
   {
     name: 'Power',
@@ -80,23 +85,25 @@ const plans = [
     savings: 98,
     popular: false,
     cta: 'Sign Up for Power',
-    ctaVariant: 'default' as const,
-    features: [
+    ctaVariant: 'outline' as const,
+    included: [
       '9 connected machines',
-      'All 11 agents (adds Kiro and Droid)',
+      'All 11 agents (+ Kiro and Droid)',
       '1-year session history',
       '100,000 messages/month',
       'Full cost dashboard',
       '5 budget alerts',
-      'OTEL export (Grafana, Datadog, and more)',
+      'OTEL export — Grafana, Datadog, and more',
       'Voice commands',
       'Cloud monitoring',
       'Code review from mobile',
       'Rust parser',
       '3 team members',
       'API access',
+      'Audit trail export',
       'Email support',
     ],
+    notIncluded: [],
   },
 ];
 
@@ -260,233 +267,27 @@ const faqs = [
   },
 ];
 
+/**
+ * Renders a cell value for the comparison table.
+ *
+ * @param value - The feature value: true (included), false (not included), or a string
+ * @returns The appropriate visual indicator
+ */
 function CellValue({ value }: { value: boolean | string }) {
   if (value === true) {
     return <Check className="mx-auto h-4 w-4 text-amber-500" />;
   }
   if (value === false) {
-    return <Minus className="mx-auto h-4 w-4 text-muted-foreground/40" />;
+    return <Minus className="mx-auto h-4 w-4 text-zinc-700" />;
   }
   return <span className="text-sm text-foreground">{value}</span>;
 }
 
-export default function PricingPage() {
-  const [annual, setAnnual] = useState(false);
-
-  return (
-    <main className="min-h-screen">
-      <Navbar />
-
-      {/* Hero */}
-      <section className="pt-32 pb-16">
-        <div className="mx-auto max-w-7xl px-6 text-center">
-          <h1 className="text-balance text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-            Simple, Transparent Pricing
-          </h1>
-          <p className="mx-auto mt-4 max-w-xl text-lg text-muted-foreground leading-relaxed">
-            Start free, scale as you grow. No hidden fees, no surprises. Cancel anytime.
-          </p>
-        </div>
-      </section>
-
-      {/* Toggle */}
-      <section className="pb-4">
-        <div className="mx-auto max-w-7xl px-6">
-          <div className="flex items-center justify-center gap-3">
-            <span className={cn('text-sm', !annual ? 'text-foreground font-medium' : 'text-muted-foreground')}>
-              Monthly
-            </span>
-            <button
-              type="button"
-              onClick={() => setAnnual(!annual)}
-              className={cn(
-                'relative h-6 w-11 rounded-full transition-colors duration-200',
-                annual ? 'bg-amber-500' : 'bg-secondary',
-              )}
-              role="switch"
-              aria-checked={annual}
-              aria-label="Toggle annual billing"
-            >
-              <span
-                className={cn(
-                  'absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-foreground transition-transform duration-200',
-                  annual && 'translate-x-5',
-                )}
-              />
-            </button>
-            <span className={cn('text-sm', annual ? 'text-foreground font-medium' : 'text-muted-foreground')}>
-              Annual{' '}
-              <span className="text-xs text-amber-500 font-medium">(Save up to $98)</span>
-              {/* WHY $98: Power plan saves $98/year ($49 x 12 = $588 vs $490 annual) */}
-            </span>
-          </div>
-        </div>
-      </section>
-
-      {/* Pricing Cards */}
-      <section className="py-12">
-        <div className="mx-auto max-w-7xl px-6">
-          <div className="grid gap-6 md:grid-cols-3">
-            {plans.map((plan) => (
-              <div
-                key={plan.name}
-                className={cn(
-                  'relative flex flex-col rounded-xl bg-card/60 p-8 transition-all duration-200',
-                  plan.popular
-                    ? 'border-2 border-amber-500/50 amber-glow'
-                    : 'border border-border/60',
-                )}
-              >
-                {plan.popular && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-amber-500 px-3 py-1 text-xs font-semibold text-background">
-                    Most Popular
-                  </div>
-                )}
-
-                <h3 className="text-xl font-semibold text-foreground">{plan.name}</h3>
-                <p className="mt-1 text-sm text-muted-foreground">{plan.description}</p>
-                {/* Fixed-height price area prevents layout shift on annual toggle */}
-                <div className="min-h-[72px]">
-                  <div className="mt-4 flex items-baseline gap-1">
-                    <span className="font-mono text-4xl font-bold text-foreground">
-                      ${annual && plan.annual > 0 ? Math.round(plan.annual / 12) : plan.monthly}
-                    </span>
-                    {plan.monthly > 0 && <span className="text-sm text-muted-foreground">/month</span>}
-                  </div>
-                  {annual && plan.savings ? (
-                    <p className="mt-1 text-xs text-amber-500">
-                      ${plan.annual}/year, save ${plan.savings}
-                    </p>
-                  ) : (
-                    <p className="mt-1 text-xs text-transparent" aria-hidden="true">
-                      &nbsp;
-                    </p>
-                  )}
-                </div>
-
-                {/* Feature list grows to fill, pushing button to bottom */}
-                <ul className="mt-6 flex-1 space-y-3">
-                  {plan.features.map((feature) => (
-                    <li key={feature} className="flex items-center gap-3 text-sm text-muted-foreground">
-                      <Check className="h-4 w-4 shrink-0 text-amber-500" />
-                      {feature}
-                    </li>
-                  ))}
-                </ul>
-
-                {/* Button pinned to bottom of card */}
-                <div className="mt-8 flex justify-center">
-                  {plan.ctaVariant === 'default' ? (
-                    <Button asChild size="sm" className="bg-amber-500 text-background hover:bg-amber-600 font-medium px-6">
-                      <Link href={`/signup?plan=${plan.name.toLowerCase()}`}>{plan.cta}</Link>
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="outline"
-                      asChild
-                      size="sm"
-                      className="border-border/60 text-muted-foreground hover:text-foreground bg-transparent px-6"
-                    >
-                      <Link href="/signup">{plan.cta}</Link>
-                    </Button>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Feature Comparison Table */}
-      <section className="py-12">
-        <div className="mx-auto max-w-5xl px-6">
-          <h2 className="text-balance text-center text-3xl font-bold tracking-tight text-foreground">
-            Compare All Features
-          </h2>
-          <p className="mx-auto mt-3 max-w-lg text-center text-muted-foreground">
-            A detailed breakdown of what each plan includes.
-          </p>
-
-          <div className="mt-12 overflow-x-auto">
-            <table className="w-full min-w-[600px]">
-              <thead>
-                <tr className="border-b border-border/60">
-                  <th className="pb-4 text-left text-sm font-medium text-muted-foreground w-[40%]">Feature</th>
-                  <th className="pb-4 text-center text-sm font-medium text-muted-foreground w-[20%]">Free</th>
-                  <th className="pb-4 text-center text-sm font-medium w-[20%]">
-                    <span className="text-amber-500">Pro</span>
-                  </th>
-                  <th className="pb-4 text-center text-sm font-medium text-muted-foreground w-[20%]">Power</th>
-                </tr>
-              </thead>
-
-              <tbody>
-                {comparisonCategories.map((category) => (
-                  <ComparisonCategory key={category.name} category={category} />
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </section>
-
-      {/* FAQ */}
-      <section className="py-16 border-t border-border/30">
-        <div className="mx-auto max-w-3xl px-6">
-          <h2 className="text-balance text-center text-3xl font-bold tracking-tight text-foreground">
-            Frequently Asked Questions
-          </h2>
-
-          <Accordion type="single" collapsible className="mt-12">
-            {faqs.map((faq, i) => (
-              <AccordionItem key={i} value={`faq-${i}`} className="border-border/40">
-                <AccordionTrigger className="text-left text-foreground hover:text-amber-500 hover:no-underline">
-                  {faq.q}
-                </AccordionTrigger>
-                <AccordionContent className="text-muted-foreground leading-relaxed">
-                  {faq.a}
-                </AccordionContent>
-              </AccordionItem>
-            ))}
-          </Accordion>
-        </div>
-      </section>
-
-      {/* Final CTA */}
-      <section className="relative overflow-hidden py-24">
-        <div className="absolute inset-0 bg-gradient-to-r from-amber-500/10 via-amber-500/5 to-transparent" />
-        <div className="absolute inset-0 dot-grid opacity-30" />
-
-        <div className="relative mx-auto max-w-7xl px-6 text-center">
-          <h2 className="mx-auto max-w-2xl text-balance text-3xl font-bold tracking-tight text-foreground md:text-4xl">
-            Start Free. No credit card required.
-          </h2>
-          <p className="mx-auto mt-4 max-w-md text-muted-foreground leading-relaxed">
-            Get full visibility into your AI coding agents in under two minutes.
-          </p>
-          <div className="mt-8">
-            <Button
-              asChild
-              size="lg"
-              className="bg-amber-500 px-10 text-background hover:bg-amber-600 font-semibold text-base h-12"
-            >
-              <Link href="/signup">
-                Get Started Free
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Link>
-            </Button>
-          </div>
-        </div>
-      </section>
-
-      <Footer />
-    </main>
-  );
-}
-
 /**
- * Renders a comparison category with its header and feature rows.
- * Extracted to avoid React Fragment key warning in the table.
+ * Renders a comparison category with its header row and feature rows.
+ * Extracted to a separate component to avoid React Fragment key warnings in the table.
+ *
+ * @param category - The category data to render
  */
 function ComparisonCategory({ category }: { category: typeof comparisonCategories[number] }) {
   return (
@@ -494,7 +295,7 @@ function ComparisonCategory({ category }: { category: typeof comparisonCategorie
       <tr>
         <td
           colSpan={4}
-          className="pt-8 pb-3 text-center text-xs font-semibold uppercase tracking-wider text-amber-500/70"
+          className="pt-8 pb-3 text-center text-[10px] font-semibold uppercase tracking-[0.2em] text-amber-500/60"
         >
           {category.name}
         </td>
@@ -503,11 +304,11 @@ function ComparisonCategory({ category }: { category: typeof comparisonCategorie
         <tr
           key={feature.name}
           className={cn(
-            'border-b border-border/20',
-            idx === category.features.length - 1 && 'border-border/40',
+            'border-b border-zinc-800/30',
+            idx === category.features.length - 1 && 'border-zinc-800/60',
           )}
         >
-          <td className="py-3.5 text-sm text-foreground">{feature.name}</td>
+          <td className="py-3.5 text-sm text-zinc-300">{feature.name}</td>
           <td className="py-3.5 text-center">
             <CellValue value={feature.free} />
           </td>
@@ -520,5 +321,368 @@ function ComparisonCategory({ category }: { category: typeof comparisonCategorie
         </tr>
       ))}
     </>
+  );
+}
+
+/**
+ * Individual pricing card for the pricing page.
+ *
+ * @param plan - The plan data to render
+ * @param annual - Whether annual billing is active
+ */
+function PricingCard({
+  plan,
+  annual,
+}: {
+  plan: (typeof plans)[number];
+  annual: boolean;
+}) {
+  const displayPrice =
+    annual && plan.annual > 0 ? Math.round(plan.annual / 12) : plan.monthly;
+
+  return (
+    <div
+      className={cn(
+        'relative flex flex-col rounded-2xl p-8 transition-all duration-300',
+        plan.popular
+          ? 'border border-amber-500/40 bg-zinc-950 amber-glow md:-my-4 md:py-12 z-10'
+          : 'border border-zinc-800/80 bg-zinc-950/60 hover:border-zinc-700/80',
+      )}
+    >
+      {/* Ambient glow for Pro */}
+      {plan.popular && (
+        <div
+          className="pointer-events-none absolute inset-0 rounded-2xl"
+          style={{
+            background:
+              'radial-gradient(ellipse 60% 40% at 50% 0%, rgba(245,158,11,0.07) 0%, transparent 70%)',
+          }}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Most Popular badge */}
+      {plan.popular && (
+        <div className="mb-5 flex justify-center">
+          <span className="rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.2em] text-amber-400">
+            Most Popular
+          </span>
+        </div>
+      )}
+
+      <div className={cn(!plan.popular && 'pt-8')}>
+        <h3
+          className={cn(
+            'text-lg font-semibold',
+            plan.popular ? 'text-amber-400' : 'text-foreground',
+          )}
+        >
+          {plan.name}
+        </h3>
+        <p className="mt-1 text-sm text-muted-foreground">{plan.description}</p>
+      </div>
+
+      <div className="mt-6 flex items-baseline gap-1">
+        <span className="text-5xl font-bold tracking-tight text-foreground">
+          ${displayPrice}
+        </span>
+        {plan.monthly > 0 && (
+          <span className="text-sm font-normal text-muted-foreground">/mo</span>
+        )}
+        {plan.monthly === 0 && (
+          <span className="text-sm font-normal text-muted-foreground">forever</span>
+        )}
+      </div>
+
+      {/* Annual savings — reserved height prevents layout shift */}
+      <div className="mt-1 h-4">
+        {annual && plan.savings ? (
+          <p className="text-xs text-amber-500/80">
+            ${plan.annual}/year — save ${plan.savings}
+          </p>
+        ) : null}
+      </div>
+
+      <div
+        className={cn(
+          'mt-6 h-px',
+          plan.popular ? 'bg-amber-500/20' : 'bg-zinc-800',
+        )}
+      />
+
+      <ul className="mt-6 flex-1 space-y-3">
+        {plan.included.map((feature) => (
+          <li
+            key={feature}
+            className="flex items-start gap-3 text-sm text-zinc-300"
+          >
+            <Check
+              className={cn(
+                'mt-0.5 h-4 w-4 shrink-0',
+                plan.popular ? 'text-amber-400' : 'text-amber-500/70',
+              )}
+            />
+            {feature}
+          </li>
+        ))}
+        {plan.notIncluded.map((feature) => (
+          <li
+            key={feature}
+            className="flex items-start gap-3 text-sm text-zinc-500"
+          >
+            <X className="mt-0.5 h-4 w-4 shrink-0 text-zinc-700" />
+            {feature}
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-8">
+        {plan.ctaVariant === 'amber' && (
+          <Button
+            asChild
+            className="w-full bg-amber-500 font-semibold text-zinc-950 hover:bg-amber-400 active:bg-amber-600 transition-colors"
+          >
+            <Link href={`/signup?plan=${plan.name.toLowerCase()}`}>{plan.cta}</Link>
+          </Button>
+        )}
+        {plan.ctaVariant === 'outline' && (
+          <Button
+            variant="outline"
+            asChild
+            className="w-full border-zinc-700 bg-transparent font-medium text-zinc-300 hover:border-zinc-500 hover:text-foreground"
+          >
+            <Link href={`/signup?plan=${plan.name.toLowerCase()}`}>{plan.cta}</Link>
+          </Button>
+        )}
+        {plan.ctaVariant === 'ghost' && (
+          <Button
+            variant="ghost"
+            asChild
+            className="w-full font-medium text-muted-foreground hover:text-foreground"
+          >
+            <Link href="/signup">{plan.cta}</Link>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Public pricing page.
+ * Includes pricing cards, full feature comparison table, FAQ, and CTA.
+ */
+export default function PricingPage() {
+  const [annual, setAnnual] = useState(false);
+  const [activeFaq, setActiveFaq] = useState(0);
+
+  return (
+    <main className="min-h-screen">
+      <Navbar />
+
+      {/* Hero */}
+      <section className="pt-32 pb-16">
+        <div className="mx-auto max-w-7xl px-6 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
+            Pricing
+          </p>
+          <h1 className="mt-3 text-balance text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+            Simple, transparent pricing
+          </h1>
+          <p className="mx-auto mt-4 max-w-xl text-lg text-muted-foreground leading-relaxed">
+            Start free, scale as you grow. No hidden fees, no surprises. Cancel anytime.
+          </p>
+        </div>
+      </section>
+
+      {/* Annual/monthly toggle */}
+      <section className="pb-4">
+        <div className="mx-auto max-w-7xl px-6">
+          <div className="flex items-center justify-center gap-4">
+            <span
+              className={cn(
+                'text-sm transition-colors',
+                !annual ? 'font-medium text-foreground' : 'text-muted-foreground',
+              )}
+            >
+              Monthly
+            </span>
+            <button
+              type="button"
+              onClick={() => setAnnual(!annual)}
+              className={cn(
+                'relative h-6 w-11 rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                annual ? 'bg-amber-500' : 'bg-zinc-700',
+              )}
+              role="switch"
+              aria-checked={annual}
+              aria-label="Toggle annual billing"
+            >
+              <span
+                className={cn(
+                  'absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200',
+                  annual && 'translate-x-5',
+                )}
+              />
+            </button>
+            <span
+              className={cn(
+                'text-sm transition-colors',
+                annual ? 'font-medium text-foreground' : 'text-muted-foreground',
+              )}
+            >
+              Annual{' '}
+              <span className="ml-1 rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-amber-400">
+                Save 2 months
+              </span>
+              {/* WHY $98: Power plan saves $98/year ($49 x 12 = $588 vs $490 annual) */}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing Cards */}
+      <section className="py-12">
+        <div className="mx-auto max-w-7xl px-6">
+          <div className="grid gap-4 md:grid-cols-3 md:items-center">
+            {plans.map((plan) => (
+              <PricingCard key={plan.name} plan={plan} annual={annual} />
+            ))}
+          </div>
+          <p className="mt-8 text-center text-xs text-muted-foreground/60">
+            14-day free trial on Pro and Power. No credit card required. Cancel anytime.
+          </p>
+        </div>
+      </section>
+
+      {/* Feature Comparison Table */}
+      <section className="py-16 border-t border-zinc-800/40">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-center text-3xl font-bold tracking-tight text-foreground">
+            Compare all features
+          </h2>
+          <p className="mx-auto mt-3 max-w-lg text-center text-muted-foreground">
+            A detailed breakdown of what each plan includes.
+          </p>
+
+          <div className="mt-12 overflow-x-auto">
+            <table className="w-full min-w-[600px]">
+              <thead>
+                <tr className="border-b border-zinc-800/60">
+                  <th className="pb-4 text-left text-sm font-medium text-muted-foreground w-[40%]">
+                    Feature
+                  </th>
+                  <th className="pb-4 text-center text-sm font-medium text-muted-foreground w-[20%]">
+                    Free
+                  </th>
+                  <th className="pb-4 text-center text-sm font-semibold w-[20%]">
+                    <span className="text-amber-400">Pro</span>
+                  </th>
+                  <th className="pb-4 text-center text-sm font-medium text-muted-foreground w-[20%]">
+                    Power
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {comparisonCategories.map((category) => (
+                  <ComparisonCategory key={category.name} category={category} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ — two-column interactive layout */}
+      <section className="py-24 border-t border-zinc-800/40">
+        <div className="mx-auto max-w-7xl px-6">
+          <div className="mx-auto max-w-2xl text-center">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
+              FAQ
+            </p>
+            <h2 className="mt-3 text-balance text-3xl font-bold tracking-tight text-foreground">
+              Frequently asked questions
+            </h2>
+          </div>
+
+          <div className="mt-16 grid gap-6 lg:grid-cols-[1fr_1.4fr] lg:gap-12">
+            {/* Left: question list */}
+            <nav aria-label="FAQ questions" className="flex flex-col gap-1">
+              {faqs.map((faq, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => setActiveFaq(i)}
+                  className={cn(
+                    'group flex w-full items-start gap-3 rounded-lg px-4 py-3.5 text-left transition-colors duration-150',
+                    i === activeFaq
+                      ? 'bg-zinc-900 text-foreground'
+                      : 'text-muted-foreground hover:bg-zinc-900/50 hover:text-foreground',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'mt-1.5 h-3 w-0.5 shrink-0 rounded-full transition-colors duration-150',
+                      i === activeFaq ? 'bg-amber-500' : 'bg-transparent',
+                    )}
+                    aria-hidden="true"
+                  />
+                  <span className="text-sm font-medium leading-snug">{faq.q}</span>
+                </button>
+              ))}
+            </nav>
+
+            {/* Right: answer panel */}
+            <div className="lg:sticky lg:top-24">
+              <div className="rounded-2xl border border-zinc-800/80 bg-zinc-950/60 p-8 lg:p-10">
+                <h3 className="text-lg font-semibold leading-snug text-foreground">
+                  {faqs[activeFaq].q}
+                </h3>
+                <div className="mt-4 h-px w-12 bg-amber-500/40" />
+                <p className="mt-5 text-base leading-relaxed text-muted-foreground">
+                  {faqs[activeFaq].a}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="relative overflow-hidden py-28 border-t border-zinc-800/40">
+        <div
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background:
+              'radial-gradient(ellipse 80% 60% at 50% 50%, rgba(245,158,11,0.06) 0%, transparent 70%)',
+          }}
+          aria-hidden="true"
+        />
+        <div className="pointer-events-none absolute inset-0 dot-grid opacity-20" aria-hidden="true" />
+
+        <div className="relative mx-auto max-w-3xl px-6 text-center">
+          <h2 className="text-balance text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+            Start monitoring your agents in 90 seconds
+          </h2>
+          <div className="mt-10">
+            <Button
+              asChild
+              size="lg"
+              className="h-13 bg-amber-500 px-10 text-base font-semibold text-zinc-950 shadow-lg shadow-amber-500/20 hover:bg-amber-400 active:bg-amber-600 transition-colors"
+            >
+              <Link href="/signup">
+                Get Started Free
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+          <p className="mt-4 text-sm text-muted-foreground/60">
+            Free plan available. No credit card required.
+          </p>
+        </div>
+      </section>
+
+      <Footer />
+    </main>
   );
 }

--- a/packages/styrby-web/src/components/landing/cost-savings.tsx
+++ b/packages/styrby-web/src/components/landing/cost-savings.tsx
@@ -3,6 +3,13 @@ import { Eye, ShieldAlert, BarChart3 } from "lucide-react"
 /**
  * Cost Savings Section — Alternating Zig-Zag Layout
  *
+ * WHY this comes AFTER features and mobile showcase: Cost tracking is a
+ * supporting benefit, not the primary value proposition. The story is remote
+ * control + session management first. Once the reader is sold on the core
+ * product, this section adds "oh, and it tracks every dollar too" as a
+ * bonus that seals the decision. Placing it here prevents leading with a
+ * frugality pitch that undersells the broader product.
+ *
  * WHY zig-zag over equal 3-col: Each value prop gets a full-width row with
  * icon on one side and text on the other, alternating sides. This creates
  * a natural reading rhythm that prevents the monotony of scanning three
@@ -13,7 +20,7 @@ import { Eye, ShieldAlert, BarChart3 } from "lucide-react"
 const valueProps = [
   {
     icon: Eye,
-    title: "Per-agent, per-session, per-model costs",
+    title: "Per-agent, per-session, per-message costs",
     description:
       "Spend tracking across all eleven agents, updated on every page load. Tag sessions by client or project. See exactly which session is eating your budget today, not at the end of the month.",
   },
@@ -21,13 +28,13 @@ const valueProps = [
     icon: ShieldAlert,
     title: "Budget limits that enforce themselves",
     description:
-      "Set daily or monthly caps per agent. Styrby warns you at your threshold, throttles the agent if you want, or kills the session automatically. Your call.",
+      "Set daily or monthly caps per agent. Styrby warns you at your threshold, throttles the agent if you want, or kills the session automatically. No more 2am surprises on your invoice.",
   },
   {
     icon: BarChart3,
-    title: "Token-level breakdowns",
+    title: "Dynamic pricing for 300+ models",
     description:
-      "Input tokens, output tokens, cache hits. See which sessions consume the most and filter by agent, model, or tags. Find the $40 session hiding in a $200 month.",
+      "Token-level breakdowns with input, output, and cache costs. Model pricing updates automatically. Find the $40 session hiding in a $200 month — then set a budget alert so it never happens again.",
   },
 ]
 
@@ -36,12 +43,13 @@ export function CostSavings() {
     <section className="relative py-16">
       <div className="absolute inset-0 dot-grid opacity-50" />
       <div className="relative mx-auto max-w-7xl px-6">
+        {/* Reframed heading — cost as a supporting benefit, not the lead */}
         <h2 className="mx-auto max-w-2xl text-balance text-center text-3xl font-semibold tracking-tighter text-foreground md:text-4xl">
-          Your AI Spend, Visible and{" "}
-          <span className="text-amber-500">Under Control</span>
+          Oh, and It Tracks Every Dollar Too
         </h2>
-        <p className="mx-auto mt-4 max-w-xl text-center text-muted-foreground leading-relaxed">
-          The average developer using AI agents has no idea what they spent last month. Styrby changes that.
+        <p className="mx-auto mt-4 max-w-xl text-center leading-relaxed text-muted-foreground">
+          Real-time cost visibility across all agents, with budget controls that actually work.
+          Because knowing is only useful if you can act on it.
         </p>
 
         {/* Alternating zig-zag rows — varied widths, offset positions */}
@@ -56,10 +64,12 @@ export function CostSavings() {
                 key={prop.title}
                 className={`gradient-border group rounded-xl bg-card/60 p-7 transition-all duration-200 hover:bg-card ${widths[index]} ${alignment}`}
               >
-                <div className={`flex flex-col gap-4 md:flex-row md:items-start md:gap-6 ${
-                  index % 2 === 1 ? "md:flex-row-reverse" : ""
-                }`}>
-                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-amber-500/10 border border-amber-500/20">
+                <div
+                  className={`flex flex-col gap-4 md:flex-row md:items-start md:gap-6 ${
+                    index % 2 === 1 ? "md:flex-row-reverse" : ""
+                  }`}
+                >
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-amber-500/20 bg-amber-500/10">
                     <prop.icon className="h-6 w-6 text-amber-500" />
                   </div>
                   <div>
@@ -72,7 +82,7 @@ export function CostSavings() {
           })}
         </div>
 
-        {/* Cost analytics screenshot */}
+        {/* Cost analytics screenshot — kept as reference for real screenshot later */}
         <div className="mx-auto mt-10 md:max-w-[85%]">
           <img
             src="/screenshots/cost-analytics.png"

--- a/packages/styrby-web/src/components/landing/cta-banner.tsx
+++ b/packages/styrby-web/src/components/landing/cta-banner.tsx
@@ -1,28 +1,67 @@
 import Link from "next/link"
+import { ArrowRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
+/**
+ * CTA Banner — final conversion section before the footer.
+ *
+ * WHY minimal copy: visitors who scroll this far have already read the
+ * feature list and pricing. A single bold statement and one button
+ * removes friction. Extra copy at this stage adds noise, not value.
+ */
 export function CTABanner() {
   return (
-    <section className="py-12">
-      <div className="mx-auto max-w-7xl px-6">
-        <div className="relative mx-auto overflow-hidden rounded-2xl border border-border/60 bg-card/40 px-8 py-12 text-center md:max-w-[70%]">
-          <div className="absolute inset-0 bg-gradient-to-r from-amber-500/10 via-amber-500/5 to-transparent" />
-          <div className="absolute inset-0 dot-grid opacity-30" />
+    <section className="relative overflow-hidden py-28">
+      {/* Ambient amber mesh gradient */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse 80% 60% at 50% 50%, rgba(245,158,11,0.06) 0%, transparent 70%)",
+        }}
+        aria-hidden="true"
+      />
 
-          <div className="relative">
-            <h2 className="mx-auto max-w-2xl text-balance text-3xl font-bold tracking-tight text-foreground md:text-4xl">
-              Your agents are running right now. Do you know what they cost?
-            </h2>
-            <p className="mx-auto mt-4 max-w-md text-muted-foreground leading-relaxed">
-              Install the CLI, scan the QR code, and find out in 90 seconds.
-            </p>
-            <div className="mt-8">
-              <Button asChild size="lg" className="bg-amber-500 px-10 text-background hover:bg-amber-600 font-semibold text-base h-12">
-                <Link href="/signup">Connect Your First Agent</Link>
-              </Button>
-            </div>
-          </div>
+      {/* Subtle dot grid texture */}
+      <div className="pointer-events-none absolute inset-0 dot-grid opacity-20" aria-hidden="true" />
+
+      {/* Top and bottom fade — blends into surrounding sections */}
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-24"
+        style={{
+          background: "linear-gradient(to bottom, hsl(240 6% 3.5%), transparent)",
+        }}
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute inset-x-0 bottom-0 h-24"
+        style={{
+          background: "linear-gradient(to top, hsl(240 6% 3.5%), transparent)",
+        }}
+        aria-hidden="true"
+      />
+
+      <div className="relative mx-auto max-w-3xl px-6 text-center">
+        <h2 className="text-balance text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+          Start monitoring your agents in 90 seconds
+        </h2>
+
+        <div className="mt-10">
+          <Button
+            asChild
+            size="lg"
+            className="h-13 bg-amber-500 px-10 text-base font-semibold text-zinc-950 shadow-lg shadow-amber-500/20 hover:bg-amber-400 active:bg-amber-600 transition-colors"
+          >
+            <Link href="/signup">
+              Connect Your First Agent
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
         </div>
+
+        <p className="mt-4 text-sm text-muted-foreground/60">
+          Free plan available. No credit card required.
+        </p>
       </div>
     </section>
   )

--- a/packages/styrby-web/src/components/landing/faq-section.tsx
+++ b/packages/styrby-web/src/components/landing/faq-section.tsx
@@ -1,10 +1,16 @@
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion"
+"use client"
 
+import { useState } from "react"
+import { cn } from "@/lib/utils"
+
+/**
+ * FAQ data — all questions and answers for the landing page.
+ *
+ * WHY no accordion: The two-column layout gives visitors a scannable
+ * question list on the left and an immediately readable answer on the
+ * right. This is faster than the expand/collapse rhythm of accordions
+ * and keeps the page feel premium rather than generic.
+ */
 const faqs = [
   {
     q: "Can you see my code or prompts?",
@@ -12,7 +18,7 @@ const faqs = [
   },
   {
     q: "What agents does Styrby support?",
-    a: "Eleven CLI coding agents: Claude Code (Anthropic), Codex (OpenAI), Gemini CLI (Google), OpenCode, Aider, Goose, Amp, Crush, Kilo, Kiro, and Droid. The Free plan includes the first three (Claude Code, Codex, Gemini CLI). Pro unlocks eight agents. Power unlocks all eleven.",
+    a: "Eleven CLI coding agents: Claude Code (Anthropic), Codex (OpenAI), Gemini CLI (Google), OpenCode, Aider, Goose, Amp, Crush, Kilo, Kiro, and Droid. The Free plan includes the first three. Pro unlocks eight agents. Power unlocks all eleven.",
   },
   {
     q: "Can I use my own API keys?",
@@ -28,7 +34,7 @@ const faqs = [
   },
   {
     q: "Can I review code from my phone?",
-    a: "Yes. Code review from mobile is a Power tier feature. Submit a review request from your phone, monitor progress, and receive push notifications when the review completes.",
+    a: "Yes. Code review from mobile is a Power tier feature. Submit a review request from your phone, monitor progress, and receive a push notification when the review completes.",
   },
   {
     q: "What are session checkpoints?",
@@ -51,31 +57,87 @@ const faqs = [
     a: "The Pro plan ($24/mo) supports up to 3 team members with shared dashboards and per-developer cost attribution. The Power plan ($49/mo) adds team-level budget alerts and OTEL export for full observability across your team.",
   },
   {
-    q: "How is this different from checking my API provider's dashboard?",
-    a: "API dashboards show you total spend after the fact, across all usage. Styrby shows you per-agent, per-session, per-message, and per-model cost breakdowns with per-file context breakdown. Tag sessions by client or project to get a cost-by-tag breakdown for invoicing. You can also set budget limits that automatically stop runaway sessions, and it works across all eleven agents in one place. No provider dashboard does that.",
+    q: "How is this different from checking my API dashboard?",
+    a: "API dashboards show you total spend after the fact, across all usage. Styrby shows per-agent, per-session, per-message, and per-model cost breakdowns with per-file context detail. Tag sessions by client or project for cost-by-tag reporting. Set budget limits that automatically pause runaway sessions. Works across all eleven agents in one place.",
   },
 ]
 
+/**
+ * FAQ section — two-column layout with clickable questions on the left
+ * and the selected answer on the right.
+ *
+ * @returns The full FAQ section with interactive question selection
+ */
 export function FAQSection() {
-  return (
-    <section className="py-16">
-      <div className="mx-auto max-w-3xl px-6">
-        <h2 className="text-balance text-center text-3xl font-bold tracking-tight text-foreground md:text-4xl">
-          Questions You Should Ask Before Trusting Any Tool With Your Agent Data
-        </h2>
+  const [active, setActive] = useState(0)
 
-        <Accordion type="single" collapsible className="mt-12">
-          {faqs.map((faq, i) => (
-            <AccordionItem key={i} value={`faq-${i}`} className="border-border/40">
-              <AccordionTrigger className="text-left text-foreground hover:text-amber-500 hover:no-underline">
-                {faq.q}
-              </AccordionTrigger>
-              <AccordionContent className="text-muted-foreground leading-relaxed">
-                {faq.a}
-              </AccordionContent>
-            </AccordionItem>
-          ))}
-        </Accordion>
+  return (
+    <section className="py-24">
+      <div className="mx-auto max-w-7xl px-6">
+
+        {/* Section header */}
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
+            FAQ
+          </p>
+          <h2 className="mt-3 text-balance text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+            Questions you should ask before trusting any tool with your agent data
+          </h2>
+        </div>
+
+        {/* Two-column layout */}
+        <div className="mt-16 grid gap-6 lg:grid-cols-[1fr_1.4fr] lg:gap-12">
+
+          {/* Left: question list */}
+          <nav aria-label="FAQ questions" className="flex flex-col gap-1">
+            {faqs.map((faq, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => setActive(i)}
+                className={cn(
+                  "group flex w-full items-start gap-3 rounded-lg px-4 py-3.5 text-left transition-colors duration-150",
+                  i === active
+                    ? "bg-zinc-900 text-foreground"
+                    : "text-muted-foreground hover:bg-zinc-900/50 hover:text-foreground"
+                )}
+              >
+                {/* Active indicator bar */}
+                <span
+                  className={cn(
+                    "mt-1.5 h-3 w-0.5 shrink-0 rounded-full transition-colors duration-150",
+                    i === active ? "bg-amber-500" : "bg-transparent"
+                  )}
+                  aria-hidden="true"
+                />
+                <span className="text-sm font-medium leading-snug">{faq.q}</span>
+              </button>
+            ))}
+          </nav>
+
+          {/* Right: answer panel */}
+          <div className="lg:sticky lg:top-24">
+            <div className="rounded-2xl border border-zinc-800/80 bg-zinc-950/60 p-8 lg:p-10">
+              {/* Question */}
+              <h3 className="text-lg font-semibold leading-snug text-foreground">
+                {faqs[active].q}
+              </h3>
+
+              {/* Amber divider */}
+              <div className="mt-4 h-px w-12 bg-amber-500/40" />
+
+              {/* Answer */}
+              <p className="mt-5 text-base leading-relaxed text-muted-foreground">
+                {faqs[active].a}
+              </p>
+            </div>
+
+            {/* Mobile fallback: show all Q&A below the list on small screens */}
+            <p className="mt-4 text-xs text-muted-foreground/50 lg:hidden">
+              Tap a question above to read the answer here.
+            </p>
+          </div>
+        </div>
       </div>
     </section>
   )

--- a/packages/styrby-web/src/components/landing/features-section.tsx
+++ b/packages/styrby-web/src/components/landing/features-section.tsx
@@ -1,54 +1,250 @@
 import Link from "next/link"
-import { BarChart3, Shield, LayoutDashboard, ArrowRight } from "lucide-react"
+import {
+  LayoutDashboard,
+  Smartphone,
+  FolderOpen,
+  BarChart3,
+  GitBranch,
+  Bell,
+  Activity,
+  Code2,
+  ArrowRight,
+} from "lucide-react"
 
 /**
- * Features Section (Homepage)
+ * Features Section (Homepage) — Bento Grid Layout
  *
- * Shows the top 3 features only. Full list lives on /features.
- * Keeps the homepage scannable without overwhelming visitors.
+ * WHY bento over equal-column grid: The multi-agent dashboard is the primary
+ * differentiator and deserves visual dominance. A 2-col spanning hero card
+ * establishes hierarchy — visitors immediately understand the core value prop
+ * before reading secondary features. The asymmetric sizing also creates visual
+ * interest that encourages scanning all eight cards.
+ *
+ * WHY remote control leads over cost tracking: Market research (and Happy Coder
+ * gaps) shows the strongest emotional hook is the workflow disruption of being
+ * tethered to a laptop. Cost tracking is a supporting benefit, not the story.
+ *
+ * Grid layout (3 cols):
+ * Row 1: [Dashboard 2×2] [Remote Control 1×2]
+ * Row 2: (Dashboard continues) [Session Management 1×1]
+ * Row 3: [Cost Tracking] [Activity Graph] [Cloud Monitoring]
+ * Row 4: [OTEL Export] [Code Review] (+ filler)
  */
 
-const features = [
-  {
-    icon: BarChart3,
-    title: "Cost Tracking Across Every Agent",
-    description:
-      "Per-session, per-agent, and per-model breakdowns. Budget limits that enforce themselves. Tag sessions by client for invoicing.",
-  },
-  {
-    icon: Shield,
-    title: "Remote Permission Control",
-    description:
-      "Approve or deny risky actions from your phone. Risk badges tell you what needs attention and what does not.",
-  },
+interface BentoFeature {
+  icon: React.ComponentType<{ className?: string }>
+  title: string
+  description: string
+  /** CSS grid column span — applied on md+ only */
+  colSpan?: "col-span-1" | "col-span-2"
+  /** CSS grid row span — applied on md+ only */
+  rowSpan?: "row-span-1" | "row-span-2"
+}
+
+const features: BentoFeature[] = [
   {
     icon: LayoutDashboard,
-    title: "Eleven Agents, One Dashboard",
+    title: "Multi-Agent Dashboard",
     description:
-      "Claude Code, Codex, Gemini CLI, OpenCode, Aider, Goose, Amp, Crush, Kilo, Kiro, and Droid in a single view. Live status, session history, and error attribution.",
+      "Monitor all 11 CLI coding agents from one place. Claude Code, Codex, Gemini CLI, OpenCode, Aider, Goose, Amp, Crush, Kilo, Kiro, and Droid. Live status, session history, error attribution, and per-agent metrics — all in a single encrypted view.",
+    colSpan: "col-span-2",
+    rowSpan: "row-span-2",
+  },
+  {
+    icon: Smartphone,
+    title: "Mobile Remote Control",
+    description:
+      "Approve permissions, review code diffs, and send voice commands from your phone. Your agents never sit idle waiting for you.",
+    colSpan: "col-span-1",
+    rowSpan: "row-span-1",
+  },
+  {
+    icon: FolderOpen,
+    title: "Session Management",
+    description:
+      "Checkpoints, sharing, export, and replay — all encrypted end-to-end with TweetNaCl.",
+    colSpan: "col-span-1",
+    rowSpan: "row-span-1",
+  },
+  {
+    icon: BarChart3,
+    title: "Smart Cost Tracking",
+    description:
+      "Per-message costs, dynamic pricing for 300+ models, and budget alerts that enforce themselves.",
+    colSpan: "col-span-1",
+    rowSpan: "row-span-1",
+  },
+  {
+    icon: Activity,
+    title: "Activity Graph",
+    description:
+      "GitHub-style contribution heatmap across all your agent sessions.",
+    colSpan: "col-span-1",
+    rowSpan: "row-span-1",
+  },
+  {
+    icon: Bell,
+    title: "Cloud Monitoring",
+    description:
+      "Async task tracking with push notifications. Know the moment a session completes or errors.",
+    colSpan: "col-span-1",
+    rowSpan: "row-span-1",
+  },
+  {
+    icon: GitBranch,
+    title: "OTEL Export",
+    description:
+      "Send traces to Grafana, Datadog, Honeycomb, or New Relic. Enterprise observability out of the box.",
+    colSpan: "col-span-1",
+    rowSpan: "row-span-1",
+  },
+  {
+    icon: Code2,
+    title: "Code Review",
+    description:
+      "Diff viewer with syntax highlighting. Review what your agent changed before it commits — from mobile.",
+    colSpan: "col-span-1",
+    rowSpan: "row-span-1",
   },
 ]
 
+/**
+ * Returns the combined className string for a bento card.
+ *
+ * @param feature - The feature definition containing span metadata
+ * @param index - Card index, used to apply hero-card specific styling
+ * @returns Tailwind className string for the card wrapper
+ */
+function cardClasses(feature: BentoFeature, index: number): string {
+  const base =
+    "group relative flex flex-col overflow-hidden rounded-xl md:rounded-2xl bg-zinc-950/80 border border-white/[0.06] shadow-[inset_0_1px_1px_rgba(255,255,255,0.06)] p-6 md:p-8 transition-all duration-200 hover:border-white/[0.10] hover:bg-zinc-900/80"
+
+  const col = feature.colSpan === "col-span-2" ? "md:col-span-2" : ""
+  const row = feature.rowSpan === "row-span-2" ? "md:row-span-2" : ""
+
+  // Hero card gets taller minimum height on desktop
+  const minH = index === 0 ? "md:min-h-[320px]" : ""
+
+  return [base, col, row, minH].filter(Boolean).join(" ")
+}
+
 export function FeaturesSection() {
+  const [heroFeature, ...restFeatures] = features
+
   return (
-    <section id="features" className="relative py-16">
+    <section id="features" className="relative py-16 md:py-24">
       <div className="absolute inset-0 dot-grid opacity-50" />
       <div className="relative mx-auto max-w-7xl px-6">
         <h2 className="mx-auto max-w-3xl text-balance text-center text-3xl font-semibold tracking-tighter text-foreground md:text-4xl">
-          Built for Developers Who Run AI Agents in Production
+          Everything You Need to Run Agents in Production
         </h2>
+        <p className="mx-auto mt-4 max-w-xl text-center text-sm leading-relaxed text-muted-foreground">
+          Remote control, session management, and full observability — for all 11 agents at once.
+        </p>
 
-        <div className="mt-12 grid gap-6 md:grid-cols-3">
-          {features.map((feature) => (
+        {/*
+          Bento grid: 3 equal columns on desktop, single column on mobile.
+          The hero card (index 0) spans 2 cols × 2 rows via md: prefixed classes.
+          All other cards are 1×1.
+        */}
+        <div className="mt-12 grid grid-cols-1 gap-4 md:grid-cols-3 md:grid-rows-[auto_auto_auto]">
+          {/* Hero card — multi-agent dashboard */}
+          <div className={cardClasses(heroFeature, 0)}>
+            {/* Subtle amber radial glow in the background */}
             <div
-              key={feature.title}
-              className="gradient-border group rounded-xl bg-card/60 p-7 transition-all duration-200 hover:bg-card"
-            >
-              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/10 border border-amber-500/20">
-                <feature.icon className="h-5 w-5 text-amber-500" />
+              className="pointer-events-none absolute inset-0 opacity-[0.03]"
+              style={{
+                background:
+                  "radial-gradient(ellipse 80% 60% at 30% 40%, rgb(245 158 11), transparent)",
+              }}
+            />
+
+            <div className="relative z-10 flex h-full flex-col">
+              {/* Icon */}
+              <div className="mb-5 flex h-11 w-11 items-center justify-center rounded-xl bg-amber-500/10 border border-amber-500/20">
+                <heroFeature.icon className="h-5 w-5 text-amber-500" />
               </div>
-              <h3 className="mb-1.5 text-base font-semibold text-foreground">{feature.title}</h3>
-              <p className="text-sm leading-relaxed text-muted-foreground">{feature.description}</p>
+
+              {/* Text */}
+              <h3 className="mb-3 text-xl font-semibold text-foreground md:text-2xl">
+                {heroFeature.title}
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground md:text-base">
+                {heroFeature.description}
+              </p>
+
+              {/* Agent pill list */}
+              <div className="mt-6 flex flex-wrap gap-2">
+                {[
+                  "Claude Code",
+                  "Codex",
+                  "Gemini CLI",
+                  "OpenCode",
+                  "Aider",
+                  "Goose",
+                  "Amp",
+                  "Crush",
+                  "Kilo",
+                  "Kiro",
+                  "Droid",
+                ].map((agent) => (
+                  <span
+                    key={agent}
+                    className="rounded-md border border-white/[0.08] bg-white/[0.04] px-2.5 py-1 font-mono text-xs text-zinc-400"
+                  >
+                    {agent}
+                  </span>
+                ))}
+              </div>
+
+              {/* Live status mockup */}
+              <div className="mt-auto pt-6">
+                <div className="rounded-xl border border-white/[0.06] bg-black/40 p-4">
+                  <div className="mb-3 flex items-center justify-between">
+                    <span className="font-mono text-xs text-zinc-500">live agents</span>
+                    <span className="flex items-center gap-1.5">
+                      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
+                      <span className="font-mono text-xs text-emerald-400">3 active</span>
+                    </span>
+                  </div>
+                  <div className="space-y-2">
+                    {[
+                      { name: "claude-code", status: "running", task: "Refactoring auth module" },
+                      { name: "codex", status: "running", task: "Writing unit tests" },
+                      { name: "aider", status: "idle", task: "Waiting for input" },
+                    ].map((row) => (
+                      <div key={row.name} className="flex items-center gap-3">
+                        <span
+                          className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                            row.status === "running"
+                              ? "bg-emerald-400"
+                              : "bg-zinc-600"
+                          }`}
+                        />
+                        <span className="w-24 shrink-0 font-mono text-xs text-zinc-400">
+                          {row.name}
+                        </span>
+                        <span className="truncate font-mono text-xs text-zinc-500">
+                          {row.task}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Remaining 7 cards */}
+          {restFeatures.map((feature) => (
+            <div key={feature.title} className={cardClasses(feature, 1)}>
+              <div className="relative z-10 flex h-full flex-col">
+                <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/10 border border-amber-500/20">
+                  <feature.icon className="h-5 w-5 text-amber-500" />
+                </div>
+                <h3 className="mb-2 text-base font-semibold text-foreground">{feature.title}</h3>
+                <p className="text-sm leading-relaxed text-muted-foreground">{feature.description}</p>
+              </div>
             </div>
           ))}
         </div>
@@ -56,7 +252,7 @@ export function FeaturesSection() {
         <div className="mt-8 text-center">
           <Link
             href="/features"
-            className="inline-flex items-center gap-1.5 text-sm font-medium text-amber-500 hover:text-amber-400 transition-colors"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-amber-500 transition-colors hover:text-amber-400"
           >
             See all features
             <ArrowRight className="h-4 w-4" />

--- a/packages/styrby-web/src/components/landing/footer.tsx
+++ b/packages/styrby-web/src/components/landing/footer.tsx
@@ -2,64 +2,110 @@ import Link from "next/link"
 import Image from "next/image"
 import { Shield } from "lucide-react"
 
-const links = [
+/**
+ * Footer navigation links — kept minimal to avoid a link farm.
+ *
+ * WHY only 6 links: More links dilute attention. These six cover the
+ * full user journey (explore → convert → legal) without visual noise.
+ */
+const productLinks = [
   { label: "Pricing", href: "/pricing" },
   { label: "Docs", href: "/docs" },
   { label: "Blog", href: "/blog" },
+]
+
+const legalLinks = [
   { label: "Privacy", href: "/privacy" },
   { label: "Terms", href: "/terms" },
 ]
 
+/**
+ * Site footer — minimal, premium, brand-forward.
+ *
+ * Layout: logo + wordmark on the left, two small link columns on the
+ * right, legal and credit row at the bottom. Generous padding to give
+ * the page a proper landing rather than being crowded by the footer.
+ *
+ * @returns The site footer element
+ */
 export function Footer() {
   return (
-    <footer className="border-t border-border/40 py-4">
-      <div className="mx-auto max-w-7xl px-6">
-        {/* Logo left, nav links centered, on the same line */}
-        <div className="relative flex items-center">
-          {/* Logo — left-aligned, taken out of flow so nav can center freely */}
-          <Link href="/" className="flex shrink-0 items-center gap-2 md:absolute md:left-0">
-            <Image
-              src="/logo.png"
-              alt="Styrby"
-              width={20}
-              height={20}
-              className="h-5 w-5"
-            />
-            <span className="text-sm font-bold text-foreground">Styrby</span>
-          </Link>
+    <footer className="border-t border-zinc-800/60">
+      <div className="mx-auto max-w-7xl px-6 py-16">
 
-          {/* Nav links — centered in the full width */}
-          <nav aria-label="Footer" className="hidden flex-1 flex-wrap items-center justify-center gap-x-4 gap-y-1 md:flex">
-            {links.map((link) => (
-              <Link
-                key={link.label}
-                href={link.href}
-                className="text-xs text-zinc-500 transition-colors hover:text-zinc-300"
-              >
-                {link.label}
-              </Link>
-            ))}
-          </nav>
+        {/* Main row: brand left, links right */}
+        <div className="flex flex-col gap-10 md:flex-row md:items-start md:justify-between">
+
+          {/* Brand mark */}
+          <div className="flex flex-col gap-4">
+            <Link href="/" className="flex items-center gap-2.5 group w-fit">
+              <Image
+                src="/icon-512.png"
+                alt="Styrby logo"
+                width={28}
+                height={28}
+                className="h-7 w-7 rounded-md"
+              />
+              <span className="text-base font-bold tracking-tight text-foreground group-hover:text-amber-400 transition-colors">
+                Styrby
+              </span>
+            </Link>
+            <p className="max-w-xs text-sm leading-relaxed text-muted-foreground">
+              Monitor, control, and understand your AI coding agents — from
+              your phone.
+            </p>
+          </div>
+
+          {/* Link columns */}
+          <div className="flex gap-16">
+            <div>
+              <p className="mb-4 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/50">
+                Product
+              </p>
+              <ul className="space-y-3">
+                {productLinks.map((link) => (
+                  <li key={link.label}>
+                    <Link
+                      href={link.href}
+                      className="text-sm text-zinc-400 transition-colors hover:text-zinc-100"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <p className="mb-4 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/50">
+                Legal
+              </p>
+              <ul className="space-y-3">
+                {legalLinks.map((link) => (
+                  <li key={link.label}>
+                    <Link
+                      href={link.href}
+                      className="text-sm text-zinc-400 transition-colors hover:text-zinc-100"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
         </div>
 
-        {/* Mobile nav links — stacked below logo */}
-        <nav aria-label="Footer mobile" className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 md:hidden">
-          {links.map((link) => (
-            <Link
-              key={link.label}
-              href={link.href}
-              className="text-xs text-zinc-500 transition-colors hover:text-zinc-300"
-            >
-              {link.label}
-            </Link>
-          ))}
-        </nav>
+        {/* Divider */}
+        <div className="mt-12 h-px bg-zinc-800/60" />
 
-        {/* Copyright row — centered */}
-        <div className="mt-3 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-zinc-500">
-          <p>&copy; 2026 Steel Motion LLC</p>
-          <div className="flex items-center gap-1">
-            <Shield className="h-3 w-3 text-amber-500" />
+        {/* Bottom row: credit and veteran badge */}
+        <div className="mt-6 flex flex-wrap items-center justify-between gap-4">
+          <p className="text-xs text-zinc-500">
+            &copy; 2026 Steel Motion LLC. All rights reserved.
+          </p>
+          <div className="flex items-center gap-1.5 text-xs text-zinc-500">
+            <Shield className="h-3.5 w-3.5 text-amber-500/70" />
             <span>Veteran-Owned Business</span>
           </div>
         </div>

--- a/packages/styrby-web/src/components/landing/hero.tsx
+++ b/packages/styrby-web/src/components/landing/hero.tsx
@@ -1,74 +1,205 @@
 import Link from "next/link"
-import { ChevronDown, Lock, Shield, Smartphone, Zap } from "lucide-react"
+import Image from "next/image"
+import { ArrowRight, Lock, Shield, Smartphone, Zap } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 
+/**
+ * Dashboard screenshot with a double-bezel frame treatment.
+ *
+ * WHY double bezel: a single thin border looks flat at large sizes. The
+ * outer ring provides contrast against the dark background; the inner ring
+ * (slightly brighter) creates a perception of depth and frames the screenshot
+ * like a physical device, which subconsciously signals premium hardware.
+ */
 function DashboardMockup() {
   return (
-    <div className="relative mx-auto mt-16 max-w-5xl px-4">
-      {/* Glow */}
-      <div className="absolute inset-0 -z-10 rounded-xl bg-amber-500/10 blur-[80px]" />
-      <img
-        src="/screenshots/dashboard-overview.png"
-        alt="Styrby dashboard showing real-time agent costs and session monitoring"
-        className="w-full rounded-xl border border-border/60 shadow-2xl"
-        width={1440}
-        height={900}
+    <div className="relative mx-auto mt-20 max-w-5xl px-4 md:px-0">
+      {/* Radial amber glow sitting behind the frame */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -inset-12 -z-10 rounded-3xl"
+        style={{
+          background:
+            "radial-gradient(ellipse 80% 50% at 50% 100%, rgba(245,158,11,0.12) 0%, transparent 70%)",
+        }}
       />
+      {/* Outer bezel — faint border ring */}
+      <div className="rounded-[18px] border border-white/[0.06] p-[3px] shadow-[0_0_0_1px_rgba(255,255,255,0.04),0_32px_80px_rgba(0,0,0,0.7)]">
+        {/* Inner bezel — slightly brighter, adds depth */}
+        <div className="rounded-[15px] border border-white/[0.09] overflow-hidden">
+          <Image
+            src="/screenshots/dashboard-overview.png"
+            alt="Styrby dashboard showing real-time agent costs and session monitoring"
+            width={1440}
+            height={900}
+            className="w-full"
+            priority
+          />
+        </div>
+      </div>
     </div>
   )
 }
 
+/**
+ * Hero section for the Styrby landing page.
+ *
+ * WHY this headline: "11 Agents. One Dashboard. Your Phone." leads with the
+ * remote-control story — not costs. The competitive moat against Anthropic
+ * Channels / Dispatch is breadth (11 agents) + mobility (your phone). The
+ * headline lands that in four words before the user has time to bounce.
+ *
+ * WHY asymmetric layout (DESIGN_VARIANCE 7): centering everything reads as
+ * generic SaaS. Pinning the headline left with a constrained max-width creates
+ * editorial tension that feels intentional and premium.
+ */
 export function Hero() {
   return (
-    <section className="relative overflow-hidden pt-32 pb-20">
-      {/* Background effects */}
-      <div className="absolute inset-0 dot-grid" />
-      <div className="absolute left-1/2 top-0 h-[500px] w-[800px] -translate-x-1/2 rounded-full bg-amber-500/5 blur-[120px]" />
+    <section className="relative overflow-hidden pt-36 pb-24">
+      {/* ── Background: mesh gradient + dot grid ── */}
+      <div aria-hidden="true" className="absolute inset-0 dot-grid opacity-50" />
 
-      <div className="relative mx-auto max-w-7xl px-6 text-center">
-        {/* WHY this headline: Atlas strategy recommends leading with control + multi-agent.
-             Anthropic launched Channels (Claude-only via Telegram) and Dispatch (Claude-only
-             via their app). Our moat is 11 agents in one encrypted app. The headline must
-             communicate that immediately. */}
-        <h1 className="mx-auto max-w-4xl text-balance text-5xl font-semibold tracking-tighter text-foreground md:text-7xl">
-          One Dashboard for{" "}
-          <span className="text-amber-500">Every AI Agent You Run</span>
+      {/* Left-anchored amber plume — asymmetric, editorial */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute left-0 top-0 -z-10"
+        style={{
+          width: "900px",
+          height: "700px",
+          background:
+            "radial-gradient(ellipse 60% 55% at 15% 30%, rgba(245,158,11,0.07) 0%, transparent 65%)",
+        }}
+      />
+      {/* Subtle right-side cool counter-weight so it doesn't look accidental */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute right-0 bottom-0 -z-10"
+        style={{
+          width: "600px",
+          height: "500px",
+          background:
+            "radial-gradient(ellipse 70% 60% at 85% 80%, rgba(99,102,241,0.04) 0%, transparent 70%)",
+        }}
+      />
+
+      <div className="relative mx-auto max-w-7xl px-6">
+        {/* ── Eyebrow badge ── */}
+        <div className="mb-8 flex items-center gap-3">
+          <div
+            className={cn(
+              "inline-flex items-center gap-2 rounded-full px-3.5 py-1.5",
+              "border border-amber-500/20 bg-amber-500/[0.06]",
+              "text-xs font-medium tracking-wide text-amber-400"
+            )}
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-live-pulse" />
+            Now supporting 11 AI coding agents
+          </div>
+        </div>
+
+        {/* ── Main headline — left-aligned, massive ── */}
+        {/*
+          WHY text-left: at DESIGN_VARIANCE 7 we break the centered-SaaS pattern.
+          The headline reads like editorial typesetting, not a template.
+          max-w-3xl keeps line lengths tight so the staggered line breaks read
+          as intentional rather than wrapping accidents.
+        */}
+        <h1
+          className={cn(
+            "max-w-3xl text-left",
+            "text-6xl md:text-[82px] font-bold leading-[0.92] tracking-tighter",
+            "text-zinc-50"
+          )}
+        >
+          {/* "11 Agents" gets the amber gradient — it's the moat, own it */}
+          <span
+            className="inline-block"
+            style={{
+              backgroundImage:
+                "linear-gradient(135deg, #F59E0B 0%, #FBBF24 45%, #FCD34D 100%)",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              backgroundClip: "text",
+            }}
+          >
+            11 Agents.
+          </span>
+          <br />
+          <span className="text-zinc-50">One Dashboard.</span>
+          <br />
+          <span className="text-zinc-300">Your Phone.</span>
         </h1>
 
-        <p className="mx-auto mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground md:text-xl">
-          See what your AI coding agents are costing you. Approve risky actions from your phone. Set budget limits that actually stop runaway spend. All end-to-end encrypted. Supports 11 CLI agents.
+        {/* ── Subheadline — controlled width, left-aligned ── */}
+        <p className="mt-7 max-w-xl text-left text-lg leading-relaxed text-zinc-400 md:text-[18px]">
+          Control every AI coding agent from anywhere. Approve permissions on
+          your commute. Review code diffs in meetings. See exactly what each
+          response costs. All end-to-end encrypted.
         </p>
 
-        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <Button asChild size="lg" className="bg-amber-500 px-8 text-background hover:bg-amber-600 font-semibold text-base h-12">
-            <Link href="/signup">Connect Your First Agent</Link>
+        {/* ── CTAs ── */}
+        <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Button
+            asChild
+            size="lg"
+            className={cn(
+              "h-12 px-7 text-base font-semibold rounded-xl",
+              "bg-amber-500 text-zinc-950 hover:bg-amber-400",
+              "shadow-[inset_0_1px_1px_rgba(255,255,255,0.25),0_4px_20px_rgba(245,158,11,0.35)]",
+              "transition-all duration-200 hover:shadow-[inset_0_1px_1px_rgba(255,255,255,0.25),0_6px_28px_rgba(245,158,11,0.5)]",
+              "group"
+            )}
+          >
+            <Link href="/signup" className="flex items-center gap-2">
+              Connect Your First Agent
+              <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
+            </Link>
           </Button>
-          <Button variant="ghost" size="lg" asChild className="gap-2 text-muted-foreground hover:text-foreground h-12">
-            <a href="#how-it-works">
-              See How It Works
-              <ChevronDown className="h-4 w-4" />
-            </a>
+
+          <Button
+            variant="ghost"
+            size="lg"
+            asChild
+            className={cn(
+              "h-12 px-7 text-base rounded-xl",
+              "border border-white/[0.10] text-zinc-400",
+              "hover:bg-white/[0.04] hover:text-zinc-200 hover:border-white/[0.16]",
+              "transition-all duration-200"
+            )}
+          >
+            <a href="#how-it-works">See How It Works</a>
           </Button>
         </div>
 
-        {/* Trust badges — WHY these 4: Each addresses a key buyer objection.
-             E2E Encrypted = security concern. Zero Knowledge = privacy concern.
-             5 Agents = multi-agent moat vs Anthropic's Claude-only tools.
-             Free Tier = lowers barrier to trial. */}
-        <div className="mt-8 flex flex-wrap items-center justify-center gap-6">
+        {/* ── Trust badges ── */}
+        {/*
+          WHY these 4: each one neutralises a specific buyer objection.
+          E2E Encrypted = "can attackers read my code?" answered.
+          Zero touch servers = "does Styrby store my IP?" answered.
+          11 Agents = "will it work with my agent?" answered.
+          Free tier = "what does it cost to try?" answered.
+        */}
+        <div className="mt-10 flex flex-wrap items-center gap-x-7 gap-y-3">
           {[
             { icon: Lock, text: "E2E Encrypted" },
             { icon: Shield, text: "Your Code Never Touches Our Servers" },
             { icon: Smartphone, text: "11 Agents, 1 Dashboard" },
             { icon: Zap, text: "Free Forever on 1 Machine" },
           ].map(({ icon: Icon, text }) => (
-            <div key={text} className="flex items-center gap-2 text-xs text-muted-foreground">
-              <Icon className="h-3.5 w-3.5 text-amber-500/70" />
-              {text}
+            <div
+              key={text}
+              className="flex items-center gap-2 text-[13px] text-zinc-500"
+            >
+              <Icon className="h-3.5 w-3.5 flex-shrink-0 text-amber-500/60" />
+              <span>{text}</span>
             </div>
           ))}
         </div>
+      </div>
 
+      {/* ── Dashboard mockup — full width within container ── */}
+      <div className="mx-auto max-w-7xl px-6">
         <DashboardMockup />
       </div>
     </section>

--- a/packages/styrby-web/src/components/landing/how-it-works.tsx
+++ b/packages/styrby-web/src/components/landing/how-it-works.tsx
@@ -1,59 +1,261 @@
-import { Terminal, QrCode, Rocket } from "lucide-react"
+/**
+ * How It Works Section — Vertical Staggered Timeline Layout
+ *
+ * WHY staggered over equal 3-col: Equal columns force all three steps to
+ * compete for attention simultaneously. A vertical timeline creates a natural
+ * reading sequence: the user flows top-to-bottom, understanding causality
+ * (step 1 enables step 2 which enables step 3). Alternating left/right
+ * placement on desktop adds visual interest while preserving the narrative.
+ *
+ * WHY CSS-only illustrations: Avoids image load latency and CLS. The terminal
+ * mockup, QR frame, and dashboard card are composed entirely of styled divs
+ * and Tailwind utility classes — they render instantly, scale perfectly on
+ * any DPR, and match the brand without a design asset pipeline.
+ */
 
-const steps = [
+/** Individual step definition */
+interface Step {
+  number: string
+  title: string
+  description: string
+  /** Which side the illustration appears on desktop */
+  illustrationSide: "left" | "right"
+  illustration: React.ReactNode
+}
+
+// ---------------------------------------------------------------------------
+// CSS-only illustration components
+// ---------------------------------------------------------------------------
+
+/**
+ * Terminal mockup showing the install command.
+ * Mimics a macOS terminal window with a title bar and blinking cursor.
+ */
+function TerminalMockup() {
+  return (
+    <div className="w-full max-w-sm overflow-hidden rounded-xl border border-white/[0.08] bg-black shadow-[0_20px_60px_rgba(0,0,0,0.6)]">
+      {/* Title bar */}
+      <div className="flex items-center gap-2 border-b border-white/[0.06] bg-zinc-900/80 px-4 py-3">
+        <span className="h-3 w-3 rounded-full bg-red-500/70" />
+        <span className="h-3 w-3 rounded-full bg-yellow-500/70" />
+        <span className="h-3 w-3 rounded-full bg-emerald-500/70" />
+        <span className="ml-2 font-mono text-xs text-zinc-500">terminal</span>
+      </div>
+      {/* Body */}
+      <div className="px-5 py-4">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-xs text-emerald-400">$</span>
+          <span className="font-mono text-xs text-zinc-200">npm install -g @styrby/cli</span>
+        </div>
+        <div className="mt-2 font-mono text-xs text-zinc-500">
+          added 1 package in 2.3s
+        </div>
+        <div className="mt-1 font-mono text-xs text-amber-400">
+          Styrby CLI v1.0.0 installed
+        </div>
+        <div className="mt-3 flex items-center gap-2">
+          <span className="font-mono text-xs text-emerald-400">$</span>
+          <span className="font-mono text-xs text-zinc-200">styrby connect</span>
+          {/* Blinking cursor */}
+          <span className="h-3.5 w-px animate-pulse bg-zinc-400" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Phone-and-QR mockup showing the pairing step.
+ * Uses nested rounded rectangles to suggest a phone frame and QR grid.
+ */
+function PairingMockup() {
+  return (
+    <div className="flex w-full max-w-sm items-center justify-center gap-8">
+      {/* QR code frame */}
+      <div className="rounded-xl border border-white/[0.08] bg-zinc-950 p-4 shadow-[0_20px_60px_rgba(0,0,0,0.5)]">
+        <div className="mb-2 font-mono text-[10px] text-zinc-500">Scan to pair</div>
+        {/* QR grid — 5×5 block pattern suggesting a QR code */}
+        <div className="grid grid-cols-7 gap-0.5">
+          {[
+            1,1,1,1,1,1,1,
+            1,0,0,0,0,0,1,
+            1,0,1,0,1,0,1,
+            1,0,0,1,0,0,1,
+            1,0,1,0,1,0,1,
+            1,0,0,0,0,0,1,
+            1,1,1,1,1,1,1,
+          ].map((filled, i) => (
+            <div
+              key={i}
+              className={`h-3.5 w-3.5 rounded-sm ${filled ? "bg-amber-400" : "bg-zinc-800"}`}
+            />
+          ))}
+        </div>
+        <div className="mt-2 font-mono text-[10px] text-zinc-500">expires in 2:00</div>
+      </div>
+
+      {/* Phone outline */}
+      <div className="flex h-28 w-14 flex-col items-center justify-center rounded-xl border-2 border-white/[0.12] bg-zinc-900/60">
+        {/* Camera notch */}
+        <div className="mb-1 h-1 w-5 rounded-full bg-zinc-700" />
+        {/* Screen content suggestion */}
+        <div className="flex h-16 w-10 flex-col items-center justify-center gap-1 rounded-lg bg-zinc-800/60 p-1">
+          <div className="h-1.5 w-7 rounded-full bg-amber-500/40" />
+          <div className="h-1.5 w-5 rounded-full bg-zinc-600" />
+          <div className="h-1.5 w-6 rounded-full bg-zinc-600" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Dashboard card mockup showing the final connected state.
+ * Shows an agent status card with health indicators.
+ */
+function DashboardMockup() {
+  return (
+    <div className="w-full max-w-sm overflow-hidden rounded-xl border border-white/[0.08] bg-zinc-950 shadow-[0_20px_60px_rgba(0,0,0,0.6)]">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-5 py-3">
+        <span className="font-mono text-xs text-zinc-400">styrby dashboard</span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
+          <span className="font-mono text-xs text-emerald-400">live</span>
+        </span>
+      </div>
+      {/* Agent cards */}
+      <div className="space-y-2 p-4">
+        {[
+          { name: "claude-code", model: "sonnet-4-5", cost: "$0.42", status: "running" },
+          { name: "codex",       model: "o3-mini",    cost: "$0.18", status: "running" },
+          { name: "aider",       model: "gpt-4o",     cost: "$0.07", status: "idle"    },
+        ].map((agent) => (
+          <div
+            key={agent.name}
+            className="flex items-center justify-between rounded-lg border border-white/[0.05] bg-white/[0.03] px-3 py-2"
+          >
+            <div className="flex items-center gap-2.5">
+              <span
+                className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                  agent.status === "running" ? "bg-emerald-400" : "bg-zinc-600"
+                }`}
+              />
+              <div>
+                <div className="font-mono text-xs text-zinc-300">{agent.name}</div>
+                <div className="font-mono text-[10px] text-zinc-500">{agent.model}</div>
+              </div>
+            </div>
+            <span className="font-mono text-xs text-amber-400">{agent.cost}</span>
+          </div>
+        ))}
+      </div>
+      {/* Footer summary */}
+      <div className="flex items-center justify-between border-t border-white/[0.06] px-5 py-3">
+        <span className="font-mono text-xs text-zinc-500">today</span>
+        <span className="font-mono text-xs text-amber-400">$0.67 total</span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Steps data
+// ---------------------------------------------------------------------------
+
+const steps: Step[] = [
   {
     number: "01",
     title: "Install the CLI",
-    description: "One command. Works alongside your existing agent setup with zero config changes.",
-    icon: Terminal,
-    code: "npm install -g @styrby/cli",
+    description:
+      "One command alongside your existing agent setup. Zero config changes required — Styrby wraps your agents without touching them.",
+    illustrationSide: "right",
+    illustration: <TerminalMockup />,
   },
   {
     number: "02",
-    title: "Sign In and Pair",
-    description: "Sign in with GitHub or email, then scan the QR code to connect your phone. The CLI walks you through it.",
-    icon: QrCode,
-    code: null,
+    title: "Sign In and Pair Your Phone",
+    description:
+      "Sign in with GitHub or email, then scan the QR code to link your phone. The CLI walks you through the E2E key exchange in under 60 seconds.",
+    illustrationSide: "left",
+    illustration: <PairingMockup />,
   },
   {
     number: "03",
-    title: "See Everything",
-    description: "Live agent activity, cost analytics, and permission controls. All encrypted, all in one place.",
-    icon: Rocket,
-    code: null,
+    title: "Control Everything From Anywhere",
+    description:
+      "Live agent status, real-time cost tracking, permission approvals, code review diffs — all encrypted and available from your phone or web dashboard.",
+    illustrationSide: "right",
+    illustration: <DashboardMockup />,
   },
 ]
 
 export function HowItWorks() {
   return (
-    <section id="how-it-works" className="scroll-mt-20 py-16">
+    <section id="how-it-works" className="scroll-mt-20 py-16 md:py-24">
       <div className="mx-auto max-w-7xl px-6">
         <h2 className="text-balance text-center text-3xl font-bold tracking-tight text-foreground md:text-4xl">
           Three Steps. Ninety Seconds. Done.
         </h2>
+        <p className="mx-auto mt-4 max-w-lg text-center text-sm text-muted-foreground">
+          Install once. Pair your phone. Your agents are under control from that moment forward.
+        </p>
 
-        <div className="mt-16 grid gap-8 md:grid-cols-3">
-          {steps.map((step, i) => (
-            <div key={step.number} className="relative text-center">
-              {/* Connecting line */}
-              {i < steps.length - 1 && (
-                <div className="absolute right-0 top-10 hidden h-px w-full translate-x-1/2 bg-gradient-to-r from-border to-transparent md:block" />
-              )}
+        {/* Vertical timeline */}
+        <div className="relative mx-auto mt-20 max-w-5xl">
+          {/* Vertical connector line — desktop only */}
+          <div className="absolute left-1/2 top-0 hidden h-full w-px -translate-x-1/2 bg-gradient-to-b from-amber-500/20 via-amber-500/10 to-transparent md:block" />
 
-              <span className="font-mono text-5xl font-bold text-amber-500/20">{step.number}</span>
-              <div className="mx-auto mt-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-secondary">
-                <step.icon className="h-7 w-7 text-amber-500" />
-              </div>
-              <h3 className="mt-6 text-xl font-semibold text-foreground">{step.title}</h3>
-              <p className="mt-2 text-sm text-muted-foreground">{step.description}</p>
+          <div className="space-y-20">
+            {steps.map((step) => {
+              const isLeft = step.illustrationSide === "left"
 
-              {step.code && (
-                <div className="mx-auto mt-4 max-w-xs rounded-lg border border-border/60 bg-secondary/60 px-4 py-3">
-                  <code className="font-mono text-xs text-amber-400">{step.code}</code>
+              return (
+                <div key={step.number} className="relative">
+                  {/* Step number node on the timeline — desktop only */}
+                  <div className="absolute left-1/2 top-0 hidden -translate-x-1/2 -translate-y-1/2 items-center justify-center md:flex">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-full border border-amber-500/30 bg-zinc-950 shadow-[0_0_0_4px_rgba(245,158,11,0.06)]">
+                      <span className="font-mono text-xs font-bold text-amber-500">{step.number}</span>
+                    </div>
+                  </div>
+
+                  {/*
+                    Two-column layout on desktop.
+                    isLeft: illustration left, text right.
+                    !isLeft: text left, illustration right.
+                  */}
+                  <div
+                    className={`flex flex-col gap-10 md:grid md:grid-cols-2 md:items-center md:gap-16 ${
+                      isLeft ? "md:flex-row-reverse" : ""
+                    }`}
+                  >
+                    {/* Text block */}
+                    <div className={isLeft ? "md:order-2" : "md:order-1"}>
+                      {/* Step number — mobile only */}
+                      <span className="mb-3 block font-mono text-4xl font-bold text-amber-500/20 md:hidden">
+                        {step.number}
+                      </span>
+                      <h3 className="text-xl font-semibold text-foreground md:text-2xl">
+                        {step.title}
+                      </h3>
+                      <p className="mt-3 text-sm leading-relaxed text-muted-foreground md:text-base">
+                        {step.description}
+                      </p>
+                    </div>
+
+                    {/* Illustration block */}
+                    <div
+                      className={`flex justify-center ${
+                        isLeft ? "md:order-1 md:justify-end" : "md:order-2 md:justify-start"
+                      }`}
+                    >
+                      {step.illustration}
+                    </div>
+                  </div>
                 </div>
-              )}
-            </div>
-          ))}
+              )
+            })}
+          </div>
         </div>
       </div>
     </section>

--- a/packages/styrby-web/src/components/landing/mobile-showcase.tsx
+++ b/packages/styrby-web/src/components/landing/mobile-showcase.tsx
@@ -1,53 +1,282 @@
 /**
  * Mobile Showcase Section
  *
- * Shows two mobile screenshots in phone frames to prove the app
- * works on phones. Key differentiator vs. competitors.
+ * WHY this section exists: The mobile remote control story is the primary
+ * differentiator vs. desktop-only dashboards. This section converts skeptics
+ * by making the phone experience concrete: not "you can use your phone" but
+ * "here is the permission approval screen, here is the diff viewer, here is
+ * the voice command interface." Show, do not tell.
+ *
+ * WHY CSS-only phone mockups: Avoids screenshot dependencies that require
+ * a finished app, introduces CLS on image load, and breaks on retina without
+ * 2x assets. Styled div mockups render instantly and can be updated alongside
+ * the code they represent.
  */
+
+/**
+ * Permission approval phone mockup.
+ * Represents the primary remote control use case: approving risky agent actions.
+ */
+function PermissionApprovalMockup() {
+  return (
+    <div className="relative w-[220px] overflow-hidden rounded-[1.75rem] border-[5px] border-zinc-700 bg-zinc-900 shadow-2xl">
+      {/* Notch */}
+      <div className="absolute left-1/2 top-0 z-10 h-5 w-20 -translate-x-1/2 rounded-b-xl bg-zinc-700" />
+
+      {/* Screen content */}
+      <div className="min-h-[420px] bg-zinc-950 px-4 pb-6 pt-10">
+        {/* Status bar */}
+        <div className="mb-5 flex items-center justify-between px-1">
+          <span className="font-mono text-[9px] text-zinc-500">9:41</span>
+          <span className="font-mono text-[9px] text-zinc-500">styrby</span>
+        </div>
+
+        {/* Permission card */}
+        <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-3">
+          <div className="mb-1 flex items-center gap-1.5">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-400" />
+            <span className="font-mono text-[9px] font-semibold text-amber-400">
+              APPROVAL NEEDED
+            </span>
+          </div>
+          <p className="font-mono text-[10px] leading-relaxed text-zinc-300">
+            claude-code wants to write to{" "}
+            <span className="text-amber-300">src/auth/tokens.ts</span>
+          </p>
+        </div>
+
+        {/* Risk badge */}
+        <div className="mt-3 flex items-center gap-2">
+          <span className="rounded-md border border-red-500/30 bg-red-500/10 px-2 py-0.5 font-mono text-[9px] text-red-400">
+            HIGH RISK
+          </span>
+          <span className="font-mono text-[9px] text-zinc-500">auth file modification</span>
+        </div>
+
+        {/* Diff preview */}
+        <div className="mt-3 overflow-hidden rounded-lg border border-white/[0.06] bg-black/40">
+          <div className="px-3 py-2">
+            <div className="font-mono text-[9px] text-red-400/80">
+              - const token = jwt.sign(payload)
+            </div>
+            <div className="font-mono text-[9px] text-emerald-400/80">
+              + const token = jwt.sign(payload, secret, &#123;
+            </div>
+            <div className="font-mono text-[9px] text-emerald-400/80">
+              +   expiresIn: &apos;1h&apos;
+            </div>
+            <div className="font-mono text-[9px] text-emerald-400/80">
+              + &#125;)
+            </div>
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div className="mt-4 grid grid-cols-2 gap-2">
+          <button className="rounded-lg border border-red-500/30 bg-red-500/10 py-2 font-mono text-[10px] text-red-400">
+            Deny
+          </button>
+          <button className="rounded-lg bg-amber-500 py-2 font-mono text-[10px] font-semibold text-black">
+            Approve
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Voice command interface phone mockup.
+ * Shows the mic UI with waveform and recent command transcript.
+ */
+function VoiceCommandMockup() {
+  return (
+    <div className="relative w-[220px] overflow-hidden rounded-[1.75rem] border-[5px] border-zinc-700 bg-zinc-900 shadow-2xl">
+      {/* Notch */}
+      <div className="absolute left-1/2 top-0 z-10 h-5 w-20 -translate-x-1/2 rounded-b-xl bg-zinc-700" />
+
+      {/* Screen content */}
+      <div className="min-h-[420px] bg-zinc-950 px-4 pb-6 pt-10">
+        {/* Status bar */}
+        <div className="mb-5 flex items-center justify-between px-1">
+          <span className="font-mono text-[9px] text-zinc-500">9:41</span>
+          <span className="font-mono text-[9px] text-zinc-500">voice</span>
+        </div>
+
+        {/* Mic circle */}
+        <div className="flex flex-col items-center py-4">
+          <div className="relative flex h-16 w-16 items-center justify-center rounded-full border-2 border-amber-500/40 bg-amber-500/10">
+            {/* Pulse rings */}
+            <div className="absolute inset-0 animate-ping rounded-full border border-amber-500/20" />
+            {/* Mic icon (CSS) */}
+            <div className="flex h-8 w-8 flex-col items-center justify-center gap-0.5">
+              <div className="h-5 w-3 rounded-full border-2 border-amber-400" />
+              <div className="h-1 w-5 border-b-2 border-amber-400" />
+              <div className="h-0.5 w-2 bg-amber-400" />
+            </div>
+          </div>
+          <p className="mt-3 font-mono text-[10px] text-amber-400">Listening...</p>
+        </div>
+
+        {/* Waveform bars */}
+        <div className="flex items-center justify-center gap-0.5">
+          {[2, 5, 8, 12, 8, 14, 10, 6, 11, 7, 4, 9, 5, 3].map((h, i) => (
+            <div
+              key={i}
+              className="w-1 rounded-full bg-amber-500/60"
+              style={{ height: `${h}px` }}
+            />
+          ))}
+        </div>
+
+        {/* Transcript */}
+        <div className="mt-4 space-y-2">
+          <div className="rounded-lg border border-white/[0.05] bg-white/[0.03] px-3 py-2">
+            <p className="font-mono text-[9px] text-zinc-500">You said</p>
+            <p className="mt-0.5 font-mono text-[10px] text-zinc-300">
+              &ldquo;Stop the codex session&rdquo;
+            </p>
+          </div>
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2">
+            <p className="font-mono text-[9px] text-emerald-500">Executed</p>
+            <p className="mt-0.5 font-mono text-[10px] text-zinc-300">
+              codex session terminated
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Code diff review phone mockup.
+ * Shows a syntax-highlighted diff with approve/comment actions.
+ */
+function CodeReviewMockup() {
+  return (
+    <div className="relative w-[220px] overflow-hidden rounded-[1.75rem] border-[5px] border-zinc-700 bg-zinc-900 shadow-2xl">
+      {/* Notch */}
+      <div className="absolute left-1/2 top-0 z-10 h-5 w-20 -translate-x-1/2 rounded-b-xl bg-zinc-700" />
+
+      {/* Screen content */}
+      <div className="min-h-[420px] bg-zinc-950 px-4 pb-6 pt-10">
+        {/* Status bar */}
+        <div className="mb-5 flex items-center justify-between px-1">
+          <span className="font-mono text-[9px] text-zinc-500">9:41</span>
+          <span className="font-mono text-[9px] text-zinc-500">diff</span>
+        </div>
+
+        {/* File header */}
+        <div className="mb-3 flex items-center justify-between">
+          <span className="font-mono text-[9px] text-zinc-400">src/api/users.ts</span>
+          <div className="flex gap-1">
+            <span className="rounded bg-emerald-500/20 px-1 font-mono text-[8px] text-emerald-400">+12</span>
+            <span className="rounded bg-red-500/20 px-1 font-mono text-[8px] text-red-400">-3</span>
+          </div>
+        </div>
+
+        {/* Diff lines */}
+        <div className="overflow-hidden rounded-lg border border-white/[0.06] bg-black/50">
+          <div className="px-3 py-2 space-y-0.5">
+            <div className="font-mono text-[8px] text-zinc-500">@@ -24,7 +24,16 @@</div>
+            <div className="font-mono text-[9px] text-zinc-500"> export async function</div>
+            <div className="font-mono text-[9px] text-zinc-500">   getUser(id: string)</div>
+            <div className="font-mono text-[9px] text-red-400/80">- &#47;&#47; TODO: add caching</div>
+            <div className="font-mono text-[9px] text-emerald-400/80">+ const cached = await</div>
+            <div className="font-mono text-[9px] text-emerald-400/80">+   redis.get(id)</div>
+            <div className="font-mono text-[9px] text-emerald-400/80">+ if (cached) return</div>
+            <div className="font-mono text-[9px] text-emerald-400/80">+   JSON.parse(cached)</div>
+          </div>
+        </div>
+
+        {/* Stats row */}
+        <div className="mt-3 flex items-center gap-3">
+          <span className="font-mono text-[9px] text-zinc-500">4 files changed</span>
+          <span className="h-3 w-px bg-zinc-700" />
+          <span className="font-mono text-[9px] text-zinc-500">claude-code</span>
+        </div>
+
+        {/* Actions */}
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          <button className="rounded-lg border border-white/[0.08] bg-white/[0.04] py-2 font-mono text-[10px] text-zinc-400">
+            Comment
+          </button>
+          <button className="rounded-lg bg-amber-500 py-2 font-mono text-[10px] font-semibold text-black">
+            Approve
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Showcase entry metadata
+// ---------------------------------------------------------------------------
+
+const showcaseItems = [
+  {
+    mockup: <PermissionApprovalMockup />,
+    label: "Permission Approval",
+    caption: "Approve or deny risky actions with full diff context — no laptop needed.",
+  },
+  {
+    mockup: <VoiceCommandMockup />,
+    label: "Voice Commands",
+    caption: "Stop sessions, trigger builds, or send prompts hands-free.",
+  },
+  {
+    mockup: <CodeReviewMockup />,
+    label: "Code Review",
+    caption: "Syntax-highlighted diffs and one-tap approval from your phone.",
+  },
+]
 
 export function MobileShowcase() {
   return (
-    <section className="py-8">
+    <section className="overflow-hidden py-16 md:py-24">
       <div className="mx-auto max-w-7xl px-6">
-        <h2 className="text-center text-3xl font-semibold tracking-tighter text-foreground md:text-4xl">
-          Control Your Agents From Anywhere
-        </h2>
-        <p className="mx-auto mt-3 max-w-lg text-center text-sm text-muted-foreground">
-          Approve permissions, track costs, and monitor sessions from your phone. No laptop required.
-        </p>
+        {/* Section header */}
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-balance text-3xl font-semibold tracking-tighter text-foreground md:text-4xl">
+            Control Your Agents From Anywhere
+          </h2>
+          <p className="mx-auto mt-4 max-w-lg text-sm leading-relaxed text-muted-foreground">
+            The full power of your development workflow, distilled to three taps. Approve
+            permissions, review diffs, and issue voice commands without touching your laptop.
+          </p>
+        </div>
 
-        <div className="mt-12 flex flex-col items-center justify-center gap-8 sm:flex-row sm:gap-12">
-          {/* Phone frame: Dashboard */}
-          <div className="relative">
-            <div className="relative w-[280px] overflow-hidden rounded-[2rem] border-[6px] border-zinc-700 bg-zinc-900 shadow-2xl">
-              {/* Notch */}
-              <div className="absolute left-1/2 top-0 z-10 h-6 w-24 -translate-x-1/2 rounded-b-xl bg-zinc-700" />
-              <img
-                src="/screenshots/mobile-dashboard.png"
-                alt="Styrby mobile dashboard showing today's spend, active sessions, and recent agent activity"
-                className="w-full"
-                width={390}
-                height={844}
-              />
+        {/* Phone mockup row */}
+        <div className="mt-14 flex flex-col items-center justify-center gap-10 sm:flex-row sm:items-start sm:gap-8">
+          {showcaseItems.map((item, i) => (
+            <div key={item.label} className="flex flex-col items-center gap-4">
+              {/*
+                Middle phone is elevated slightly on desktop for visual depth.
+                WHY: The three-phone layout needs a focal point. Elevating the
+                center phone creates a pyramid that draws the eye to the most
+                important mockup (voice commands — the most novel capability).
+              */}
+              <div className={i === 1 ? "sm:-mt-6" : ""}>
+                {item.mockup}
+              </div>
+              <div className="max-w-[200px] text-center">
+                <p className="text-xs font-semibold text-foreground">{item.label}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{item.caption}</p>
+              </div>
             </div>
-            <p className="mt-3 text-center text-xs text-muted-foreground">Dashboard</p>
-          </div>
+          ))}
+        </div>
 
-          {/* Phone frame: Cost Analytics */}
-          <div className="relative">
-            <div className="relative w-[280px] overflow-hidden rounded-[2rem] border-[6px] border-zinc-700 bg-zinc-900 shadow-2xl">
-              {/* Notch */}
-              <div className="absolute left-1/2 top-0 z-10 h-6 w-24 -translate-x-1/2 rounded-b-xl bg-zinc-700" />
-              <img
-                src="/screenshots/mobile-costs.png"
-                alt="Styrby mobile cost analytics showing monthly total, per-agent breakdown, and spending chart"
-                className="w-full"
-                width={390}
-                height={844}
-              />
-            </div>
-            <p className="mt-3 text-center text-xs text-muted-foreground">Cost Analytics</p>
-          </div>
+        {/* Bottom CTA callout */}
+        <div className="mx-auto mt-16 max-w-xl rounded-xl border border-white/[0.06] bg-zinc-950/80 p-6 text-center shadow-[inset_0_1px_1px_rgba(255,255,255,0.06)]">
+          <p className="text-sm font-semibold text-foreground">
+            Your agents work around the clock. Now you can too — without being desk-bound.
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            E2E encrypted. Zero-knowledge architecture. Your code never leaves your machine unencrypted.
+          </p>
         </div>
       </div>
     </section>

--- a/packages/styrby-web/src/components/landing/navbar.tsx
+++ b/packages/styrby-web/src/components/landing/navbar.tsx
@@ -7,6 +7,19 @@ import { Menu, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
+/**
+ * Floating pill-style navbar with glass-morphism treatment.
+ *
+ * WHY this design approach:
+ * - Floating pill separates the nav visually from page content, giving the
+ *   hero room to breathe underneath instead of being pinned to the edge.
+ * - Glass effect with `backdrop-blur-2xl` creates depth without a heavy
+ *   opaque bar dominating the viewport.
+ * - The inset top shadow adds a subtle highlight that makes the pill feel
+ *   illuminated from above — a luxury detail borrowed from hardware product UX.
+ * - On scroll, the border brightens slightly so the nav stays legible against
+ *   any section color the user scrolls into.
+ */
 export function Navbar() {
   const [scrolled, setScrolled] = useState(false)
   const [mobileOpen, setMobileOpen] = useState(false)
@@ -23,9 +36,7 @@ export function Navbar() {
   useEffect(() => {
     if (!mobileOpen) return
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setMobileOpen(false)
-      }
+      if (e.key === 'Escape') setMobileOpen(false)
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
@@ -41,83 +52,142 @@ export function Navbar() {
   }, [mobileOpen])
 
   return (
-    <nav
-      aria-label="Main navigation"
-      className={cn(
-        "fixed top-0 left-0 right-0 z-50 transition-all duration-200",
-        scrolled
-          ? "glass border-b border-border/50"
-          : "bg-transparent"
-      )}
-    >
-      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">
-        <Link href="/" className="flex items-center gap-2">
-          <Image src="/logo.png" alt="Styrby" width={24} height={24} className="h-6 w-6 " />
-          <span className="text-lg font-bold text-foreground">Styrby</span>
-        </Link>
+    <div className="fixed top-0 left-0 right-0 z-50 flex justify-center px-4 pt-4">
+      <nav
+        aria-label="Main navigation"
+        className={cn(
+          "w-full max-w-5xl rounded-full transition-all duration-300",
+          "bg-zinc-950/80 backdrop-blur-2xl",
+          "border shadow-[inset_0_1px_1px_rgba(255,255,255,0.06)]",
+          scrolled
+            ? "border-white/[0.10] shadow-[inset_0_1px_1px_rgba(255,255,255,0.07),0_8px_32px_rgba(0,0,0,0.4)]"
+            : "border-white/[0.06]"
+        )}
+      >
+        <div className="flex h-14 items-center justify-between px-5">
+          {/* Logo lockup */}
+          <Link href="/" className="flex items-center gap-2.5 group">
+            <Image
+              src="/icon-512.png"
+              alt="Styrby S mark"
+              width={30}
+              height={30}
+              className="h-[30px] w-[30px] rounded-md transition-opacity duration-200 group-hover:opacity-80"
+            />
+            <span className="text-[15px] font-semibold tracking-tight text-foreground">
+              Styrby
+            </span>
+          </Link>
 
-        <div className="hidden items-center gap-8 md:flex">
-          <Link href="/features" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
-            Features
-          </Link>
-          <Link href="/pricing" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
-            Pricing
-          </Link>
-          <Link href="/docs" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
-            Docs
-          </Link>
-          <Link href="/blog" className="text-sm text-muted-foreground transition-colors hover:text-foreground">
-            Blog
-          </Link>
+          {/* Desktop nav links */}
+          <div className="hidden items-center gap-7 md:flex">
+            {[
+              { href: "/features", label: "Features" },
+              { href: "/pricing", label: "Pricing" },
+              { href: "/docs", label: "Docs" },
+              { href: "/blog", label: "Blog" },
+            ].map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className={cn(
+                  "relative text-sm text-zinc-400 transition-colors duration-200 hover:text-zinc-100",
+                  "after:absolute after:-bottom-0.5 after:left-0 after:h-px after:w-0 after:bg-amber-500",
+                  "after:transition-[width] after:duration-200 hover:after:w-full"
+                )}
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+
+          {/* Desktop CTAs */}
+          <div className="hidden items-center gap-2.5 md:flex">
+            <Button
+              variant="ghost"
+              asChild
+              className="h-8 px-4 text-sm text-zinc-400 hover:text-zinc-100 hover:bg-white/[0.06] rounded-full"
+            >
+              <Link href="/login">Sign In</Link>
+            </Button>
+            <Button
+              asChild
+              className={cn(
+                "h-8 px-4 text-sm font-medium rounded-full",
+                "bg-amber-500 text-zinc-950 hover:bg-amber-400",
+                "shadow-[inset_0_1px_1px_rgba(255,255,255,0.25),0_2px_8px_rgba(245,158,11,0.35)]",
+                "transition-all duration-200 hover:shadow-[inset_0_1px_1px_rgba(255,255,255,0.25),0_4px_16px_rgba(245,158,11,0.45)]"
+              )}
+            >
+              <Link href="/signup">Start Free</Link>
+            </Button>
+          </div>
+
+          {/* Mobile hamburger */}
+          <button
+            type="button"
+            className="text-zinc-400 hover:text-zinc-100 transition-colors md:hidden"
+            onClick={() => setMobileOpen(!mobileOpen)}
+            aria-label={mobileOpen ? "Close menu" : "Open menu"}
+            aria-expanded={mobileOpen}
+            aria-controls="mobile-nav-menu"
+          >
+            {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
         </div>
+      </nav>
 
-        <div className="hidden items-center gap-3 md:flex">
-          <Button variant="outline" asChild className="border-border text-foreground hover:bg-accent bg-transparent">
-            <Link href="/login">Sign In</Link>
-          </Button>
-          <Button asChild className="bg-amber-500 text-background hover:bg-amber-600 font-medium">
-            <Link href="/signup">Start Free</Link>
-          </Button>
-        </div>
-
-        <button
-          type="button"
-          className="text-muted-foreground md:hidden"
-          onClick={() => setMobileOpen(!mobileOpen)}
-          aria-label={mobileOpen ? "Close menu" : "Open menu"}
-          aria-expanded={mobileOpen}
-          aria-controls="mobile-nav-menu"
-        >
-          {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-        </button>
-      </div>
-
+      {/* Mobile menu — drops below the pill */}
       {mobileOpen && (
-        <div id="mobile-nav-menu" ref={mobileMenuRef} className="glass border-b border-border/50 px-6 pb-6 md:hidden">
-          <div className="flex flex-col gap-4">
-            <Link href="/features" className="text-sm text-muted-foreground" onClick={() => setMobileOpen(false)}>
-              Features
-            </Link>
-            <Link href="/pricing" className="text-sm text-muted-foreground" onClick={() => setMobileOpen(false)}>
-              Pricing
-            </Link>
-            <Link href="/docs" className="text-sm text-muted-foreground" onClick={() => setMobileOpen(false)}>
-              Docs
-            </Link>
-            <Link href="/blog" className="text-sm text-muted-foreground" onClick={() => setMobileOpen(false)}>
-              Blog
-            </Link>
-            <div className="flex flex-col gap-2 pt-2">
-              <Button variant="outline" asChild className="border-border text-foreground bg-transparent">
+        <div
+          id="mobile-nav-menu"
+          ref={mobileMenuRef}
+          className={cn(
+            "absolute left-4 right-4 top-[72px] rounded-2xl md:hidden",
+            "bg-zinc-950/95 backdrop-blur-2xl",
+            "border border-white/[0.08]",
+            "shadow-[0_16px_48px_rgba(0,0,0,0.5)]",
+            "px-5 py-5"
+          )}
+        >
+          <div className="flex flex-col gap-1">
+            {[
+              { href: "/features", label: "Features" },
+              { href: "/pricing", label: "Pricing" },
+              { href: "/docs", label: "Docs" },
+              { href: "/blog", label: "Blog" },
+            ].map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className="rounded-lg px-3 py-2.5 text-sm text-zinc-400 hover:bg-white/[0.05] hover:text-zinc-100 transition-colors"
+                onClick={() => setMobileOpen(false)}
+              >
+                {label}
+              </Link>
+            ))}
+            <div className="mt-3 flex flex-col gap-2 border-t border-white/[0.06] pt-3">
+              <Button
+                variant="outline"
+                asChild
+                className="border-white/[0.10] bg-transparent text-zinc-300 hover:bg-white/[0.06] hover:text-zinc-100 rounded-xl"
+              >
                 <Link href="/login">Sign In</Link>
               </Button>
-              <Button asChild className="bg-amber-500 text-background hover:bg-amber-600">
+              <Button
+                asChild
+                className={cn(
+                  "rounded-xl font-medium",
+                  "bg-amber-500 text-zinc-950 hover:bg-amber-400",
+                  "shadow-[inset_0_1px_1px_rgba(255,255,255,0.25)]"
+                )}
+              >
                 <Link href="/signup">Start Free</Link>
               </Button>
             </div>
           </div>
         </div>
       )}
-    </nav>
+    </div>
   )
 }

--- a/packages/styrby-web/src/components/landing/pricing-section.tsx
+++ b/packages/styrby-web/src/components/landing/pricing-section.tsx
@@ -2,20 +2,29 @@
 
 import { useState } from "react"
 import Link from "next/link"
-import { Check } from "lucide-react"
+import { Check, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
+/**
+ * Pricing data for all three tiers.
+ *
+ * WHY decoy layout: Pro is styled as "most popular" and highlighted with
+ * amber — it looks like the obvious choice. Power is priced close enough
+ * that informed buyers self-upgrade. Free anchors the low end so $24
+ * feels reasonable.
+ */
 const plans = [
   {
     name: "Free",
+    tagline: "For developers exploring",
     monthly: 0,
     annual: 0,
     savings: null,
     popular: false,
     cta: "Start Free",
-    ctaVariant: "outline" as const,
-    features: [
+    ctaVariant: "ghost" as const,
+    included: [
       "1 connected machine",
       "3 agents: Claude Code, Codex, Gemini CLI",
       "7-day session history",
@@ -23,73 +32,118 @@ const plans = [
       "Cost dashboard",
       "1 budget alert",
       "E2E encryption",
+      "Push notifications",
+      "Offline queue",
+    ],
+    notIncluded: [
+      "Per-message cost tracking",
+      "Session checkpoints",
+      "Team management",
+      "Voice commands",
     ],
   },
   {
     name: "Pro",
+    tagline: "For developers who ship daily",
     monthly: 24,
     annual: 240,
     savings: 48,
     popular: true,
     cta: "Connect 3 Machines",
-    ctaVariant: "default" as const,
-    features: [
+    ctaVariant: "amber" as const,
+    included: [
       "3 connected machines",
-      "8 agents (adds OpenCode, Aider, Goose, Amp, Crush, Kilo)",
+      "8 agents (+ OpenCode, Aider, Goose, Amp, Crush, Kilo)",
       "90-day session history",
       "25,000 messages/month",
       "Full cost dashboard",
+      "Per-message cost tracking",
+      "Context breakdown by file",
       "Session checkpoints and sharing",
-      "Team management (3 members)",
+      "Export and import",
+      "Activity graph",
+      "Team management — 3 members",
       "3 budget alerts",
       "Email support",
     ],
+    notIncluded: [],
   },
   {
     name: "Power",
+    tagline: "For teams and power users",
     monthly: 49,
     annual: 490,
     savings: 98,
     popular: false,
     cta: "Connect 9 Machines",
-    ctaVariant: "default" as const,
-    features: [
+    ctaVariant: "outline" as const,
+    included: [
       "9 connected machines",
-      "All 11 agents (adds Kiro and Droid)",
+      "All 11 agents (+ Kiro and Droid)",
       "1-year session history",
       "100,000 messages/month",
       "Full cost dashboard",
+      "OTEL export — Grafana, Datadog, and more",
       "Voice commands",
       "Cloud monitoring",
       "Code review from mobile",
-      "OTEL export",
       "5 budget alerts",
       "3 team members",
       "API access",
+      "Audit trail export",
       "Email support",
     ],
+    notIncluded: [],
   },
 ]
 
+/**
+ * Pricing section for the landing page.
+ *
+ * Uses a decoy pricing layout: Pro is visually highlighted as the
+ * recommended choice, but Power is close enough in price that informed
+ * buyers self-select to it. This increases average revenue per user
+ * without aggressive upselling.
+ *
+ * @returns The full pricing section with toggle and three-card layout
+ */
 export function PricingSection() {
   const [annual, setAnnual] = useState(false)
 
   return (
-    <section id="pricing" className="py-16">
+    <section id="pricing" className="py-24">
       <div className="mx-auto max-w-7xl px-6">
-        <h2 className="text-balance text-center text-3xl font-bold tracking-tight text-foreground md:text-4xl">
-          One Price. Everything Included. No Per-Token Fees.
-        </h2>
 
-        {/* Toggle */}
-        <div className="mt-8 flex items-center justify-center gap-3">
-          <span className={cn("text-sm", !annual ? "text-foreground" : "text-muted-foreground")}>Monthly</span>
+        {/* Section header */}
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
+            Pricing
+          </p>
+          <h2 className="mt-3 text-balance text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+            One price. Everything included. No per-token fees.
+          </h2>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            Flat monthly pricing. Your AI API costs are yours to manage — we
+            only charge for Styrby.
+          </p>
+        </div>
+
+        {/* Annual/monthly toggle */}
+        <div className="mt-10 flex items-center justify-center gap-4">
+          <span
+            className={cn(
+              "text-sm transition-colors",
+              !annual ? "font-medium text-foreground" : "text-muted-foreground"
+            )}
+          >
+            Monthly
+          </span>
           <button
             type="button"
             onClick={() => setAnnual(!annual)}
             className={cn(
-              "relative h-6 w-11 rounded-full transition-colors duration-200",
-              annual ? "bg-amber-500" : "bg-secondary"
+              "relative h-6 w-11 rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+              annual ? "bg-amber-500" : "bg-zinc-700"
             )}
             role="switch"
             aria-checked={annual}
@@ -97,80 +151,194 @@ export function PricingSection() {
           >
             <span
               className={cn(
-                "absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-foreground transition-transform duration-200",
+                "absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200",
                 annual && "translate-x-5"
               )}
             />
           </button>
-          <span className={cn("text-sm", annual ? "text-foreground" : "text-muted-foreground")}>
-            Annual <span className="text-xs text-amber-500">(Save up to $98)</span>
-              {/* WHY $98: Power plan saves $98/year ($49 x 12 = $588 vs $490 annual) */}
+          <span
+            className={cn(
+              "text-sm transition-colors",
+              annual ? "font-medium text-foreground" : "text-muted-foreground"
+            )}
+          >
+            Annual{" "}
+            <span className="ml-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-amber-400 border border-amber-500/20">
+              Save 2 months
+            </span>
           </span>
         </div>
 
-        <div className="mt-12 grid gap-6 md:grid-cols-3">
+        {/* Cards — Pro is slightly elevated via scale and z-index */}
+        <div className="mt-12 grid items-start gap-4 md:grid-cols-3 md:items-center">
           {plans.map((plan) => (
-            <div
-              key={plan.name}
-              className={cn(
-                "relative flex flex-col rounded-xl bg-card/60 p-8 transition-all duration-200",
-                plan.popular
-                  ? "border-2 border-amber-500/50 amber-glow"
-                  : "border border-border/60"
-              )}
-            >
-              {plan.popular && (
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-amber-500 px-3 py-1 text-xs font-semibold text-background">
-                  Most Popular
-                </div>
-              )}
-
-              <h3 className="text-xl font-semibold text-foreground">{plan.name}</h3>
-              {/* Fixed-height price area prevents layout shift on annual toggle */}
-              <div className="min-h-[72px]">
-                <div className="mt-4 flex items-baseline gap-1">
-                  <span className="font-mono text-4xl font-bold text-foreground">
-                    ${annual && plan.annual > 0 ? Math.round(plan.annual / 12) : plan.monthly}
-                  </span>
-                  {plan.monthly > 0 && <span className="text-sm text-muted-foreground">/month</span>}
-                </div>
-                {annual && plan.savings ? (
-                  <p className="mt-1 text-xs text-amber-500">
-                    ${plan.annual}/year, save ${plan.savings}
-                  </p>
-                ) : (
-                  <p className="mt-1 text-xs text-transparent" aria-hidden="true">
-                    &nbsp;
-                  </p>
-                )}
-              </div>
-
-              {/* Feature list grows to fill, pushing button to bottom */}
-              <ul className="mt-6 flex-1 space-y-3">
-                {plan.features.map((feature) => (
-                  <li key={feature} className="flex items-center gap-3 text-sm text-muted-foreground">
-                    <Check className="h-4 w-4 shrink-0 text-amber-500" />
-                    {feature}
-                  </li>
-                ))}
-              </ul>
-
-              {/* Button pinned to bottom of card */}
-              <div className="mt-8 flex justify-center">
-                {plan.ctaVariant === "default" ? (
-                  <Button asChild size="sm" className="bg-amber-500 text-background hover:bg-amber-600 font-medium px-6">
-                    <Link href={`/signup?plan=${plan.name.toLowerCase()}`}>{plan.cta}</Link>
-                  </Button>
-                ) : (
-                  <Button variant="outline" asChild size="sm" className="border-border/60 text-muted-foreground hover:text-foreground bg-transparent px-6">
-                    <Link href="/signup">{plan.cta}</Link>
-                  </Button>
-                )}
-              </div>
-            </div>
+            <PricingCard key={plan.name} plan={plan} annual={annual} />
           ))}
         </div>
+
+        {/* Trust footnote */}
+        <p className="mt-8 text-center text-xs text-muted-foreground/60">
+          14-day free trial on Pro and Power. No credit card required. Cancel anytime.
+        </p>
       </div>
     </section>
+  )
+}
+
+/**
+ * Individual pricing card.
+ *
+ * @param plan - The plan data to render
+ * @param annual - Whether annual billing is selected
+ */
+function PricingCard({
+  plan,
+  annual,
+}: {
+  plan: (typeof plans)[number]
+  annual: boolean
+}) {
+  const displayPrice =
+    annual && plan.annual > 0 ? Math.round(plan.annual / 12) : plan.monthly
+
+  return (
+    <div
+      className={cn(
+        "relative flex flex-col rounded-2xl p-8 transition-all duration-300",
+        plan.popular
+          ? // Pro: amber border, subtle amber bloom behind the card, slightly taller via py
+            "border border-amber-500/40 bg-zinc-950 amber-glow md:-my-4 md:py-12 z-10"
+          : // Free and Power: true black with faint zinc border, inner glow on hover
+            "border border-zinc-800/80 bg-zinc-950/60 hover:border-zinc-700/80 hover:bg-zinc-950/80"
+      )}
+    >
+      {/* Ambient radial glow behind Pro card */}
+      {plan.popular && (
+        <div
+          className="pointer-events-none absolute inset-0 rounded-2xl"
+          style={{
+            background:
+              "radial-gradient(ellipse 60% 40% at 50% 0%, rgba(245,158,11,0.07) 0%, transparent 70%)",
+          }}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Most Popular eyebrow badge */}
+      {plan.popular && (
+        <div className="mb-5 flex justify-center">
+          <span className="rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.2em] text-amber-400">
+            Most Popular
+          </span>
+        </div>
+      )}
+
+      {/* Plan name + tagline */}
+      <div className={cn(!plan.popular && "pt-8")}>
+        <h3
+          className={cn(
+            "text-lg font-semibold",
+            plan.popular ? "text-amber-400" : "text-foreground"
+          )}
+        >
+          {plan.name}
+        </h3>
+        <p className="mt-1 text-sm text-muted-foreground">{plan.tagline}</p>
+      </div>
+
+      {/* Price */}
+      <div className="mt-6 flex items-baseline gap-1">
+        <span className="text-5xl font-bold tracking-tight text-foreground">
+          ${displayPrice}
+        </span>
+        {plan.monthly > 0 && (
+          <span className="text-sm font-normal text-muted-foreground">/mo</span>
+        )}
+        {plan.monthly === 0 && (
+          <span className="text-sm font-normal text-muted-foreground">forever</span>
+        )}
+      </div>
+
+      {/* Annual savings line — always reserve height to prevent layout shift */}
+      <div className="mt-1 h-4">
+        {annual && plan.savings ? (
+          <p className="text-xs text-amber-500/80">
+            ${plan.annual}/year — save ${plan.savings}
+          </p>
+        ) : null}
+      </div>
+
+      {/* Divider */}
+      <div
+        className={cn(
+          "mt-6 h-px",
+          plan.popular ? "bg-amber-500/20" : "bg-zinc-800"
+        )}
+      />
+
+      {/* Feature list — included */}
+      <ul className="mt-6 flex-1 space-y-3">
+        {plan.included.map((feature) => (
+          <li
+            key={feature}
+            className="flex items-start gap-3 text-sm text-zinc-300"
+          >
+            <Check
+              className={cn(
+                "mt-0.5 h-4 w-4 shrink-0",
+                plan.popular ? "text-amber-400" : "text-amber-500/70"
+              )}
+            />
+            {feature}
+          </li>
+        ))}
+
+        {/* Not included (Free only) */}
+        {plan.notIncluded.length > 0 &&
+          plan.notIncluded.map((feature) => (
+            <li
+              key={feature}
+              className="flex items-start gap-3 text-sm text-zinc-500"
+            >
+              <X className="mt-0.5 h-4 w-4 shrink-0 text-zinc-700" />
+              {feature}
+            </li>
+          ))}
+      </ul>
+
+      {/* CTA button */}
+      <div className="mt-8">
+        {plan.ctaVariant === "amber" && (
+          <Button
+            asChild
+            className="w-full bg-amber-500 font-semibold text-zinc-950 hover:bg-amber-400 active:bg-amber-600 transition-colors"
+          >
+            <Link href={`/signup?plan=${plan.name.toLowerCase()}`}>
+              {plan.cta}
+            </Link>
+          </Button>
+        )}
+        {plan.ctaVariant === "outline" && (
+          <Button
+            variant="outline"
+            asChild
+            className="w-full border-zinc-700 bg-transparent font-medium text-zinc-300 hover:border-zinc-500 hover:text-foreground"
+          >
+            <Link href={`/signup?plan=${plan.name.toLowerCase()}`}>
+              {plan.cta}
+            </Link>
+          </Button>
+        )}
+        {plan.ctaVariant === "ghost" && (
+          <Button
+            variant="ghost"
+            asChild
+            className="w-full font-medium text-muted-foreground hover:text-foreground"
+          >
+            <Link href="/signup">{plan.cta}</Link>
+          </Button>
+        )}
+      </div>
+    </div>
   )
 }

--- a/packages/styrby-web/src/components/landing/problem-section.tsx
+++ b/packages/styrby-web/src/components/landing/problem-section.tsx
@@ -1,35 +1,40 @@
-import { EyeOff, SmartphoneNfc, Layers } from "lucide-react"
+import { Layers, SmartphoneNfc, AlertTriangle } from "lucide-react"
 
 /**
  * Problem Section — Hero + Supporting Pair Layout
  *
- * WHY 1+2 over equal 3-col: The primary pain point (blind spending) is the
- * emotional hook. Giving it a full-width hero card with larger typography
- * creates visual weight that matches its importance. The two secondary
- * problems sit below in a 2-column grid, establishing visual hierarchy
- * that guides the user: "here's the BIG problem, and two more."
+ * WHY 1+2 over equal 3-col: The primary pain point (fragmented multi-agent chaos)
+ * is the emotional hook for developers running production workloads. Giving it a
+ * full-width hero card with larger typography creates visual weight that matches
+ * its importance. The two secondary problems sit below in a 2-column grid,
+ * establishing visual hierarchy: "here is the BIG problem, and two more."
+ *
+ * WHY these three pain points: They map directly to the three product pillars.
+ * No unified view -> Multi-Agent Dashboard. No remote control -> Mobile Remote.
+ * Surprise costs -> Smart Cost Tracking. Each problem section primes the reader
+ * for the corresponding features section below.
  */
 
 const problems = [
   {
-    icon: EyeOff,
-    title: "Blind Spending",
+    icon: Layers,
+    title: "No Unified View",
     description:
-      "Most developers have no idea what their AI agents cost per session. By the time the invoice arrives, the damage is done.",
+      "Running 5+ agents across projects with no single place to see what is active, what is stuck, and what is burning tokens on a loop. You are context-switching between terminals to figure out basic status.",
     primary: true,
   },
   {
-    icon: SmartphoneNfc,
-    title: "No Remote Control",
+    icon: AlertTriangle,
+    title: "Surprise Bills",
     description:
-      "Your agent needs approval, but you stepped away. Now it sits idle until you walk back to your laptop.",
+      "Getting paged at 2am because an agent ran up $400 in tokens overnight. By the time the invoice arrives, the damage is done and there was no way to stop it remotely.",
     primary: false,
   },
   {
-    icon: Layers,
-    title: "Multi-Agent Chaos",
+    icon: SmartphoneNfc,
+    title: "Laptop-Tethered Approvals",
     description:
-      "Multiple agents across several projects on different machines. Which ones are active? Which are stuck? Which are burning tokens on a loop? You have no idea.",
+      "No way to approve risky permissions without being at your desk. Your agent sits idle for hours — or worse, proceeds without approval — while you are away from your machine.",
     primary: false,
   },
 ]
@@ -42,26 +47,28 @@ export function ProblemSection() {
     <section className="py-16">
       <div className="mx-auto max-w-7xl px-6">
         <h2 className="mx-auto max-w-3xl text-balance text-center text-3xl font-semibold tracking-tighter text-foreground md:text-4xl">
-          You{"'"}re Running AI Agents Blind.{" "}
-          <span className="text-amber-500">That Gets Expensive Fast.</span>
+          Running AI Agents at Scale{" "}
+          <span className="text-amber-500">Is Harder Than It Should Be.</span>
         </h2>
 
         <div className="mx-auto mt-16 max-w-5xl space-y-6">
           {/* Primary problem — full width, larger treatment */}
           <div className="gradient-border group rounded-xl bg-card/60 p-8 transition-all duration-200 hover:bg-card md:p-10">
             <div className="flex flex-col gap-5 md:flex-row md:items-start md:gap-8">
-              <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-amber-500/10 border border-amber-500/20">
+              <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl border border-amber-500/20 bg-amber-500/10">
                 <primary.icon className="h-7 w-7 text-amber-500" />
               </div>
               <div>
                 <h3 className="mb-2 text-xl font-semibold text-foreground">{primary.title}</h3>
-                <p className="max-w-xl text-base leading-relaxed text-muted-foreground">{primary.description}</p>
+                <p className="max-w-xl text-base leading-relaxed text-muted-foreground">
+                  {primary.description}
+                </p>
               </div>
             </div>
           </div>
 
           {/* Secondary problems — 2-column grid */}
-          <div className="grid gap-6 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {secondary.map((problem) => (
               <div
                 key={problem.title}

--- a/packages/styrby-web/src/components/landing/social-proof.tsx
+++ b/packages/styrby-web/src/components/landing/social-proof.tsx
@@ -128,9 +128,14 @@ const agents = [
 
 export function SocialProof() {
   return (
-    <section className="border-y border-border/40 py-10">
+    <section className="py-10">
+      {/* Top separator */}
       <div className="mx-auto max-w-7xl px-6">
-        <p className="mb-6 text-center text-sm text-muted-foreground">
+        <div className="h-px bg-zinc-800/60" />
+      </div>
+
+      <div className="mx-auto max-w-7xl px-6 py-10">
+        <p className="mb-6 text-center text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground/60">
           Works with 11 CLI coding agents you already use
         </p>
         <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-4 lg:flex-nowrap lg:gap-x-6">
@@ -158,6 +163,11 @@ export function SocialProof() {
             </span>
           ))}
         </div>
+      </div>
+
+      {/* Bottom separator */}
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="h-px bg-zinc-800/60" />
       </div>
     </section>
   )

--- a/packages/styrby-web/tailwind.config.ts
+++ b/packages/styrby-web/tailwind.config.ts
@@ -115,7 +115,9 @@ const config: Config = {
         },
       },
       fontFamily: {
-        sans: ['var(--font-space-grotesk)', 'system-ui', 'sans-serif'],
+        /* Outfit: geometric display type for headlines and body copy */
+        sans: ['var(--font-outfit)', 'system-ui', 'sans-serif'],
+        /* JetBrains Mono: developer-grade monospace for code, costs, agent IDs */
         mono: ['var(--font-jetbrains)', 'ui-monospace', 'monospace'],
       },
       borderRadius: {


### PR DESCRIPTION
## Summary

Complete visual overhaul of the homepage, pricing page, and all landing sections. Shifts messaging from cost-focused to remote-control-first. Fixes the wrong logo.

### Key Changes
- **Logo**: Bastard curved arrow replaced with correct S mark (`icon-512.png`)
- **Font**: Space Grotesk → Outfit (premium geometric)
- **Hero**: "11 Agents. One Dashboard. Your Phone." — left-aligned, amber gradient
- **Narrative**: Remote control + dashboard first, costs as supporting benefit
- **Features**: Bento grid with 8 cards (was generic 3-column)
- **How It Works**: Vertical timeline with CSS-only illustrations
- **Pricing**: Pro card elevated with amber glow (decoy effect)
- **FAQ**: Accordion → two-column interactive
- **Footer**: Minimal, brand-forward
- **Mobile Showcase**: 3 CSS-only phone mockups (permissions, voice, code review)

### Design System
- Vantablack cards with inner glow (`shadow-[inset_0_1px_1px_rgba(255,255,255,0.06)]`)
- Floating pill navbar with glass effect
- Eyebrow badge pattern
- Double-bezel frame for mockups
- a11y: all text-zinc-600 → text-zinc-500

## Test Plan
- [x] TypeScript: 0 errors
- [x] Web build: passes
- [x] Tests: 847/847 passed
- [ ] CI passes
- [ ] Vercel preview shows redesigned homepage

---
🤖 Shipped with [Claude Code](https://claude.com/claude-code)