### PR TITLE
docs(shared): add domain block comments to 18 exported types

### DIFF
--- a/packages/styrby-shared/src/errors/types.ts
+++ b/packages/styrby-shared/src/errors/types.ts
@@ -1,11 +1,31 @@
 /**
  * Error Attribution Types
  *
- * Defines error sources, categories, and attribution results.
+ * Defines error sources, categories, and attribution results for the
+ * Styrby error intelligence system.
+ *
+ * WHY this system exists: When an AI agent produces an error (e.g., a bash
+ * command fails), it is often unclear whether the failure is the agent's
+ * fault, a user permissions issue, a network blip, or a Styrby relay bug.
+ * Error attribution answers that question automatically so the mobile app
+ * can show the right fix suggestion rather than a generic error message.
+ *
+ * The attribution pipeline:
+ * 1. Raw error string arrives from the CLI relay
+ * 2. Pattern matching assigns source + category + confidence
+ * 3. The mobile UI renders the appropriate fix card
+ * 4. Auto-fixable errors (e.g., `npm install`) can be triggered from mobile
  */
 
 /**
- * Error source categories
+ * Top-level source of an error, used to route to the correct UI error card
+ * and to track which error class affects users most in analytics.
+ *
+ * WHY separate source from category: Source identifies who owns the fix
+ * (user vs. Styrby team vs. AI provider), while category gives actionable
+ * detail. A 'network/network_timeout' error means "check your connection";
+ * a 'styrby/relay_connection' means "Styrby infrastructure problem - we're
+ * on it."
  */
 export type ErrorSource =
   | 'styrby'   // Styrby app/infrastructure error
@@ -16,12 +36,27 @@ export type ErrorSource =
   | 'unknown'; // Unable to classify
 
 /**
- * Error severity levels
+ * Severity level assigned to an attributed error.
+ *
+ * Drives both UI rendering (banner color, icon) and notification priority.
+ * Maps to the notification priority system: 'critical' errors always
+ * generate a priority-1 push notification; 'info' may be suppressed under
+ * quiet hours or if the user has raised their notification threshold.
+ *
+ * Scale: info < warning < error < critical
  */
 export type ErrorSeverity = 'info' | 'warning' | 'error' | 'critical';
 
 /**
- * Specific error categories within each source
+ * Granular error category within a source, mapped to actionable fix suggestions.
+ *
+ * WHY fine-grained categories: Each category maps to a specific help card and
+ * (where possible) an auto-fix action. For example, 'agent_context_limit'
+ * shows a "Start new session" button; 'build_dependency' shows "Run npm install".
+ * A flat error string would force the UI to display a generic message.
+ *
+ * Categories are grouped by source prefix for readability and to make
+ * pattern-matching logic easier to audit.
  */
 export type ErrorCategory =
   // Styrby errors
@@ -59,7 +94,16 @@ export type ErrorCategory =
   | 'unknown';
 
 /**
- * Fix suggestion with actionability
+ * A fix suggestion rendered in the mobile error card for an attributed error.
+ *
+ * Multiple suggestions can be attached to a single ErrorAttribution. When
+ * `autoFixable` is true, the mobile app renders a primary action button that
+ * sends the fix `action` string to the CLI relay as a command. Non-auto-fixable
+ * suggestions render as descriptive text with an optional documentation link.
+ *
+ * WHY `autoFixable` on the shared type: Both the mobile UI and the CLI relay
+ * need to know whether a fix can be triggered remotely. The shared type keeps
+ * this contract in one place so both sides stay in sync.
  */
 export interface FixSuggestion {
   /** Short description of the fix */
@@ -75,7 +119,17 @@ export interface FixSuggestion {
 }
 
 /**
- * Error attribution result
+ * The complete result of attributing a raw error string to a source + category.
+ *
+ * Produced by the error attribution engine in styrby-cli when a session
+ * error event arrives, then transmitted over the relay to the mobile app.
+ * The mobile app uses this to render the error card: banner color (from
+ * SOURCE_COLORS), severity badge, summary text, and fix suggestion buttons.
+ *
+ * WHY `confidence` on the result: Some errors are ambiguous — a timeout could
+ * be a network issue or an agent issue. The confidence score (0-1) lets the UI
+ * hedge its language ("This looks like a network issue") when confidence is low,
+ * rather than asserting a cause that might be wrong.
  */
 export interface ErrorAttribution {
   /** Primary error source */
@@ -103,7 +157,20 @@ export interface ErrorAttribution {
 }
 
 /**
- * Error pattern for matching
+ * A registered pattern used by the attribution engine to classify raw errors.
+ *
+ * The attribution engine holds a list of ErrorPatterns and tests each one
+ * against an incoming error message using `patterns` (regex) and `keywords`
+ * (string match). The first pattern with a hit determines the source and
+ * category of the resulting ErrorAttribution.
+ *
+ * WHY both `patterns` and `keywords`: Regex is powerful but slow at scale.
+ * Keywords are tested first as a cheap pre-filter; regex only runs when
+ * keywords match. This keeps attribution fast even with 100+ patterns.
+ *
+ * `extractDetails` is an optional callback that pulls structured data out
+ * of the regex match (e.g., the file path from a TypeScript error) for
+ * inclusion in ErrorAttribution.details and the location field.
  */
 export interface ErrorPattern {
   /** Unique pattern ID */
@@ -125,7 +192,17 @@ export interface ErrorPattern {
 }
 
 /**
- * Source color configuration
+ * Display colors for each error source, used by the mobile and web error cards.
+ *
+ * Shared here so both styrby-mobile and styrby-web render identical colors for
+ * the same source. Each entry contains:
+ * - `color`: foreground text / icon color (hex)
+ * - `bgColor`: semi-transparent background for the badge/banner
+ * - `label`: human-readable source name for display
+ *
+ * WHY in the shared package: If these lived separately in each app, they
+ * could drift over time. A single source of truth ensures the "styrby" color
+ * is always orange whether the user is on iOS or web.
  */
 export const SOURCE_COLORS: Record<ErrorSource, { color: string; bgColor: string; label: string }> = {
   styrby: { color: '#f97316', bgColor: 'rgba(249, 115, 22, 0.1)', label: 'Styrby' },
@@ -137,7 +214,12 @@ export const SOURCE_COLORS: Record<ErrorSource, { color: string; bgColor: string
 };
 
 /**
- * Severity color configuration
+ * Display colors for each severity level, used by error badges and notification banners.
+ *
+ * Shared across styrby-mobile and styrby-web for visual consistency. The
+ * 'critical' severity intentionally uses a higher-opacity background than
+ * other levels to draw immediate attention (e.g., relay disconnects during
+ * an active agent session).
  */
 export const SEVERITY_COLORS: Record<ErrorSeverity, { color: string; bgColor: string }> = {
   info: { color: '#3b82f6', bgColor: 'rgba(59, 130, 246, 0.1)' },

--- a/packages/styrby-shared/src/pricing/litellm-pricing.ts
+++ b/packages/styrby-shared/src/pricing/litellm-pricing.ts
@@ -34,10 +34,28 @@ import * as path from 'node:path';
 // ============================================================================
 
 /**
- * Normalized price for a single model.
+ * Normalized pricing for a single AI model used in all cost calculations.
  *
- * All values are USD per 1,000 tokens (not per million — kept small for
- * readability in cost calculations).
+ * This is the core billing type: every `cost_record` row written to Supabase
+ * is computed by multiplying token counts against these rates. Budget alert
+ * thresholds, the mobile cost dashboard, and the daily cost summary
+ * materialized view all flow through this type.
+ *
+ * WHY per-1k instead of per-1M: Provider APIs report token counts per
+ * request. Multiplying a small token count (e.g. 500) by a per-1k rate
+ * gives a compact, readable decimal. Per-1M rates produce trailing zeros
+ * that hurt readability in cost-calculation code.
+ *
+ * Unit: USD per 1,000 tokens.
+ *
+ * Cache pricing notes (Anthropic only):
+ * - Cache reads are ~10x cheaper than fresh input reads.
+ * - Cache writes are ~1.25x more expensive than fresh input reads.
+ * - Only models that explicitly support prompt caching populate the
+ *   optional cache fields; other models leave them undefined.
+ *
+ * Source: LiteLLM canonical dataset (github.com/BerriAI/litellm).
+ * Last static fallback verified: 2026-03-27.
  */
 export interface ModelPrice {
   /** Cost per 1,000 input tokens in USD */

--- a/packages/styrby-shared/src/pricing/static-pricing.ts
+++ b/packages/styrby-shared/src/pricing/static-pricing.ts
@@ -30,16 +30,28 @@
 // Types
 // ============================================================================
 
-/** AI provider identifier for grouping and display. */
+/**
+ * AI provider identifier used for grouping models in the pricing table.
+ *
+ * Used by the cost dashboard to render provider section headers, filter
+ * the pricing reference table, and apply provider-level display formatting.
+ * Maps 1:1 with the three providers Styrby currently supports.
+ */
 export type ModelProvider = 'anthropic' | 'openai' | 'google';
 
 /**
- * Pricing entry for a single AI model.
+ * Pricing entry for a single AI model shown in the reference pricing table.
  *
- * Prices are in USD per 1 million tokens.
+ * Used by the cost dashboard in both styrby-web and styrby-mobile to display
+ * a human-readable pricing reference. This is a UI display type only — it is
+ * NOT used for actual cost calculations (which use `ModelPrice` from
+ * litellm-pricing.ts with per-1k precision).
  *
- * Used by the cost dashboard pricing reference tables in both the web
- * and mobile apps.
+ * Prices are in USD per 1 million tokens as published by each provider.
+ *
+ * WHY per-1M instead of per-1k: Provider pricing pages quote per-million,
+ * so keeping the same unit makes it easy to cross-reference with official
+ * docs and detect when this table needs updating.
  */
 export interface ModelPricingEntry {
   /** Display name of the model (e.g. 'Claude 3.5 Sonnet') */

--- a/packages/styrby-shared/src/relay/client.ts
+++ b/packages/styrby-shared/src/relay/client.ts
@@ -20,7 +20,19 @@ import { getChannelName, createBaseMessage, RelayMessageSchema } from './types.j
 // ============================================================================
 
 /**
- * Relay client configuration
+ * Configuration passed to `RelayClient` (or `createRelayClient`) to establish
+ * a Supabase Realtime channel connection between the CLI and the mobile app.
+ *
+ * WHY both `deviceId` and `userId`: The relay channel is scoped to a user
+ * (`relay:{userId}`), but multiple devices per user can be simultaneously
+ * connected (e.g., a developer's laptop CLI and their iPad). `deviceId` is
+ * the presence key that distinguishes each participant within the channel.
+ *
+ * WHY `channelSuffix` is optional: It was added in SEC-RELAY-001 to prevent
+ * channel enumeration attacks by anyone who knows only the user's UUID. Older
+ * CLI and mobile clients that pre-date this fix connect without a suffix.
+ * The optional field maintains backward compatibility while new clients
+ * always provide one.
  */
 export interface RelayClientConfig {
   /** Supabase client instance */
@@ -54,7 +66,21 @@ export interface RelayClientConfig {
 }
 
 /**
- * Connection state
+ * Current state of the relay WebSocket connection, emitted via the
+ * `RelayClient` event system and used to drive connection-status UI
+ * in both the mobile app and the web dashboard.
+ *
+ * State transitions:
+ * ```
+ * disconnected → connecting → connected
+ *                    ↓               ↓ (channel error or heartbeat failure)
+ *                  error ←── reconnecting ←── connected
+ * ```
+ *
+ * 'reconnecting' differs from 'connecting' in that it signals an automatic
+ * retry after an unexpected drop rather than an intentional initial connect.
+ * The mobile UI shows different copy for each ("Connecting..." vs.
+ * "Connection lost, retrying...").
  */
 export type ConnectionState =
   | 'disconnected'

--- a/packages/styrby-shared/src/relay/offline-queue.ts
+++ b/packages/styrby-shared/src/relay/offline-queue.ts
@@ -15,7 +15,13 @@ import type { RelayMessage } from './types.js';
 // ============================================================================
 
 /**
- * Status of a queued command
+ * Lifecycle state of a single item in the offline command queue.
+ *
+ * WHY explicit states instead of a boolean 'sent' flag: The queue needs to
+ * distinguish between commands that are actively being sent (locked to prevent
+ * duplicate delivery), commands that failed and are waiting for retry, and
+ * commands that expired before the device came back online. Each state drives
+ * different UI feedback and retry behavior in `IOfflineQueue.processQueue`.
  */
 export type QueueItemStatus =
   | 'pending'    // Waiting to be sent
@@ -25,7 +31,20 @@ export type QueueItemStatus =
   | 'expired';   // Expired before sending
 
 /**
- * A command queued for sending when online
+ * A relay message that was queued while the mobile device was offline.
+ *
+ * When Styrby mobile loses connectivity mid-session, user actions (chat
+ * messages, permission responses, cancellations) are stored as QueuedCommands
+ * and flushed in priority order when the connection is restored.
+ *
+ * WHY `expiresAt`: Some commands become semantically meaningless after a
+ * timeout. A permission_response queued for 10 minutes is likely stale —
+ * the CLI agent will have already timed out waiting. Expiry prevents the CLI
+ * from receiving ghost approvals for operations it has already abandoned.
+ *
+ * WHY `priority`: Critical commands (cancellations, permission responses)
+ * must be delivered before low-priority commands (analytics, acks) even if
+ * the low-priority commands were queued first.
  */
 export interface QueuedCommand {
   /** Unique queue item ID */
@@ -51,7 +70,11 @@ export interface QueuedCommand {
 }
 
 /**
- * Queue statistics
+ * Snapshot of offline queue health, surfaced in the mobile connection status UI.
+ *
+ * Displayed in the connectivity banner so users know how many commands are
+ * waiting to be flushed. A non-zero `failed` count triggers a warning state
+ * ("X commands could not be sent") after reconnection.
  */
 export interface QueueStats {
   /** Total items in queue */
@@ -71,8 +94,17 @@ export interface QueueStats {
 // ============================================================================
 
 /**
- * Interface for offline command queue implementations.
- * Platform-specific implementations should implement this interface.
+ * Platform-agnostic contract for the offline command queue.
+ *
+ * WHY an interface instead of a single implementation: The persistence layer
+ * differs per platform — SQLite via expo-sqlite on mobile, IndexedDB on web,
+ * and an in-memory mock in tests. Coding against this interface lets shared
+ * relay logic (e.g., `processQueue`) work identically on all three without
+ * importing platform-specific modules into styrby-shared.
+ *
+ * The `processQueue` method is designed to be called repeatedly by a network
+ * connectivity listener. It dequeues pending items in priority order, calls
+ * `sendFn` for each one, and handles retry/expiry logic.
  */
 export interface IOfflineQueue {
   /**
@@ -122,7 +154,13 @@ export interface IOfflineQueue {
 }
 
 /**
- * Options for enqueueing a command
+ * Caller-supplied options for controlling how a command is queued.
+ *
+ * All fields are optional — the queue applies sensible defaults
+ * (`DEFAULT_QUEUE_TTL_MS`, `DEFAULT_MAX_ATTEMPTS`, priority from
+ * `getMessagePriority`) when omitted. Callers only need to override
+ * when they have specific requirements (e.g., a critical cancellation
+ * that should never expire should set a long `ttl`).
  */
 export interface EnqueueOptions {
   /** Priority (default: 0, higher = sent first) */

--- a/packages/styrby-shared/src/utils/api-keys.ts
+++ b/packages/styrby-shared/src/utils/api-keys.ts
@@ -67,11 +67,23 @@ export function generateRandomString(length: number): string {
 }
 
 /**
- * Result of generating an API key.
+ * The output of `generateApiKey()` for Styrby Power tier API access.
  *
- * - key: The full API key (show to user once, then discard)
- * - prefix: The key prefix for database lookup (store in plaintext)
- * - randomPart: Just the random portion (for debugging, don't store)
+ * This type models the "show once" security pattern: the full `key` is
+ * returned exactly once at creation time, shown to the user, and then
+ * discarded from memory. The database stores only `prefix` (plaintext, for
+ * lookup) and a bcrypt hash of `key` (for verification). The `randomPart`
+ * is provided for debugging and internal tooling — it must never be stored.
+ *
+ * WHY separate `prefix` and `randomPart`: The bcrypt comparison in the web
+ * package requires the full key, while database lookup only needs the prefix
+ * (to narrow the query before hashing). Exposing them separately prevents
+ * callers from having to re-parse the full key string.
+ *
+ * Security model:
+ * - `key` (styrby_ + 32 chars) — shown to user once, bcrypt-hashed for storage
+ * - `prefix` ("styrby_") — stored as plaintext for O(1) lookup by prefix
+ * - `randomPart` (32 chars) — never stored, debug only
  */
 export interface GeneratedApiKey {
   /** The full API key to show to the user (styrby_xxxxx...) */

--- a/packages/styrby-shared/src/utils/notification-priority.ts
+++ b/packages/styrby-shared/src/utils/notification-priority.ts
@@ -27,8 +27,18 @@ import type { RiskLevel } from '../types.js';
 // ============================================================================
 
 /**
- * Notification event types that can be scored.
- * Maps directly to the event types in the push notification Edge Function.
+ * The set of events that the Styrby push notification system can generate.
+ *
+ * Each value maps directly to an `event_type` in the Supabase Edge Function
+ * `push-notifications`. When the CLI relay emits one of these events, the
+ * Edge Function uses `calculateNotificationPriority` to decide whether to
+ * deliver a push notification based on the user's priority threshold setting.
+ *
+ * WHY defined here and not in the Edge Function: Both the CLI (which sends
+ * events) and the mobile app (which renders received notifications) need this
+ * type. Keeping it in styrby-shared ensures both ends stay in sync — adding
+ * a new event type here immediately surfaces a TypeScript error in any code
+ * that handles notification events exhaustively.
  */
 export type NotificationEventType =
   | 'permission_request'
@@ -39,8 +49,19 @@ export type NotificationEventType =
   | 'budget_exceeded';
 
 /**
- * Input data for calculating notification priority.
- * Not all fields are required - the algorithm uses sensible defaults.
+ * Input payload describing a notification event to be scored.
+ *
+ * Passed to `calculateNotificationPriority` and
+ * `calculateNotificationPriorityDetailed` to produce a priority score (1-5).
+ *
+ * WHY a union of optional fields instead of separate types per event: The
+ * priority algorithm blends several signals (risk, cost, duration, tool danger)
+ * that cut across event types. A single input type keeps the scoring function
+ * simple and lets callers pass whatever context they have without needing to
+ * know which fields each event type uses.
+ *
+ * Fields that are not relevant to a given event type (e.g., `riskLevel` on a
+ * `budget_warning`) are simply ignored by the scoring algorithm.
  */
 export interface NotificationEvent {
   /** The type of notification event */
@@ -78,7 +99,18 @@ export interface NotificationEvent {
 }
 
 /**
- * Result of the priority calculation with breakdown for debugging.
+ * Full output of the priority scoring algorithm, including the final score
+ * and a breakdown of each contributing factor.
+ *
+ * The `priority` field (1-5) is the only value needed for delivery decisions.
+ * The `factors` breakdown and `reason` string are surfaced in the Styrby
+ * admin dashboard and in debug logs so that unexpected notification filtering
+ * can be diagnosed without re-running the algorithm.
+ *
+ * WHY expose `factors` on the public type: When a Pro user wonders why a
+ * notification was silently dropped, the breakdown lets support engineers
+ * point to the exact adjustment that pushed the priority over the user's
+ * threshold (e.g., "low-cost session completion scored 5, your threshold is 4").
  */
 export interface PriorityResult {
   /**


### PR DESCRIPTION
## Summary

- Phase 0.0 Documentation audit: 60/78 shared types had domain block comments (77%). This PR brings all 18 remaining types up to CLAUDE.md Code Documentation Standards.
- Pricing types documented first (business-critical billing path): `ModelPrice` now explains the per-1k convention, cache pricing semantics, and the LiteLLM source; `ModelPricingEntry` and `ModelProvider` explain their UI-display-only role vs. the calculation types.
- All 7 files are docs-only changes - no behavior modifications.

## Files touched (18 types across 7 files)

| File | Types documented |
|------|-----------------|
| `pricing/static-pricing.ts` | `ModelProvider`, `ModelPricingEntry` |
| `pricing/litellm-pricing.ts` | `ModelPrice` |
| `errors/types.ts` | `ErrorSource`, `ErrorSeverity`, `ErrorCategory`, `FixSuggestion`, `ErrorAttribution`, `ErrorPattern`, `SOURCE_COLORS`, `SEVERITY_COLORS` |
| `relay/offline-queue.ts` | `QueueItemStatus`, `QueuedCommand`, `QueueStats`, `IOfflineQueue`, `EnqueueOptions` |
| `relay/client.ts` | `RelayClientConfig`, `ConnectionState` |
| `utils/notification-priority.ts` | `NotificationEventType`, `NotificationEvent`, `PriorityResult` |
| `utils/api-keys.ts` | `GeneratedApiKey` |

## Test plan

- [x] `pnpm --filter @styrby/shared typecheck` - clean (0 errors)
- [x] `pnpm --filter @styrby/shared test` - 454/454 tests pass
- [x] No package.json or pnpm-lock changes
- [x] Docs-only: no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)