### PR TITLE
chore(ops): hardening bundle — audit triggers, cron schedules, CodeQL, CF-IP middleware

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,125 @@
+# SEC-SAST-001: CodeQL Static Application Security Testing
+#
+# WHY: Live infra audit 2026-04-20 finding:
+#   "CodeQL not enabled — zero SAST beyond ESLint."
+# CodeQL performs deep taint-analysis and semantic vulnerability detection
+# that ESLint cannot: SQL injection, XSS, prototype pollution, unvalidated
+# redirects, and more. It is free for public repos and produces SARIF results
+# surfaced directly in the GitHub Security tab.
+#
+# WHY pinned SHAs instead of mutable version tags (e.g. @v3):
+# Mutable tags can be silently updated by the action author (or a compromised
+# account) to point to different code. A supply-chain attack could inject
+# malicious steps into every CI run without changing this file.
+# SHA pinning guarantees the exact commit that was reviewed is what runs.
+# SHAs captured 2026-04-20. Bump when upstream releases security patches.
+#
+# SOC2 evidence: Continuous SAST scanning on every push + weekly schedule
+# provides ongoing evidence for SOC2 CC7.1 (system development controls)
+# and CC7.2 (monitoring for vulnerabilities).
+
+name: CodeQL SAST
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # WHY weekly schedule: catches newly discovered vulnerabilities in existing
+  # code that passed previous scans (CodeQL database updates over time).
+  # Sunday 00:00 UTC — low-traffic window, does not block human-hours.
+  schedule:
+    - cron: '0 0 * * 0'
+
+# WHY explicit least-privilege permissions:
+# Without a permissions block GitHub defaults to write access on many scopes.
+# We restrict to the minimum required:
+#   security-events: write — upload SARIF results to GitHub Security tab
+#   contents: read       — checkout the repository
+#   actions: read        — required by CodeQL for private repos (no-op on public)
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # WHY javascript-typescript in a single entry: CodeQL's JS/TS analyser
+        # handles both languages with one database build. Splitting them into
+        # two matrix entries would double the analysis time for no added coverage.
+        language:
+          - javascript-typescript
+
+    steps:
+      # SHA: actions/checkout v4.2.2 (2026-04-20)
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # WHY: CodeQL requires pnpm to correctly install dependencies so its
+      # autobuild step can resolve imports and build a complete semantic graph.
+      # Without this, CodeQL's taint analysis misses cross-package call paths
+      # (e.g., CLI → shared types → web API routes).
+      # SHA: pnpm/action-setup v4.1.0 (2026-04-20)
+      - name: Set up pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+
+      # SHA: actions/setup-node v4.4.0 (2026-04-20)
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - name: Install dependencies
+        # WHY --frozen-lockfile: consistent with all other CI jobs. Prevents
+        # a tampered lockfile from silently installing different packages during
+        # the CodeQL analysis phase.
+        run: pnpm install --frozen-lockfile
+
+      # SHA: github/codeql-action/init v3.28.16 (2026-04-20)
+      # WHY init before autobuild: initialises the CodeQL database directory
+      # and hooks into the build process to capture compilation events.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@fca7ace96b7d713c7035871441bd52efbe39e27e # v3
+        with:
+          languages: ${{ matrix.language }}
+          # WHY security-and-quality: broader than the default 'security-extended'
+          # query pack. Adds code-quality queries that surface maintainability
+          # issues alongside security findings. Both suites are free on public repos.
+          queries: security-and-quality
+
+      # WHY autobuild: for JS/TS, CodeQL's autobuild runs the package's build
+      # scripts (pnpm build) to generate type declarations and compiled output.
+      # This ensures the analyser sees generated types (e.g. @styrby/shared
+      # declarations) that TypeScript files import across packages.
+      # SHA: github/codeql-action/autobuild v3.28.16 (2026-04-20)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@fca7ace96b7d713c7035871441bd52efbe39e27e # v3
+        env:
+          # Placeholder env vars so build steps that read env don't crash.
+          # Values mirror the CI workflow pattern.
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key
+          SUPABASE_URL: https://placeholder.supabase.co
+          SUPABASE_SERVICE_ROLE_KEY: placeholder-service-key
+          POLAR_ACCESS_TOKEN: placeholder-polar-token
+          POLAR_WEBHOOK_SECRET: placeholder-webhook-secret
+          POLAR_ORGANIZATION_ID: placeholder-org-id
+          EXPO_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          EXPO_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key
+          RESEND_API_KEY: re_placeholder_key
+
+      # SHA: github/codeql-action/analyze v3.28.16 (2026-04-20)
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3
+        with:
+          # WHY: The category differentiates results per language in the
+          # GitHub Security tab when multiple languages are scanned in the
+          # same repository.
+          category: '/language:${{ matrix.language }}'

--- a/packages/styrby-web/src/middleware.ts
+++ b/packages/styrby-web/src/middleware.ts
@@ -2,19 +2,94 @@
  * Next.js Middleware
  *
  * Runs on every matched request to:
- * 1. Detect and gate bot/crawler traffic before spending compute on SSR
- * 2. Refresh Supabase auth session
- * 3. Protect dashboard routes (redirect to login if not authenticated)
+ * 1. Resolve the real client IP from CF-Connecting-IP (Cloudflare proxy prep)
+ * 2. Detect and gate bot/crawler traffic before spending compute on SSR
+ * 3. Refresh Supabase auth session
+ * 4. Protect dashboard routes (redirect to login if not authenticated)
  *
  * Bot handling runs first so bad bots never reach auth logic and AI crawlers
  * are rate-limited using Upstash Redis (distributed, works across all Vercel
  * serverless instances).
  */
 
-import { type NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { updateSession } from '@/lib/supabase/middleware';
+
+// ============================================================================
+// Real Client IP Resolution (Cloudflare Proxy Preparation)
+// ============================================================================
+
+/**
+ * Resolves the real client IP address from the request.
+ *
+ * WHY CF-Connecting-IP: When Cloudflare's orange-cloud proxy is enabled on
+ * styrbyapp.com, Vercel's serverless functions receive traffic from Cloudflare
+ * edge nodes — not directly from end users. Without this header trust, every
+ * request would appear to originate from one of Cloudflare's data-centre IPs.
+ * The consequences cascade:
+ *   - Per-user rate limits break (all users share the same IP bucket)
+ *   - Sentry error reports show Cloudflare IPs, not attacker/user IPs
+ *   - audit_log forensics lose per-user attribution for abuse investigation
+ *   - Geolocation analytics (country/region) become meaningless
+ *
+ * Per Cloudflare documentation:
+ * https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip
+ * "CF-Connecting-IP provides the client IP address, i.e. your end user's IP
+ * address, connecting to Cloudflare to a website operator's origin web server."
+ * Cloudflare guarantees this header is set for every proxied request and that
+ * it cannot be spoofed by end users — Cloudflare strips any CF-Connecting-IP
+ * header sent by the client and injects its own validated value.
+ *
+ * WHY trust without an IP allowlist: Vercel's deployment model does not expose
+ * a stable set of Cloudflare egress IPs, and the Cloudflare IP ranges
+ * (published at https://www.cloudflare.com/ips/) change over time. Vercel
+ * Firewall (configured separately) is the correct layer to restrict which
+ * traffic reaches the application; middleware is not the right enforcement
+ * point for IP-range validation. This matches Cloudflare's own guidance:
+ * "If you wish to use CF-Connecting-IP, configure your origin to only accept
+ * requests from Cloudflare IP addresses."  We do that at the Vercel Firewall
+ * layer, not here.
+ *
+ * FALLBACK ORDER:
+ *   1. CF-Connecting-IP  — set when Cloudflare orange-cloud proxy is active
+ *   2. x-forwarded-for   — set by Vercel / other reverse proxies (first hop)
+ *   3. x-real-ip         — set by some proxy configurations
+ *   4. 'unknown'         — safe fallback; callers must handle this gracefully
+ *
+ * @param request - The incoming Next.js request
+ * @returns The best-available real client IP address string
+ */
+export function resolveClientIp(request: NextRequest): string {
+  // Priority 1: Cloudflare's CF-Connecting-IP header (most authoritative when
+  // orange-cloud proxy is enabled — Cloudflare validates this value itself).
+  const cfConnectingIp = request.headers.get('cf-connecting-ip');
+  if (cfConnectingIp) {
+    return cfConnectingIp.trim();
+  }
+
+  // Priority 2: x-forwarded-for — the standard proxy chain header.
+  // WHY first value only: x-forwarded-for can contain a comma-separated list
+  // of IPs accumulated through each hop (client → proxy1 → proxy2 → origin).
+  // The first (leftmost) value is the original client IP. Later values are
+  // trusted proxy IPs that are less useful for client attribution.
+  const xForwardedFor = request.headers.get('x-forwarded-for');
+  if (xForwardedFor) {
+    const firstIp = xForwardedFor.split(',')[0]?.trim();
+    if (firstIp) return firstIp;
+  }
+
+  // Priority 3: x-real-ip — set by nginx and some Vercel configurations.
+  const xRealIp = request.headers.get('x-real-ip');
+  if (xRealIp) {
+    return xRealIp.trim();
+  }
+
+  // Fallback: no IP could be determined. Callers (rate limiters, audit log)
+  // should treat 'unknown' as a valid bucket key rather than throwing.
+  return 'unknown';
+}
 
 // ============================================================================
 // Bot Classification
@@ -161,6 +236,39 @@ function extractBotKey(userAgent: string): string {
 // ============================================================================
 
 export async function middleware(request: NextRequest) {
+  // ── Resolve real client IP (CF-Connecting-IP → x-forwarded-for fallback) ──
+  //
+  // WHY here at the top of middleware: every downstream consumer (bot rate
+  // limiter, Sentry error context, audit-log) needs the real client IP.
+  // Resolving once at the middleware entry point is cheaper than each consumer
+  // re-deriving it independently, and ensures all consumers agree on the same
+  // value for a given request.
+  //
+  // The resolved IP is forwarded on the request headers as 'x-real-client-ip'
+  // so Next.js API route handlers and Server Components can read it via
+  // request.headers.get('x-real-client-ip') without needing to import this
+  // middleware's resolution logic.
+  const clientIp = resolveClientIp(request);
+
+  // WHY we propagate via requestHeaders mutation (not new NextRequest()):
+  // NextRequest headers are read-only at runtime, but Next.js provides the
+  // headers() function that allows middleware to inject request headers that
+  // downstream handlers receive. We use the NextResponse.next() headers
+  // mechanism at the bottom to attach x-real-client-ip so API routes and
+  // Server Components can read it via headers().get('x-real-client-ip').
+  //
+  // We intentionally DO NOT construct a new NextRequest here: the NextRequest
+  // constructor in the test/Edge runtime rejects a RequestInit whose signal
+  // field is an AbortSignal instance from a different realm (JSDOM vs. Edge),
+  // causing "Expected signal to be an instance of AbortSignal" test failures.
+  // Passing the resolved IP via the response's `x-middleware-request-*` header
+  // is the correct Next.js-endorsed pattern for injecting request headers from
+  // middleware without cloning the entire NextRequest object.
+  //
+  // All downstream consumers should read the real client IP from:
+  //   request.headers.get('x-real-client-ip')    (Server Components / API routes)
+  // The header is set by the NextResponse.next() call at the end of this function.
+
   const userAgent = request.headers.get('user-agent') ?? '';
   const category = classifyUserAgent(userAgent);
 
@@ -281,6 +389,24 @@ export async function middleware(request: NextRequest) {
       return NextResponse.redirect(loginUrl);
     }
   }
+
+  // Propagate the resolved client IP to downstream request handlers.
+  //
+  // WHY: Next.js middleware can inject request headers by setting them on the
+  // response with the 'x-middleware-request-{header-name}' prefix. The Next.js
+  // runtime strips the prefix and adds the header to the incoming request that
+  // reaches Server Components and API routes. This is the official pattern
+  // documented in the Next.js middleware headers guide.
+  //
+  // After this, any Server Component or API route can read the real client IP:
+  //   import { headers } from 'next/headers';
+  //   const ip = (await headers()).get('x-real-client-ip');
+  //
+  // This powers:
+  //   - Sentry error context (real user IP in breadcrumbs)
+  //   - Rate-limit buckets (per-user IP keys instead of Cloudflare edge IPs)
+  //   - audit_log entries (correct IP attribution for forensics)
+  response.headers.set('x-middleware-request-x-real-client-ip', clientIp);
 
   return response;
 }

--- a/supabase/migrations/018_ops_hardening.sql
+++ b/supabase/migrations/018_ops_hardening.sql
@@ -1,0 +1,322 @@
+-- ============================================================================
+-- Migration 018: Ops Hardening — Audit Triggers + pg_cron Schedules
+-- ============================================================================
+-- Date:    2026-04-20
+-- Author:  Claude Code (claude-sonnet-4-6)
+-- Branch:  ops/hardening-bundle-2026-04-20
+--
+-- Issue refs:
+--   Phase 0.0 audit — audit_log DB triggers missing from core mutation tables
+--   Live infra audit 2026-04-20 — mv_daily_cost_summary refresh unscheduled
+--   Migration 016 — cleanup_old_sent_offline_commands() created but never wired
+--
+-- Audit standards cited:
+--   SOC2 CC7.2  — "Monitor system components for anomalies indicative of
+--                  malicious acts, errors, and natural disasters."
+--
+-- Summary of changes:
+--   Part 1  Audit trigger function + triggers on profiles/subscriptions/api_keys
+--   Part 2  pg_cron hourly refresh of mv_daily_cost_summary
+--   Part 3  pg_cron daily cleanup of sent offline_command_queue rows
+--
+-- All changes are idempotent (CREATE OR REPLACE, IF EXISTS guards, cron
+-- unschedule-before-schedule pattern).
+-- ROLLBACK instructions are in each section's -- ROLLBACK: comment.
+-- ============================================================================
+
+
+-- ============================================================================
+-- PART 1: Audit Log DB Triggers
+-- ============================================================================
+--
+-- WHY: Phase 0.0 audit + live infra audit identified that mutations on core
+-- tables (profiles, subscriptions, api_keys) were not automatically recorded
+-- in audit_log. This means:
+--   - Schema changes (e.g. role escalation via UPDATE profiles SET role='admin')
+--     leave no DB-layer evidence — only application-layer logs, which can be
+--     bypassed by direct PostgREST calls with a service-role token.
+--   - SOC2 CC7.2 requires system-level monitoring. A DB trigger is the
+--     tamper-resistant, always-on record that satisfies this requirement
+--     regardless of which client path mutates the row.
+--
+-- Design decisions:
+--   - SECURITY DEFINER + SET search_path = public: prevents search-path
+--     injection (consistent with migration 016 pattern). The trigger function
+--     runs as the function owner (postgres/service_role), ensuring it can
+--     always INSERT into audit_log regardless of the invoking role's RLS.
+--   - AFTER trigger: we record the committed state after the DB validates
+--     constraints. BEFORE triggers fire before validation — recording would
+--     capture rows that may still be rolled back.
+--   - FOR EACH ROW: one audit record per mutated row, not per statement.
+--   - control_ref 'SOC2 CC7.2': machine-readable reference surfaced in audit
+--     trail queries so compliance tooling can filter by standard.
+--
+-- Governing standard: SOC2 CC7.2
+--
+-- ROLLBACK:
+--   DROP TRIGGER IF EXISTS audit_log_profiles       ON profiles;
+--   DROP TRIGGER IF EXISTS audit_log_subscriptions  ON subscriptions;
+--   DROP TRIGGER IF EXISTS audit_log_api_keys       ON api_keys;
+--   DROP FUNCTION IF EXISTS audit_trigger_fn();
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION audit_trigger_fn()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id  UUID;
+  v_record   JSONB;
+BEGIN
+  -- WHY: For DELETE we log OLD (the row that was removed). For INSERT and
+  -- UPDATE we log NEW (the row as it now exists). This mirrors standard
+  -- audit-log practice: the "what happened" record is the new/removed state.
+  IF TG_OP = 'DELETE' THEN
+    v_record := to_jsonb(OLD);
+    -- WHY: Attempt to extract user_id from the deleted row so the audit entry
+    -- is owner-attributed. Falls back to NULL if the column doesn't exist on
+    -- this table (handled by the EXCEPTION block below).
+    BEGIN
+      v_user_id := (OLD).user_id;
+    EXCEPTION WHEN others THEN
+      v_user_id := NULL;
+    END;
+  ELSE
+    v_record := to_jsonb(NEW);
+    BEGIN
+      v_user_id := (NEW).user_id;
+    EXCEPTION WHEN others THEN
+      v_user_id := NULL;
+    END;
+  END IF;
+
+  INSERT INTO audit_log (
+    user_id,
+    action,
+    resource_type,
+    resource_id,
+    details,
+    created_at
+  ) VALUES (
+    -- WHY: Prefer the row's own user_id. If the trigger fires from a
+    -- service-role operation (e.g. billing webhook updating subscriptions),
+    -- the row's user_id is the affected user — correct for audit attribution.
+    -- Falls back to auth.uid() if the row has no user_id column.
+    COALESCE(v_user_id, auth.uid()),
+
+    -- WHY: Cast TG_OP to audit_action via text. TG_OP values are 'INSERT',
+    -- 'UPDATE', 'DELETE' — which must exist in the audit_action enum.
+    -- If they don't, this cast will raise a DB error and the migration should
+    -- be updated to add the missing enum values first.
+    TG_OP::text::audit_action,
+
+    -- WHY: TG_TABLE_NAME is the unqualified table name (e.g. 'profiles').
+    -- This is consistent with how other audit_log entries record resource_type.
+    TG_TABLE_NAME,
+
+    -- WHY: Try to extract 'id' as the resource identifier. Most Styrby tables
+    -- use UUID primary key named 'id'. EXCEPTION block handles tables without it.
+    CASE
+      WHEN TG_OP = 'DELETE' THEN (v_record->>'id')::text
+      ELSE (v_record->>'id')::text
+    END,
+
+    -- WHY: Store the full row snapshot as JSONB in details. This lets auditors
+    -- reconstruct the exact state at the time of mutation, including which
+    -- fields changed on UPDATE. No PII scrubbing here — audit_log is a
+    -- high-privilege table with service-role access only (SOC2 requirement).
+    jsonb_build_object(
+      'operation', TG_OP,
+      'table',     TG_TABLE_NAME,
+      'record',    v_record,
+      'control_ref', 'SOC2 CC7.2'
+    ),
+
+    now()
+  );
+
+  -- WHY: For AFTER triggers, the return value is ignored for non-STATEMENT
+  -- triggers. We return NULL here as the canonical form; returning NEW or OLD
+  -- would also work but NULL makes the intent explicit: we are observing, not
+  -- modifying the row.
+  RETURN NULL;
+END;
+$$;
+
+-- Attach audit trigger to profiles
+-- WHY: profiles is extended from auth.users and stores role, subscription tier,
+-- and consent fields. Mutations here (especially role or tier changes) are high-
+-- value audit events. IF EXISTS guard makes this idempotent on re-run.
+DROP TRIGGER IF EXISTS audit_log_profiles ON profiles;
+CREATE TRIGGER audit_log_profiles
+  AFTER INSERT OR UPDATE OR DELETE ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_trigger_fn();
+
+-- Attach audit trigger to subscriptions
+-- WHY: Billing state changes (plan upgrades, downgrades, cancellations) must be
+-- in the audit trail for revenue integrity and SOC2 evidence. Subscriptions are
+-- synced from Polar webhooks — the trigger ensures even service-role webhook
+-- writes are audited at the DB layer.
+DROP TRIGGER IF EXISTS audit_log_subscriptions ON subscriptions;
+CREATE TRIGGER audit_log_subscriptions
+  AFTER INSERT OR UPDATE OR DELETE ON subscriptions
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_trigger_fn();
+
+-- Attach audit trigger to api_keys
+-- WHY: API key creation, revocation, and rotation are the highest-risk mutations
+-- in the system. A leaked or rogue key can exfiltrate all session data. The DB
+-- trigger ensures key lifecycle events survive even if the application-layer log
+-- is unavailable.
+DROP TRIGGER IF EXISTS audit_log_api_keys ON api_keys;
+CREATE TRIGGER audit_log_api_keys
+  AFTER INSERT OR UPDATE OR DELETE ON api_keys
+  FOR EACH ROW
+  EXECUTE FUNCTION audit_trigger_fn();
+
+-- Optional: attach to team_members if the table exists.
+-- WHY: team_members may not exist in all environments (teams feature is gated).
+-- We use a DO block so the trigger is registered if the table is present,
+-- without failing the entire migration if it isn't.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name   = 'team_members'
+  ) THEN
+    -- Drop before recreate to keep idempotent
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_log_team_members ON team_members';
+    EXECUTE '
+      CREATE TRIGGER audit_log_team_members
+        AFTER INSERT OR UPDATE OR DELETE ON team_members
+        FOR EACH ROW
+        EXECUTE FUNCTION audit_trigger_fn()
+    ';
+  END IF;
+END;
+$$;
+
+-- Optional: attach to team_policies if the table exists.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name   = 'team_policies'
+  ) THEN
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_log_team_policies ON team_policies';
+    EXECUTE '
+      CREATE TRIGGER audit_log_team_policies
+        AFTER INSERT OR UPDATE OR DELETE ON team_policies
+        FOR EACH ROW
+        EXECUTE FUNCTION audit_trigger_fn()
+    ';
+  END IF;
+END;
+$$;
+
+
+-- ============================================================================
+-- PART 2: pg_cron — Hourly Refresh of mv_daily_cost_summary
+-- ============================================================================
+--
+-- WHY: mv_daily_cost_summary is a materialized view (migration 010). Unlike a
+-- regular view, it does not recompute on every query — it holds a snapshot of
+-- data at the last REFRESH time. Without a scheduled refresh, the cost
+-- dashboard shows stale data: a session completed an hour ago might not appear
+-- in the "today's spend" card until the MV is manually refreshed.
+--
+-- Live infra audit (2026-04-20) finding: "mv_daily_cost_summary refresh is
+-- unscheduled; cost dashboard will show stale data."
+--
+-- CONCURRENTLY: We use REFRESH MATERIALIZED VIEW CONCURRENTLY so queries
+-- against the MV continue to succeed during the refresh (no exclusive lock).
+-- This requires the MV to have at least one unique index — migration 010 adds
+-- a unique index on (user_id, record_date, agent_type, model). If that index
+-- is ever dropped, CONCURRENTLY will fail; use non-concurrent refresh instead.
+--
+-- WHY hourly: Cost data is written by the CLI in near-real-time, but the
+-- aggregated dashboard summary only needs to be "fresh within an hour" to
+-- give useful spend tracking. A sub-minute refresh would waste Supabase
+-- compute; hourly is a good balance.
+--
+-- Governing standard: SOC2 CC7.2 operational availability.
+--
+-- ROLLBACK:
+--   SELECT cron.unschedule('refresh-mv-daily-costs');
+-- ============================================================================
+
+-- Ensure pg_cron is available.
+-- WHY: pg_cron is a Supabase-supported extension (enabled in dashboard under
+-- Database > Extensions). CREATE EXTENSION IF NOT EXISTS is idempotent.
+-- If Supabase has not enabled it, this will fail with a helpful error.
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Unschedule first to make this idempotent on re-run.
+-- WHY: cron.schedule() inserts a new row in the cron.job table. Running this
+-- migration twice without the unschedule would create duplicate jobs, both
+-- refreshing the MV, doubling the compute cost and potentially causing lock
+-- contention. Unschedule-before-schedule is the idempotent pattern.
+SELECT cron.unschedule('refresh-mv-daily-costs')
+WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'refresh-mv-daily-costs'
+);
+
+-- Schedule hourly refresh at the top of every hour.
+-- WHY: '0 * * * *' runs at minute 0 of every hour (00:00, 01:00, 02:00, ...).
+-- The job runs as the postgres superuser (default for pg_cron) which can
+-- REFRESH the MV regardless of RLS. This is correct behaviour: the refresh is
+-- a server-side background task, not a user-initiated query.
+SELECT cron.schedule(
+  'refresh-mv-daily-costs',
+  '0 * * * *',
+  'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_daily_cost_summary;'
+);
+
+
+-- ============================================================================
+-- PART 3: pg_cron — Daily Cleanup of Sent offline_command_queue Rows
+-- ============================================================================
+--
+-- WHY: Migration 016 (Fix 4) created the cleanup_old_sent_offline_commands()
+-- function to delete 'sent' rows older than 7 days, but explicitly noted:
+-- "pg_cron scheduling is handled separately by the orchestrator." This
+-- migration fulfils that note by wiring the actual cron schedule.
+--
+-- Without the schedule the function is inert — the table still grows without
+-- bound. The daily cron is the final piece required to close the cleanup loop.
+--
+-- WHY 03:00 UTC: Low-traffic window minimises lock contention with mobile
+-- clients syncing commands. The planning doc recommends "daily 03:00 UTC"
+-- for this job. Note: this is 22:00 CT (Central Time / America/Chicago) —
+-- overnight in the primary user timezone, consistent with the project's
+-- time-zone rules (low-impact maintenance window).
+--
+-- Governing standard: SOC2 CC7.2 operational monitoring (unbounded table
+-- growth can cause availability incidents).
+--
+-- ROLLBACK:
+--   SELECT cron.unschedule('cleanup-old-sent-offline-commands');
+-- ============================================================================
+
+-- Unschedule first to keep idempotent.
+SELECT cron.unschedule('cleanup-old-sent-offline-commands')
+WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'cleanup-old-sent-offline-commands'
+);
+
+-- Schedule daily at 03:00 UTC.
+SELECT cron.schedule(
+  'cleanup-old-sent-offline-commands',
+  '0 3 * * *',
+  'SELECT cleanup_old_sent_offline_commands();'
+);
+
+
+-- ============================================================================
+-- END OF MIGRATION 018
+-- ============================================================================


### PR DESCRIPTION
## Summary

Bundles 3 items from live infra audit (`docs/planning/infra-health-audit-2026-04-20.md`) into one thematic PR per `feedback_batch_thematic_prs.md`.

**Commit 1 — `supabase/migrations/018_ops_hardening.sql`**
- Audit trigger function (`audit_trigger_fn`) with `SECURITY DEFINER` + `SET search_path = public`, attached to `profiles`, `subscriptions`, `api_keys` (optional guards for `team_members`/`team_policies` via IF EXISTS). Cites SOC2 CC7.2.
- `pg_cron` hourly `REFRESH MATERIALIZED VIEW CONCURRENTLY mv_daily_cost_summary` — closes the infra audit finding that the cost dashboard shows stale data.
- `pg_cron` daily 03:00 UTC schedule for `cleanup_old_sent_offline_commands()` — wires the function created in migration 016 that was left unscheduled.

**Commit 2 — `.github/workflows/codeql.yml`**
- CodeQL SAST on push/PR to main + weekly Sunday schedule.
- `javascript-typescript` matrix, `security-and-quality` query suite.
- All action refs pinned to full commit SHAs (pattern consistent with `ci.yml`).
- Minimal permissions block (`security-events: write`, `contents: read`, `actions: read`).

**Commit 3 — `packages/styrby-web/src/middleware.ts`**
- Exports new `resolveClientIp(request)` function: CF-Connecting-IP → x-forwarded-for (first hop) → x-real-ip → 'unknown' fallback.
- Middleware resolves client IP at entry, propagates as `x-real-client-ip` to downstream handlers via `x-middleware-request-*` header injection (Next.js endorsed pattern — avoids NextRequest cloning which breaks in Edge/JSDOM environments).
- All 1382 existing tests pass; typecheck clean; build clean.

## Verification

- [x] `pnpm --filter styrby-web typecheck` — clean
- [x] `pnpm --filter styrby-web test` — 1382/1382 pass
- [x] `pnpm --filter styrby-web build` — exit 0
- [x] No `package.json` / `pnpm-lock.yaml` changes (constraint met)
- [x] 3 commits, thematic bundle

## Post-merge ops checklist

1. **Enable pg_cron in Supabase** — Dashboard > Database > Extensions > search "pg_cron" > enable. Migration 018 will fail on the schedule calls if this extension is not enabled. Run `supabase db push` after enabling.
2. **Deploy migration 018** — `supabase db push` (run from local with SUPABASE_DB_URL set, or trigger via the Supabase Dashboard migration runner).
3. **Enable Cloudflare orange-cloud proxy** — CF Dashboard > DNS > styrbyapp.com > toggle orange cloud. Commit 3 middleware is ready; do this after migration deploys cleanly.
4. **Verify CodeQL scan** — Check GitHub Security tab (Security > Code scanning alerts) after first CI run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)