### PR TITLE
docs(env): annotate SUPABASE_SERVICE_ROLE_KEY with Feb 2026 dual-key guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,19 @@ SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_ANON_KEY=your-anon-key-here
 
 # Service Role Key - KEEP SECRET, server-side only
-# Get from: Supabase Dashboard > Project Settings > API > service_role (reveal)
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+#
+# WHY sb_secret_ format: As of Feb 2026, Supabase runs a dual-key format in
+# parallel. Projects have two tabs in Dashboard > Project Settings > API Keys:
+#   1. "Publishable and secret API keys"  -> NEW: sb_publishable_... / sb_secret_...
+#   2. "Legacy anon, service_role API keys" -> OLD JWT: eyJhbGciOiJI...
+#
+# Use the NEW format. Supabase edge function runtime auto-injects the new
+# value into SUPABASE_SERVICE_ROLE_KEY; if your server code or vault holds
+# the legacy JWT, the Authorization header char-by-char comparison fails
+# with 401 Unauthorized even though both formats are technically valid.
+#
+# Copy from: "Publishable and secret API keys" tab -> Reveal the secret key.
+SUPABASE_SERVICE_ROLE_KEY=sb_secret_your-secret-key-here
 
 # For Expo mobile app (EXPO_PUBLIC_ prefix exposes to client)
 EXPO_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co

--- a/packages/styrby-web/.env.example
+++ b/packages/styrby-web/.env.example
@@ -11,7 +11,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # because NEXT_PUBLIC_ vars are not available in Edge/Node server contexts
 # that use the service role client directly.
 SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# WHY sb_secret_ format: Supabase Feb 2026 dual-key transition replaced legacy
+# JWT service_role with sb_secret_... Edge function runtime uses NEW format;
+# server-side Next.js must match or calls to edge functions (push, webhooks)
+# will 401. Copy from Dashboard > Project Settings > API Keys >
+# "Publishable and secret API keys" tab.
+SUPABASE_SERVICE_ROLE_KEY=sb_secret_your-secret-key
 
 # App URL
 NEXT_PUBLIC_APP_URL=http://localhost:3000


### PR DESCRIPTION
## Summary

Annotate both \`.env.example\` files with guidance on Supabase's Feb 2026 dual-key format transition. The edge function runtime now serves the new \`sb_secret_...\` format via auto-inject; holding the legacy JWT in vault or Vercel causes 401 Unauthorized on edge function calls.

## Context

On 2026-04-20 the push notification pipeline hit a 401 cascade because the vault secret \`supabase_functions_api_key\` was seeded with the legacy JWT while the edge function runtime received the new \`sb_secret_...\` format. Resolution: re-seed vault from the "Publishable and secret API keys" tab. This PR updates the docs so future secret rotations don't repeat the mistake.

## Files touched

- \`.env.example\` — root; expands the service_role comment with the two-tab explanation
- \`packages/styrby-web/.env.example\` — web package; same annotation

## Not in this PR

- \`docs/infrastructure/environment-variables.md\` is gitignored (per CLAUDE.md); its dual-key changelog entry is LOCAL ONLY and was updated in-session.
- Vercel env var + vault rotation are external to the repo and were done manually by the user.

## Governing standards

- SOC2 CC6.6 — access control documentation
- ISO 27001 A.5.9 — documented operating procedures

## Test plan

- [x] Both \`.env.example\` files re-read end to end
- [ ] CI lint/build/typecheck pass (no code paths touched)
- [ ] Docs render correctly in GitHub diff view

🤖 Generated with [Claude Code](https://claude.com/claude-code)