### PR TITLE
fix(web): harden env var reads against trailing-newline paste errors (prod /api/sessions 500 fix)

### DIFF
--- a/packages/styrby-web/next.config.ts
+++ b/packages/styrby-web/next.config.ts
@@ -261,7 +261,11 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: 'Access-Control-Allow-Origin',
-            value: process.env.NEXT_PUBLIC_APP_URL || 'https://styrbyapp.com',
+            // WHY `.trim()` + fallback chain: Vercel env vars occasionally get
+            // pasted with trailing newlines; an `\n` in a response header is
+            // URL-encoded to `%0A` by downstream proxies and also triggers
+            // strict header-validator rejections. Trim defensively before use.
+            value: (process.env.NEXT_PUBLIC_APP_URL || '').trim() || 'https://styrbyapp.com',
           },
           {
             key: 'Access-Control-Allow-Methods',

--- a/packages/styrby-web/src/lib/__tests__/env.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/env.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the env accessor helpers.
+ *
+ * WHY these tests exist: on 2026-04-20 a trailing-newline in a Vercel env
+ * var crashed `/api/sessions` at module-import time. `getEnv()` /
+ * `requireEnv()` / `getEnvOr()` were introduced as the defensive boundary
+ * for all security-sensitive env reads. These tests lock in the trim
+ * semantics so a future refactor cannot silently re-expose the bug class.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getEnv, requireEnv, getEnvOr } from '../env';
+
+// Save a snapshot of process.env for teardown; we mutate it in-place in tests.
+const originalEnv = { ...process.env };
+
+describe('getEnv', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns the value when set and non-empty', () => {
+    process.env.STYRBY_TEST_VAR = 'hello';
+    expect(getEnv('STYRBY_TEST_VAR')).toBe('hello');
+  });
+
+  it('returns undefined when unset', () => {
+    delete process.env.STYRBY_TEST_VAR;
+    expect(getEnv('STYRBY_TEST_VAR')).toBeUndefined();
+  });
+
+  it('trims a trailing newline (primary bug class — Vercel paste error)', () => {
+    process.env.STYRBY_TEST_VAR = 'https://styrbyapp.com\n';
+    expect(getEnv('STYRBY_TEST_VAR')).toBe('https://styrbyapp.com');
+  });
+
+  it('trims a trailing CRLF', () => {
+    process.env.STYRBY_TEST_VAR = 'https://styrbyapp.com\r\n';
+    expect(getEnv('STYRBY_TEST_VAR')).toBe('https://styrbyapp.com');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    process.env.STYRBY_TEST_VAR = '   eyJhbGciOi...   ';
+    expect(getEnv('STYRBY_TEST_VAR')).toBe('eyJhbGciOi...');
+  });
+
+  it('trims tabs', () => {
+    process.env.STYRBY_TEST_VAR = '\tsecret\t';
+    expect(getEnv('STYRBY_TEST_VAR')).toBe('secret');
+  });
+
+  it('returns undefined for a value that trims to empty (all-whitespace)', () => {
+    process.env.STYRBY_TEST_VAR = '   \n\t  ';
+    expect(getEnv('STYRBY_TEST_VAR')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    process.env.STYRBY_TEST_VAR = '';
+    expect(getEnv('STYRBY_TEST_VAR')).toBeUndefined();
+  });
+
+  it('preserves internal whitespace (only trims edges)', () => {
+    // Not that a real env var would contain spaces, but verify we don't
+    // accidentally collapse/replace internal characters.
+    process.env.STYRBY_TEST_VAR = '  a b c  ';
+    expect(getEnv('STYRBY_TEST_VAR')).toBe('a b c');
+  });
+});
+
+describe('requireEnv', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns the trimmed value when set', () => {
+    process.env.STYRBY_TEST_VAR = 'real-secret\n';
+    expect(requireEnv('STYRBY_TEST_VAR')).toBe('real-secret');
+  });
+
+  it('throws when unset', () => {
+    delete process.env.STYRBY_TEST_VAR;
+    expect(() => requireEnv('STYRBY_TEST_VAR')).toThrow(/STYRBY_TEST_VAR/);
+  });
+
+  it('throws when value trims to empty', () => {
+    process.env.STYRBY_TEST_VAR = '   \n';
+    expect(() => requireEnv('STYRBY_TEST_VAR')).toThrow(/STYRBY_TEST_VAR/);
+  });
+
+  it('error message names the missing variable for fast diagnosis', () => {
+    delete process.env.STYRBY_TEST_VAR;
+    try {
+      requireEnv('STYRBY_TEST_VAR');
+    } catch (err) {
+      expect((err as Error).message).toContain('STYRBY_TEST_VAR');
+      expect((err as Error).message).toContain('unset or blank');
+    }
+  });
+});
+
+describe('getEnvOr', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns the trimmed env value when set', () => {
+    process.env.STYRBY_TEST_VAR = 'override\n';
+    expect(getEnvOr('STYRBY_TEST_VAR', 'default')).toBe('override');
+  });
+
+  it('returns the fallback when unset', () => {
+    delete process.env.STYRBY_TEST_VAR;
+    expect(getEnvOr('STYRBY_TEST_VAR', 'default')).toBe('default');
+  });
+
+  it('returns the fallback when env value trims to empty', () => {
+    process.env.STYRBY_TEST_VAR = '  \n';
+    expect(getEnvOr('STYRBY_TEST_VAR', 'default')).toBe('default');
+  });
+});

--- a/packages/styrby-web/src/lib/env.ts
+++ b/packages/styrby-web/src/lib/env.ts
@@ -1,0 +1,79 @@
+/**
+ * Environment variable accessor with whitespace sanitization.
+ *
+ * WHY this module exists: On 2026-04-20 a production 500 cascade on
+ * `/api/sessions` traced back to Vercel environment variables set with a
+ * trailing newline character (a common paste-from-dashboard hazard). The
+ * leaked `\n` surfaced in the `Access-Control-Allow-Origin` header as
+ * `https://styrbyapp.com%0A`, and — critically — caused `new Redis({ url })`
+ * in rate-limiter module-import code to throw on URL parsing, crashing the
+ * entire route module before any handler could run. Next.js then served
+ * the /500 error page even for GETs on endpoints that have no GET handler.
+ *
+ * The fix: read every security-sensitive env var through `getEnv()` so
+ * trailing / leading whitespace is stripped at the boundary. Defensive
+ * programming at the env-read site neutralizes an entire class of bugs
+ * without requiring callers to remember the idiom.
+ *
+ * Governing standards:
+ * - OWASP ASVS V14.1 (build and deployment — environment config hygiene)
+ * - SOC2 CC7.2 (system operations — configuration error detection)
+ *
+ * @module lib/env
+ */
+
+/**
+ * Read and trim an environment variable.
+ *
+ * Returns `undefined` when the variable is unset or trims to empty string.
+ * Trims whitespace including ASCII `\n`, `\r`, `\t`, and surrounding spaces.
+ *
+ * @param name - Exact env var name (case-sensitive)
+ * @returns The trimmed value, or undefined if unset/blank
+ *
+ * @example
+ * const url = getEnv('NEXT_PUBLIC_APP_URL');
+ * if (url) {
+ *   // Safe to use in HTTP headers, URL parsing, etc.
+ * }
+ */
+export function getEnv(name: string): string | undefined {
+  const raw = process.env[name];
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+/**
+ * Read a required env var. Throws at read time if unset or blank.
+ *
+ * Use this for server-only secrets where a missing value is a
+ * misconfiguration that should fail fast.
+ *
+ * @param name - Exact env var name
+ * @returns The trimmed value (never empty)
+ * @throws Error if unset or trims to empty
+ *
+ * @example
+ * const key = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
+ */
+export function requireEnv(name: string): string {
+  const value = getEnv(name);
+  if (value === undefined) {
+    throw new Error(
+      `Required environment variable "${name}" is unset or blank. ` +
+        `Check Vercel dashboard / .env.local / GitHub Actions secrets.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Read an env var with a default fallback.
+ *
+ * @param name - Exact env var name
+ * @param fallback - Returned if the env var is unset or trims to empty
+ */
+export function getEnvOr(name: string, fallback: string): string {
+  return getEnv(name) ?? fallback;
+}

--- a/packages/styrby-web/src/lib/rateLimit.ts
+++ b/packages/styrby-web/src/lib/rateLimit.ts
@@ -18,6 +18,7 @@
 
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
+import { getEnv } from './env';
 
 // ============================================================================
 // Types
@@ -56,21 +57,41 @@ type RateLimitResult = {
  *
  * WHY: In local development and CI, Redis env vars may not be set.
  * We fall back to in-memory rather than crashing at import time.
+ *
+ * WHY `getEnv` (not `process.env` directly): On 2026-04-20 a trailing
+ * newline in the Vercel-stored `UPSTASH_REDIS_REST_URL` was passed through
+ * to `new Redis({ url })` at module-import time, which threw during URL
+ * parsing and crashed the entire route module — causing 500s on every
+ * API endpoint that imported this module (including GETs with no handler
+ * defined, which should normally 405). `getEnv` trims whitespace so
+ * paste-errors in the Vercel dashboard can never crash the serverless
+ * function at boot.
  */
-const isRedisConfigured =
-  !!process.env.UPSTASH_REDIS_REST_URL &&
-  !!process.env.UPSTASH_REDIS_REST_TOKEN;
+const upstashUrl = getEnv('UPSTASH_REDIS_REST_URL');
+const upstashToken = getEnv('UPSTASH_REDIS_REST_TOKEN');
+const isRedisConfigured = !!upstashUrl && !!upstashToken;
 
 /**
  * Shared Redis client instance (singleton).
- * Only created if Upstash credentials are available.
+ * Only created if Upstash credentials are available AND the URL parses.
+ *
+ * The try/catch is defensive belt-and-suspenders: even after trimming,
+ * a malformed URL value (e.g., missing protocol, typo) should not crash
+ * the module — it should silently fall back to in-memory rate limiting.
  */
-const redis = isRedisConfigured
-  ? new Redis({
-      url: process.env.UPSTASH_REDIS_REST_URL!,
-      token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-    })
-  : null;
+let redis: Redis | null = null;
+if (isRedisConfigured) {
+  try {
+    redis = new Redis({ url: upstashUrl!, token: upstashToken! });
+  } catch (err) {
+    // Module-load error: log + continue with null. In-memory fallback takes over.
+    // Do not throw — throwing here crashes every route that imports rateLimit.
+    console.error(
+      '[rateLimit] Failed to initialize Upstash Redis client; falling back to in-memory:',
+      err,
+    );
+  }
+}
 
 // ============================================================================
 // Rate Limiter Instances (cached per config)
@@ -101,8 +122,12 @@ function getLimiter(prefix: string, config: RateLimitConfig): Ratelimit {
     const windowSeconds = Math.ceil(config.windowMs / 1000);
     const duration = `${windowSeconds} s` as `${number} s`;
 
+    // WHY non-null assertion: callers gate on `redis !== null` in the
+    // `rateLimit()` hot path before reaching this function. `Redis.fromEnv()`
+    // was removed because it re-reads `process.env` without trimming, which
+    // defeats the whitespace sanitization applied during singleton init.
     limiter = new Ratelimit({
-      redis: redis ?? Redis.fromEnv(),
+      redis: redis!,
       limiter: Ratelimit.slidingWindow(config.maxRequests, duration),
       prefix: `styrby:ratelimit:${prefix}`,
       analytics: false, // Disable analytics to reduce Redis commands
@@ -223,8 +248,9 @@ export async function rateLimit(
 ): Promise<RateLimitResult> {
   const ip = getClientIp(request);
 
-  // Fallback to in-memory if Redis is not configured
-  if (!isRedisConfigured) {
+  // Fallback to in-memory if Redis is not configured OR if client init failed
+  // (e.g., malformed URL in env var — we logged and set redis=null above).
+  if (!isRedisConfigured || redis === null) {
     return inMemoryRateLimit(ip, config, keyPrefix);
   }
 

--- a/packages/styrby-web/src/middleware/api-auth.ts
+++ b/packages/styrby-web/src/middleware/api-auth.ts
@@ -28,6 +28,7 @@ import { extractApiKeyPrefix, isValidApiKeyFormat } from '@styrby/shared';
 import { getClientIp } from '@/lib/rateLimit';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
+import { getEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -84,21 +85,30 @@ const API_RATE_LIMIT = {
  * FALLBACK: If UPSTASH_REDIS_REST_URL is not set (local dev, CI), falls back
  * to in-memory rate limiting (better than no limiting at all).
  */
-const isRedisConfigured =
-  !!process.env.UPSTASH_REDIS_REST_URL &&
-  !!process.env.UPSTASH_REDIS_REST_TOKEN;
+// WHY getEnv: see packages/styrby-web/src/lib/env.ts for the root-cause write-up.
+// Trimmed env access prevents trailing-newline paste errors in Vercel from
+// crashing `new Redis({ url })` at module-import time (which 500s every route
+// that imports this file).
+const upstashUrl = getEnv('UPSTASH_REDIS_REST_URL');
+const upstashToken = getEnv('UPSTASH_REDIS_REST_TOKEN');
+const isRedisConfigured = !!upstashUrl && !!upstashToken;
 
-const apiKeyLimiter = isRedisConfigured
-  ? new Ratelimit({
-      redis: new Redis({
-        url: process.env.UPSTASH_REDIS_REST_URL!,
-        token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-      }),
+let apiKeyLimiter: Ratelimit | null = null;
+if (isRedisConfigured) {
+  try {
+    apiKeyLimiter = new Ratelimit({
+      redis: new Redis({ url: upstashUrl!, token: upstashToken! }),
       limiter: Ratelimit.slidingWindow(API_RATE_LIMIT.maxRequests, '60 s'),
       prefix: 'styrby:api-key-ratelimit',
       analytics: false,
-    })
-  : null;
+    });
+  } catch (err) {
+    console.error(
+      '[api-auth] Failed to initialize Upstash Redis rate limiter; falling back to in-memory:',
+      err,
+    );
+  }
+}
 
 /** In-memory fallback store for local dev/CI without Redis */
 const apiRateLimitStore = new Map<string, { count: number; resetAt: number }>();


### PR DESCRIPTION
## Summary

Fixes a production 500 cascade on every \`/api/sessions\` request. Root cause: a trailing newline in the Vercel-saved \`UPSTASH_REDIS_REST_URL\` crashed \`new Redis({ url })\` at module-import time, which killed every route that imports \`lib/rateLimit.ts\`.

Adds \`src/lib/env.ts\` (trimmed env accessors) + defensive init wrappers at every Redis client call site, + CORS origin trim in \`next.config.ts\`.

## Observed symptom

\`\`\`http
GET /api/sessions HTTP/2
  → 500 Internal Server Error
  ← access-control-allow-origin: https://styrbyapp.com%0A   ← \`%0A\` = URL-encoded \\n
  ← x-matched-path: /500
\`\`\`

\`/\`, \`/login\`, and \`/dashboard\` worked fine; the 500 was specific to routes importing the rateLimit module.

## Root cause

1. \`NEXT_PUBLIC_APP_URL\` in Vercel had a trailing newline (paste-from-dashboard hazard)
2. \`new Redis({ url: process.env.UPSTASH_REDIS_REST_URL! })\` threw when that URL contained \`\\n\`
3. The throw happened at module scope, crashing every API route that imported rateLimit
4. Next.js served /500 even for GETs on endpoints with no GET handler (would normally 405)

## Fix

| File | Change |
|---|---|
| \`src/lib/env.ts\` (NEW) | \`getEnv()\` / \`requireEnv()\` / \`getEnvOr()\` helpers that trim whitespace at read time |
| \`src/lib/__tests__/env.test.ts\` (NEW) | 16 unit tests locking in trim semantics |
| \`src/lib/rateLimit.ts\` | Route Upstash init through getEnv; wrap \`new Redis(...)\` in try/catch with in-memory fallback; remove \`Redis.fromEnv()\` fallback (it re-reads process.env without trimming) |
| \`src/middleware/api-auth.ts\` | Same pattern for apiKeyLimiter |
| \`next.config.ts\` | \`.trim()\` \`NEXT_PUBLIC_APP_URL\` before setting Access-Control-Allow-Origin |

## Verification

- \`pnpm --filter styrby-web test src/lib/__tests__/env.test.ts\` → 16/16 pass
- \`pnpm --filter styrby-web typecheck\` → clean
- \`pnpm --filter styrby-web lint\` → clean
- \`pnpm --filter @styrby/shared build\` → clean

## Governing standards

- OWASP ASVS V14.1 (build and deployment — env config hygiene)
- SOC2 CC7.2 (system operations — configuration error detection)

## Rollout

1. Merge this PR → Vercel redeploys
2. Production \`/api/sessions\` returns 401 (no auth) instead of 500 (module crash)
3. Follow-up cleanup: user can optionally clean the trailing newline in Vercel env vars, but the code is now tolerant either way

## Follow-up (not in this PR)

Migrate remaining \`process.env.FOO\` reads in web/ to \`getEnv('FOO')\` opportunistically when touching surrounding code.

## Test plan

- [x] Unit tests pass locally (16/16)
- [x] Typecheck + lint + shared-build clean
- [ ] CI lint + build + tests green
- [ ] Prod /api/sessions returns 401 after deploy (not 500)
- [ ] CORS header no longer shows \`%0A\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)