### PR TITLE
chore(web): migrate critical process.env reads to getEnv/requireEnv helpers

### DIFF
--- a/packages/styrby-web/src/app/api/internal/test-push/route.ts
+++ b/packages/styrby-web/src/app/api/internal/test-push/route.ts
@@ -61,6 +61,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import { z } from 'zod';
+import { getEnv } from '@/lib/env';
 
 // ============================================================================
 // Request Schema
@@ -186,8 +187,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // ──────────────────────────────────────────
   // Step 5: Build edge function URL + service role key
   // ──────────────────────────────────────────
-  const supabaseUrl = process.env.SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const supabaseUrl = getEnv('SUPABASE_URL');
+  const serviceRoleKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
 
   if (!supabaseUrl || !serviceRoleKey) {
     console.error('[test-push] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');

--- a/packages/styrby-web/src/app/api/v1/costs/breakdown/route.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/breakdown/route.ts
@@ -33,6 +33,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
+import { requireEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Query Schema
@@ -48,8 +49,8 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireEnv('SUPABASE_URL'),
+    requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
     {
       cookies: {
         getAll() {

--- a/packages/styrby-web/src/app/api/v1/costs/export/route.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/export/route.ts
@@ -32,6 +32,7 @@ import { createServerClient } from '@supabase/ssr';
 import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
 import { rateLimit, RATE_LIMITS } from '@/lib/rateLimit';
+import { requireEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Query Schema
@@ -55,8 +56,8 @@ const QuerySchema = z.object({
  */
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireEnv('SUPABASE_URL'),
+    requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
     {
       cookies: {
         getAll() {

--- a/packages/styrby-web/src/app/api/v1/costs/route.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/route.ts
@@ -36,6 +36,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
+import { requireEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Query Schema
@@ -51,8 +52,8 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireEnv('SUPABASE_URL'),
+    requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
     {
       cookies: {
         getAll() {

--- a/packages/styrby-web/src/app/api/v1/machines/route.ts
+++ b/packages/styrby-web/src/app/api/v1/machines/route.ts
@@ -30,6 +30,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
+import { requireEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Query Schema
@@ -45,8 +46,8 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireEnv('SUPABASE_URL'),
+    requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
     {
       cookies: {
         getAll() {

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/route.ts
@@ -43,6 +43,7 @@ import { createServerClient } from '@supabase/ssr';
 import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import type { SessionCheckpoint } from '@styrby/shared';
 import { z } from 'zod';
+import { requireEnv } from '@/lib/env';
 
 // ============================================================================
 // Constants
@@ -105,8 +106,8 @@ const PostBodySchema = z.object({
  */
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireEnv('SUPABASE_URL'),
+    requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
     {
       cookies: {
         getAll() { return []; },

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/route.ts
@@ -25,6 +25,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
+import { requireEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Query Schema
@@ -54,8 +55,8 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireEnv('SUPABASE_URL'),
+    requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
     {
       cookies: {
         getAll() {

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/route.ts
@@ -13,6 +13,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { requireEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Supabase Admin Client
@@ -20,8 +21,8 @@ import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middlew
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireEnv('SUPABASE_URL'),
+    requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
     {
       cookies: {
         getAll() {

--- a/packages/styrby-web/src/app/api/v1/sessions/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/route.ts
@@ -24,6 +24,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
+import { requireEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Query Schema
@@ -43,8 +44,8 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireEnv('SUPABASE_URL'),
+    requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
     {
       cookies: {
         getAll() {

--- a/packages/styrby-web/src/app/invite/[token]/invite-actions.tsx
+++ b/packages/styrby-web/src/app/invite/[token]/invite-actions.tsx
@@ -10,6 +10,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createBrowserClient } from '@supabase/ssr';
+import { requireEnv } from '@/lib/env';
 
 interface InviteActionsProps {
   token: string;
@@ -26,8 +27,8 @@ export function InviteActions({ token, teamName }: InviteActionsProps) {
    * Creates a Supabase client for browser-side operations.
    */
   const supabase = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    requireEnv('NEXT_PUBLIC_SUPABASE_URL'),
+    requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY')
   );
 
   /**

--- a/packages/styrby-web/src/app/layout.tsx
+++ b/packages/styrby-web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { CookieConsent } from '@/components/cookie-consent';
 import { SWRegister } from '@/components/sw-register';
+import { getEnvOr } from '@/lib/env';
 
 /**
  * WHY Outfit: geometric sans-serif with tight tracking and optical weight that
@@ -44,7 +45,7 @@ export const metadata: Metadata = {
   description:
     'Monitor costs, approve permissions, and control Claude Code, Codex, Gemini CLI, OpenCode, and Aider from one premium dashboard.',
   metadataBase: new URL(
-    process.env.NEXT_PUBLIC_APP_URL || 'https://styrbyapp.com'
+    getEnvOr('NEXT_PUBLIC_APP_URL', 'https://styrbyapp.com')
   ),
   icons: {
     icon: [

--- a/packages/styrby-web/src/middleware/api-auth.ts
+++ b/packages/styrby-web/src/middleware/api-auth.ts
@@ -28,7 +28,7 @@ import { extractApiKeyPrefix, isValidApiKeyFormat } from '@styrby/shared';
 import { getClientIp } from '@/lib/rateLimit';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
-import { getEnv } from '@/lib/env';
+import { getEnv, requireEnv } from '@/lib/env';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -171,8 +171,8 @@ async function checkApiRateLimit(keyId: string): Promise<{ allowed: boolean; rem
  */
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireEnv('SUPABASE_URL'),
+    requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
## Summary

Follow-up to #84. Extends the env-trimming helpers from \`src/lib/env.ts\` to 12 additional security-sensitive call sites across web — every v1 API route, the api-auth middleware, and a few more spots where module-load failure on a malformed env var could 500 an entire route tree.

**Base branch:** \`fix/env-var-whitespace-hardening-2026-04-20\` (PR #84). Rebase to \`main\` auto after #84 lands.

## Call sites migrated

| File | Change |
|---|---|
| 7× \`app/api/v1/*\` routes | \`process.env.X!\` → \`requireEnv('X')\` for SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY |
| \`app/api/internal/test-push/route.ts\` | \`process.env.X\` → \`getEnv('X')\` (undefined handled by admin gate) |
| \`middleware/api-auth.ts\` | Supabase admin client init via \`requireEnv\` |
| \`app/invite/[token]/invite-actions.tsx\` | Anon key init via \`requireEnv\` |
| \`app/layout.tsx\` | \`process.env.NEXT_PUBLIC_APP_URL || fallback\` → \`getEnvOr('NEXT_PUBLIC_APP_URL', fallback)\` |

## Why \`requireEnv\` (not \`getEnv\`)

\`requireEnv\` throws at read time if the var is unset OR trims to empty — that's the right behavior for *required* server secrets. Previous code used the \`!\` non-null assertion, which silently allowed \`undefined\` through, causing a crash later at \`createClient(undefined, ...)\` with a useless stack trace. The new error message names the missing var: \`"Required environment variable X is unset or blank. Check Vercel dashboard / .env.local / GitHub Actions secrets."\`

## Not in this PR

- \`process.env.NODE_ENV\` checks — Vercel-injected, trusted, always clean.
- Error boundary \`NODE_ENV === 'development'\` display logic — harmless.
- Docs-page renders of env var literal names — display-only.

## Verification

- \`pnpm --filter @styrby/shared build\` → clean
- \`pnpm --filter styrby-web typecheck\` → clean
- \`pnpm --filter styrby-web lint\` → clean
- Existing \`env.test.ts\` (16 tests) → pass

## Governing standards

- OWASP ASVS V14.1 (build & deploy env config hygiene)
- SOC2 CC7.2 (configuration error detection)

## Test plan

- [x] Local typecheck + lint clean
- [x] Env unit tests pass
- [ ] CI green
- [ ] After #84 + this land, verify \`curl https://www.styrbyapp.com/api/sessions\` returns 401 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)