### PR TITLE
feat(shared): team governance types + CLI policyEngine

### DIFF
--- a/packages/styrby-cli/src/approvals/__tests__/policyEngine.test.ts
+++ b/packages/styrby-cli/src/approvals/__tests__/policyEngine.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for runPolicyEngine.
+ *
+ * These tests stub `fetch` to avoid any real network traffic — the
+ * edge function itself ships in PR #3. We cover:
+ *   - exit-code correctness for approved / denied / timeout / cancelled
+ *   - poll cadence (respect pollIntervalMs)
+ *   - cancellation via external AbortSignal cleans up the pending row
+ *   - pre-check emits the expected status message
+ *
+ * @module approvals/__tests__/policyEngine
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runPolicyEngine } from '../policyEngine.js';
+import type { TeamPolicy } from 'styrby-shared';
+
+const UUID = '00000000-0000-0000-0000-000000000001';
+
+function makeFetch(
+  responses: Array<
+    | { status: 'pending' | 'approved' | 'denied'; approvalId?: string; reason?: string }
+    | Error
+  >,
+): { fetchImpl: typeof fetch; calls: Array<{ body: any }> } {
+  const calls: Array<{ body: any }> = [];
+  let i = 0;
+  const fetchImpl = (async (_url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : {};
+    calls.push({ body });
+    const next = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    if (next instanceof Error) throw next;
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      async json() {
+        return {
+          approvalId: next.approvalId ?? UUID,
+          status: next.status,
+          reason: next.reason,
+        };
+      },
+      async text() {
+        return '';
+      },
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const baseInput = {
+  sessionId: UUID,
+  riskLevel: 'high' as const,
+  toolName: 'Bash',
+  supabaseUrl: 'https://example.supabase.co',
+  authToken: 'jwt',
+  pollIntervalMs: 5,
+  timeoutMs: 500,
+};
+
+describe('runPolicyEngine exit codes', () => {
+  it('returns APPROVED (0) when server returns approved on submit', async () => {
+    const { fetchImpl, calls } = makeFetch([{ status: 'approved' }]);
+    const res = await runPolicyEngine({ ...baseInput, fetchImpl });
+    expect(res.status).toBe('approved');
+    expect(res.exitCode).toBe(0);
+    expect(calls[0].body.action).toBe('submit');
+  });
+
+  it('returns DENIED (10) when server returns denied on submit', async () => {
+    const { fetchImpl } = makeFetch([{ status: 'denied', reason: 'blocked' }]);
+    const res = await runPolicyEngine({ ...baseInput, fetchImpl });
+    expect(res.status).toBe('denied');
+    expect(res.exitCode).toBe(10);
+    expect(res.reason).toBe('blocked');
+  });
+
+  it('returns APPROVED after a pending poll then an approval', async () => {
+    const { fetchImpl, calls } = makeFetch([
+      { status: 'pending' },
+      { status: 'pending' },
+      { status: 'approved' },
+    ]);
+    const res = await runPolicyEngine({ ...baseInput, fetchImpl });
+    expect(res.exitCode).toBe(0);
+    // submit + 2 polls = 3 fetch calls
+    expect(calls.length).toBe(3);
+    expect(calls[1].body.action).toBe('poll');
+    expect(calls[2].body.action).toBe('poll');
+  });
+
+  it('returns TIMEOUT (124) when polls never resolve', async () => {
+    const { fetchImpl, calls } = makeFetch([{ status: 'pending' }]);
+    const res = await runPolicyEngine({
+      ...baseInput,
+      fetchImpl,
+      pollIntervalMs: 10,
+      timeoutMs: 40,
+    });
+    expect(res.status).toBe('timeout');
+    expect(res.exitCode).toBe(124);
+    // at least one cancel attempted
+    expect(calls.some((c) => c.body.action === 'cancel')).toBe(true);
+  });
+});
+
+describe('runPolicyEngine cancellation', () => {
+  it('returns CANCELLED (130) when the external signal aborts mid-poll', async () => {
+    const { fetchImpl, calls } = makeFetch([{ status: 'pending' }]);
+    const controller = new AbortController();
+    const statusMessages: string[] = [];
+
+    const promise = runPolicyEngine({
+      ...baseInput,
+      fetchImpl,
+      pollIntervalMs: 50,
+      timeoutMs: 5000,
+      signal: controller.signal,
+      onStatus: (m) => statusMessages.push(m),
+    });
+
+    // Abort after first submit settles.
+    setTimeout(() => controller.abort(), 10);
+
+    const res = await promise;
+    expect(res.status).toBe('cancelled');
+    expect(res.exitCode).toBe(130);
+    expect(calls.some((c) => c.body.action === 'cancel')).toBe(true);
+  });
+});
+
+describe('runPolicyEngine pre-check', () => {
+  it('emits a "will require approval from ..." message when pre-check yields pending', async () => {
+    const { fetchImpl } = makeFetch([{ status: 'approved' }]);
+    const messages: string[] = [];
+
+    const policy: TeamPolicy = {
+      id: UUID,
+      teamId: UUID,
+      name: 'Require approval for Bash',
+      description: null,
+      ruleType: 'tool_allowlist',
+      threshold: null,
+      approverRole: 'any_admin',
+      approverUserId: null,
+      agentFilter: ['bash'],
+      action: 'require_approval',
+      settings: {},
+      enabled: true,
+      priority: 100,
+      createdBy: UUID,
+      createdAt: '2026-04-20T00:00:00.000Z',
+      updatedAt: '2026-04-20T00:00:00.000Z',
+    };
+
+    await runPolicyEngine({
+      ...baseInput,
+      fetchImpl,
+      onStatus: (m) => messages.push(m),
+      preCheck: {
+        policy,
+        roster: [
+          { userId: 'u-owner', role: 'owner', active: true },
+          { userId: 'u-admin', role: 'admin', active: true },
+          { userId: 'u-member', role: 'member', active: true },
+        ],
+        requesterUserId: 'u-member',
+      },
+    });
+
+    const precheck = messages.find((m) => m.startsWith('Pre-check:'));
+    expect(precheck).toBeDefined();
+    expect(precheck!).toContain('require approval from');
+    expect(precheck!).toContain('u-owner');
+    expect(precheck!).toContain('u-admin');
+  });
+});
+
+describe('runPolicyEngine SIGINT handler lifecycle', () => {
+  it('does not leak SIGINT listeners across invocations', async () => {
+    const { fetchImpl } = makeFetch([{ status: 'approved' }]);
+    const before = process.listenerCount('SIGINT');
+    await runPolicyEngine({ ...baseInput, fetchImpl });
+    await runPolicyEngine({ ...baseInput, fetchImpl });
+    await runPolicyEngine({ ...baseInput, fetchImpl });
+    const after = process.listenerCount('SIGINT');
+    expect(after).toBe(before);
+  });
+});

--- a/packages/styrby-cli/src/approvals/policyEngine.ts
+++ b/packages/styrby-cli/src/approvals/policyEngine.ts
@@ -1,0 +1,405 @@
+/**
+ * CLI policy engine (Phase 2.1).
+ *
+ * Called by the CLI before executing a tool call that may be governed
+ * by a team policy. Polls the Supabase `resolve-approval` edge function
+ * until the approval terminates or timeout elapses.
+ *
+ * Responsibilities:
+ *   - Submit the approval request (if not already created server-side).
+ *   - Poll every 5 s for up to 60 s.
+ *   - Emit the correct exit code for the CLI runner to interpret.
+ *   - Clean up (cancel the pending row) on SIGINT so we never leave
+ *     orphaned `pending` approvals blocking other tool calls.
+ *
+ * The *decision logic* lives in `styrby-shared` (team/approval-chain)
+ * and is used here only for the client-side pre-check — "this call will
+ * require approval from X, Y, Z" — rendered in the terminal before we
+ * submit. The authoritative decision always comes from the edge
+ * function and the DB.
+ *
+ * @module approvals/policyEngine
+ */
+
+import {
+  evaluateApprovalChain,
+  POLICY_ENGINE_EXIT_CODES,
+  type Approval,
+  type ApprovalChainResult,
+  type PolicyEngineExitCode,
+  type RosterMember,
+  type TeamPolicy,
+} from 'styrby-shared';
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/** Risk classification for the tool call. Passed through to the server. */
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+/** Inputs to {@link runPolicyEngine}. */
+export interface PolicyEngineInput {
+  /** Active Styrby session id. */
+  sessionId: string;
+
+  /** Tool-call risk classification. */
+  riskLevel: RiskLevel;
+
+  /** Tool being invoked (e.g., 'Bash'). Pass-through to the server. */
+  toolName: string;
+
+  /** Estimated USD cost of the call, if known. */
+  estimatedCostUsd?: number;
+
+  /** Arbitrary payload describing the call (parsed by server policies). */
+  requestPayload?: Record<string, unknown>;
+
+  /** Supabase project URL (required). */
+  supabaseUrl: string;
+
+  /** User-scoped Supabase JWT (required). */
+  authToken: string;
+
+  /**
+   * Optional — pre-fetched policy + roster + requester used for the
+   * client-side pre-check ("will require approval from X, Y, Z"). When
+   * omitted, the pre-check is skipped and we go straight to polling.
+   */
+  preCheck?: {
+    policy: TeamPolicy | null;
+    roster: ReadonlyArray<RosterMember>;
+    requesterUserId: string;
+  };
+
+  // -------- Test seams (all optional) ---------------------------------------
+
+  /**
+   * Override for `fetch`. Defaults to `globalThis.fetch`. Tests swap this
+   * out to stub the edge function.
+   */
+  fetchImpl?: typeof fetch;
+
+  /**
+   * Override poll interval (ms). Defaults to 5000 ms. Tests reduce this
+   * to run quickly.
+   */
+  pollIntervalMs?: number;
+
+  /** Override timeout (ms). Defaults to 60_000 ms. */
+  timeoutMs?: number;
+
+  /**
+   * AbortSignal the caller can raise to cancel early. We always register
+   * a SIGINT handler too, but tests use this to drive cancellation
+   * deterministically.
+   */
+  signal?: AbortSignal;
+
+  /**
+   * Stream of status messages — one line per poll / decision. Tests pass
+   * a recorder; real CLI passes stderr or the TUI.
+   */
+  onStatus?: (message: string) => void;
+}
+
+/** Result of {@link runPolicyEngine}. */
+export interface PolicyEngineResult {
+  exitCode: PolicyEngineExitCode;
+  status: 'approved' | 'denied' | 'timeout' | 'cancelled';
+  approvalId?: string;
+  reason?: string;
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/**
+ * Run the policy engine for one tool call.
+ *
+ * @param input - See {@link PolicyEngineInput}.
+ * @returns Terminal status + CLI exit code.
+ *
+ * @example
+ *   const result = await runPolicyEngine({
+ *     sessionId, riskLevel: 'high', toolName: 'Bash',
+ *     supabaseUrl, authToken,
+ *   });
+ *   process.exit(result.exitCode);
+ */
+export async function runPolicyEngine(
+  input: PolicyEngineInput,
+): Promise<PolicyEngineResult> {
+  const {
+    sessionId,
+    riskLevel,
+    toolName,
+    estimatedCostUsd,
+    requestPayload,
+    supabaseUrl,
+    authToken,
+    preCheck,
+    fetchImpl = globalThis.fetch,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    signal: externalSignal,
+    onStatus = () => {},
+  } = input;
+
+  // --- Client-side pre-check (optional) ------------------------------------
+  // WHY this is ONLY advisory: the server re-evaluates the chain on every
+  //   vote. The terminal message is UX — never relied on for security.
+  if (preCheck) {
+    const pre = evaluateApprovalChain({
+      policy: preCheck.policy,
+      approvals: [],
+      roster: preCheck.roster,
+      requesterUserId: preCheck.requesterUserId,
+    });
+    emitPreCheckMessage(onStatus, pre);
+  }
+
+  // --- Wire up cancellation (SIGINT + external signal) ---------------------
+  const controller = new AbortController();
+  const onSigint = () => {
+    onStatus('Cancellation requested (SIGINT). Cleaning up...');
+    controller.abort(new Error('SIGINT'));
+  };
+  const onExternalAbort = () => controller.abort(externalSignal?.reason);
+
+  // WHY we guard with `once`: repeated SIGINTs shouldn't multiply handlers.
+  process.once('SIGINT', onSigint);
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort(externalSignal.reason);
+    } else {
+      externalSignal.addEventListener('abort', onExternalAbort, { once: true });
+    }
+  }
+
+  let approvalId: string | undefined;
+
+  try {
+    // --- Submit the approval request ---------------------------------------
+    // TODO(pr-3): stub until PR #3 adds the `resolve-approval` edge function.
+    //   That PR wires up POST /functions/v1/resolve-approval which (a)
+    //   creates the pending approval row when one doesn't yet exist and
+    //   (b) returns `{ approvalId, status }` on every subsequent poll.
+    //   For now this module calls the endpoint optimistically; in
+    //   unit tests the fetch is stubbed, so no network traffic occurs.
+    const submitResult = await postResolveApproval(fetchImpl, {
+      supabaseUrl,
+      authToken,
+      body: {
+        sessionId,
+        riskLevel,
+        toolName,
+        estimatedCostUsd,
+        requestPayload: requestPayload ?? {},
+        action: 'submit',
+      },
+      signal: controller.signal,
+    });
+    approvalId = submitResult.approvalId;
+
+    if (submitResult.status === 'approved' || submitResult.status === 'denied') {
+      // Server can short-circuit (e.g., policy action = 'block').
+      return terminalResult(submitResult.status, approvalId, submitResult.reason);
+    }
+
+    // --- Poll loop ---------------------------------------------------------
+    const deadline = Date.now() + timeoutMs;
+    while (!controller.signal.aborted) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        onStatus(`Approval timed out after ${timeoutMs} ms.`);
+        await safeCancel(fetchImpl, supabaseUrl, authToken, approvalId);
+        return {
+          exitCode: POLICY_ENGINE_EXIT_CODES.TIMEOUT,
+          status: 'timeout',
+          approvalId,
+          reason: 'Timeout waiting for approval.',
+        };
+      }
+
+      const waitMs = Math.min(pollIntervalMs, remaining);
+      await sleep(waitMs, controller.signal);
+
+      if (controller.signal.aborted) break;
+
+      const poll = await postResolveApproval(fetchImpl, {
+        supabaseUrl,
+        authToken,
+        body: { approvalId, action: 'poll' },
+        signal: controller.signal,
+      });
+
+      if (poll.status === 'approved' || poll.status === 'denied') {
+        return terminalResult(poll.status, approvalId, poll.reason);
+      }
+      onStatus(`Approval still ${poll.status}. Polling again in ${waitMs} ms.`);
+    }
+
+    // --- Cancelled ---------------------------------------------------------
+    await safeCancel(fetchImpl, supabaseUrl, authToken, approvalId);
+    return {
+      exitCode: POLICY_ENGINE_EXIT_CODES.CANCELLED,
+      status: 'cancelled',
+      approvalId,
+      reason: 'Approval cancelled by user.',
+    };
+  } finally {
+    process.removeListener('SIGINT', onSigint);
+    if (externalSignal) {
+      externalSignal.removeEventListener('abort', onExternalAbort);
+    }
+  }
+}
+
+// ============================================================================
+// Internals
+// ============================================================================
+
+/** Payload the `resolve-approval` edge function speaks. */
+interface ResolveApprovalRequest {
+  sessionId?: string;
+  riskLevel?: RiskLevel;
+  toolName?: string;
+  estimatedCostUsd?: number;
+  requestPayload?: Record<string, unknown>;
+  approvalId?: string;
+  action: 'submit' | 'poll' | 'cancel';
+}
+
+/** Shape of the edge-function response. */
+interface ResolveApprovalResponse {
+  approvalId: string;
+  status: Approval['status'];
+  reason?: string;
+}
+
+async function postResolveApproval(
+  fetchImpl: typeof fetch,
+  opts: {
+    supabaseUrl: string;
+    authToken: string;
+    body: ResolveApprovalRequest;
+    signal: AbortSignal;
+  },
+): Promise<ResolveApprovalResponse> {
+  const url = `${opts.supabaseUrl.replace(/\/+$/, '')}/functions/v1/resolve-approval`;
+  const res = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${opts.authToken}`,
+    },
+    body: JSON.stringify(opts.body),
+    signal: opts.signal,
+  });
+
+  if (!res.ok) {
+    const text = await safeText(res);
+    throw new Error(
+      `resolve-approval HTTP ${res.status}: ${text || res.statusText}`,
+    );
+  }
+
+  return (await res.json()) as ResolveApprovalResponse;
+}
+
+async function safeCancel(
+  fetchImpl: typeof fetch,
+  supabaseUrl: string,
+  authToken: string,
+  approvalId: string | undefined,
+): Promise<void> {
+  if (!approvalId) return;
+  // WHY we swallow errors here: we are already on the exit path. Failing
+  //   to cancel a row is noisy but not fatal — the cron sweeper defined
+  //   in migration 021 will mark it 'expired' within 15 minutes.
+  try {
+    await postResolveApproval(fetchImpl, {
+      supabaseUrl,
+      authToken,
+      body: { approvalId, action: 'cancel' },
+      signal: neverAbort,
+    });
+  } catch {
+    // intentional swallow — best-effort cleanup
+  }
+}
+
+/** A never-aborting signal so cleanup fetches don't inherit the aborted parent. */
+const neverAbort: AbortSignal = new AbortController().signal;
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Sleep that resolves early when `signal` aborts. Tests advance fake
+ * timers and immediately abort to simulate SIGINT mid-wait.
+ */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function terminalResult(
+  status: 'approved' | 'denied',
+  approvalId: string | undefined,
+  reason?: string,
+): PolicyEngineResult {
+  return {
+    exitCode:
+      status === 'approved'
+        ? POLICY_ENGINE_EXIT_CODES.APPROVED
+        : POLICY_ENGINE_EXIT_CODES.DENIED,
+    status,
+    approvalId,
+    reason,
+  };
+}
+
+function emitPreCheckMessage(
+  onStatus: (m: string) => void,
+  result: ApprovalChainResult,
+): void {
+  if (result.status === 'auto-approved') {
+    onStatus('Pre-check: no approval required for this call.');
+    return;
+  }
+  if (result.status === 'denied') {
+    onStatus(`Pre-check: this call will be denied (${result.reason}).`);
+    return;
+  }
+  if (result.requiredApprovers.length === 0) {
+    onStatus(
+      'Pre-check: approval required but no eligible approvers are available. ' +
+        'An admin must fix the policy.',
+    );
+    return;
+  }
+  onStatus(
+    `Pre-check: this call will require approval from one of ${result.requiredApprovers.join(', ')}.`,
+  );
+}

--- a/packages/styrby-shared/package.json
+++ b/packages/styrby-shared/package.json
@@ -44,6 +44,10 @@
     "./tokenizers": {
       "types": "./dist/tokenizers/index.d.ts",
       "import": "./dist/tokenizers/index.js"
+    },
+    "./team": {
+      "types": "./dist/team/index.d.ts",
+      "import": "./dist/team/index.js"
     }
   },
   "scripts": {

--- a/packages/styrby-shared/src/index.ts
+++ b/packages/styrby-shared/src/index.ts
@@ -53,16 +53,19 @@ export * from './hooks/index.js';
 export * from './tokenizers/index.js';
 
 // Phase 2 — Team Tier (0.8.7 + 0.9.2).
-// Team governance types (DB-mirroring interfaces + Zod schemas + runtime
-// constant arrays). Safe to barrel: pure types/data, zero platform deps.
+// DB-mirror types (interfaces + Zod schemas + runtime constants). These
+// are the thin shape-of-table types used by CRUD API code. The policy
+// engine in `./team/` owns the canonical names `TeamPolicy` and
+// `ApprovalStatus` (richer engine-flavored variants); the DB variants are
+// prefixed `Db*` at the source to keep both accessible without collision.
 export * from './teams/index.js';
 // Tier-check utilities covering all six billing tiers including the team family.
 // Both web and mobile consume these so a gating decision can never disagree
 // across surfaces (SOC2 CC6.1).
 export * from './tiers/index.js';
 // Phase 2.1 — team governance runtime helpers (role matrix, approval chain
-// evaluator). Team TYPES live in `./teams/`; this module adds the behavioral
-// utilities consumed by CLI policyEngine + web admin + mobile push-approval.
+// evaluator) + the engine-flavored TeamPolicy/ApprovalStatus used by the
+// policy engine in CLI, web admin, and mobile push-approval.
 export * from './team/index.js';
 
 // WHY: The full pricing module is NOT re-exported from the barrel.

--- a/packages/styrby-shared/src/index.ts
+++ b/packages/styrby-shared/src/index.ts
@@ -60,6 +60,10 @@ export * from './teams/index.js';
 // Both web and mobile consume these so a gating decision can never disagree
 // across surfaces (SOC2 CC6.1).
 export * from './tiers/index.js';
+// Phase 2.1 — team governance runtime helpers (role matrix, approval chain
+// evaluator). Team TYPES live in `./teams/`; this module adds the behavioral
+// utilities consumed by CLI policyEngine + web admin + mobile push-approval.
+export * from './team/index.js';
 
 // WHY: The full pricing module is NOT re-exported from the barrel.
 // litellm-pricing.ts uses Node.js builtins (node:path, node:os, node:fs, node:crypto)

--- a/packages/styrby-shared/src/team/__tests__/approval-chain.test.ts
+++ b/packages/styrby-shared/src/team/__tests__/approval-chain.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for the approval-chain evaluator.
+ *
+ * Covers the happy path plus the edge cases called out in the module
+ * docstring (revoked approver, downgraded team, zero approvers,
+ * self-approval). Includes a determinism property test: for the same
+ * input, the output is byte-identical every invocation.
+ *
+ * @module team/__tests__/approval-chain
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateApprovalChain, type RosterMember } from '../approval-chain.js';
+import type { Approval, TeamPolicy } from '../types.js';
+
+const UUID = (n: number) => `00000000-0000-0000-0000-${String(n).padStart(12, '0')}`;
+const ISO = '2026-04-20T00:00:00.000Z';
+
+/** Factory: policy requiring any admin approval. */
+function policyRequireApproval(overrides: Partial<TeamPolicy> = {}): TeamPolicy {
+  return {
+    id: UUID(1),
+    teamId: UUID(2),
+    name: 'Require approval for Bash',
+    description: null,
+    ruleType: 'tool_allowlist',
+    threshold: null,
+    approverRole: 'any_admin',
+    approverUserId: null,
+    agentFilter: ['bash'],
+    action: 'require_approval',
+    settings: {},
+    enabled: true,
+    priority: 100,
+    createdBy: UUID(3),
+    createdAt: ISO,
+    updatedAt: ISO,
+    ...overrides,
+  };
+}
+
+function member(userId: string, role: RosterMember['role'], active = true): RosterMember {
+  return { userId, role, active };
+}
+
+function approval(
+  status: Approval['status'],
+  resolverUserId: string | null,
+  requesterUserId: string = UUID(100),
+): Pick<Approval, 'status' | 'resolverUserId' | 'requesterUserId'> {
+  return { status, resolverUserId, requesterUserId };
+}
+
+describe('evaluateApprovalChain — happy paths', () => {
+  it('auto-approves when no policy applies', () => {
+    const result = evaluateApprovalChain({
+      policy: null,
+      approvals: [],
+      roster: [],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('auto-approved');
+    expect(result.requiredApprovers).toEqual([]);
+  });
+
+  it('auto-approves when policy action is allow_with_audit', () => {
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval({ action: 'allow_with_audit' }),
+      approvals: [],
+      roster: [member(UUID(10), 'admin')],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('auto-approved');
+  });
+
+  it('denies when policy action is block', () => {
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval({ action: 'block' }),
+      approvals: [],
+      roster: [member(UUID(10), 'admin')],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('denied');
+  });
+
+  it('returns pending with the admin list when awaiting votes', () => {
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval(),
+      approvals: [],
+      roster: [
+        member(UUID(10), 'owner'),
+        member(UUID(11), 'admin'),
+        member(UUID(12), 'member'),
+      ],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('pending');
+    expect(result.requiredApprovers.sort()).toEqual([UUID(10), UUID(11)].sort());
+  });
+
+  it('auto-approves once an eligible approver votes approved', () => {
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval(),
+      approvals: [approval('approved', UUID(11))],
+      roster: [member(UUID(11), 'admin')],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('auto-approved');
+  });
+
+  it('denies on first eligible denial', () => {
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval(),
+      approvals: [
+        approval('denied', UUID(11)),
+        approval('approved', UUID(10)), // later approval should NOT override
+      ],
+      roster: [member(UUID(10), 'owner'), member(UUID(11), 'admin')],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('denied');
+  });
+});
+
+describe('evaluateApprovalChain — edge cases', () => {
+  it('ignores votes from a revoked (inactive) approver', () => {
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval(),
+      approvals: [approval('approved', UUID(11))],
+      roster: [member(UUID(11), 'admin', /* active */ false)],
+      requesterUserId: UUID(100),
+    });
+    // Revoked approver's vote is disregarded, nobody else eligible →
+    // fail-safe pending.
+    expect(result.status).toBe('pending');
+    expect(result.requiredApprovers).toEqual([]);
+    expect(result.reason).toMatch(/no eligible approvers/i);
+  });
+
+  it('handles team downgrade: admin demoted to member no longer eligible', () => {
+    // The once-admin 11 is now a member — their historical approval
+    // does NOT satisfy the policy.
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval(),
+      approvals: [approval('approved', UUID(11))],
+      roster: [member(UUID(11), 'member')],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('pending');
+    expect(result.requiredApprovers).toEqual([]);
+  });
+
+  it('fails safe to pending when zero approvers are configured', () => {
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval(),
+      approvals: [],
+      roster: [member(UUID(100), 'member')], // only the requester, and they are not an approver
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('pending');
+    expect(result.requiredApprovers).toEqual([]);
+    expect(result.reason).toMatch(/no eligible approvers/i);
+  });
+
+  it('disallows self-approval even for owners', () => {
+    const ownerAndRequester = UUID(10);
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval(),
+      approvals: [approval('approved', ownerAndRequester)],
+      roster: [
+        member(ownerAndRequester, 'owner'),
+        member(UUID(11), 'admin'),
+      ],
+      requesterUserId: ownerAndRequester,
+    });
+    // Owner voted for their own request — filtered out. Admin 11 still
+    // pending → result is pending with 11 as required.
+    expect(result.status).toBe('pending');
+    expect(result.requiredApprovers).toEqual([UUID(11)]);
+  });
+
+  it('honors specific_user approver role', () => {
+    const specific = UUID(11);
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval({
+        approverRole: 'specific_user',
+        approverUserId: specific,
+      }),
+      approvals: [],
+      roster: [
+        member(UUID(10), 'owner'),
+        member(specific, 'member'),
+      ],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('pending');
+    expect(result.requiredApprovers).toEqual([specific]);
+  });
+
+  it('treats specific_user policy with null approverUserId as misconfigured', () => {
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval({
+        approverRole: 'specific_user',
+        approverUserId: null,
+      }),
+      approvals: [],
+      roster: [member(UUID(10), 'owner'), member(UUID(11), 'admin')],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('pending');
+    expect(result.requiredApprovers).toEqual([]);
+    expect(result.reason).toMatch(/no eligible approvers/i);
+  });
+
+  it('falls back to admin-or-owner when approverRole is null', () => {
+    const result = evaluateApprovalChain({
+      policy: policyRequireApproval({ approverRole: null }),
+      approvals: [],
+      roster: [
+        member(UUID(10), 'owner'),
+        member(UUID(11), 'admin'),
+        member(UUID(12), 'member'),
+      ],
+      requesterUserId: UUID(100),
+    });
+    expect(result.status).toBe('pending');
+    expect(result.requiredApprovers.sort()).toEqual([UUID(10), UUID(11)].sort());
+  });
+});
+
+describe('evaluateApprovalChain — determinism', () => {
+  it('returns byte-identical output for the same input across many invocations', () => {
+    // Simple property-style test: same input → same output, 100 iterations.
+    const input = {
+      policy: policyRequireApproval(),
+      approvals: [approval('approved', UUID(11))],
+      roster: [member(UUID(10), 'owner'), member(UUID(11), 'admin')],
+      requesterUserId: UUID(100),
+    };
+    const first = JSON.stringify(evaluateApprovalChain(input));
+    for (let i = 0; i < 100; i += 1) {
+      expect(JSON.stringify(evaluateApprovalChain(input))).toBe(first);
+    }
+  });
+});

--- a/packages/styrby-shared/src/team/__tests__/role-matrix.test.ts
+++ b/packages/styrby-shared/src/team/__tests__/role-matrix.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the role → permission matrix.
+ *
+ * Exhaustively walks every (role × permission) pair so any accidental
+ * matrix edit that drops or flips a bit fails loudly.
+ *
+ * @module team/__tests__/role-matrix
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  canApprove,
+  canEditPolicy,
+  canInvite,
+  canManageBilling,
+  canRevokeMember,
+  hasPermission,
+  ROLE_PERMISSION_MATRIX,
+} from '../role-matrix.js';
+import { ALL_POLICY_ROLES, type Permission, type PolicyRole } from '../types.js';
+
+const EXPECTED: Record<PolicyRole, Record<Permission, boolean>> = {
+  owner: {
+    invite: true,
+    revokeMember: true,
+    approve: true,
+    editPolicy: true,
+    manageBilling: true,
+  },
+  admin: {
+    invite: true,
+    revokeMember: true,
+    approve: true,
+    editPolicy: true,
+    manageBilling: false,
+  },
+  approver: {
+    invite: false,
+    revokeMember: false,
+    approve: true,
+    editPolicy: false,
+    manageBilling: false,
+  },
+  member: {
+    invite: false,
+    revokeMember: false,
+    approve: false,
+    editPolicy: false,
+    manageBilling: false,
+  },
+};
+
+describe('ROLE_PERMISSION_MATRIX', () => {
+  it('is frozen', () => {
+    expect(Object.isFrozen(ROLE_PERMISSION_MATRIX)).toBe(true);
+    for (const role of ALL_POLICY_ROLES) {
+      expect(Object.isFrozen(ROLE_PERMISSION_MATRIX[role])).toBe(true);
+    }
+  });
+
+  it('matches the expected 4×5 truth table', () => {
+    for (const role of ALL_POLICY_ROLES) {
+      for (const perm of Object.keys(EXPECTED.owner) as Permission[]) {
+        expect(
+          hasPermission(role, perm),
+          `role=${role}, perm=${perm}`,
+        ).toBe(EXPECTED[role][perm]);
+      }
+    }
+  });
+});
+
+describe('named helpers', () => {
+  it('canInvite matches matrix', () => {
+    for (const role of ALL_POLICY_ROLES) {
+      expect(canInvite(role)).toBe(EXPECTED[role].invite);
+    }
+  });
+
+  it('canRevokeMember matches matrix', () => {
+    for (const role of ALL_POLICY_ROLES) {
+      expect(canRevokeMember(role)).toBe(EXPECTED[role].revokeMember);
+    }
+  });
+
+  it('canApprove matches matrix', () => {
+    for (const role of ALL_POLICY_ROLES) {
+      expect(canApprove(role)).toBe(EXPECTED[role].approve);
+    }
+  });
+
+  it('canEditPolicy matches matrix', () => {
+    for (const role of ALL_POLICY_ROLES) {
+      expect(canEditPolicy(role)).toBe(EXPECTED[role].editPolicy);
+    }
+  });
+
+  it('canManageBilling matches matrix', () => {
+    for (const role of ALL_POLICY_ROLES) {
+      expect(canManageBilling(role)).toBe(EXPECTED[role].manageBilling);
+    }
+  });
+});

--- a/packages/styrby-shared/src/team/__tests__/types.test.ts
+++ b/packages/styrby-shared/src/team/__tests__/types.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for team-governance zod schemas and literal-union types.
+ *
+ * The schemas are the contract between the server (migration 021) and
+ * every client surface. A regression here is a silent cross-tenant
+ * bug waiting to happen.
+ *
+ * @module team/__tests__/types
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  approvalSchema,
+  billingEventSchema,
+  exportRequestSchema,
+  integrationSchema,
+  sessionShareSchema,
+  teamPolicySchema,
+  ALL_POLICY_ROLES,
+  POLICY_ENGINE_EXIT_CODES,
+  type PolicyRole,
+  type Permission,
+} from '../types.js';
+
+const UUID = '00000000-0000-0000-0000-000000000001';
+const ISO = '2026-04-20T00:00:00.000Z';
+
+describe('teamPolicySchema', () => {
+  const base = {
+    id: UUID,
+    teamId: UUID,
+    name: 'Block risky tools',
+    description: null,
+    ruleType: 'tool_allowlist' as const,
+    threshold: null,
+    approverRole: 'admin' as const,
+    approverUserId: null,
+    agentFilter: ['bash'],
+    action: 'require_approval' as const,
+    settings: {},
+    enabled: true,
+    priority: 100,
+    createdBy: UUID,
+    createdAt: ISO,
+    updatedAt: ISO,
+  };
+
+  it('accepts a valid row', () => {
+    expect(() => teamPolicySchema.parse(base)).not.toThrow();
+  });
+
+  it('rejects empty name', () => {
+    expect(() => teamPolicySchema.parse({ ...base, name: '' })).toThrow();
+  });
+
+  it('rejects over-long name', () => {
+    expect(() => teamPolicySchema.parse({ ...base, name: 'x'.repeat(201) })).toThrow();
+  });
+
+  it('rejects unknown ruleType', () => {
+    expect(() =>
+      teamPolicySchema.parse({ ...base, ruleType: 'made_up' as unknown as 'cost_threshold' }),
+    ).toThrow();
+  });
+
+  it('rejects unknown action', () => {
+    expect(() =>
+      teamPolicySchema.parse({ ...base, action: 'nuke' as unknown as 'block' }),
+    ).toThrow();
+  });
+
+  it('allows null approverRole (default admin-or-owner)', () => {
+    expect(() =>
+      teamPolicySchema.parse({ ...base, approverRole: null }),
+    ).not.toThrow();
+  });
+});
+
+describe('approvalSchema', () => {
+  const base = {
+    id: UUID,
+    teamId: UUID,
+    sessionId: UUID,
+    policyId: UUID,
+    requesterUserId: UUID,
+    toolName: 'Bash',
+    estimatedCostUsd: 0.05,
+    requestPayload: { command: 'ls' },
+    status: 'pending' as const,
+    resolverUserId: null,
+    resolutionNote: null,
+    expiresAt: ISO,
+    createdAt: ISO,
+    resolvedAt: null,
+  };
+
+  it('accepts each valid status', () => {
+    for (const status of ['pending', 'approved', 'denied', 'expired', 'cancelled'] as const) {
+      expect(() => approvalSchema.parse({ ...base, status })).not.toThrow();
+    }
+  });
+
+  it('rejects empty toolName', () => {
+    expect(() => approvalSchema.parse({ ...base, toolName: '' })).toThrow();
+  });
+
+  it('rejects unknown status', () => {
+    expect(() =>
+      approvalSchema.parse({ ...base, status: 'ghosted' as unknown as 'pending' }),
+    ).toThrow();
+  });
+});
+
+describe('sessionShareSchema', () => {
+  it('accepts a valid share', () => {
+    expect(() =>
+      sessionShareSchema.parse({
+        id: UUID,
+        sessionId: UUID,
+        sharedWithUserId: UUID,
+        sharedByUserId: UUID,
+        permission: 'view',
+        expiresAt: null,
+        createdAt: ISO,
+        revokedAt: null,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('exportRequestSchema', () => {
+  it('accepts a ready export', () => {
+    expect(() =>
+      exportRequestSchema.parse({
+        id: UUID,
+        userId: UUID,
+        format: 'zip',
+        scope: 'all',
+        status: 'ready',
+        errorMessage: null,
+        downloadUrl: 'https://storage.example/obj',
+        downloadPath: 'exports/abc.zip',
+        sizeBytes: 1024,
+        expiresAt: ISO,
+        createdAt: ISO,
+        completedAt: ISO,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('integrationSchema', () => {
+  it('accepts an active integration', () => {
+    expect(() =>
+      integrationSchema.parse({
+        id: UUID,
+        teamId: UUID,
+        provider: 'slack',
+        displayName: 'Engineering',
+        externalAccountId: 'T0001',
+        configEncrypted: 'base64opaque==',
+        encryptionKeyId: 'default',
+        status: 'active',
+        lastError: null,
+        installedBy: UUID,
+        installedAt: ISO,
+        updatedAt: ISO,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('billingEventSchema', () => {
+  it('accepts a received Polar event', () => {
+    expect(() =>
+      billingEventSchema.parse({
+        id: UUID,
+        userId: UUID,
+        subscriptionId: UUID,
+        eventType: 'subscription.created',
+        amountUsd: 49.0,
+        currency: 'USD',
+        status: 'received',
+        polarEventId: 'evt_abc',
+        rawPayload: { polar: 'raw' },
+        processedAt: null,
+        createdAt: ISO,
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects empty polarEventId', () => {
+    expect(() =>
+      billingEventSchema.parse({
+        id: UUID,
+        userId: null,
+        subscriptionId: null,
+        eventType: 'subscription.created',
+        amountUsd: null,
+        currency: null,
+        status: 'received',
+        polarEventId: '',
+        rawPayload: {},
+        processedAt: null,
+        createdAt: ISO,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('type-level invariants', () => {
+  it('ALL_POLICY_ROLES enumerates every PolicyRole once', () => {
+    const expected: PolicyRole[] = ['owner', 'admin', 'approver', 'member'];
+    expect([...ALL_POLICY_ROLES].sort()).toEqual(expected.sort());
+  });
+
+  it('Permission union covers all five governance capabilities', () => {
+    // Assignment is the assertion — typecheck fails if a variant is missing.
+    const perms: Permission[] = [
+      'invite',
+      'revokeMember',
+      'approve',
+      'editPolicy',
+      'manageBilling',
+    ];
+    expect(perms).toHaveLength(5);
+  });
+
+  it('exit codes are stable', () => {
+    expect(POLICY_ENGINE_EXIT_CODES).toEqual({
+      APPROVED: 0,
+      DENIED: 10,
+      TIMEOUT: 124,
+      CANCELLED: 130,
+    });
+  });
+});

--- a/packages/styrby-shared/src/team/approval-chain.ts
+++ b/packages/styrby-shared/src/team/approval-chain.ts
@@ -1,0 +1,247 @@
+/**
+ * Approval-chain evaluator (Phase 2.1).
+ *
+ * Pure function that decides whether a proposed tool call can auto-approve,
+ * must wait for humans, or must be denied outright.
+ *
+ * Used in three places:
+ *   1. CLI `policyEngine` — client-side pre-check, show "will require
+ *      approval from X, Y, Z" UI before submitting.
+ *   2. Supabase edge function `resolve-approval` — re-run server-side on
+ *      every vote tally to decide the terminal status.
+ *   3. Web / mobile admin UIs — preview what will happen for a given
+ *      policy + roster.
+ *
+ * Keeping this pure (no I/O, no clock unless injected) means we can drop
+ * it into all three surfaces without touching transport code.
+ *
+ * @module team/approval-chain
+ */
+
+import type { Approval, PolicyRole, TeamPolicy } from './types.js';
+
+// ============================================================================
+// Inputs & outputs
+// ============================================================================
+
+/**
+ * A member of the team's current roster. We keep this minimal (id + role +
+ * active flag) because the chain evaluator never needs profile data.
+ */
+export interface RosterMember {
+  userId: string;
+  role: PolicyRole;
+  /**
+   * `true` if the member is still active on the team. Revoked members stay
+   * in roster snapshots so that historical decisions remain reproducible.
+   */
+  active: boolean;
+}
+
+/** Inputs to {@link evaluateApprovalChain}. */
+export interface ApprovalChainInput {
+  /**
+   * The policy that flagged the tool call. When `null`, the caller is asking
+   * "is there even a policy to evaluate?" — we return `auto-approved` so
+   * the CLI can pass through without requiring humans.
+   */
+  policy: TeamPolicy | null;
+
+  /**
+   * All approval rows for this (session, tool) pair. Votes from revoked
+   * approvers are filtered out by {@link evaluateApprovalChain}.
+   */
+  approvals: ReadonlyArray<Pick<Approval, 'status' | 'resolverUserId' | 'requesterUserId'>>;
+
+  /** Current roster snapshot. */
+  roster: ReadonlyArray<RosterMember>;
+
+  /** User who requested the tool call. Used to block self-approval. */
+  requesterUserId: string;
+}
+
+/** Terminal status returned from the evaluator. */
+export type ApprovalChainStatus = 'auto-approved' | 'pending' | 'denied';
+
+/** Result of {@link evaluateApprovalChain}. */
+export interface ApprovalChainResult {
+  status: ApprovalChainStatus;
+
+  /**
+   * Users currently eligible to approve. Empty when `status` is terminal
+   * (auto-approved or denied).
+   */
+  requiredApprovers: string[];
+
+  /** Human-readable rationale. Always present for terminal statuses. */
+  reason?: string;
+}
+
+// ============================================================================
+// Evaluator
+// ============================================================================
+
+/**
+ * Pure, deterministic approval-chain evaluator.
+ *
+ * Decision tree:
+ *   1. No policy                         → auto-approved
+ *   2. Policy action 'allow_with_audit'  → auto-approved
+ *   3. Policy action 'block'             → denied
+ *   4. Any approval row `denied`         → denied (first denier wins)
+ *   5. Any approval row `approved` by an active eligible approver → auto-approved
+ *   6. No eligible approvers found       → pending, fail-safe reason
+ *   7. Otherwise                         → pending with eligible approver list
+ *
+ * Edge cases handled (each has a WHY comment at the relevant branch):
+ *   - Approver revoked mid-approval (inactive roster member).
+ *   - Team downgraded (approver role no longer matches policy).
+ *   - Zero approvers configured (fail-safe to pending — never auto-approve).
+ *   - Self-approval (requester attempts to approve their own request).
+ *
+ * @param input - Policy, approvals, roster, requester.
+ * @returns Terminal status + remaining required approvers.
+ */
+export function evaluateApprovalChain(
+  input: ApprovalChainInput,
+): ApprovalChainResult {
+  const { policy, approvals, roster, requesterUserId } = input;
+
+  // --- 1. No policy guarding this call. Pass through. -----------------------
+  if (!policy) {
+    return {
+      status: 'auto-approved',
+      requiredApprovers: [],
+      reason: 'No matching policy — tool call auto-approved.',
+    };
+  }
+
+  // --- 2/3. Policy action short-circuits. -----------------------------------
+  if (policy.action === 'allow_with_audit') {
+    return {
+      status: 'auto-approved',
+      requiredApprovers: [],
+      reason: `Policy "${policy.name}" allows with audit only.`,
+    };
+  }
+
+  if (policy.action === 'block') {
+    return {
+      status: 'denied',
+      requiredApprovers: [],
+      reason: `Policy "${policy.name}" blocks this tool call.`,
+    };
+  }
+
+  // Past this point, action must be 'require_approval'.
+
+  // Build the set of *currently eligible* approvers from the roster.
+  // WHY this is computed from a fresh roster snapshot every call:
+  //   an approver revoked after the policy was written must NOT be
+  //   counted, even if their historical vote already exists in
+  //   `approvals`. Security failure mode: granting a revoked user
+  //   lingering authority is a CC6 violation.
+  const eligibleApproverIds = roster
+    .filter((m) => m.active && isEligibleApproverFor(m, policy))
+    // WHY exclude the requester: prevent self-approval. Even an owner
+    // who initiates a tool call must not be able to rubber-stamp their
+    // own request (SOC2 CC6.3, separation of duties).
+    .filter((m) => m.userId !== requesterUserId)
+    .map((m) => m.userId);
+
+  // --- 6. Zero approvers configured. Fail-safe. -----------------------------
+  if (eligibleApproverIds.length === 0) {
+    // WHY pending (not auto-approved) when no approvers exist:
+    //   an admin misconfiguration MUST NOT silently bypass the control.
+    //   The pending row forces a human to notice the dead-end and fix
+    //   the policy or roster.
+    return {
+      status: 'pending',
+      requiredApprovers: [],
+      reason:
+        `Policy "${policy.name}" requires approval, but no eligible approvers remain. ` +
+        'An admin must re-configure the policy or add approvers.',
+    };
+  }
+
+  // --- 4. First denial wins. ------------------------------------------------
+  // WHY iterate `approvals` ordered by status priority, not chronologically:
+  //   a single denial is decisive; any approval after a denial does not
+  //   re-open the decision.
+  const denialByEligible = approvals.find(
+    (a) =>
+      a.status === 'denied' &&
+      a.resolverUserId !== null &&
+      eligibleApproverIds.includes(a.resolverUserId),
+  );
+  if (denialByEligible) {
+    return {
+      status: 'denied',
+      requiredApprovers: [],
+      reason: `Request denied by ${denialByEligible.resolverUserId}.`,
+    };
+  }
+
+  // --- 5. Single eligible approval is sufficient. ---------------------------
+  // WHY single approval rather than M-of-N: migration 021 models policy
+  //   `approverRole` as a single slot (owner | admin | any_admin |
+  //    specific_user). Multi-signature chains are a Phase 3+ feature —
+  //   capture them via N separate policies if needed in the interim.
+  const approvalByEligible = approvals.find(
+    (a) =>
+      a.status === 'approved' &&
+      a.resolverUserId !== null &&
+      eligibleApproverIds.includes(a.resolverUserId),
+  );
+  if (approvalByEligible) {
+    return {
+      status: 'auto-approved',
+      requiredApprovers: [],
+      reason: `Approved by ${approvalByEligible.resolverUserId}.`,
+    };
+  }
+
+  // --- 7. Still waiting. ----------------------------------------------------
+  return {
+    status: 'pending',
+    requiredApprovers: eligibleApproverIds,
+  };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Decide whether a roster member is currently eligible to approve under
+ * this policy. Encapsulates the policy's `approverRole` semantics so the
+ * evaluator above reads cleanly.
+ */
+function isEligibleApproverFor(
+  member: RosterMember,
+  policy: TeamPolicy,
+): boolean {
+  const approverRole = policy.approverRole;
+
+  // Default-fallback: if the policy did not specify an approver role,
+  // require an owner or admin. Matches the behavior described in
+  // migration 021 (admin-or-owner as the safe default).
+  if (approverRole === null || approverRole === undefined) {
+    return member.role === 'owner' || member.role === 'admin';
+  }
+
+  switch (approverRole) {
+    case 'owner':
+      return member.role === 'owner';
+    case 'admin':
+      return member.role === 'admin' || member.role === 'owner';
+    case 'any_admin':
+      return member.role === 'admin' || member.role === 'owner';
+    case 'specific_user':
+      // WHY the type-level fallback: if the DB returned 'specific_user'
+      //   but the `approverUserId` column is NULL (bad data), we treat
+      //   this as "no eligible approvers" — caller will see the
+      //   misconfiguration-fail-safe branch above.
+      return policy.approverUserId !== null && member.userId === policy.approverUserId;
+  }
+}

--- a/packages/styrby-shared/src/team/index.ts
+++ b/packages/styrby-shared/src/team/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Team governance barrel (Phase 2.1).
+ *
+ * Re-exports the types + role matrix + approval-chain evaluator used by
+ * CLI, web, and mobile for Team/Business tier governance.
+ *
+ * @module team
+ */
+
+export * from './types.js';
+export * from './role-matrix.js';
+export * from './approval-chain.js';

--- a/packages/styrby-shared/src/team/role-matrix.ts
+++ b/packages/styrby-shared/src/team/role-matrix.ts
@@ -1,0 +1,100 @@
+/**
+ * Role → permission matrix (Phase 2.1).
+ *
+ * Single source of truth for "can role X do Y?" across CLI, web, and
+ * mobile. Every governance UI MUST import from here instead of
+ * re-deriving the check inline — otherwise a member screen on mobile
+ * and admin screen on web can disagree about who can approve, which
+ * is a SOC2 CC6 (Logical Access) defect.
+ *
+ * The matrix pairs with migration 021 RLS policies. RLS is the
+ * enforcement boundary; this matrix is the *UI* contract that keeps
+ * the frontends honest before they hit the server.
+ *
+ * @module team/role-matrix
+ */
+
+import type { Permission, PolicyRole } from './types.js';
+
+/**
+ * The full permission matrix.
+ *
+ * WHY frozen object + explicit listing rather than a boolean-returning
+ * switch: freezing the literal makes it trivially testable (tests
+ * assert directly on MATRIX[role][perm]) and trivially auditable by
+ * humans. A switch hides the matrix in control flow.
+ */
+export const ROLE_PERMISSION_MATRIX: Readonly<
+  Record<PolicyRole, Readonly<Record<Permission, boolean>>>
+> = Object.freeze({
+  owner: Object.freeze({
+    invite: true,
+    revokeMember: true,
+    approve: true,
+    editPolicy: true,
+    manageBilling: true,
+  }),
+  admin: Object.freeze({
+    invite: true,
+    revokeMember: true,
+    approve: true,
+    editPolicy: true,
+    manageBilling: false, // only owners touch billing
+  }),
+  approver: Object.freeze({
+    // 'approver' is a policy-scoped capability: designated users can
+    // approve, but they cannot manage team membership or policy.
+    invite: false,
+    revokeMember: false,
+    approve: true,
+    editPolicy: false,
+    manageBilling: false,
+  }),
+  member: Object.freeze({
+    invite: false,
+    revokeMember: false,
+    approve: false,
+    editPolicy: false,
+    manageBilling: false,
+  }),
+});
+
+/**
+ * Generic permission check. Prefer the named helpers below for
+ * call-site readability.
+ *
+ * @param role - Role of the acting user
+ * @param permission - Governance permission being checked
+ * @returns `true` if the role grants the permission
+ */
+export function hasPermission(
+  role: PolicyRole,
+  permission: Permission,
+): boolean {
+  return ROLE_PERMISSION_MATRIX[role][permission];
+}
+
+/** Can this role invite new members to the team? */
+export function canInvite(role: PolicyRole): boolean {
+  return hasPermission(role, 'invite');
+}
+
+/** Can this role revoke another team member? */
+export function canRevokeMember(role: PolicyRole): boolean {
+  return hasPermission(role, 'revokeMember');
+}
+
+/** Can this role resolve a pending approval request? */
+export function canApprove(role: PolicyRole): boolean {
+  return hasPermission(role, 'approve');
+}
+
+/** Can this role edit / add / delete team policies? */
+export function canEditPolicy(role: PolicyRole): boolean {
+  return hasPermission(role, 'editPolicy');
+}
+
+/** Can this role manage subscription / billing / seats? */
+export function canManageBilling(role: PolicyRole): boolean {
+  return hasPermission(role, 'manageBilling');
+}

--- a/packages/styrby-shared/src/team/types.ts
+++ b/packages/styrby-shared/src/team/types.ts
@@ -1,0 +1,308 @@
+/**
+ * Team governance types (Phase 2.1).
+ *
+ * TypeScript + Zod mirrors of the `team_policies`, `approvals`,
+ * `sessions_shared`, `exports`, `integrations`, and `billing_events`
+ * tables defined in `supabase/migrations/021_team_governance.sql`.
+ *
+ * These types are the single shared truth for CLI, web, and mobile.
+ * Import from `@styrby/shared` (barrel) or this module directly.
+ *
+ * WHY this lives in `@styrby/shared` rather than per-surface:
+ *   - One team-governance domain, three UIs (CLI polls, web dashboards,
+ *     mobile push-approvals). Any drift between surfaces would manifest
+ *     as hard-to-debug cross-tenant bugs. Colocate the truth.
+ *   - The migration is the schema contract; these types are its dual.
+ *
+ * @module team/types
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Role matrix
+// ============================================================================
+
+/**
+ * Database-level team role as stored in `team_members.role` (migration 006).
+ *
+ * The physical column only knows three roles. "Approver" authority is
+ * derived at runtime from {@link TeamPolicy.approverRole} rather than being
+ * a separate row in `team_members`. See {@link PolicyRole} for the logical
+ * extension used by the approval-chain evaluator.
+ */
+export type DbRole = 'owner' | 'admin' | 'member';
+
+/**
+ * Logical role used by the approval-chain engine.
+ *
+ * `approver` is a policy-scoped capability, not a stored column. A user
+ * is an "approver" for a given approval request when:
+ *   (a) they are owner/admin AND the policy's `approverRole` is
+ *       'owner', 'admin', or 'any_admin', OR
+ *   (b) the policy's `approverRole` is 'specific_user' and they are
+ *       the named `approverUserId`.
+ *
+ * The helpers in {@link ./role-matrix} encode the (db-role, policy-role)
+ * → permission mapping so every surface asks the same question.
+ */
+export type PolicyRole = 'owner' | 'admin' | 'approver' | 'member';
+
+/** All four logical roles as a const array for exhaustive iteration in tests. */
+export const ALL_POLICY_ROLES: readonly PolicyRole[] = [
+  'owner',
+  'admin',
+  'approver',
+  'member',
+] as const;
+
+/**
+ * A single governance permission the role matrix decides.
+ *
+ * Keep this list tight — each new permission is a new policy surface
+ * that every client must handle consistently.
+ */
+export type Permission =
+  | 'invite'
+  | 'revokeMember'
+  | 'approve'
+  | 'editPolicy'
+  | 'manageBilling';
+
+// ============================================================================
+// team_policies
+// ============================================================================
+
+/** Allowed values for {@link TeamPolicy.ruleType}. Mirrors SQL CHECK constraint. */
+export type PolicyRuleType =
+  | 'cost_threshold'
+  | 'agent_filter'
+  | 'tool_allowlist'
+  | 'time_window';
+
+/** Allowed values for {@link TeamPolicy.action}. Mirrors SQL CHECK constraint. */
+export type PolicyAction = 'block' | 'require_approval' | 'allow_with_audit';
+
+/** Allowed values for {@link TeamPolicy.approverRole}. */
+export type PolicyApproverRole =
+  | 'owner'
+  | 'admin'
+  | 'any_admin'
+  | 'specific_user';
+
+/**
+ * Zod schema for {@link TeamPolicy}. Shapes the row as returned from
+ * PostgREST (snake_case) but the derived TS type uses camelCase via
+ * the post-parse transform in callers. See the `TeamPolicy` interface
+ * for the public-facing camelCase type.
+ */
+export const teamPolicySchema = z.object({
+  id: z.string().uuid(),
+  teamId: z.string().uuid(),
+  name: z.string().min(1).max(200),
+  description: z.string().nullable(),
+  ruleType: z.enum([
+    'cost_threshold',
+    'agent_filter',
+    'tool_allowlist',
+    'time_window',
+  ]),
+  threshold: z.number().nullable(),
+  approverRole: z
+    .enum(['owner', 'admin', 'any_admin', 'specific_user'])
+    .nullable(),
+  approverUserId: z.string().uuid().nullable(),
+  agentFilter: z.array(z.string()),
+  action: z.enum(['block', 'require_approval', 'allow_with_audit']),
+  settings: z.record(z.unknown()),
+  enabled: z.boolean(),
+  priority: z.number().int(),
+  createdBy: z.string().uuid().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/** A team approval / blocking policy. Mirrors the `team_policies` row. */
+export type TeamPolicy = z.infer<typeof teamPolicySchema>;
+
+// ============================================================================
+// approvals
+// ============================================================================
+
+/** Lifecycle states for a single approval request. */
+export type ApprovalStatus =
+  | 'pending'
+  | 'approved'
+  | 'denied'
+  | 'expired'
+  | 'cancelled';
+
+/** Zod schema for {@link Approval}. */
+export const approvalSchema = z.object({
+  id: z.string().uuid(),
+  teamId: z.string().uuid(),
+  sessionId: z.string().uuid().nullable(),
+  policyId: z.string().uuid().nullable(),
+  requesterUserId: z.string().uuid(),
+  toolName: z.string().min(1),
+  estimatedCostUsd: z.number().nullable(),
+  requestPayload: z.record(z.unknown()),
+  status: z.enum(['pending', 'approved', 'denied', 'expired', 'cancelled']),
+  resolverUserId: z.string().uuid().nullable(),
+  resolutionNote: z.string().nullable(),
+  expiresAt: z.string(),
+  createdAt: z.string(),
+  resolvedAt: z.string().nullable(),
+});
+
+/** Per-tool-call governance event. Mirrors the `approvals` row. */
+export type Approval = z.infer<typeof approvalSchema>;
+
+// ============================================================================
+// sessions_shared
+// ============================================================================
+
+/** Share-grant permission level. */
+export type SharePermission = 'view' | 'comment' | 'collab';
+
+/** Zod schema for {@link SessionShare}. */
+export const sessionShareSchema = z.object({
+  id: z.string().uuid(),
+  sessionId: z.string().uuid(),
+  sharedWithUserId: z.string().uuid(),
+  sharedByUserId: z.string().uuid(),
+  permission: z.enum(['view', 'comment', 'collab']),
+  expiresAt: z.string().nullable(),
+  createdAt: z.string(),
+  revokedAt: z.string().nullable(),
+});
+
+/** Ad-hoc per-session share grant. Mirrors `sessions_shared`. */
+export type SessionShare = z.infer<typeof sessionShareSchema>;
+
+// ============================================================================
+// exports (GDPR)
+// ============================================================================
+
+export type ExportFormat = 'json' | 'csv' | 'zip';
+export type ExportScope = 'all' | 'sessions' | 'messages' | 'costs' | 'team';
+export type ExportStatus =
+  | 'pending'
+  | 'processing'
+  | 'ready'
+  | 'failed'
+  | 'expired';
+
+/** Zod schema for {@link ExportRequest}. */
+export const exportRequestSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  format: z.enum(['json', 'csv', 'zip']),
+  scope: z.enum(['all', 'sessions', 'messages', 'costs', 'team']),
+  status: z.enum(['pending', 'processing', 'ready', 'failed', 'expired']),
+  errorMessage: z.string().nullable(),
+  downloadUrl: z.string().nullable(),
+  downloadPath: z.string().nullable(),
+  sizeBytes: z.number().nullable(),
+  expiresAt: z.string(),
+  createdAt: z.string(),
+  completedAt: z.string().nullable(),
+});
+
+/** GDPR export-request lifecycle. Mirrors the `exports` row. */
+export type ExportRequest = z.infer<typeof exportRequestSchema>;
+
+// ============================================================================
+// integrations
+// ============================================================================
+
+export type IntegrationProvider =
+  | 'slack'
+  | 'github'
+  | 'linear'
+  | 'jira'
+  | 'pagerduty'
+  | 'webhook_generic';
+
+export type IntegrationStatus = 'active' | 'paused' | 'error' | 'revoked';
+
+/**
+ * Zod schema for {@link Integration}.
+ *
+ * WHY `configEncrypted` is typed as opaque `string`:
+ *   The column holds a base64-encoded libsodium secretbox. Decryption is
+ *   a server-only concern — clients should never introspect it, and typing
+ *   it as `unknown` would invite accidental leaks into logs/UIs.
+ */
+export const integrationSchema = z.object({
+  id: z.string().uuid(),
+  teamId: z.string().uuid(),
+  provider: z.enum([
+    'slack',
+    'github',
+    'linear',
+    'jira',
+    'pagerduty',
+    'webhook_generic',
+  ]),
+  displayName: z.string().nullable(),
+  externalAccountId: z.string().nullable(),
+  configEncrypted: z.string(),
+  encryptionKeyId: z.string(),
+  status: z.enum(['active', 'paused', 'error', 'revoked']),
+  lastError: z.string().nullable(),
+  installedBy: z.string().uuid().nullable(),
+  installedAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/** Third-party integration credentials. Mirrors the `integrations` row. */
+export type Integration = z.infer<typeof integrationSchema>;
+
+// ============================================================================
+// billing_events
+// ============================================================================
+
+/** Polar webhook billing event status. */
+export type BillingEventStatus =
+  | 'received'
+  | 'processed'
+  | 'failed'
+  | 'skipped_duplicate';
+
+/** Zod schema for {@link BillingEvent}. */
+export const billingEventSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid().nullable(),
+  subscriptionId: z.string().uuid().nullable(),
+  eventType: z.string().min(1),
+  amountUsd: z.number().nullable(),
+  currency: z.string().nullable(),
+  status: z.enum(['received', 'processed', 'failed', 'skipped_duplicate']),
+  polarEventId: z.string().min(1),
+  rawPayload: z.record(z.unknown()),
+  processedAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+/** Polar webhook event log. Mirrors the `billing_events` row. */
+export type BillingEvent = z.infer<typeof billingEventSchema>;
+
+// ============================================================================
+// Exit codes for the CLI policy engine
+// ============================================================================
+
+/**
+ * CLI exit codes emitted by {@link ../../../../styrby-cli/src/approvals/policyEngine}.
+ *
+ * Kept in the shared module so docs, web dashboard, and CLI all agree.
+ */
+export const POLICY_ENGINE_EXIT_CODES = {
+  APPROVED: 0,
+  DENIED: 10,
+  TIMEOUT: 124,
+  CANCELLED: 130, // 128 + SIGINT (2)
+} as const;
+
+export type PolicyEngineExitCode =
+  (typeof POLICY_ENGINE_EXIT_CODES)[keyof typeof POLICY_ENGINE_EXIT_CODES];

--- a/packages/styrby-shared/src/teams/__tests__/types.test.ts
+++ b/packages/styrby-shared/src/teams/__tests__/types.test.ts
@@ -12,12 +12,12 @@ import { describe, it, expect } from 'vitest';
 import {
   TEAM_ROLES,
   POLICY_TYPES,
-  APPROVAL_STATUSES,
+  DB_APPROVAL_STATUSES,
   TEAM_TIER_IDS,
   TeamSchema,
   TeamMemberSchema,
   TeamInvitationSchema,
-  TeamPolicySchema,
+  DbTeamPolicySchema,
   TeamApprovalRequestSchema,
   SharedSessionSchema,
   TeamExportSchema,
@@ -47,13 +47,13 @@ describe('POLICY_TYPES', () => {
   });
 });
 
-describe('APPROVAL_STATUSES', () => {
+describe('DB_APPROVAL_STATUSES', () => {
   it('contains pending, approved, rejected, and expired', () => {
-    expect(APPROVAL_STATUSES).toContain('pending');
-    expect(APPROVAL_STATUSES).toContain('approved');
-    expect(APPROVAL_STATUSES).toContain('rejected');
-    expect(APPROVAL_STATUSES).toContain('expired');
-    expect(APPROVAL_STATUSES).toHaveLength(4);
+    expect(DB_APPROVAL_STATUSES).toContain('pending');
+    expect(DB_APPROVAL_STATUSES).toContain('approved');
+    expect(DB_APPROVAL_STATUSES).toContain('rejected');
+    expect(DB_APPROVAL_STATUSES).toContain('expired');
+    expect(DB_APPROVAL_STATUSES).toHaveLength(4);
   });
 });
 
@@ -209,10 +209,10 @@ describe('TeamInvitationSchema', () => {
 });
 
 // ---------------------------------------------------------------------------
-// TeamPolicySchema
+// DbTeamPolicySchema
 // ---------------------------------------------------------------------------
 
-describe('TeamPolicySchema', () => {
+describe('DbTeamPolicySchema', () => {
   const valid = {
     id: uuid,
     teamId: uuid,
@@ -222,23 +222,23 @@ describe('TeamPolicySchema', () => {
   };
 
   it('accepts a valid policy row', () => {
-    expect(() => TeamPolicySchema.parse(valid)).not.toThrow();
+    expect(() => DbTeamPolicySchema.parse(valid)).not.toThrow();
   });
 
   it('accepts all policyType values', () => {
     for (const pt of POLICY_TYPES) {
-      expect(() => TeamPolicySchema.parse({ ...valid, policyType: pt })).not.toThrow();
+      expect(() => DbTeamPolicySchema.parse({ ...valid, policyType: pt })).not.toThrow();
     }
   });
 
   it('accepts arbitrary value shapes (unknown)', () => {
-    expect(() => TeamPolicySchema.parse({ ...valid, value: [1, 2, 3] })).not.toThrow();
-    expect(() => TeamPolicySchema.parse({ ...valid, value: 'string' })).not.toThrow();
-    expect(() => TeamPolicySchema.parse({ ...valid, value: null })).not.toThrow();
+    expect(() => DbTeamPolicySchema.parse({ ...valid, value: [1, 2, 3] })).not.toThrow();
+    expect(() => DbTeamPolicySchema.parse({ ...valid, value: 'string' })).not.toThrow();
+    expect(() => DbTeamPolicySchema.parse({ ...valid, value: null })).not.toThrow();
   });
 
   it('rejects unknown policyType', () => {
-    expect(() => TeamPolicySchema.parse({ ...valid, policyType: 'unknown_policy' })).toThrow();
+    expect(() => DbTeamPolicySchema.parse({ ...valid, policyType: 'unknown_policy' })).toThrow();
   });
 });
 
@@ -263,7 +263,7 @@ describe('TeamApprovalRequestSchema', () => {
   });
 
   it('accepts all status values', () => {
-    for (const st of APPROVAL_STATUSES) {
+    for (const st of DB_APPROVAL_STATUSES) {
       expect(() => TeamApprovalRequestSchema.parse({ ...valid, status: st })).not.toThrow();
     }
   });

--- a/packages/styrby-shared/src/teams/types.ts
+++ b/packages/styrby-shared/src/teams/types.ts
@@ -30,7 +30,7 @@ import { z } from 'zod';
 export const TEAM_ROLES = ['owner', 'admin', 'member'] as const;
 
 /**
- * All policy type strings a TeamPolicy can have.
+ * All policy type strings a DbTeamPolicy can have.
  * Drives both DB values and UI label lookups.
  */
 export const POLICY_TYPES = [
@@ -43,7 +43,7 @@ export const POLICY_TYPES = [
 /**
  * All status strings for a TeamApprovalRequest lifecycle.
  */
-export const APPROVAL_STATUSES = ['pending', 'approved', 'rejected', 'expired'] as const;
+export const DB_APPROVAL_STATUSES = ['pending', 'approved', 'rejected', 'expired'] as const;
 
 /**
  * Tier identifiers that qualify as "team" tiers in the billing model.
@@ -62,7 +62,7 @@ export type TeamRole = (typeof TEAM_ROLES)[number];
 export type PolicyType = (typeof POLICY_TYPES)[number];
 
 /** Lifecycle status for an approval request. */
-export type ApprovalStatus = (typeof APPROVAL_STATUSES)[number];
+export type DbApprovalStatus = (typeof DB_APPROVAL_STATUSES)[number];
 
 /** Billing tier identifier for teams (superset of TierId's 'team'). */
 export type TeamBillingTier = 'team' | 'business' | 'enterprise';
@@ -257,7 +257,7 @@ export const TeamInvitationSchema = z.object({
 });
 
 // ============================================================================
-// TeamPolicy
+// DbTeamPolicy
 // ============================================================================
 
 /**
@@ -272,7 +272,7 @@ export const TeamInvitationSchema = z.object({
  *
  * DB table: `team_policies` (migration 021)
  */
-export interface TeamPolicy {
+export interface DbTeamPolicy {
   /** UUID primary key. */
   id: string;
 
@@ -297,13 +297,13 @@ export interface TeamPolicy {
 }
 
 /**
- * Zod schema for {@link TeamPolicy}. Use for API response validation.
+ * Zod schema for {@link DbTeamPolicy}. Use for API response validation.
  *
  * WHY `value` is `z.unknown()`: the JSON blob is policyType-specific and
  * validated at the application layer where the type is narrowed. Keeping
  * this schema generic avoids duplicating policy-specific validation here.
  */
-export const TeamPolicySchema = z.object({
+export const DbTeamPolicySchema = z.object({
   id: z.string().uuid(),
   teamId: z.string().uuid(),
   policyType: z.enum(POLICY_TYPES),
@@ -348,7 +348,7 @@ export interface TeamApprovalRequest {
   command: string;
 
   /** Current lifecycle stage of the approval request. */
-  status: ApprovalStatus;
+  status: DbApprovalStatus;
 
   /** ISO-8601 timestamp when the request was submitted. */
   createdAt: string;
@@ -369,7 +369,7 @@ export const TeamApprovalRequestSchema = z.object({
   requesterId: z.string().uuid(),
   approverId: z.string().uuid().nullable(),
   command: z.string().min(1),
-  status: z.enum(APPROVAL_STATUSES),
+  status: z.enum(DB_APPROVAL_STATUSES),
   createdAt: z.string().datetime(),
   resolvedAt: z.string().datetime().nullable(),
 });


### PR DESCRIPTION
## Summary

PR #2 of the Teams Phase 2.1 stacked-PR series (planning doc §2.1). Lands the client-side governance primitives before the server edge function (PR #3) so the CLI, web, and mobile surfaces can all consume the same types and logic.

- `@styrby/shared/team/types` — zod + TS mirrors of every migration-021 table (team_policies, approvals, sessions_shared, exports, integrations, billing_events). Shared canonical exit codes for the policy engine.
- `@styrby/shared/team/role-matrix` — frozen 4-role × 5-permission matrix with named helpers (`canInvite`, `canRevokeMember`, `canApprove`, `canEditPolicy`, `canManageBilling`). One truth table for all surfaces.
- `@styrby/shared/team/approval-chain` — pure, deterministic evaluator. Handles: no policy, `allow_with_audit`, `block`, first-denial-wins, first-approval-wins, revoked approver (ignored), team-downgrade, zero eligible approvers (fail-safe pending), self-approval (CC6.3 SoD), null `approverUserId` on `specific_user` (misconfigured).
- `styrby-cli/approvals/policyEngine` — polls `resolve-approval` edge function (5 s / 60 s). Exit codes 0/10/124/130. SIGINT + external `AbortSignal` cleanly cancel the pending row. Uses the shared evaluator for a client-side pre-check (terminal shows "will require approval from X, Y, Z" before submit).
- Edge-function fetch is stubbed with a TODO pointing to PR #3 of the stack. All tests mock the fetch — no network traffic.

## Test plan

- [x] `pnpm --filter @styrby/shared test` — 551 tests, 19 files, 38 new (17 types + 7 role-matrix + 14 approval-chain).
- [x] `pnpm --filter @styrby/shared typecheck` — clean.
- [x] `pnpm --filter styrby-cli test` — 1157 pass / 12 skip, 7 new policyEngine tests.
- [x] `pnpm --filter styrby-cli typecheck` — clean.
- [x] Approval-chain determinism test: 100-iteration byte-identical output check.
- [x] SIGINT listener-leak regression test (no handler growth across invocations).

## Stack context

- PR #1 (db migration 021) — open at #88 with auto-merge queued. This PR branches from `origin/main` (not #88) so the stack stays independent.
- PR #3 — adds the `manage-team` + `resolve-approval` edge functions. The stub TODO in `policyEngine.ts` points there.

## Tech debt captured during PR #1 / PR #2 (to resolve later in Phase 2)

- `agent_type` enum expansion — needed before Phase 2.4 lands. Not blocking for PR #2 / #3.
- CI RLS test job — migration 021 adds RLS policies on six new tables; no CI job currently exercises the RLS surface end-to-end.

Auto-merge will be enabled on this PR. Continuing to PR #3 once opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)