### PR TITLE
feat(shared): wire real tokenizers (Phase 1.1) — exact counts

### DIFF
--- a/packages/styrby-mobile/metro.config.js
+++ b/packages/styrby-mobile/metro.config.js
@@ -31,4 +31,25 @@ config.resolver.nodeModulesPaths = [
   path.resolve(workspaceRoot, 'node_modules/.pnpm/node_modules'),
 ];
 
+// WHY blockList for tokenizer packages:
+// `@anthropic-ai/tokenizer` and `gpt-tokenizer` are installed as
+// optionalDependencies of `@styrby/shared` for the CLI's exact-token-count
+// path. They transitively pull `tiktoken` (Rust/WASM) which catastrophically
+// breaks Metro. The shared module hides the import via dynamic
+// `import('@anthropic-ai/tokenizer'.toString())`, but `@anthropic-ai/tokenizer`
+// internally uses CommonJS `require('tiktoken/lite')` which Metro's static
+// resolver still finds.
+//
+// Blocking these packages at the Metro layer guarantees the mobile bundle
+// never tries to compile them, regardless of how they get pulled in. The
+// shared module's heuristic fallback path runs on mobile.
+//
+// If a future feature needs exact counts on mobile, route through a server
+// proxy (`/api/tokenize`) — do NOT lift this block.
+config.resolver.blockList = [
+  /node_modules\/@anthropic-ai\/tokenizer\/.*/,
+  /node_modules\/gpt-tokenizer\/.*/,
+  /node_modules\/tiktoken\/.*/,
+];
+
 module.exports = withNativeWind(config, { input: './global.css' });

--- a/packages/styrby-shared/package.json
+++ b/packages/styrby-shared/package.json
@@ -56,6 +56,11 @@
     "libsodium-wrappers": "^0.7.15",
     "zod": "^3.25.76"
   },
+  "optionalDependencies": {
+    "@anthropic-ai/tokenizer": "0.0.4",
+    "gpt-tokenizer": "3.4.0"
+  },
+  "//optionalDependencies": "PINNED EXACT — bumping these requires regenerating fixtures in src/tokenizers/__tests__/accuracy.test.ts. Declared optional because src/tokenizers/index.ts uses dynamic-import-with-string-toString to hide them from Metro (mobile bundle) and falls back to the heuristic when they're absent.",
   "devDependencies": {
     "@types/libsodium-wrappers": "^0.7.14",
     "@types/node": "^22.15.18",

--- a/packages/styrby-shared/src/tokenizers/__tests__/accuracy.test.ts
+++ b/packages/styrby-shared/src/tokenizers/__tests__/accuracy.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Accuracy regression for the tokenizer abstraction (Task 1.1.5).
+ *
+ * Locks two properties:
+ *
+ * 1. **Exactness**: When the real tokenizer packages (`@anthropic-ai/tokenizer`,
+ *    `gpt-tokenizer`) are installed in the runtime — which is true for the
+ *    CLI and tests — `countTokens()` MUST return `exact: true` for
+ *    Anthropic and OpenAI model families. Regression here means a future
+ *    refactor accidentally degraded the path back to the heuristic.
+ *
+ * 2. **Stability**: A small set of fixed prompts produces a stable token
+ *    count from each tokenizer. If those numbers shift, either the
+ *    tokenizer package was upgraded (intentional) or the call shape changed
+ *    (almost certainly a bug). The test failure forces reviewers to
+ *    acknowledge the change before it lands.
+ *
+ * 3. **Heuristic bound**: The legacy `heuristicTokens()` is bounded — it must
+ *    not drift more than ±50% from the exact count for typical English
+ *    prompts. (The plan target is ±35%; we leave headroom for short prompts
+ *    where the heuristic is noisier.)
+ *
+ * WHY no live API calls: The `@anthropic-ai/tokenizer` and `gpt-tokenizer`
+ * packages ARE the same tokenizers the model servers use. Their output is
+ * the ground truth by definition; comparing to a live API would test
+ * network latency, not accuracy.
+ *
+ * @module tokenizers/__tests__/accuracy
+ */
+
+import { describe, it, expect } from 'vitest';
+import { countTokens, heuristicTokens, detectModelFamily } from '../index.js';
+
+// ============================================================================
+// Fixed fixtures
+// ============================================================================
+
+/**
+ * Each fixture pairs a prompt with the exact token counts produced by
+ * the currently-pinned tokenizer libraries. If a future PR changes the
+ * pinned tokenizer version, these expected values need to be regenerated
+ * and the diff needs reviewer eyes.
+ *
+ * Counts captured against:
+ *   - `@anthropic-ai/tokenizer@0.0.4`
+ *   - `gpt-tokenizer@3.4.0`
+ */
+const FIXTURES = [
+  {
+    name: 'short greeting',
+    prompt: 'Hello, world! This is a test.',
+    expectedAnthropic: 9,
+    expectedOpenai: 9,
+  },
+  {
+    name: 'classic pangram',
+    prompt: 'The quick brown fox jumps over the lazy dog.',
+    expectedAnthropic: 10,
+    expectedOpenai: 10,
+  },
+  {
+    name: 'multi-sentence English paragraph',
+    prompt:
+      'Styrby brings your AI coding agent to your phone. Approve every dangerous command. Review every change. Sleep at night.',
+    expectedAnthropic: 26,
+    expectedOpenai: 26,
+  },
+  {
+    name: 'code snippet (typescript)',
+    prompt: 'export async function ship(pr: number) {\n  return await merge(pr);\n}',
+    expectedAnthropic: 19,
+    expectedOpenai: 16,
+  },
+];
+
+// ============================================================================
+// Exactness — countTokens() must report exact: true when real deps load
+// ============================================================================
+
+describe('countTokens — exactness contract', () => {
+  it('returns exact=true for an Anthropic model when @anthropic-ai/tokenizer is installed', async () => {
+    const result = await countTokens('Hello world', 'claude-sonnet-4');
+    expect(result.source).toBe('anthropic-tokenizer');
+    expect(result.exact).toBe(true);
+    expect(result.tokens).toBeGreaterThan(0);
+  });
+
+  it('returns exact=true for an OpenAI model when gpt-tokenizer is installed', async () => {
+    const result = await countTokens('Hello world', 'gpt-4');
+    expect(result.source).toBe('gpt-tokenizer');
+    expect(result.exact).toBe(true);
+    expect(result.tokens).toBeGreaterThan(0);
+  });
+
+  it('returns exact=false (heuristic) for an unknown model family', async () => {
+    const result = await countTokens('Hello world', 'mystery-model-9000');
+    expect(result.source).toBe('heuristic');
+    expect(result.exact).toBe(false);
+    expect(result.tokens).toBeGreaterThan(0);
+  });
+
+  it('returns exact=false (heuristic) when no model is provided', async () => {
+    const result = await countTokens('Hello world');
+    expect(result.source).toBe('heuristic');
+    expect(result.exact).toBe(false);
+  });
+});
+
+// ============================================================================
+// Stability — fixed prompts must produce known counts
+// ============================================================================
+
+describe('countTokens — fixture stability', () => {
+  for (const fixture of FIXTURES) {
+    it(`Anthropic count for "${fixture.name}" is stable`, async () => {
+      const result = await countTokens(fixture.prompt, 'claude-sonnet-4');
+      expect(result.exact).toBe(true);
+      // WHY exact equality (not within tolerance): The pinned tokenizer
+      // version produces deterministic counts. A change here means the
+      // tokenizer package was upgraded — bump the expected value AND
+      // call out the version bump in the PR description.
+      expect(result.tokens).toBe(fixture.expectedAnthropic);
+    });
+
+    it(`OpenAI count for "${fixture.name}" is stable`, async () => {
+      const result = await countTokens(fixture.prompt, 'gpt-4');
+      expect(result.exact).toBe(true);
+      expect(result.tokens).toBe(fixture.expectedOpenai);
+    });
+  }
+});
+
+// ============================================================================
+// Heuristic bound — must not drift wildly from exact
+// ============================================================================
+
+describe('heuristicTokens — drift bound vs exact', () => {
+  /**
+   * The plan documents the heuristic's drift as up to ±35% from real
+   * server counts. We assert ±50% to leave headroom for short prompts
+   * where the heuristic is noisiest (a 5-token prompt off by 2 tokens
+   * is already 40% drift, which is fine — short prompts matter little
+   * in cost dollars).
+   */
+  const MAX_DRIFT = 0.5;
+
+  for (const fixture of FIXTURES) {
+    it(`heuristic for "${fixture.name}" stays within ±${MAX_DRIFT * 100}% of Anthropic exact`, () => {
+      const heuristic = heuristicTokens(fixture.prompt);
+      const exact = fixture.expectedAnthropic;
+      const drift = Math.abs(heuristic - exact) / exact;
+      expect(drift).toBeLessThanOrEqual(MAX_DRIFT);
+    });
+  }
+
+  it('heuristic returns 0 for empty input (no crash, no negative)', () => {
+    expect(heuristicTokens('')).toBe(0);
+  });
+
+  it('heuristic is deterministic — same input → same output', () => {
+    const text = 'A reproducibility test.';
+    expect(heuristicTokens(text)).toBe(heuristicTokens(text));
+    expect(heuristicTokens(text)).toBe(heuristicTokens(text));
+  });
+});
+
+// ============================================================================
+// Model family detection — drives which tokenizer is picked
+// ============================================================================
+
+describe('detectModelFamily', () => {
+  it.each([
+    ['claude-sonnet-4', 'anthropic'],
+    ['claude-opus-4-7', 'anthropic'],
+    ['claude-haiku-4-5', 'anthropic'],
+    ['anthropic/claude-3', 'anthropic'],
+    ['gpt-4', 'openai'],
+    ['gpt-4o', 'openai'],
+    ['gpt-3.5-turbo', 'openai'],
+    ['o1-preview', 'openai'],
+    ['o3-mini', 'openai'],
+    ['gemini-2.5-pro', 'unknown'],
+    ['llama-3.3', 'unknown'],
+    [null, 'unknown'],
+    [undefined, 'unknown'],
+    ['', 'unknown'],
+  ])('detectModelFamily(%j) → %s', (input, expected) => {
+    expect(detectModelFamily(input as string | null | undefined)).toBe(expected);
+  });
+});

--- a/packages/styrby-shared/src/tokenizers/index.ts
+++ b/packages/styrby-shared/src/tokenizers/index.ts
@@ -23,6 +23,19 @@
  * dependency does NOT break the build for environments that ship without
  * the native add-ons (e.g., the mobile bundle).
  *
+ * ## DO NOT IMPORT FROM MOBILE
+ *
+ * `@anthropic-ai/tokenizer` transitively pulls in `tiktoken` (Rust/WASM)
+ * which catastrophically breaks the Metro bundler. The string-toString
+ * trick (`'@anthropic-ai/tokenizer'.toString()`) hides the import from
+ * Metro static analysis, but only as long as no consumer file in
+ * `packages/styrby-mobile/` reaches this module. Mobile must stick to
+ * `heuristicTokens()` (sync, no deps) for any token estimation.
+ *
+ * If a future feature requires exact counts on mobile, add a server-side
+ * proxy endpoint (`/api/tokenize`) that mobile calls instead of importing
+ * this module directly.
+ *
  * @module tokenizers
  */
 
@@ -61,7 +74,14 @@ export function detectModelFamily(model: string | undefined | null): ModelFamily
   if (!model) return 'unknown';
   const m = model.toLowerCase();
   if (m.includes('claude') || m.startsWith('anthropic/')) return 'anthropic';
-  if (m.startsWith('gpt-') || m.startsWith('o1') || m.startsWith('openai/')) return 'openai';
+  // WHY the o-family regex: OpenAI's reasoning models follow `o<digit>` then
+  // either end-of-string or a `-suffix` (o1, o1-mini, o1-preview, o3, o3-mini,
+  // o4-mini, …). The boundary requirement (`(-|$)`) prevents false positives
+  // for any future non-OpenAI model whose name happens to start with `o<digit>`
+  // followed by other characters (e.g., a hypothetical `o2x` or `o9z`).
+  // The previous `startsWith('o1')` check missed o3+ silently; this version
+  // covers them while staying conservative against unrelated names.
+  if (m.startsWith('gpt-') || /^o\d+(-|$)/.test(m) || m.startsWith('openai/')) return 'openai';
   return 'unknown';
 }
 
@@ -99,6 +119,9 @@ let gptTokenizerLoaded = false;
 /**
  * Load `@anthropic-ai/tokenizer` if installed. Returns null when the
  * package is absent so callers can fall back gracefully.
+ *
+ * @returns The loaded tokenizer module, or `null` if the optional dep
+ *          is not installed in the current runtime (cached after first call).
  */
 async function loadAnthropicTokenizer(): Promise<AnthropicTokenizerModule | null> {
   if (anthropicTokenizerLoaded) return anthropicTokenizer;
@@ -119,6 +142,9 @@ async function loadAnthropicTokenizer(): Promise<AnthropicTokenizerModule | null
 
 /**
  * Load `gpt-tokenizer` if installed. Returns null when the package is absent.
+ *
+ * @returns The loaded tokenizer module, or `null` if the optional dep
+ *          is not installed in the current runtime (cached after first call).
  */
 async function loadGptTokenizer(): Promise<GptTokenizerModule | null> {
   if (gptTokenizerLoaded) return gptTokenizer;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,13 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(jsdom@28.0.0)(lightningcss@1.27.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    optionalDependencies:
+      '@anthropic-ai/tokenizer':
+        specifier: 0.0.4
+        version: 0.0.4
+      gpt-tokenizer:
+        specifier: 3.4.0
+        version: 3.4.0
 
   packages/styrby-videos:
     dependencies:
@@ -665,6 +672,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/tokenizer@0.0.4':
+    resolution: {integrity: sha512-EHRKbxlxlc8W4KCBEseByJ7YwyYCmgu9OyN59H9+IYIGPoKv8tXyQXinkeGDI+cI8Tiuz9wk2jZb/kK7AyvL7g==}
 
   '@asamuzakjp/css-color@4.1.2':
     resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
@@ -4933,6 +4943,9 @@ packages:
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@22.15.35':
     resolution: {integrity: sha512-stV91mHxlWpDksiUiivmFfQzjy2JLlb2NUTxKipiANEbxBZsdbDU9fSrT7SHY4uoCXAxYfJZVasn3x2/hqpd3g==}
 
@@ -7280,6 +7293,9 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  gpt-tokenizer@3.4.0:
+    resolution: {integrity: sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -10091,6 +10107,9 @@ packages:
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
+  tiktoken@1.0.22:
+    resolution: {integrity: sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -10276,6 +10295,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -10825,6 +10847,12 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@anthropic-ai/tokenizer@0.0.4':
+    dependencies:
+      '@types/node': 18.19.130
+      tiktoken: 1.0.22
+    optional: true
 
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
@@ -14688,14 +14716,14 @@ snapshots:
       '@remotion/studio-shared': 4.0.438(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@rspack/core': 1.7.6(@swc/helpers@0.5.15)
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
-      css-loader: 5.2.7(webpack@5.105.0)
+      css-loader: 5.2.7(webpack@5.105.0(esbuild@0.25.0))
       esbuild: 0.25.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-refresh: 0.18.0
       remotion: 4.0.438(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       source-map: 0.7.3
-      style-loader: 4.0.0(webpack@5.105.0)
+      style-loader: 4.0.0(webpack@5.105.0(esbuild@0.25.0))
       webpack: 5.105.0(esbuild@0.25.0)
     transitivePeerDependencies:
       - '@swc/core'
@@ -15230,7 +15258,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -15279,7 +15307,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       typescript: 5.9.3
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - browserslist
 
@@ -15555,6 +15583,11 @@ snapshots:
   '@types/node-forge@1.3.14':
     dependencies:
       '@types/node': 22.15.35
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+    optional: true
 
   '@types/node@22.15.35':
     dependencies:
@@ -16958,7 +16991,7 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-loader@5.2.7(webpack@5.105.0):
+  css-loader@5.2.7(webpack@5.105.0(esbuild@0.25.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       loader-utils: 2.0.4
@@ -17482,9 +17515,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       eslint: 9.39.2(jiti@1.21.7)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-expo: 0.1.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react-hooks: 4.6.2(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
@@ -17521,6 +17554,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@1.21.7)
+      get-tsconfig: 4.13.6
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -17536,29 +17584,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
-      get-tsconfig: 4.13.6
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -17581,7 +17614,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -17592,7 +17625,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -18435,6 +18468,9 @@ snapshots:
       slash: 3.0.0
 
   gopd@1.2.0: {}
+
+  gpt-tokenizer@3.4.0:
+    optional: true
 
   graceful-fs@4.2.11: {}
 
@@ -20843,7 +20879,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0
 
   react-shallow-renderer@16.15.0(react@18.3.1):
     dependencies:
@@ -21585,7 +21621,7 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  style-loader@4.0.0(webpack@5.105.0):
+  style-loader@4.0.0(webpack@5.105.0(esbuild@0.25.0)):
     dependencies:
       webpack: 5.105.0(esbuild@0.25.0)
 
@@ -21722,6 +21758,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.0
 
+  terser-webpack-plugin@5.3.16(webpack@5.105.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 7.0.5
+      terser: 5.46.0
+      webpack: 5.105.0
+
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -21757,6 +21802,9 @@ snapshots:
       any-promise: 1.3.0
 
   throat@5.0.0: {}
+
+  tiktoken@1.0.22:
+    optional: true
 
   tiny-invariant@1.3.3: {}
 
@@ -21953,6 +22001,9 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   uncrypto@0.1.3: {}
+
+  undici-types@5.26.5:
+    optional: true
 
   undici-types@6.21.0: {}
 
@@ -22323,6 +22374,38 @@ snapshots:
   webidl-conversions@8.0.1: {}
 
   webpack-sources@3.3.3: {}
+
+  webpack@5.105.0:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.19.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.0):
     dependencies:


### PR DESCRIPTION
## Summary

Phase 1.1 of `docs/planning/styrby-improve-19Apr.md` ("honest cost math"). Wires real tokenizers (`@anthropic-ai/tokenizer`, `gpt-tokenizer`) into the abstraction that was previously falling back silently to a `words * 1.3` heuristic with documented ±35% drift.

## Why

Pre-PR: every CLI session wrote estimated token counts to `cost_records` with up to 35% drift. Cost dashboard, budget alerts, weekly summaries all displayed numbers up to a third off real Anthropic/OpenAI server-side counts. SOC2 CC4.1 (monitoring) expects metrics to reasonably match the source of truth — 35% fails that bar.

Post-PR: Anthropic + OpenAI sessions get **exact** counts (`exact: true` in the result envelope; deterministic and matches the model's own tokenizer because we're using the official libraries Anthropic ships and the OpenAI BPE tables `gpt-tokenizer` mirrors).

## Audit

3 parallel `Explore` agents audited `amp.ts`, `crush.ts`, `goose.ts`. **All three already use server-reported token counts** from their respective JSONL/usage metadata streams — no estimation work needed. Only `aider.ts` uses the abstraction (already migrated in PR #78). Without the audit, I'd have spent hours refactoring code that was already correct.

## Bug fix included

`detectModelFamily` was matching only `o1*` for OpenAI's reasoning family — silently dropping `o3-mini`, `o4-mini`, etc. (these models would have routed to the heuristic). Tightened to `/^o\d+(-|$)/` covering o1/o3/o4+ while rejecting unrelated names.

## Code-reviewer agent

Independent `general-purpose` review run before push found 3 fixable items, all addressed:
- Mobile-bundle safety: added explicit `DO NOT IMPORT FROM MOBILE` doc block (anthropic-ai/tokenizer transitively pulls Rust/WASM tiktoken which would break Metro)
- Regex over-broad: tightened from `/^o\d/` to `/^o\d+(-|$)/`
- `dependencies` vs `optionalDependencies` mismatch: moved to optionalDependencies + added `@returns` JSDoc

## Test plan

- [x] 32 new tests in `packages/styrby-shared/src/tokenizers/__tests__/accuracy.test.ts`
  - Exactness contract (4 tests): `exact: true` for Anthropic + OpenAI when deps load; `exact: false` for unknown / no model
  - Fixture stability (8 tests): 4 known prompts, hard-coded counts so a tokenizer version bump forces a fixture regen
  - Heuristic drift bound (6 tests): `heuristicTokens()` stays within ±50% of exact (plan target ±35%; we leave headroom for short prompts)
  - detectModelFamily (14 tests): claude/gpt-4/o1-preview/o3-mini/gemini/llama/null/undefined/empty
- [x] Shared suite: 551 → 583 (+32) green
- [x] CLI suite: 1159 unchanged (no migration needed per audit)
- [ ] CI passes

## Deferred to follow-up PRs

- Task 1.1.3 — HF tokenizers via napi-rs in `styrby-native` (Rust scope)
- Task 1.1.6 — Backfill `cost_records` recomputation job (operations scope)

## Standards

- SOC2 CC4.1 (monitoring) — metrics now match source of truth for Anthropic + OpenAI families
- Per-line code review with `// nosemgrep`-style rationale (existing pattern from PR #93)

🤖 Generated with [Claude Code](https://claude.com/claude-code)