### PR TITLE
refactor(web,cli): split 4 god-files — Phase 1 #4 batch 3

### DIFF
--- a/packages/styrby-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/styrby-cli/src/agent/acp/AcpBackend.ts
@@ -1,24 +1,20 @@
 /**
- * AcpBackend - Agent Client Protocol backend using official SDK
+ * AcpBackend - Agent Client Protocol backend (thin coordinator).
  *
- * This module provides a universal backend implementation using the official
- * @agentclientprotocol/sdk. Agent-specific behavior (timeouts, filtering,
- * error handling) is delegated to TransportHandler implementations.
+ * Concerns are split into sibling modules: acpTypes, streamBridge, retryHelper,
+ * errorFormatting, permissionHandling, processLifecycle, sessionUpdateDispatcher,
+ * sessionUpdateHandlers. This class only owns subprocess + connection state and
+ * routes work to those modules.
  */
 
-import { spawn, type ChildProcess } from 'node:child_process';
-import { Readable, Writable } from 'node:stream';
-import { buildSafeEnv } from '@/utils/safeEnv';
+import { type ChildProcess } from 'node:child_process';
 import {
   ClientSideConnection,
   ndJsonStream,
   type Client,
   type Agent,
   type SessionNotification,
-  type RequestPermissionRequest,
   type RequestPermissionResponse,
-  type InitializeRequest,
-  type NewSessionRequest,
   type PromptRequest,
   type ContentBlock,
 } from '@agentclientprotocol/sdk';
@@ -29,241 +25,23 @@ import type {
   AgentMessageHandler,
   SessionId,
   StartSessionResult,
-  McpServerConfig,
 } from '../core';
 import { logger } from '@/ui/logger';
-import { delay } from '@/utils/time';
-import packageJson from '../../../package.json';
+import { type TransportHandler, DefaultTransport } from '../transport';
+import { type HandlerContext } from './sessionUpdateHandlers';
+import { dispatchSessionUpdate } from './sessionUpdateDispatcher';
+import { type AcpPermissionHandler, type AcpBackendOptions } from './acpTypes';
+import { nodeToWebStreams, createFilteredStdoutStream } from './streamBridge';
+import { extractSendPromptErrorDetail } from './errorFormatting';
+import { createPermissionHandler } from './permissionHandling';
+import { spawnAgentProcess, attachProcessListeners, initializeAcpConnection, createAcpSession } from './processLifecycle';
+
+// Re-export public types so existing callers (`import { AcpBackendOptions } from '../acp/AcpBackend'`)
+// continue to compile unchanged.
+export type { AcpPermissionHandler, AcpBackendOptions } from './acpTypes';
 
 /**
- * Retry configuration for ACP operations
- */
-const RETRY_CONFIG = {
-  /** Maximum number of retry attempts for init/newSession */
-  maxAttempts: 3,
-  /** Base delay between retries in ms */
-  baseDelayMs: 1000,
-  /** Maximum delay between retries in ms */
-  maxDelayMs: 5000,
-} as const;
-import {
-  type TransportHandler,
-  type StderrContext,
-  type ToolNameContext,
-  DefaultTransport,
-} from '../transport';
-import {
-  type SessionUpdate,
-  type HandlerContext,
-  DEFAULT_IDLE_TIMEOUT_MS,
-  DEFAULT_TOOL_CALL_TIMEOUT_MS,
-  handleAgentMessageChunk,
-  handleAgentThoughtChunk,
-  handleToolCallUpdate,
-  handleToolCall,
-  handleLegacyMessageChunk,
-  handlePlanUpdate,
-  handleThinkingUpdate,
-} from './sessionUpdateHandlers';
-
-/**
- * Extended RequestPermissionRequest with additional fields that may be present
- */
-type ExtendedRequestPermissionRequest = RequestPermissionRequest & {
-  toolCall?: {
-    id?: string;
-    kind?: string;
-    toolName?: string;
-    input?: Record<string, unknown>;
-    arguments?: Record<string, unknown>;
-    content?: Record<string, unknown>;
-  };
-  kind?: string;
-  input?: Record<string, unknown>;
-  arguments?: Record<string, unknown>;
-  content?: Record<string, unknown>;
-  options?: Array<{
-    optionId?: string;
-    name?: string;
-    kind?: string;
-  }>;
-};
-
-/**
- * Extended SessionNotification with additional fields
- */
-type ExtendedSessionNotification = SessionNotification & {
-  update?: {
-    sessionUpdate?: string;
-    toolCallId?: string;
-    status?: string;
-    kind?: string | unknown;
-    content?: {
-      text?: string;
-      error?: string | { message?: string };
-      [key: string]: unknown;
-    } | string | unknown;
-    locations?: unknown[];
-    messageChunk?: {
-      textDelta?: string;
-    };
-    plan?: unknown;
-    thinking?: unknown;
-    [key: string]: unknown;
-  };
-}
-
-/**
- * Permission handler interface for ACP backends
- */
-export interface AcpPermissionHandler {
-  /**
-   * Handle a tool permission request
-   * @param toolCallId - The unique ID of the tool call
-   * @param toolName - The name of the tool being called
-   * @param input - The input parameters for the tool
-   * @returns Promise resolving to permission result with decision
-   */
-  handleToolCall(
-    toolCallId: string,
-    toolName: string,
-    input: unknown
-  ): Promise<{ decision: 'approved' | 'approved_for_session' | 'denied' | 'abort' }>;
-}
-
-/**
- * Configuration for AcpBackend
- */
-export interface AcpBackendOptions {
-  /** Agent name for identification */
-  agentName: string;
-
-  /** Working directory for the agent */
-  cwd: string;
-
-  /** Command to spawn the ACP agent */
-  command: string;
-
-  /** Arguments for the agent command */
-  args?: string[];
-
-  /** Environment variables to pass to the agent */
-  env?: Record<string, string>;
-
-  /** MCP servers to make available to the agent */
-  mcpServers?: Record<string, McpServerConfig>;
-
-  /** Optional permission handler for tool approval */
-  permissionHandler?: AcpPermissionHandler;
-
-  /** Transport handler for agent-specific behavior (timeouts, filtering, etc.) */
-  transportHandler?: TransportHandler;
-
-  /** Optional callback to check if prompt has change_title instruction */
-  hasChangeTitleInstruction?: (prompt: string) => boolean;
-}
-
-/**
- * Convert Node.js streams to Web Streams for ACP SDK
- * 
- * NOTE: This function registers event handlers on stdout. If you also register
- * handlers directly on stdout (e.g., for logging), both will fire.
- */
-function nodeToWebStreams(
-  stdin: Writable, 
-  stdout: Readable
-): { writable: WritableStream<Uint8Array>; readable: ReadableStream<Uint8Array> } {
-  // Convert Node writable to Web WritableStream
-  const writable = new WritableStream<Uint8Array>({
-    write(chunk) {
-      return new Promise((resolve, reject) => {
-        const ok = stdin.write(chunk, (err) => {
-          if (err) {
-            logger.debug(`[AcpBackend] Error writing to stdin:`, err);
-            reject(err);
-          }
-        });
-        if (ok) {
-          resolve();
-        } else {
-          stdin.once('drain', resolve);
-        }
-      });
-    },
-    close() {
-      return new Promise((resolve) => {
-        stdin.end(resolve);
-      });
-    },
-    abort(reason) {
-      stdin.destroy(reason instanceof Error ? reason : new Error(String(reason)));
-    }
-  });
-
-  // Convert Node readable to Web ReadableStream
-  // Filter out non-JSON debug output from gemini CLI (experiments, flags, etc.)
-  const readable = new ReadableStream<Uint8Array>({
-    start(controller) {
-      stdout.on('data', (chunk: Buffer) => {
-        controller.enqueue(new Uint8Array(chunk));
-      });
-      stdout.on('end', () => {
-        controller.close();
-      });
-      stdout.on('error', (err) => {
-        logger.debug(`[AcpBackend] Stdout error:`, err);
-        controller.error(err);
-      });
-    },
-    cancel() {
-      stdout.destroy();
-    }
-  });
-
-  return { writable, readable };
-}
-
-/**
- * Helper to run an async operation with retry logic
- */
-async function withRetry<T>(
-  operation: () => Promise<T>,
-  options: {
-    operationName: string;
-    maxAttempts: number;
-    baseDelayMs: number;
-    maxDelayMs: number;
-    onRetry?: (attempt: number, error: Error) => void;
-  }
-): Promise<T> {
-  let lastError: Error | null = null;
-
-  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
-    try {
-      return await operation();
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-
-      if (attempt < options.maxAttempts) {
-        // Calculate delay with exponential backoff
-        const delayMs = Math.min(
-          options.baseDelayMs * Math.pow(2, attempt - 1),
-          options.maxDelayMs
-        );
-
-        logger.debug(`[AcpBackend] ${options.operationName} failed (attempt ${attempt}/${options.maxAttempts}): ${lastError.message}. Retrying in ${delayMs}ms...`);
-        options.onRetry?.(attempt, lastError);
-
-        await delay(delayMs);
-      }
-    }
-  }
-
-  throw lastError;
-}
-
-/**
- * ACP backend using the official @agentclientprotocol/sdk
+ * ACP backend using the official `@agentclientprotocol/sdk`.
  */
 export class AcpBackend implements AgentBackend {
   private listeners: AgentMessageHandler[] = [];
@@ -271,29 +49,29 @@ export class AcpBackend implements AgentBackend {
   private connection: ClientSideConnection | null = null;
   private acpSessionId: string | null = null;
   private disposed = false;
-  /** Track active tool calls to prevent duplicate events */
+
+  /** Track active tool calls to prevent duplicate events. */
   private activeToolCalls = new Set<string>();
   private toolCallTimeouts = new Map<string, NodeJS.Timeout>();
-  /** Track tool call start times for performance monitoring */
+  /** Track tool call start times for performance monitoring. */
   private toolCallStartTimes = new Map<string, number>();
-  /** Pending permission requests that need response */
+  /** Pending permission requests that need response. */
   private pendingPermissions = new Map<string, (response: RequestPermissionResponse) => void>();
-
-  /** Map from permission request ID to real tool call ID for tracking */
-  private permissionToToolCallMap = new Map<string, string>();
-
-  /** Map from real tool call ID to tool name for auto-approval */
+  /** Map from real tool call ID to tool name for auto-approval. */
   private toolCallIdToNameMap = new Map<string, string>();
 
-  /** Track if we just sent a prompt with change_title instruction */
+  /** Track if we just sent a prompt with change_title instruction. */
   private recentPromptHadChangeTitle = false;
-
-  /** Track tool calls count since last prompt (to identify first tool call) */
+  /** Track tool calls count since last prompt (to identify first tool call). */
   private toolCallCountSincePrompt = 0;
-  /** Timeout for emitting 'idle' status after last message chunk */
+  /** Timeout for emitting 'idle' status after last message chunk. */
   private idleTimeout: NodeJS.Timeout | null = null;
 
-  /** Transport handler for agent-specific behavior */
+  /** Promise resolver for waitForResponseComplete — set when waiting for response. */
+  private idleResolver: (() => void) | null = null;
+  private waitingForResponse = false;
+
+  /** Transport handler for agent-specific behavior. */
   private readonly transport: TransportHandler;
 
   constructor(private options: AcpBackendOptions) {
@@ -302,7 +80,7 @@ export class AcpBackend implements AgentBackend {
 
   onMessage(handler: AgentMessageHandler): void {
     this.listeners.push(handler);
-  } 
+  }
 
   offMessage(handler: AgentMessageHandler): void {
     const index = this.listeners.indexOf(handler);
@@ -332,454 +110,74 @@ export class AcpBackend implements AgentBackend {
 
     try {
       logger.debug(`[AcpBackend] Starting session: ${sessionId}`);
-      // Spawn the ACP agent process
-      const args = this.options.args || [];
-      
-      // SECURITY: Use buildSafeEnv() to prevent leaking secrets to agent subprocesses.
-      const safeEnv = buildSafeEnv(this.options.env);
-
-      // On Windows, spawn via cmd.exe to handle .cmd files and PATH resolution.
-      // SECURITY: Each argument is passed as a separate element to cmd.exe /c
-      // to prevent shell metacharacter injection. Previously, args were joined
-      // with spaces which would allow `;`, `&`, `|` in arguments to execute
-      // arbitrary commands.
-      if (process.platform === 'win32') {
-        this.process = spawn('cmd.exe', ['/c', this.options.command, ...args], {
-          cwd: this.options.cwd,
-          env: safeEnv,
-          stdio: ['pipe', 'pipe', 'pipe'],
-          windowsHide: true,
-        });
-      } else {
-        this.process = spawn(this.options.command, args, {
-          cwd: this.options.cwd,
-          env: safeEnv,
-          // Use 'pipe' for all stdio to capture output without printing to console
-          // stdout and stderr will be handled by our event listeners
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
-      }
-      
-      // Ensure stderr doesn't leak to console - redirect to logger only
-      // This prevents gemini CLI debug output from appearing in user's console
-      if (this.process.stderr) {
-        // stderr is already handled by the event listener below
-        // but we ensure it doesn't go to parent's stderr
-      }
-
-      if (!this.process.stdin || !this.process.stdout || !this.process.stderr) {
-        throw new Error('Failed to create stdio pipes');
-      }
-
-      // Handle stderr output via transport handler
-      this.process.stderr.on('data', (data: Buffer) => {
-        const text = data.toString();
-        if (!text.trim()) return;
-
-        // Build context for transport handler
-        const hasActiveInvestigation = this.transport.isInvestigationTool
-          ? Array.from(this.activeToolCalls).some(id => this.transport.isInvestigationTool!(id))
-          : false;
-
-        const context: StderrContext = {
-          activeToolCalls: this.activeToolCalls,
-          hasActiveInvestigation,
-        };
-
-        // Log to file (not console)
-        if (hasActiveInvestigation) {
-          logger.debug(`[AcpBackend] 🔍 Agent stderr (during investigation): ${text.trim()}`);
-        } else {
-          logger.debug(`[AcpBackend] Agent stderr: ${text.trim()}`);
-        }
-
-        // Let transport handler process stderr and optionally emit messages
-        if (this.transport.handleStderr) {
-          const result = this.transport.handleStderr(text, context);
-          if (result.message) {
-            this.emit(result.message);
-          }
-        }
+      this.process = spawnAgentProcess({
+        command: this.options.command,
+        args: this.options.args,
+        cwd: this.options.cwd,
+        env: this.options.env,
+      });
+      attachProcessListeners(this.process, {
+        transport: this.transport,
+        getActiveToolCalls: () => this.activeToolCalls,
+        isDisposed: () => this.disposed,
+        emit: (msg) => this.emit(msg),
       });
 
-      this.process.on('error', (err) => {
-        // Log to file only, not console
-        logger.debug(`[AcpBackend] Process error:`, err);
-        this.emit({ type: 'status', status: 'error', detail: err.message });
-      });
-
-      this.process.on('exit', (code, signal) => {
-        if (!this.disposed && code !== 0 && code !== null) {
-          logger.debug(`[AcpBackend] Process exited with code ${code}, signal ${signal}`);
-          this.emit({ type: 'status', status: 'stopped', detail: `Exit code: ${code}` });
-        }
-      });
-
-      // Create Web Streams from Node streams
-      const streams = nodeToWebStreams(
-        this.process.stdin,
-        this.process.stdout
-      );
-      const writable = streams.writable;
-      const readable = streams.readable;
-
-      // Filter stdout via transport handler before ACP parsing
-      // Some agents output debug info that breaks JSON-RPC parsing
-      const transport = this.transport;
-      const filteredReadable = new ReadableStream<Uint8Array>({
-        async start(controller) {
-          const reader = readable.getReader();
-          const decoder = new TextDecoder();
-          const encoder = new TextEncoder();
-          let buffer = '';
-          let filteredCount = 0;
-
-          try {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) {
-                // Flush any remaining buffer
-                if (buffer.trim()) {
-                  const filtered = transport.filterStdoutLine?.(buffer);
-                  if (filtered === undefined) {
-                    controller.enqueue(encoder.encode(buffer));
-                  } else if (filtered !== null) {
-                    controller.enqueue(encoder.encode(filtered));
-                  } else {
-                    filteredCount++;
-                  }
-                }
-                if (filteredCount > 0) {
-                  logger.debug(`[AcpBackend] Filtered out ${filteredCount} non-JSON lines from ${transport.agentName} stdout`);
-                }
-                controller.close();
-                break;
-              }
-
-              // Decode and accumulate data
-              buffer += decoder.decode(value, { stream: true });
-
-              // Process line by line (ndJSON is line-delimited)
-              const lines = buffer.split('\n');
-              buffer = lines.pop() || ''; // Keep last incomplete line in buffer
-
-              for (const line of lines) {
-                if (!line.trim()) continue;
-
-                // Use transport handler to filter lines
-                // Note: filterStdoutLine returns null to filter out, string to keep
-                // If method not implemented (undefined), pass through original line
-                const filtered = transport.filterStdoutLine?.(line);
-                if (filtered === undefined) {
-                  // Method not implemented, pass through
-                  controller.enqueue(encoder.encode(line + '\n'));
-                } else if (filtered !== null) {
-                  // Method returned transformed line
-                  controller.enqueue(encoder.encode(filtered + '\n'));
-                } else {
-                  // Method returned null, filter out
-                  filteredCount++;
-                }
-              }
-            }
-          } catch (error) {
-            logger.debug(`[AcpBackend] Error filtering stdout stream:`, error);
-            controller.error(error);
-          } finally {
-            reader.releaseLock();
-          }
-        }
-      });
-
-      // Create ndJSON stream for ACP
+      // Bridge stdio to Web Streams + filter non-JSON noise per transport.
+      const { writable, readable } = nodeToWebStreams(this.process.stdin!, this.process.stdout!);
+      const filteredReadable = createFilteredStdoutStream(readable, this.transport);
       const stream = ndJsonStream(writable, filteredReadable);
 
-      // Create Client implementation
+      // Build the ACP Client implementation. Permission handling is fully
+      // factored out — see permissionHandling.ts.
       const client: Client = {
         sessionUpdate: async (params: SessionNotification) => {
           this.handleSessionUpdate(params);
         },
-        requestPermission: async (params: RequestPermissionRequest): Promise<RequestPermissionResponse> => {
-          
-          const extendedParams = params as ExtendedRequestPermissionRequest;
-          const toolCall = extendedParams.toolCall;
-          let toolName = toolCall?.kind || toolCall?.toolName || extendedParams.kind || 'Unknown tool';
-          // Use toolCallId as the single source of truth for permission ID
-          // This ensures mobile app sends back the same ID that we use to store pending requests
-          const toolCallId = toolCall?.id || randomUUID();
-          const permissionId = toolCallId; // Use same ID for consistency!
-          
-          // Extract input/arguments from various possible locations FIRST (before checking toolName)
-          let input: Record<string, unknown> = {};
-          if (toolCall) {
-            input = toolCall.input || toolCall.arguments || toolCall.content || {};
-          } else {
-            // If no toolCall, try to extract from params directly
-            input = extendedParams.input || extendedParams.arguments || extendedParams.content || {};
-          }
-          
-          // If toolName is "other" or "Unknown tool", try to determine real tool name
-          const context: ToolNameContext = {
-            recentPromptHadChangeTitle: this.recentPromptHadChangeTitle,
-            toolCallCountSincePrompt: this.toolCallCountSincePrompt,
-          };
-          toolName = this.transport.determineToolName?.(toolName, toolCallId, input, context) ?? toolName;
-          
-          if (toolName !== (toolCall?.kind || toolCall?.toolName || extendedParams.kind || 'Unknown tool')) {
-            logger.debug(`[AcpBackend] Detected tool name: ${toolName} from toolCallId: ${toolCallId}`);
-          }
-          
-          // Increment tool call counter for context tracking
-          this.toolCallCountSincePrompt++;
-          
-          const options = extendedParams.options || [];
-          
-          // Log permission request for debugging (include full params to understand structure)
-          logger.debug(`[AcpBackend] Permission request: tool=${toolName}, toolCallId=${toolCallId}, input=`, JSON.stringify(input));
-          logger.debug(`[AcpBackend] Permission request params structure:`, JSON.stringify({
-            hasToolCall: !!toolCall,
-            toolCallKind: toolCall?.kind,
-            toolCallId: toolCall?.id,
-            paramsKind: extendedParams.kind,
-            paramsKeys: Object.keys(params),
-          }, null, 2));
-          
-          // Emit permission request event for UI/mobile handling
-          this.emit({
-            type: 'permission-request',
-            id: permissionId,
-            reason: toolName,
-            payload: {
-              ...params,
-              permissionId,
-              toolCallId,
-              toolName,
-              input,
-              options: options.map((opt) => ({
-                id: opt.optionId,
-                name: opt.name,
-                kind: opt.kind,
-              })),
-            },
-          });
-          
-          // Use permission handler if provided, otherwise auto-approve
-          if (this.options.permissionHandler) {
-            try {
-              const result = await this.options.permissionHandler.handleToolCall(
-                toolCallId,
-                toolName,
-                input
-              );
-              
-              // Map permission decision to ACP response
-              // ACP uses optionId from the request options
-              let optionId = 'cancel'; // Default to cancel/deny
-              
-              if (result.decision === 'approved' || result.decision === 'approved_for_session') {
-                // Find the appropriate optionId from the request options
-                // Look for 'proceed_once' or 'proceed_always' in options
-                const proceedOnceOption = options.find((opt) =>
-                  opt.optionId === 'proceed_once' || opt.name?.toLowerCase().includes('once')
-                );
-                const proceedAlwaysOption = options.find((opt) =>
-                  opt.optionId === 'proceed_always' || opt.name?.toLowerCase().includes('always')
-                );
-                
-                if (result.decision === 'approved_for_session' && proceedAlwaysOption) {
-                  optionId = proceedAlwaysOption.optionId || 'proceed_always';
-                } else if (proceedOnceOption) {
-                  optionId = proceedOnceOption.optionId || 'proceed_once';
-                } else if (options.length > 0) {
-                  // Fallback to first option if no specific match
-                  optionId = options[0].optionId || 'proceed_once';
-                }
-                
-                // Emit tool-result with permissionId so UI can close the timer
-                // This is needed because tool_call_update comes with a different ID
-                this.emit({
-                  type: 'tool-result',
-                  toolName,
-                  result: { status: 'approved', decision: result.decision },
-                  callId: permissionId,
-                });
-              } else {
-                // Denied or aborted - find cancel option
-                const cancelOption = options.find((opt) =>
-                  opt.optionId === 'cancel' || opt.name?.toLowerCase().includes('cancel')
-                );
-                if (cancelOption) {
-                  optionId = cancelOption.optionId || 'cancel';
-                }
-                
-                // Emit tool-result for denied/aborted
-                this.emit({
-                  type: 'tool-result',
-                  toolName,
-                  result: { status: 'denied', decision: result.decision },
-                  callId: permissionId,
-                });
-              }
-              
-              return { outcome: { outcome: 'selected', optionId } };
-            } catch (error) {
-              // Log to file only, not console
-              logger.debug('[AcpBackend] Error in permission handler:', error);
-              // Fallback to deny on error
-              return { outcome: { outcome: 'selected', optionId: 'cancel' } };
-            }
-          }
-          
-          // Auto-approve with 'proceed_once' if no permission handler
-          // optionId must match one from the request options (e.g., 'proceed_once', 'proceed_always', 'cancel')
-          const proceedOnceOption = options.find((opt) => 
-            opt.optionId === 'proceed_once' || (typeof opt.name === 'string' && opt.name.toLowerCase().includes('once'))
-          );
-          const defaultOptionId = proceedOnceOption?.optionId || (options.length > 0 && options[0].optionId ? options[0].optionId : 'proceed_once');
-          return { outcome: { outcome: 'selected', optionId: defaultOptionId } };
-        },
-      };
-
-      // Create ClientSideConnection
-      this.connection = new ClientSideConnection(
-        (agent: Agent) => client,
-        stream
-      );
-
-      // Initialize the connection with timeout and retry
-      const initRequest: InitializeRequest = {
-        protocolVersion: 1,
-        clientCapabilities: {
-          fs: {
-            readTextFile: false,
-            writeTextFile: false,
+        requestPermission: createPermissionHandler({
+          transport: this.transport,
+          permissionHandler: this.options.permissionHandler,
+          getRecentPromptHadChangeTitle: () => this.recentPromptHadChangeTitle,
+          getToolCallCountSincePrompt: () => this.toolCallCountSincePrompt,
+          incrementToolCallCount: () => {
+            this.toolCallCountSincePrompt++;
           },
-        },
-        clientInfo: {
-          name: 'happy-cli',
-          version: packageJson.version,
-        },
+          emit: (msg) => this.emit(msg),
+        }),
       };
 
-      const initTimeout = this.transport.getInitTimeout();
-      logger.debug(`[AcpBackend] Initializing connection (timeout: ${initTimeout}ms)...`);
+      this.connection = new ClientSideConnection((_agent: Agent) => client, stream);
 
-      await withRetry(
-        async () => {
-          let timeoutHandle: NodeJS.Timeout | null = null;
-          try {
-            const result = await Promise.race([
-              this.connection!.initialize(initRequest).then((res) => {
-                if (timeoutHandle) {
-                  clearTimeout(timeoutHandle);
-                  timeoutHandle = null;
-                }
-                return res;
-              }),
-              new Promise<never>((_, reject) => {
-                timeoutHandle = setTimeout(() => {
-                  reject(new Error(`Initialize timeout after ${initTimeout}ms - ${this.transport.agentName} did not respond`));
-                }, initTimeout);
-              }),
-            ]);
-            return result;
-          } finally {
-            if (timeoutHandle) {
-              clearTimeout(timeoutHandle);
-            }
-          }
-        },
-        {
-          operationName: 'Initialize',
-          maxAttempts: RETRY_CONFIG.maxAttempts,
-          baseDelayMs: RETRY_CONFIG.baseDelayMs,
-          maxDelayMs: RETRY_CONFIG.maxDelayMs,
-        }
+      await initializeAcpConnection(this.connection, this.transport);
+      this.acpSessionId = await createAcpSession(
+        this.connection,
+        this.transport,
+        this.options.cwd,
+        this.options.mcpServers
       );
-      logger.debug(`[AcpBackend] Initialize completed`);
-
-      // Create a new session with retry
-      const mcpServers = this.options.mcpServers
-        ? Object.entries(this.options.mcpServers).map(([name, config]) => ({
-            name,
-            command: config.command,
-            args: config.args || [],
-            env: config.env
-              ? Object.entries(config.env).map(([envName, envValue]) => ({ name: envName, value: envValue }))
-              : [],
-          }))
-        : [];
-
-      const newSessionRequest: NewSessionRequest = {
-        cwd: this.options.cwd,
-        mcpServers: mcpServers as unknown as NewSessionRequest['mcpServers'],
-      };
-
-      logger.debug(`[AcpBackend] Creating new session...`);
-
-      const sessionResponse = await withRetry(
-        async () => {
-          let timeoutHandle: NodeJS.Timeout | null = null;
-          try {
-            const result = await Promise.race([
-              this.connection!.newSession(newSessionRequest).then((res) => {
-                if (timeoutHandle) {
-                  clearTimeout(timeoutHandle);
-                  timeoutHandle = null;
-                }
-                return res;
-              }),
-              new Promise<never>((_, reject) => {
-                timeoutHandle = setTimeout(() => {
-                  reject(new Error(`New session timeout after ${initTimeout}ms - ${this.transport.agentName} did not respond`));
-                }, initTimeout);
-              }),
-            ]);
-            return result;
-          } finally {
-            if (timeoutHandle) {
-              clearTimeout(timeoutHandle);
-            }
-          }
-        },
-        {
-          operationName: 'NewSession',
-          maxAttempts: RETRY_CONFIG.maxAttempts,
-          baseDelayMs: RETRY_CONFIG.baseDelayMs,
-          maxDelayMs: RETRY_CONFIG.maxDelayMs,
-        }
-      );
-      this.acpSessionId = sessionResponse.sessionId;
-      logger.debug(`[AcpBackend] Session created: ${this.acpSessionId}`);
 
       this.emitIdleStatus();
 
-      // Send initial prompt if provided
       if (initialPrompt) {
         this.sendPrompt(sessionId, initialPrompt).catch((error) => {
-          // Log to file only, not console
           logger.debug('[AcpBackend] Error sending initial prompt:', error);
           this.emit({ type: 'status', status: 'error', detail: String(error) });
         });
       }
 
       return { sessionId };
-
     } catch (error) {
-      // Log to file only, not console
       logger.debug('[AcpBackend] Error starting session:', error);
-      this.emit({ 
-        type: 'status', 
-        status: 'error', 
-        detail: error instanceof Error ? error.message : String(error) 
+      this.emit({
+        type: 'status',
+        status: 'error',
+        detail: error instanceof Error ? error.message : String(error),
       });
       throw error;
     }
   }
 
-  /**
-   * Create handler context for session update processing
-   */
+  /** Build the per-update handler context shared with sessionUpdateHandlers. */
   private createHandlerContext(): HandlerContext {
     return {
       transport: this.transport,
@@ -807,91 +205,29 @@ export class AcpBackend implements AgentBackend {
   }
 
   private handleSessionUpdate(params: SessionNotification): void {
-    const notification = params as ExtendedSessionNotification;
-    const update = notification.update;
-
-    if (!update) {
-      logger.debug('[AcpBackend] Received session update without update field:', params);
-      return;
-    }
-
-    const sessionUpdateType = update.sessionUpdate;
-
-    // Log session updates for debugging (but not every chunk to avoid log spam)
-    if (sessionUpdateType !== 'agent_message_chunk') {
-      logger.debug(`[AcpBackend] Received session update: ${sessionUpdateType}`, JSON.stringify({
-        sessionUpdate: sessionUpdateType,
-        toolCallId: update.toolCallId,
-        status: update.status,
-        kind: update.kind,
-        hasContent: !!update.content,
-        hasLocations: !!update.locations,
-      }, null, 2));
-    }
-
     const ctx = this.createHandlerContext();
-
-    // Dispatch to appropriate handler based on update type
-    if (sessionUpdateType === 'agent_message_chunk') {
-      handleAgentMessageChunk(update as SessionUpdate, ctx);
-      return;
-    }
-
-    if (sessionUpdateType === 'tool_call_update') {
-      const result = handleToolCallUpdate(update as SessionUpdate, ctx);
-      if (result.toolCallCountSincePrompt !== undefined) {
-        this.toolCallCountSincePrompt = result.toolCallCountSincePrompt;
-      }
-      return;
-    }
-
-    if (sessionUpdateType === 'agent_thought_chunk') {
-      handleAgentThoughtChunk(update as SessionUpdate, ctx);
-      return;
-    }
-
-    if (sessionUpdateType === 'tool_call') {
-      handleToolCall(update as SessionUpdate, ctx);
-      return;
-    }
-
-    // Handle legacy and auxiliary update types
-    handleLegacyMessageChunk(update as SessionUpdate, ctx);
-    handlePlanUpdate(update as SessionUpdate, ctx);
-    handleThinkingUpdate(update as SessionUpdate, ctx);
-
-    // Log unhandled session update types for debugging
-    // Cast to string to avoid TypeScript errors (SDK types don't include all Gemini-specific update types)
-    const updateTypeStr = sessionUpdateType as string;
-    const handledTypes = ['agent_message_chunk', 'tool_call_update', 'agent_thought_chunk', 'tool_call'];
-    if (updateTypeStr &&
-        !handledTypes.includes(updateTypeStr) &&
-        !update.messageChunk &&
-        !update.plan &&
-        !update.thinking) {
-      logger.debug(`[AcpBackend] Unhandled session update type: ${updateTypeStr}`, JSON.stringify(update, null, 2));
+    const result = dispatchSessionUpdate(params, ctx);
+    if (result.toolCallCountSincePrompt !== undefined) {
+      this.toolCallCountSincePrompt = result.toolCallCountSincePrompt;
     }
   }
 
-  // Promise resolver for waitForIdle - set when waiting for response to complete
-  private idleResolver: (() => void) | null = null;
-  private waitingForResponse = false;
-
   async sendPrompt(sessionId: SessionId, prompt: string): Promise<void> {
-    // Check if prompt contains change_title instruction (via optional callback)
     const promptHasChangeTitle = this.options.hasChangeTitleInstruction?.(prompt) ?? false;
 
-    // Reset tool call counter and set flag
+    // Reset per-prompt counters BEFORE the disposed/connection guards so callers
+    // observing recentPromptHadChangeTitle see a consistent state on error.
     this.toolCallCountSincePrompt = 0;
     this.recentPromptHadChangeTitle = promptHasChangeTitle;
-    
+
     if (promptHasChangeTitle) {
-      logger.debug('[AcpBackend] Prompt contains change_title instruction - will auto-approve first "other" tool call if it matches pattern');
+      logger.debug(
+        '[AcpBackend] Prompt contains change_title instruction - will auto-approve first "other" tool call if it matches pattern'
+      );
     }
     if (this.disposed) {
       throw new Error('Backend has been disposed');
     }
-
     if (!this.connection || !this.acpSessionId) {
       throw new Error('Session not started');
     }
@@ -900,14 +236,12 @@ export class AcpBackend implements AgentBackend {
     this.waitingForResponse = true;
 
     try {
-      logger.debug(`[AcpBackend] Sending prompt (length: ${prompt.length}): ${prompt.substring(0, 100)}...`);
+      logger.debug(
+        `[AcpBackend] Sending prompt (length: ${prompt.length}): ${prompt.substring(0, 100)}...`
+      );
       logger.debug(`[AcpBackend] Full prompt: ${prompt}`);
-      
-      const contentBlock: ContentBlock = {
-        type: 'text',
-        text: prompt,
-      };
 
+      const contentBlock: ContentBlock = { type: 'text', text: prompt };
       const promptRequest: PromptRequest = {
         sessionId: this.acpSessionId,
         prompt: [contentBlock],
@@ -916,49 +250,30 @@ export class AcpBackend implements AgentBackend {
       logger.debug(`[AcpBackend] Prompt request:`, JSON.stringify(promptRequest, null, 2));
       await this.connection.prompt(promptRequest);
       logger.debug('[AcpBackend] Prompt request sent to ACP connection');
-      
-      // Don't emit 'idle' here - it will be emitted after all message chunks are received
-      // The idle timeout in handleSessionUpdate will emit 'idle' after the last chunk
 
+      // 'idle' is emitted after all message chunks are received; the idle
+      // timeout in handleSessionUpdate fires it after the last chunk.
     } catch (error) {
       logger.debug('[AcpBackend] Error sending prompt:', error);
       this.waitingForResponse = false;
-      
-      // Extract error details for better error handling
-      let errorDetail: string;
-      if (error instanceof Error) {
-        errorDetail = error.message;
-      } else if (typeof error === 'object' && error !== null) {
-        const errObj = error as Record<string, unknown>;
-        // Try to extract structured error information
-        const fallbackMessage = (typeof errObj.message === 'string' ? errObj.message : undefined) || String(error);
-        if (errObj.code !== undefined) {
-          errorDetail = JSON.stringify({ code: errObj.code, message: fallbackMessage });
-        } else if (typeof errObj.message === 'string') {
-          errorDetail = errObj.message;
-        } else {
-          errorDetail = String(error);
-        }
-      } else {
-        errorDetail = String(error);
-      }
-      
-      this.emit({ 
-        type: 'status', 
-        status: 'error', 
-        detail: errorDetail
+      this.emit({
+        type: 'status',
+        status: 'error',
+        detail: extractSendPromptErrorDetail(error),
       });
       throw error;
     }
   }
 
   /**
-   * Wait for the response to complete (idle status after all chunks received)
-   * Call this after sendPrompt to wait for Gemini to finish responding
+   * Wait for the response to complete (idle status after all chunks received).
+   * Call this after `sendPrompt` to wait for the agent to finish responding.
+   *
+   * @param timeoutMs - Maximum wait, default 120s.
    */
   async waitForResponseComplete(timeoutMs: number = 120000): Promise<void> {
     if (!this.waitingForResponse) {
-      return; // Already completed or no prompt sent
+      return;
     }
 
     return new Promise((resolve, reject) => {
@@ -977,19 +292,16 @@ export class AcpBackend implements AgentBackend {
     });
   }
 
-  /**
-   * Helper to emit idle status and resolve any waiting promises
-   */
+  /** Emit idle status and resolve any waiting `waitForResponseComplete` promise. */
   private emitIdleStatus(): void {
     this.emit({ type: 'status', status: 'idle' });
-    // Resolve any waiting promises
     if (this.idleResolver) {
       logger.debug('[AcpBackend] Resolving idle waiter');
       this.idleResolver();
     }
   }
 
-  async cancel(sessionId: SessionId): Promise<void> {
+  async cancel(_sessionId: SessionId): Promise<void> {
     if (!this.connection || !this.acpSessionId) {
       return;
     }
@@ -998,25 +310,21 @@ export class AcpBackend implements AgentBackend {
       await this.connection.cancel({ sessionId: this.acpSessionId });
       this.emit({ type: 'status', status: 'stopped', detail: 'Cancelled by user' });
     } catch (error) {
-      // Log to file only, not console
       logger.debug('[AcpBackend] Error cancelling:', error);
     }
   }
 
   /**
-   * Emit permission response event for UI/logging purposes.
+   * Emit a permission-response event for UI/logging only.
    *
-   * **IMPORTANT:** For ACP backends, this method does NOT send the actual permission
-   * response to the agent. The ACP protocol requires synchronous permission handling,
-   * which is done inside the `requestPermission` RPC handler via `this.options.permissionHandler`.
+   * **IMPORTANT:** For ACP backends this method does NOT send the actual
+   * permission response to the agent — the ACP protocol requires synchronous
+   * permission handling, which is performed inside `requestPermission` via
+   * `this.options.permissionHandler`. This method exists so other parts of
+   * the CLI (UI dialogs, audit log) can still react to decisions.
    *
-   * This method only emits a `permission-response` event for:
-   * - UI updates (e.g., closing permission dialogs)
-   * - Logging and debugging
-   * - Other parts of the CLI that need to react to permission decisions
-   *
-   * @param requestId - The ID of the permission request
-   * @param approved - Whether the permission was granted
+   * @param requestId - The ID of the permission request.
+   * @param approved  - Whether the permission was granted.
    */
   async respondToPermission(requestId: string, approved: boolean): Promise<void> {
     logger.debug(`[AcpBackend] Permission response event (UI only): ${requestId} = ${approved}`);
@@ -1025,29 +333,27 @@ export class AcpBackend implements AgentBackend {
 
   async dispose(): Promise<void> {
     if (this.disposed) return;
-    
+
     logger.debug('[AcpBackend] Disposing backend');
     this.disposed = true;
 
-    // Try graceful shutdown first
+    // Try graceful shutdown first.
     if (this.connection && this.acpSessionId) {
       try {
-        // Send cancel to stop any ongoing work
         await Promise.race([
           this.connection.cancel({ sessionId: this.acpSessionId }),
-          new Promise((resolve) => setTimeout(resolve, 2000)), // 2s timeout for graceful shutdown
+          // 2s budget for the agent to acknowledge the cancel before we move on.
+          new Promise((resolve) => setTimeout(resolve, 2000)),
         ]);
       } catch (error) {
         logger.debug('[AcpBackend] Error during graceful shutdown:', error);
       }
     }
 
-    // Kill the process
     if (this.process) {
-      // Try SIGTERM first, then SIGKILL after timeout
+      // SIGTERM first; escalate to SIGKILL if the process hasn't exited in 1s.
       this.process.kill('SIGTERM');
-      
-      // Give process 1 second to terminate gracefully
+
       await new Promise<void>((resolve) => {
         const timeout = setTimeout(() => {
           if (this.process) {
@@ -1056,28 +362,25 @@ export class AcpBackend implements AgentBackend {
           }
           resolve();
         }, 1000);
-        
+
         this.process?.once('exit', () => {
           clearTimeout(timeout);
           resolve();
         });
       });
-      
+
       this.process = null;
     }
 
-    // Clear timeouts
     if (this.idleTimeout) {
       clearTimeout(this.idleTimeout);
       this.idleTimeout = null;
     }
 
-    // Clear state
     this.listeners = [];
     this.connection = null;
     this.acpSessionId = null;
     this.activeToolCalls.clear();
-    // Clear all tool call timeouts
     for (const timeout of this.toolCallTimeouts.values()) {
       clearTimeout(timeout);
     }

--- a/packages/styrby-cli/src/agent/acp/__tests__/errorFormatting.test.ts
+++ b/packages/styrby-cli/src/agent/acp/__tests__/errorFormatting.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { extractSendPromptErrorDetail } from '../errorFormatting';
+
+/**
+ * extractSendPromptErrorDetail must produce a stable, non-empty string for
+ * every shape of error the ACP SDK / JSON-RPC layer can throw, so the
+ * mobile UI never shows `[object Object]` to a user.
+ */
+describe('extractSendPromptErrorDetail', () => {
+  it('returns Error.message for Error instances', () => {
+    const err = new Error('boom');
+    expect(extractSendPromptErrorDetail(err)).toBe('boom');
+  });
+
+  it('returns Error.message even when subclassed', () => {
+    class CustomError extends Error {}
+    expect(extractSendPromptErrorDetail(new CustomError('nope'))).toBe('nope');
+  });
+
+  it('serializes objects with a code field as JSON {code,message}', () => {
+    const detail = extractSendPromptErrorDetail({ code: -32000, message: 'rpc' });
+    expect(JSON.parse(detail)).toEqual({ code: -32000, message: 'rpc' });
+  });
+
+  it('falls back to String(error) when object has code but no message', () => {
+    const detail = extractSendPromptErrorDetail({ code: 1 });
+    const parsed = JSON.parse(detail);
+    expect(parsed.code).toBe(1);
+    // message becomes the String() representation of the object
+    expect(typeof parsed.message).toBe('string');
+  });
+
+  it('returns plain message string for objects with message but no code', () => {
+    expect(extractSendPromptErrorDetail({ message: 'plain' })).toBe('plain');
+  });
+
+  it('returns String(error) for objects without message or code', () => {
+    expect(extractSendPromptErrorDetail({ foo: 'bar' })).toBe('[object Object]');
+  });
+
+  it('returns String(value) for primitives', () => {
+    expect(extractSendPromptErrorDetail('string error')).toBe('string error');
+    expect(extractSendPromptErrorDetail(42)).toBe('42');
+    expect(extractSendPromptErrorDetail(null)).toBe('null');
+    expect(extractSendPromptErrorDetail(undefined)).toBe('undefined');
+  });
+});

--- a/packages/styrby-cli/src/agent/acp/__tests__/permissionHandling.test.ts
+++ b/packages/styrby-cli/src/agent/acp/__tests__/permissionHandling.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { mapDecisionToOptionId } from '../permissionHandling';
+
+/**
+ * mapDecisionToOptionId is the security-critical bridge between the user's
+ * decision and the optionId we send to the agent. Wrong mapping = either
+ * silently denying approved work, or silently approving denied work.
+ */
+describe('mapDecisionToOptionId', () => {
+  const fullOptions = [
+    { optionId: 'proceed_once', name: 'Proceed once' },
+    { optionId: 'proceed_always', name: 'Proceed always' },
+    { optionId: 'cancel', name: 'Cancel' },
+  ];
+
+  describe('approval decisions', () => {
+    it('selects proceed_once for "approved"', () => {
+      expect(mapDecisionToOptionId('approved', fullOptions)).toBe('proceed_once');
+    });
+
+    it('selects proceed_always for "approved_for_session" when available', () => {
+      expect(mapDecisionToOptionId('approved_for_session', fullOptions)).toBe('proceed_always');
+    });
+
+    it('falls back to proceed_once for approved_for_session if proceed_always absent', () => {
+      const opts = [
+        { optionId: 'proceed_once', name: 'Proceed once' },
+        { optionId: 'cancel', name: 'Cancel' },
+      ];
+      expect(mapDecisionToOptionId('approved_for_session', opts)).toBe('proceed_once');
+    });
+
+    it('matches by name fragment when optionId is unconventional', () => {
+      const opts = [
+        { optionId: 'opt_a', name: 'Allow once now' },
+        { optionId: 'opt_b', name: 'Cancel please' },
+      ];
+      expect(mapDecisionToOptionId('approved', opts)).toBe('opt_a');
+    });
+
+    it('falls back to first option if no proceed_once-like exists', () => {
+      const opts = [{ optionId: 'first', name: 'First' }];
+      expect(mapDecisionToOptionId('approved', opts)).toBe('first');
+    });
+
+    it('returns "proceed_once" sentinel when options array is empty', () => {
+      expect(mapDecisionToOptionId('approved', [])).toBe('proceed_once');
+    });
+  });
+
+  describe('denial decisions', () => {
+    it('selects cancel for "denied"', () => {
+      expect(mapDecisionToOptionId('denied', fullOptions)).toBe('cancel');
+    });
+
+    it('selects cancel for "abort"', () => {
+      expect(mapDecisionToOptionId('abort', fullOptions)).toBe('cancel');
+    });
+
+    it('matches cancel by name fragment when optionId differs', () => {
+      const opts = [{ optionId: 'opt_x', name: 'Cancel the request' }];
+      expect(mapDecisionToOptionId('denied', opts)).toBe('opt_x');
+    });
+
+    it('returns literal "cancel" when no cancel option exists', () => {
+      const opts = [{ optionId: 'proceed_once' }];
+      expect(mapDecisionToOptionId('denied', opts)).toBe('cancel');
+    });
+  });
+
+  it('handles options with missing optionId gracefully', () => {
+    const opts = [{ name: 'Once' }, { name: 'Cancel' }];
+    expect(mapDecisionToOptionId('approved', opts)).toBe('proceed_once');
+    expect(mapDecisionToOptionId('denied', opts)).toBe('cancel');
+  });
+});

--- a/packages/styrby-cli/src/agent/acp/__tests__/retryHelper.test.ts
+++ b/packages/styrby-cli/src/agent/acp/__tests__/retryHelper.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import { withRetry, withTimeout, RETRY_CONFIG } from '../retryHelper';
+
+/**
+ * withRetry / withTimeout are the resilience primitives used to bound and
+ * recover ACP initialize + newSession RPCs. Wrong behavior here = either
+ * stuck sessions or aggressive retry storms against a degraded agent.
+ */
+describe('RETRY_CONFIG', () => {
+  it('exposes sane defaults', () => {
+    expect(RETRY_CONFIG.maxAttempts).toBeGreaterThanOrEqual(2);
+    expect(RETRY_CONFIG.baseDelayMs).toBeGreaterThan(0);
+    expect(RETRY_CONFIG.maxDelayMs).toBeGreaterThanOrEqual(RETRY_CONFIG.baseDelayMs);
+  });
+});
+
+describe('withRetry', () => {
+  it('returns the value on first success without retrying', async () => {
+    const op = vi.fn().mockResolvedValue('ok');
+    const result = await withRetry(op, {
+      operationName: 'test',
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+    });
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on failure and resolves on a later attempt', async () => {
+    const op = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error('first'))
+      .mockRejectedValueOnce(new Error('second'))
+      .mockResolvedValue('third');
+
+    const result = await withRetry(op, {
+      operationName: 'test',
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+    });
+    expect(result).toBe('third');
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws the last error when all attempts fail', async () => {
+    const op = vi.fn().mockRejectedValue(new Error('persistent'));
+    await expect(
+      withRetry(op, {
+        operationName: 'test',
+        maxAttempts: 2,
+        baseDelayMs: 1,
+        maxDelayMs: 1,
+      })
+    ).rejects.toThrow('persistent');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('wraps non-Error throws into Error so the catch path is consistent', async () => {
+    const op = vi.fn().mockRejectedValue('plain string');
+    await expect(
+      withRetry(op, {
+        operationName: 'test',
+        maxAttempts: 1,
+        baseDelayMs: 1,
+        maxDelayMs: 1,
+      })
+    ).rejects.toThrow('plain string');
+  });
+
+  it('invokes onRetry between attempts but not after the final failure', async () => {
+    const onRetry = vi.fn();
+    const op = vi.fn().mockRejectedValue(new Error('fail'));
+    await expect(
+      withRetry(op, {
+        operationName: 'test',
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 1,
+        onRetry,
+      })
+    ).rejects.toThrow();
+    // onRetry fires after attempts 1 and 2, NOT after attempt 3 (final).
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenNthCalledWith(1, 1, expect.any(Error));
+    expect(onRetry).toHaveBeenNthCalledWith(2, 2, expect.any(Error));
+  });
+});
+
+describe('withTimeout', () => {
+  it('resolves with the operation value when it completes in time', async () => {
+    const result = await withTimeout(
+      () => Promise.resolve('done'),
+      100,
+      'should not fire'
+    );
+    expect(result).toBe('done');
+  });
+
+  it('rejects with the timeout message when the operation hangs', async () => {
+    await expect(
+      withTimeout(() => new Promise(() => undefined), 10, 'too slow')
+    ).rejects.toThrow('too slow');
+  });
+
+  it('propagates the underlying rejection unchanged when it loses the race', async () => {
+    await expect(
+      withTimeout(() => Promise.reject(new Error('inner')), 100, 'timeout-msg')
+    ).rejects.toThrow('inner');
+  });
+});

--- a/packages/styrby-cli/src/agent/acp/__tests__/sessionUpdateDispatcher.test.ts
+++ b/packages/styrby-cli/src/agent/acp/__tests__/sessionUpdateDispatcher.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionNotification } from '@agentclientprotocol/sdk';
+import { dispatchSessionUpdate } from '../sessionUpdateDispatcher';
+import type { HandlerContext } from '../sessionUpdateHandlers';
+import type { TransportHandler } from '../../transport';
+
+/**
+ * dispatchSessionUpdate is the routing layer between raw ACP notifications
+ * and the per-type handlers. We verify routing correctness without re-testing
+ * the handler internals (those are covered by sessionUpdateHandlers.test.ts).
+ */
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  const transport: TransportHandler = {
+    agentName: 'test',
+    getInitTimeout: () => 1000,
+  } as TransportHandler;
+  return {
+    transport,
+    activeToolCalls: new Set(),
+    toolCallStartTimes: new Map(),
+    toolCallTimeouts: new Map(),
+    toolCallIdToNameMap: new Map(),
+    idleTimeout: null,
+    toolCallCountSincePrompt: 0,
+    emit: vi.fn(),
+    emitIdleStatus: vi.fn(),
+    clearIdleTimeout: vi.fn(),
+    setIdleTimeout: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeNotification(update: Record<string, unknown> | undefined): SessionNotification {
+  return { sessionId: 's1', update } as unknown as SessionNotification;
+}
+
+describe('dispatchSessionUpdate', () => {
+  it('returns empty result and emits nothing when notification has no update field', () => {
+    const ctx = makeCtx();
+    const result = dispatchSessionUpdate(makeNotification(undefined), ctx);
+    expect(result).toEqual({});
+    expect(ctx.emit).not.toHaveBeenCalled();
+  });
+
+  it('routes agent_message_chunk to the chunk handler (resets idle timer)', () => {
+    const ctx = makeCtx();
+    const result = dispatchSessionUpdate(
+      makeNotification({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'hello' },
+      }),
+      ctx
+    );
+    expect(result).toEqual({});
+    // The chunk handler emits a message and arms an idle timeout.
+    expect(ctx.emit).toHaveBeenCalled();
+    expect(ctx.setIdleTimeout).toHaveBeenCalled();
+  });
+
+  it('routes tool_call_update and surfaces toolCallCountSincePrompt back to caller', () => {
+    const ctx = makeCtx({
+      activeToolCalls: new Set(['call-1']),
+      toolCallIdToNameMap: new Map([['call-1', 'shell']]),
+      toolCallStartTimes: new Map([['call-1', Date.now()]]),
+    });
+    const result = dispatchSessionUpdate(
+      makeNotification({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'call-1',
+        status: 'completed',
+      }),
+      ctx
+    );
+    // Either undefined (handler made no change) or a number — but the key
+    // must be present in the dispatcher's response shape regardless.
+    expect(result).toHaveProperty('toolCallCountSincePrompt');
+  });
+
+  it('routes agent_thought_chunk without surfacing tool-call state', () => {
+    const ctx = makeCtx();
+    const result = dispatchSessionUpdate(
+      makeNotification({
+        sessionUpdate: 'agent_thought_chunk',
+        content: { type: 'text', text: 'thinking' },
+      }),
+      ctx
+    );
+    expect(result).toEqual({});
+  });
+
+  it('routes tool_call to the tool-call handler', () => {
+    const ctx = makeCtx();
+    const result = dispatchSessionUpdate(
+      makeNotification({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'tc-1',
+        kind: 'read',
+        content: {},
+      }),
+      ctx
+    );
+    expect(result).toEqual({});
+    // tool_call handler emits at least one message.
+    expect(ctx.emit).toHaveBeenCalled();
+  });
+
+  it('falls through to legacy/plan/thinking handlers for unknown update types', () => {
+    const ctx = makeCtx();
+    // No primary type matches → all three legacy handlers are invoked.
+    // None of them emit when their respective fields are absent, so this
+    // should be a clean no-op that simply logs.
+    const result = dispatchSessionUpdate(
+      makeNotification({ sessionUpdate: 'totally_unknown' }),
+      ctx
+    );
+    expect(result).toEqual({});
+    expect(ctx.emit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/styrby-cli/src/agent/acp/acpTypes.ts
+++ b/packages/styrby-cli/src/agent/acp/acpTypes.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared types for the ACP backend.
+ *
+ * WHY: The official `@agentclientprotocol/sdk` types are intentionally narrow,
+ * but real agents (Crush, Gemini CLI, Codex) emit richer payloads with extra
+ * fields the SDK doesn't model. We extend the SDK types here so the rest of
+ * the backend can talk in well-typed shapes without scattering `as any` casts.
+ */
+
+import type {
+  RequestPermissionRequest,
+  SessionNotification,
+} from '@agentclientprotocol/sdk';
+import type { McpServerConfig } from '../core';
+import type { TransportHandler } from '../transport';
+
+/**
+ * Extended `RequestPermissionRequest` with fields some agents add.
+ *
+ * - `toolCall`: Crush-style nested object describing the call.
+ * - `kind` / `input` / `arguments` / `content`: top-level variants used by other agents.
+ * - `options`: the choices the agent presents to the user (proceed_once, …).
+ */
+export type ExtendedRequestPermissionRequest = RequestPermissionRequest & {
+  toolCall?: {
+    id?: string;
+    kind?: string;
+    toolName?: string;
+    input?: Record<string, unknown>;
+    arguments?: Record<string, unknown>;
+    content?: Record<string, unknown>;
+  };
+  kind?: string;
+  input?: Record<string, unknown>;
+  arguments?: Record<string, unknown>;
+  content?: Record<string, unknown>;
+  options?: Array<{
+    optionId?: string;
+    name?: string;
+    kind?: string;
+  }>;
+};
+
+/**
+ * Extended `SessionNotification` whose `update` payload models the optional
+ * fields agents emit (tool_call_update, plan, thinking, …).
+ */
+export type ExtendedSessionNotification = SessionNotification & {
+  update?: {
+    sessionUpdate?: string;
+    toolCallId?: string;
+    status?: string;
+    kind?: string | unknown;
+    content?:
+      | {
+          text?: string;
+          error?: string | { message?: string };
+          [key: string]: unknown;
+        }
+      | string
+      | unknown;
+    locations?: unknown[];
+    messageChunk?: {
+      textDelta?: string;
+    };
+    plan?: unknown;
+    thinking?: unknown;
+    [key: string]: unknown;
+  };
+};
+
+/**
+ * Permission-handler interface implemented by callers (mobile dialog, CLI prompt).
+ *
+ * `handleToolCall` is awaited synchronously inside the ACP `requestPermission`
+ * RPC; the returned decision drives which `optionId` we send back to the agent.
+ */
+export interface AcpPermissionHandler {
+  /**
+   * Decide whether a tool call should proceed.
+   *
+   * @param toolCallId - Unique ID of the tool call (also the permission ID).
+   * @param toolName   - Resolved tool name (e.g., 'read_file', 'shell').
+   * @param input      - Tool input parameters as supplied by the agent.
+   * @returns A decision payload; defaults to 'denied' on error.
+   */
+  handleToolCall(
+    toolCallId: string,
+    toolName: string,
+    input: unknown
+  ): Promise<{
+    decision: 'approved' | 'approved_for_session' | 'denied' | 'abort';
+  }>;
+}
+
+/**
+ * Configuration for {@link AcpBackend}.
+ */
+export interface AcpBackendOptions {
+  /** Agent name for identification (used by transport handlers + logs). */
+  agentName: string;
+  /** Working directory the agent subprocess runs in. */
+  cwd: string;
+  /** Command/binary used to spawn the ACP agent. */
+  command: string;
+  /** Arguments for the agent command. */
+  args?: string[];
+  /** Environment variables passed to the agent (merged with safe defaults). */
+  env?: Record<string, string>;
+  /** MCP servers to make available to the agent. */
+  mcpServers?: Record<string, McpServerConfig>;
+  /** Optional permission handler for tool approval decisions. */
+  permissionHandler?: AcpPermissionHandler;
+  /** Transport handler for agent-specific behavior (timeouts, filtering, …). */
+  transportHandler?: TransportHandler;
+  /** Optional callback to detect a `change_title` instruction in the prompt. */
+  hasChangeTitleInstruction?: (prompt: string) => boolean;
+}

--- a/packages/styrby-cli/src/agent/acp/errorFormatting.ts
+++ b/packages/styrby-cli/src/agent/acp/errorFormatting.ts
@@ -1,0 +1,41 @@
+/**
+ * Error formatting helpers for ACP backend.
+ *
+ * WHY: Errors thrown by the ACP SDK and JSON-RPC layer come in many shapes
+ * (Error instances, plain objects with `code`/`message`, raw strings). The
+ * mobile UI needs a stable string representation so users see useful detail
+ * rather than `[object Object]`. Centralizing the extraction keeps that
+ * normalization logic out of `sendPrompt` and unit-testable in isolation.
+ */
+
+/**
+ * Extract a stable error-detail string from an unknown caught value.
+ *
+ * Priority:
+ * 1. {@link Error} instances → `error.message`
+ * 2. Objects with a `code` field → JSON of `{ code, message }`
+ * 3. Objects with a string `message` → that message
+ * 4. Anything else → `String(error)`
+ *
+ * @param error - The caught value (typed `unknown` from a `catch` clause).
+ * @returns A non-empty string suitable for surfacing to the UI / status emit.
+ */
+export function extractSendPromptErrorDetail(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'object' && error !== null) {
+    const errObj = error as Record<string, unknown>;
+    const fallbackMessage =
+      (typeof errObj.message === 'string' ? errObj.message : undefined) ||
+      String(error);
+    if (errObj.code !== undefined) {
+      return JSON.stringify({ code: errObj.code, message: fallbackMessage });
+    }
+    if (typeof errObj.message === 'string') {
+      return errObj.message;
+    }
+    return String(error);
+  }
+  return String(error);
+}

--- a/packages/styrby-cli/src/agent/acp/permissionHandling.ts
+++ b/packages/styrby-cli/src/agent/acp/permissionHandling.ts
@@ -1,0 +1,218 @@
+/**
+ * Permission-request handling for the ACP backend.
+ *
+ * WHY: The ACP `requestPermission` RPC is fired by the agent every time it
+ * wants to invoke a tool (read file, run shell, edit file, etc.). The logic
+ * to (a) figure out the real tool name, (b) round-trip a decision through
+ * the user's permission handler, and (c) emit lifecycle events for the UI
+ * is non-trivial — pulling it out of `AcpBackend.startSession` keeps that
+ * method readable and lets us unit-test the permission flow in isolation.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from '@agentclientprotocol/sdk';
+import { logger } from '@/ui/logger';
+import type { AgentMessage } from '../core';
+import type { TransportHandler, ToolNameContext } from '../transport';
+import type {
+  AcpPermissionHandler,
+  ExtendedRequestPermissionRequest,
+} from './acpTypes';
+
+/**
+ * State + collaborators required by {@link createPermissionHandler}.
+ *
+ * The factory is pure with respect to this object — it never mutates the
+ * input — so callers can pass a stable bag of getters/setters bound to the
+ * AcpBackend instance.
+ */
+export interface PermissionHandlerDeps {
+  /** Transport handler used to resolve fuzzy tool names. */
+  transport: TransportHandler;
+  /** Optional user-supplied permission handler (mobile dialog, CLI prompt, …). */
+  permissionHandler?: AcpPermissionHandler;
+  /** Read the "did the most recent prompt include a change_title instruction" flag. */
+  getRecentPromptHadChangeTitle: () => boolean;
+  /** Read the running tool-call counter for context tracking. */
+  getToolCallCountSincePrompt: () => number;
+  /** Increment the tool-call counter (called once per permission request). */
+  incrementToolCallCount: () => void;
+  /** Emit an AgentMessage to all listeners. */
+  emit: (msg: AgentMessage) => void;
+}
+
+/**
+ * Build the ACP `requestPermission` callback bound to an AcpBackend instance.
+ *
+ * @param deps - State + collaborators; see {@link PermissionHandlerDeps}.
+ * @returns A function matching the SDK's `Client.requestPermission` signature.
+ */
+export function createPermissionHandler(
+  deps: PermissionHandlerDeps
+): (params: RequestPermissionRequest) => Promise<RequestPermissionResponse> {
+  return async (params: RequestPermissionRequest): Promise<RequestPermissionResponse> => {
+    const extendedParams = params as ExtendedRequestPermissionRequest;
+    const toolCall = extendedParams.toolCall;
+    let toolName =
+      toolCall?.kind || toolCall?.toolName || extendedParams.kind || 'Unknown tool';
+
+    // WHY: Use toolCallId as the SINGLE source of truth for the permission ID.
+    // Mobile app sends back this exact ID when the user taps approve/deny;
+    // diverging IDs here means we can never correlate the response.
+    const toolCallId = toolCall?.id || randomUUID();
+    const permissionId = toolCallId;
+
+    // Extract input/arguments from the various shapes agents use BEFORE we
+    // attempt to refine the tool name (some transports use input to detect it).
+    let input: Record<string, unknown> = {};
+    if (toolCall) {
+      input = toolCall.input || toolCall.arguments || toolCall.content || {};
+    } else {
+      input = extendedParams.input || extendedParams.arguments || extendedParams.content || {};
+    }
+
+    // If the SDK gave us a generic name like "other" or "Unknown tool", let
+    // the transport try to recover the real one from input + context.
+    const ctx: ToolNameContext = {
+      recentPromptHadChangeTitle: deps.getRecentPromptHadChangeTitle(),
+      toolCallCountSincePrompt: deps.getToolCallCountSincePrompt(),
+    };
+    const originalName =
+      toolCall?.kind || toolCall?.toolName || extendedParams.kind || 'Unknown tool';
+    toolName = deps.transport.determineToolName?.(toolName, toolCallId, input, ctx) ?? toolName;
+
+    if (toolName !== originalName) {
+      logger.debug(
+        `[AcpBackend] Detected tool name: ${toolName} from toolCallId: ${toolCallId}`
+      );
+    }
+
+    deps.incrementToolCallCount();
+
+    const options = extendedParams.options || [];
+
+    logger.debug(
+      `[AcpBackend] Permission request: tool=${toolName}, toolCallId=${toolCallId}, input=`,
+      JSON.stringify(input)
+    );
+    logger.debug(
+      `[AcpBackend] Permission request params structure:`,
+      JSON.stringify(
+        {
+          hasToolCall: !!toolCall,
+          toolCallKind: toolCall?.kind,
+          toolCallId: toolCall?.id,
+          paramsKind: extendedParams.kind,
+          paramsKeys: Object.keys(params),
+        },
+        null,
+        2
+      )
+    );
+
+    // Always emit so UI / mobile can display the pending request.
+    deps.emit({
+      type: 'permission-request',
+      id: permissionId,
+      reason: toolName,
+      payload: {
+        ...params,
+        permissionId,
+        toolCallId,
+        toolName,
+        input,
+        options: options.map((opt) => ({
+          id: opt.optionId,
+          name: opt.name,
+          kind: opt.kind,
+        })),
+      },
+    });
+
+    if (deps.permissionHandler) {
+      try {
+        const result = await deps.permissionHandler.handleToolCall(toolCallId, toolName, input);
+        const optionId = mapDecisionToOptionId(result.decision, options);
+
+        // WHY: Emit tool-result with permissionId so the UI's pending-permission
+        // timer can be cleared. The follow-up `tool_call_update` carries a
+        // different ID and would not close the dialog on its own.
+        const approved =
+          result.decision === 'approved' || result.decision === 'approved_for_session';
+        deps.emit({
+          type: 'tool-result',
+          toolName,
+          result: {
+            status: approved ? 'approved' : 'denied',
+            decision: result.decision,
+          },
+          callId: permissionId,
+        });
+
+        return { outcome: { outcome: 'selected', optionId } };
+      } catch (error) {
+        logger.debug('[AcpBackend] Error in permission handler:', error);
+        // Fail closed: if the user-supplied handler throws, deny rather than
+        // accidentally approving a destructive tool call.
+        return { outcome: { outcome: 'selected', optionId: 'cancel' } };
+      }
+    }
+
+    // No handler configured → auto-approve once. We deliberately prefer
+    // 'proceed_once' over 'proceed_always' so an unattended CLI never grants
+    // session-scoped approval implicitly.
+    const proceedOnceOption = options.find(
+      (opt) =>
+        opt.optionId === 'proceed_once' ||
+        (typeof opt.name === 'string' && opt.name.toLowerCase().includes('once'))
+    );
+    const defaultOptionId =
+      proceedOnceOption?.optionId ||
+      (options.length > 0 && options[0].optionId ? options[0].optionId : 'proceed_once');
+    return { outcome: { outcome: 'selected', optionId: defaultOptionId } };
+  };
+}
+
+/**
+ * Map a {@link AcpPermissionHandler} decision to an ACP `optionId` chosen
+ * from the request's option list.
+ *
+ * Pure helper — exported for unit testing.
+ *
+ * @param decision - The decision returned by the user-supplied permission handler.
+ * @param options  - The options array from the original permission request.
+ * @returns The selected `optionId` string. Defaults to `'cancel'` for safety.
+ */
+export function mapDecisionToOptionId(
+  decision: 'approved' | 'approved_for_session' | 'denied' | 'abort',
+  options: Array<{ optionId?: string; name?: string; kind?: string }>
+): string {
+  if (decision === 'approved' || decision === 'approved_for_session') {
+    const proceedOnceOption = options.find(
+      (opt) => opt.optionId === 'proceed_once' || opt.name?.toLowerCase().includes('once')
+    );
+    const proceedAlwaysOption = options.find(
+      (opt) => opt.optionId === 'proceed_always' || opt.name?.toLowerCase().includes('always')
+    );
+
+    if (decision === 'approved_for_session' && proceedAlwaysOption) {
+      return proceedAlwaysOption.optionId || 'proceed_always';
+    }
+    if (proceedOnceOption) {
+      return proceedOnceOption.optionId || 'proceed_once';
+    }
+    if (options.length > 0) {
+      return options[0].optionId || 'proceed_once';
+    }
+    return 'proceed_once';
+  }
+
+  // denied or abort → look for a cancel option, else literal 'cancel'.
+  const cancelOption = options.find(
+    (opt) => opt.optionId === 'cancel' || opt.name?.toLowerCase().includes('cancel')
+  );
+  return cancelOption?.optionId || 'cancel';
+}

--- a/packages/styrby-cli/src/agent/acp/processLifecycle.ts
+++ b/packages/styrby-cli/src/agent/acp/processLifecycle.ts
@@ -1,0 +1,233 @@
+/**
+ * Process lifecycle helpers for the ACP backend.
+ *
+ * WHY: Spawning the agent subprocess, wiring stderr/error/exit listeners, and
+ * driving the ACP `initialize` + `newSession` RPCs are mechanically distinct
+ * concerns from the per-message routing AcpBackend does at runtime. Keeping
+ * them out of the main class file makes startSession readable and lets us
+ * exercise the spawn/teardown contracts in focused tests.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { buildSafeEnv } from '@/utils/safeEnv';
+import {
+  ClientSideConnection,
+  type InitializeRequest,
+  type NewSessionRequest,
+} from '@agentclientprotocol/sdk';
+import { logger } from '@/ui/logger';
+import type { AgentMessage, McpServerConfig } from '../core';
+import type { TransportHandler, StderrContext } from '../transport';
+import { RETRY_CONFIG, withRetry, withTimeout } from './retryHelper';
+import packageJson from '../../../package.json';
+
+/** Options accepted by {@link spawnAgentProcess}. */
+export interface SpawnAgentOptions {
+  /** Binary or shim used to launch the agent. */
+  command: string;
+  /** Argument vector passed to the binary. */
+  args?: string[];
+  /** Working directory for the spawned process. */
+  cwd: string;
+  /** Caller-supplied environment merged into the safe baseline. */
+  env?: Record<string, string>;
+}
+
+/**
+ * Spawn the ACP agent subprocess with a hardened environment.
+ *
+ * SECURITY: On Windows we route through `cmd.exe /c` to support `.cmd` shims
+ * + PATH resolution. Every argument is passed as its OWN array element so
+ * shell metacharacters (`;`, `&`, `|`) inside a value can never inject extra
+ * commands. The environment is built via `buildSafeEnv` to prevent secret
+ * leakage to the agent.
+ *
+ * @param options - Spawn configuration; see {@link SpawnAgentOptions}.
+ * @returns The spawned `ChildProcess`. Throws if any stdio pipe is missing.
+ */
+export function spawnAgentProcess(options: SpawnAgentOptions): ChildProcess {
+  const args = options.args || [];
+  const safeEnv = buildSafeEnv(options.env);
+
+  let proc: ChildProcess;
+  if (process.platform === 'win32') {
+    proc = spawn('cmd.exe', ['/c', options.command, ...args], {
+      cwd: options.cwd,
+      env: safeEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+  } else {
+    proc = spawn(options.command, args, {
+      cwd: options.cwd,
+      env: safeEnv,
+      // 'pipe' for all stdio so stdout/stderr never leak to the parent TTY.
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }
+
+  if (!proc.stdin || !proc.stdout || !proc.stderr) {
+    throw new Error('Failed to create stdio pipes');
+  }
+
+  return proc;
+}
+
+/** Collaborators required by {@link attachProcessListeners}. */
+export interface ProcessListenerDeps {
+  /** Transport handler — used for stderr classification + custom emits. */
+  transport: TransportHandler;
+  /** Read the live set of in-flight tool call IDs. */
+  getActiveToolCalls: () => Set<string>;
+  /** Whether the backend has been disposed (suppresses stop-emit on shutdown). */
+  isDisposed: () => boolean;
+  /** Emit an AgentMessage to listeners. */
+  emit: (msg: AgentMessage) => void;
+}
+
+/**
+ * Wire stderr / error / exit listeners on a spawned agent process.
+ *
+ * @param proc - The agent subprocess.
+ * @param deps - Collaborators; see {@link ProcessListenerDeps}.
+ */
+export function attachProcessListeners(proc: ChildProcess, deps: ProcessListenerDeps): void {
+  proc.stderr!.on('data', (data: Buffer) => {
+    const text = data.toString();
+    if (!text.trim()) return;
+
+    // WHY: Some tool kinds count as "investigations" (e.g. read-only file
+    // inspection); we change log tagging during them so post-mortems can
+    // distinguish noisy debug output from genuine errors.
+    const activeToolCalls = deps.getActiveToolCalls();
+    const hasActiveInvestigation = deps.transport.isInvestigationTool
+      ? Array.from(activeToolCalls).some((id) => deps.transport.isInvestigationTool!(id))
+      : false;
+
+    const context: StderrContext = {
+      activeToolCalls,
+      hasActiveInvestigation,
+    };
+
+    if (hasActiveInvestigation) {
+      logger.debug(`[AcpBackend] 🔍 Agent stderr (during investigation): ${text.trim()}`);
+    } else {
+      logger.debug(`[AcpBackend] Agent stderr: ${text.trim()}`);
+    }
+
+    if (deps.transport.handleStderr) {
+      const result = deps.transport.handleStderr(text, context);
+      if (result.message) {
+        deps.emit(result.message);
+      }
+    }
+  });
+
+  proc.on('error', (err) => {
+    logger.debug(`[AcpBackend] Process error:`, err);
+    deps.emit({ type: 'status', status: 'error', detail: err.message });
+  });
+
+  proc.on('exit', (code, signal) => {
+    if (!deps.isDisposed() && code !== 0 && code !== null) {
+      logger.debug(`[AcpBackend] Process exited with code ${code}, signal ${signal}`);
+      deps.emit({ type: 'status', status: 'stopped', detail: `Exit code: ${code}` });
+    }
+  });
+}
+
+/**
+ * Run the ACP `initialize` RPC with retry + timeout.
+ *
+ * @param connection - The active ClientSideConnection.
+ * @param transport  - Used for the timeout budget + agent name.
+ */
+export async function initializeAcpConnection(
+  connection: ClientSideConnection,
+  transport: TransportHandler
+): Promise<void> {
+  const initRequest: InitializeRequest = {
+    protocolVersion: 1,
+    clientCapabilities: {
+      fs: { readTextFile: false, writeTextFile: false },
+    },
+    clientInfo: {
+      name: 'happy-cli',
+      version: packageJson.version,
+    },
+  };
+
+  const initTimeout = transport.getInitTimeout();
+  logger.debug(`[AcpBackend] Initializing connection (timeout: ${initTimeout}ms)...`);
+
+  await withRetry(
+    () =>
+      withTimeout(
+        () => connection.initialize(initRequest),
+        initTimeout,
+        `Initialize timeout after ${initTimeout}ms - ${transport.agentName} did not respond`
+      ),
+    {
+      operationName: 'Initialize',
+      maxAttempts: RETRY_CONFIG.maxAttempts,
+      baseDelayMs: RETRY_CONFIG.baseDelayMs,
+      maxDelayMs: RETRY_CONFIG.maxDelayMs,
+    }
+  );
+  logger.debug(`[AcpBackend] Initialize completed`);
+}
+
+/**
+ * Run the ACP `newSession` RPC with retry + timeout.
+ *
+ * @param connection - The initialized ClientSideConnection.
+ * @param transport  - Used for the timeout budget + agent name.
+ * @param cwd        - Working directory of the new session.
+ * @param mcpServers - Optional map of MCP servers to expose to the agent.
+ * @returns The session ID returned by the agent.
+ */
+export async function createAcpSession(
+  connection: ClientSideConnection,
+  transport: TransportHandler,
+  cwd: string,
+  mcpServers?: Record<string, McpServerConfig>
+): Promise<string> {
+  const initTimeout = transport.getInitTimeout();
+  const mcpServerList = mcpServers
+    ? Object.entries(mcpServers).map(([name, config]) => ({
+        name,
+        command: config.command,
+        args: config.args || [],
+        env: config.env
+          ? Object.entries(config.env).map(([envName, envValue]) => ({
+              name: envName,
+              value: envValue,
+            }))
+          : [],
+      }))
+    : [];
+
+  const newSessionRequest: NewSessionRequest = {
+    cwd,
+    mcpServers: mcpServerList as unknown as NewSessionRequest['mcpServers'],
+  };
+
+  logger.debug(`[AcpBackend] Creating new session...`);
+
+  const sessionResponse = await withRetry(
+    () =>
+      withTimeout(
+        () => connection.newSession(newSessionRequest),
+        initTimeout,
+        `New session timeout after ${initTimeout}ms - ${transport.agentName} did not respond`
+      ),
+    {
+      operationName: 'NewSession',
+      maxAttempts: RETRY_CONFIG.maxAttempts,
+      baseDelayMs: RETRY_CONFIG.baseDelayMs,
+      maxDelayMs: RETRY_CONFIG.maxDelayMs,
+    }
+  );
+  logger.debug(`[AcpBackend] Session created: ${sessionResponse.sessionId}`);
+  return sessionResponse.sessionId;
+}

--- a/packages/styrby-cli/src/agent/acp/retryHelper.ts
+++ b/packages/styrby-cli/src/agent/acp/retryHelper.ts
@@ -1,0 +1,132 @@
+/**
+ * Retry helper for ACP operations.
+ *
+ * WHY: ACP agent subprocesses (Crush, Gemini CLI, etc.) are flaky on first
+ * connect — JSON-RPC initialize and newSession can race against the agent's
+ * own startup. Without retry, a transient failure aborts the whole session.
+ * Exponential backoff with a small attempt cap recovers without hammering.
+ */
+
+import { logger } from '@/ui/logger';
+import { delay } from '@/utils/time';
+
+/**
+ * Default retry configuration for ACP init/newSession operations.
+ *
+ * WHY: 3 attempts × (1s, 2s, 4s capped at 5s) = ~7s worst case. Long enough
+ * to ride out a slow agent boot, short enough that a real failure surfaces
+ * quickly to the user.
+ */
+export const RETRY_CONFIG = {
+  /** Maximum number of retry attempts for init/newSession */
+  maxAttempts: 3,
+  /** Base delay between retries in ms */
+  baseDelayMs: 1000,
+  /** Maximum delay between retries in ms */
+  maxDelayMs: 5000,
+} as const;
+
+/**
+ * Options controlling a single {@link withRetry} invocation.
+ */
+export interface WithRetryOptions {
+  /** Human-readable name for the operation, used in debug logs. */
+  operationName: string;
+  /** Maximum number of attempts (inclusive of the first try). */
+  maxAttempts: number;
+  /** Initial backoff delay in milliseconds. */
+  baseDelayMs: number;
+  /** Cap on the backoff delay in milliseconds. */
+  maxDelayMs: number;
+  /** Optional hook fired before each retry attempt (after the failure). */
+  onRetry?: (attempt: number, error: Error) => void;
+}
+
+/**
+ * Run an async operation with exponential-backoff retry.
+ *
+ * @param operation - The async function to retry on rejection.
+ * @param options   - Retry policy configuration; see {@link WithRetryOptions}.
+ * @returns The resolved value of the first successful attempt.
+ * @throws The last captured error if all attempts fail.
+ *
+ * @example
+ * await withRetry(() => connection.initialize(req), {
+ *   operationName: 'Initialize',
+ *   maxAttempts: RETRY_CONFIG.maxAttempts,
+ *   baseDelayMs: RETRY_CONFIG.baseDelayMs,
+ *   maxDelayMs: RETRY_CONFIG.maxDelayMs,
+ * });
+ */
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  options: WithRetryOptions
+): Promise<T> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+
+      if (attempt < options.maxAttempts) {
+        // WHY: Exponential backoff (2^(n-1) * base) clamped to maxDelayMs avoids
+        // unbounded waits if the cap is misconfigured.
+        const delayMs = Math.min(
+          options.baseDelayMs * Math.pow(2, attempt - 1),
+          options.maxDelayMs
+        );
+
+        logger.debug(
+          `[AcpBackend] ${options.operationName} failed (attempt ${attempt}/${options.maxAttempts}): ${lastError.message}. Retrying in ${delayMs}ms...`
+        );
+        options.onRetry?.(attempt, lastError);
+
+        await delay(delayMs);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Race a promise against a timeout, rejecting if the timeout fires first.
+ *
+ * WHY: ACP RPCs (initialize, newSession) can hang indefinitely if the agent
+ * subprocess deadlocks. Promise.race with a setTimeout reject path bounds
+ * the wait, and the finally block guarantees the timer is cleared so the
+ * Node event loop can exit cleanly even on success.
+ *
+ * @param promiseFactory - A function that produces the operation promise.
+ * @param timeoutMs      - Maximum time to wait, in milliseconds.
+ * @param timeoutMessage - Error message used when the timeout fires.
+ */
+export async function withTimeout<T>(
+  promiseFactory: () => Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<T> {
+  let timeoutHandle: NodeJS.Timeout | null = null;
+  try {
+    return await Promise.race([
+      promiseFactory().then((res) => {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+          timeoutHandle = null;
+        }
+        return res;
+      }),
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(new Error(timeoutMessage));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}

--- a/packages/styrby-cli/src/agent/acp/sessionUpdateDispatcher.ts
+++ b/packages/styrby-cli/src/agent/acp/sessionUpdateDispatcher.ts
@@ -1,0 +1,131 @@
+/**
+ * Session-update dispatcher for the ACP backend.
+ *
+ * WHY: The ACP `sessionUpdate` RPC is fired for every chunk, tool call,
+ * thought, plan, and thinking event the agent emits. AcpBackend itself only
+ * needs to know "given this notification, route it to the right per-type
+ * handler and let me know if any state escapes back". Pulling the dispatch
+ * out of the class keeps `AcpBackend` under the orchestrator LOC budget and
+ * makes the routing trivially testable.
+ */
+
+import type { SessionNotification } from '@agentclientprotocol/sdk';
+import { logger } from '@/ui/logger';
+import {
+  type SessionUpdate,
+  type HandlerContext,
+  handleAgentMessageChunk,
+  handleAgentThoughtChunk,
+  handleToolCallUpdate,
+  handleToolCall,
+  handleLegacyMessageChunk,
+  handlePlanUpdate,
+  handleThinkingUpdate,
+} from './sessionUpdateHandlers';
+import type { ExtendedSessionNotification } from './acpTypes';
+
+/** Update-type strings the dispatcher knows how to handle as primary cases. */
+const HANDLED_TYPES = [
+  'agent_message_chunk',
+  'tool_call_update',
+  'agent_thought_chunk',
+  'tool_call',
+] as const;
+
+/**
+ * Result returned to the caller after dispatch.
+ *
+ * Currently only `tool_call_update` produces escaping state (the running
+ * tool-call counter), so we surface that explicitly so the AcpBackend
+ * instance can keep its mirror in sync.
+ */
+export interface DispatchResult {
+  /** New value for `toolCallCountSincePrompt`, if the handler changed it. */
+  toolCallCountSincePrompt?: number;
+}
+
+/**
+ * Route a single ACP `sessionUpdate` notification to its per-type handler.
+ *
+ * @param params - The raw SDK notification.
+ * @param ctx    - Handler context bound to the AcpBackend instance.
+ * @returns Any state the caller needs to mirror back onto its instance.
+ */
+export function dispatchSessionUpdate(
+  params: SessionNotification,
+  ctx: HandlerContext
+): DispatchResult {
+  const notification = params as ExtendedSessionNotification;
+  const update = notification.update;
+
+  if (!update) {
+    logger.debug('[AcpBackend] Received session update without update field:', params);
+    return {};
+  }
+
+  const sessionUpdateType = update.sessionUpdate;
+
+  // WHY: agent_message_chunk fires hundreds of times per response — logging
+  // each chunk floods the debug log and makes post-mortems unreadable.
+  if (sessionUpdateType !== 'agent_message_chunk') {
+    logger.debug(
+      `[AcpBackend] Received session update: ${sessionUpdateType}`,
+      JSON.stringify(
+        {
+          sessionUpdate: sessionUpdateType,
+          toolCallId: update.toolCallId,
+          status: update.status,
+          kind: update.kind,
+          hasContent: !!update.content,
+          hasLocations: !!update.locations,
+        },
+        null,
+        2
+      )
+    );
+  }
+
+  if (sessionUpdateType === 'agent_message_chunk') {
+    handleAgentMessageChunk(update as SessionUpdate, ctx);
+    return {};
+  }
+
+  if (sessionUpdateType === 'tool_call_update') {
+    const result = handleToolCallUpdate(update as SessionUpdate, ctx);
+    return { toolCallCountSincePrompt: result.toolCallCountSincePrompt };
+  }
+
+  if (sessionUpdateType === 'agent_thought_chunk') {
+    handleAgentThoughtChunk(update as SessionUpdate, ctx);
+    return {};
+  }
+
+  if (sessionUpdateType === 'tool_call') {
+    handleToolCall(update as SessionUpdate, ctx);
+    return {};
+  }
+
+  // Legacy / auxiliary update types — these handlers are no-ops if the
+  // corresponding fields aren't present, so calling all three is safe.
+  handleLegacyMessageChunk(update as SessionUpdate, ctx);
+  handlePlanUpdate(update as SessionUpdate, ctx);
+  handleThinkingUpdate(update as SessionUpdate, ctx);
+
+  // WHY: Cast to string — the SDK's enum doesn't include all Gemini-specific
+  // update types, but we still want to log unknown shapes for debugging.
+  const updateTypeStr = sessionUpdateType as string;
+  if (
+    updateTypeStr &&
+    !(HANDLED_TYPES as readonly string[]).includes(updateTypeStr) &&
+    !update.messageChunk &&
+    !update.plan &&
+    !update.thinking
+  ) {
+    logger.debug(
+      `[AcpBackend] Unhandled session update type: ${updateTypeStr}`,
+      JSON.stringify(update, null, 2)
+    );
+  }
+
+  return {};
+}

--- a/packages/styrby-cli/src/agent/acp/streamBridge.ts
+++ b/packages/styrby-cli/src/agent/acp/streamBridge.ts
@@ -1,0 +1,161 @@
+/**
+ * Stream bridging utilities for the ACP backend.
+ *
+ * WHY: The ACP SDK consumes WHATWG Web Streams (ReadableStream / WritableStream)
+ * but Node.js child processes expose classic Node streams. We bridge them
+ * here so the backend can drive a subprocess via the SDK transparently.
+ *
+ * We also wrap the resulting readable in a *line-aware filter* so transport
+ * handlers (Gemini CLI in particular) can drop debug output that would
+ * otherwise crash JSON-RPC parsing.
+ */
+
+import { Readable, Writable } from 'node:stream';
+import { logger } from '@/ui/logger';
+import type { TransportHandler } from '../transport';
+
+/**
+ * Bridge a Node child-process stdio pair to WHATWG Web Streams.
+ *
+ * NOTE: This function registers a `data` listener on `stdout`. If callers
+ * also attach their own `data` listener the chunk will be delivered to both,
+ * which is fine but worth knowing.
+ *
+ * @param stdin  - The child's writable stdin stream.
+ * @param stdout - The child's readable stdout stream.
+ * @returns A `{ writable, readable }` pair of Web Streams.
+ */
+export function nodeToWebStreams(
+  stdin: Writable,
+  stdout: Readable
+): { writable: WritableStream<Uint8Array>; readable: ReadableStream<Uint8Array> } {
+  const writable = new WritableStream<Uint8Array>({
+    write(chunk) {
+      return new Promise((resolve, reject) => {
+        const ok = stdin.write(chunk, (err) => {
+          if (err) {
+            logger.debug(`[AcpBackend] Error writing to stdin:`, err);
+            reject(err);
+          }
+        });
+        if (ok) {
+          resolve();
+        } else {
+          // WHY: Backpressure — wait for the kernel buffer to drain before
+          // resolving so the SDK doesn't outpace the subprocess.
+          stdin.once('drain', resolve);
+        }
+      });
+    },
+    close() {
+      return new Promise((resolve) => {
+        stdin.end(resolve);
+      });
+    },
+    abort(reason) {
+      stdin.destroy(reason instanceof Error ? reason : new Error(String(reason)));
+    },
+  });
+
+  const readable = new ReadableStream<Uint8Array>({
+    start(controller) {
+      stdout.on('data', (chunk: Buffer) => {
+        controller.enqueue(new Uint8Array(chunk));
+      });
+      stdout.on('end', () => {
+        controller.close();
+      });
+      stdout.on('error', (err) => {
+        logger.debug(`[AcpBackend] Stdout error:`, err);
+        controller.error(err);
+      });
+    },
+    cancel() {
+      stdout.destroy();
+    },
+  });
+
+  return { writable, readable };
+}
+
+/**
+ * Wrap a raw stdout ReadableStream with a transport-driven, line-aware filter.
+ *
+ * WHY: Some agents (notably Gemini CLI) emit non-JSON lines to stdout
+ * (experiment flags, banner output). Those lines crash the JSON-RPC ndjson
+ * parser. The transport's `filterStdoutLine` returns:
+ *   - `null`      → drop the line
+ *   - `string`    → replace the line with this content
+ *   - `undefined` → method not implemented, pass the line through unchanged
+ *
+ * @param readable  - The raw byte stream from the child process.
+ * @param transport - Transport handler whose `filterStdoutLine` (if any) we apply.
+ * @returns A filtered ReadableStream safe to feed to `ndJsonStream`.
+ */
+export function createFilteredStdoutStream(
+  readable: ReadableStream<Uint8Array>,
+  transport: TransportHandler
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = readable.getReader();
+      const decoder = new TextDecoder();
+      const encoder = new TextEncoder();
+      let buffer = '';
+      let filteredCount = 0;
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            // WHY: On EOF the agent may have left a line without trailing \n.
+            // We must still apply the filter (or pass through) so the parser
+            // sees the final record.
+            if (buffer.trim()) {
+              const filtered = transport.filterStdoutLine?.(buffer);
+              if (filtered === undefined) {
+                controller.enqueue(encoder.encode(buffer));
+              } else if (filtered !== null) {
+                controller.enqueue(encoder.encode(filtered));
+              } else {
+                filteredCount++;
+              }
+            }
+            if (filteredCount > 0) {
+              logger.debug(
+                `[AcpBackend] Filtered out ${filteredCount} non-JSON lines from ${transport.agentName} stdout`
+              );
+            }
+            controller.close();
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+
+          // ndJSON is line-delimited: split, reserve any trailing partial
+          // line for the next chunk so we never break a record mid-stream.
+          const lines = buffer.split('\n');
+          buffer = lines.pop() || '';
+
+          for (const line of lines) {
+            if (!line.trim()) continue;
+
+            const filtered = transport.filterStdoutLine?.(line);
+            if (filtered === undefined) {
+              controller.enqueue(encoder.encode(line + '\n'));
+            } else if (filtered !== null) {
+              controller.enqueue(encoder.encode(filtered + '\n'));
+            } else {
+              filteredCount++;
+            }
+          }
+        }
+      } catch (error) {
+        logger.debug(`[AcpBackend] Error filtering stdout stream:`, error);
+        controller.error(error);
+      } finally {
+        reader.releaseLock();
+      }
+    },
+  });
+}

--- a/packages/styrby-cli/src/gemini/__tests__/errorFormatter.test.ts
+++ b/packages/styrby-cli/src/gemini/__tests__/errorFormatter.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for `formatGeminiError`, `classifyPromptError`, and
+ * `extractResetTimeSuffix`.
+ *
+ * The classifier was previously an inlined nested if/else inside
+ * `runGemini.ts` — these tests pin every branch documented in the
+ * pre-refactor source so future changes can't silently regress them.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  formatGeminiError,
+  classifyPromptError,
+  extractResetTimeSuffix,
+} from '@/gemini/utils/errorFormatter';
+
+describe('extractResetTimeSuffix', () => {
+  it('extracts hours/minutes/seconds combo', () => {
+    expect(extractResetTimeSuffix('Your quota will reset after 3h20m35s.')).toBe(' Quota resets in 3h20m35s.');
+  });
+
+  it('extracts minutes only', () => {
+    expect(extractResetTimeSuffix('reset after 5m')).toBe(' Quota resets in 5m.');
+  });
+
+  it('returns empty string when no match', () => {
+    expect(extractResetTimeSuffix('something unrelated')).toBe('');
+  });
+
+  it('returns empty string when match has no time parts', () => {
+    expect(extractResetTimeSuffix('reset after')).toBe('');
+  });
+
+  it('is case-insensitive', () => {
+    expect(extractResetTimeSuffix('Reset After 1h2m3s')).toBe(' Quota resets in 1h2m3s.');
+  });
+});
+
+describe('formatGeminiError', () => {
+  it('classifies AbortError', () => {
+    const err = new Error('cancelled');
+    err.name = 'AbortError';
+    const r = formatGeminiError(err);
+    expect(r.kind).toBe('abort');
+    expect(r.message).toBe('Aborted by user');
+  });
+
+  it('classifies 404 / model not found by code', () => {
+    const r = formatGeminiError({ code: 404, message: 'gone' }, { displayedModel: 'gemini-2.5-flash' });
+    expect(r.kind).toBe('model-not-found');
+    expect(r.message).toContain('gemini-2.5-flash');
+    expect(r.message).toContain('not found');
+  });
+
+  it('classifies 404 / model not found by message text', () => {
+    const r = formatGeminiError({ message: 'model X not found' });
+    expect(r.kind).toBe('model-not-found');
+    expect(r.message).toContain('gemini-2.5-pro'); // default
+  });
+
+  it('classifies -32603 as empty-response', () => {
+    const r = formatGeminiError({ code: -32603, message: 'internal' });
+    expect(r.kind).toBe('empty-response');
+    expect(r.message).toContain('temporary');
+  });
+
+  it('classifies "empty response" details as empty-response', () => {
+    const r = formatGeminiError({ data: { details: 'Model returned empty response' } });
+    expect(r.kind).toBe('empty-response');
+  });
+
+  it('classifies 429 as rate-limit', () => {
+    expect(formatGeminiError({ code: 429 }).kind).toBe('rate-limit');
+  });
+
+  it('classifies RESOURCE_EXHAUSTED in details as rate-limit', () => {
+    expect(
+      formatGeminiError({ data: { details: 'RESOURCE_EXHAUSTED' } }).kind,
+    ).toBe('rate-limit');
+  });
+
+  it('classifies Resource exhausted message as rate-limit', () => {
+    expect(formatGeminiError({ message: 'Resource exhausted' }).kind).toBe('rate-limit');
+  });
+
+  it('classifies quota errors with reset suffix', () => {
+    const r = formatGeminiError({
+      data: { details: 'quota exhausted - reset after 1h30m' },
+    });
+    expect(r.kind).toBe('quota-exceeded');
+    expect(r.message).toContain('Quota resets in 1h30m.');
+  });
+
+  it('classifies quota errors without reset suffix', () => {
+    const r = formatGeminiError({ message: 'quota limit reached' });
+    expect(r.kind).toBe('quota-exceeded');
+    expect(r.message).not.toContain('Quota resets in');
+  });
+
+  it('classifies authentication required', () => {
+    const r = formatGeminiError({ message: 'Authentication required' });
+    expect(r.kind).toBe('auth-required');
+    expect(r.message).toContain('happy gemini project set');
+  });
+
+  it('classifies code -32000 as auth-required', () => {
+    expect(formatGeminiError({ code: -32000 }).kind).toBe('auth-required');
+  });
+
+  it('classifies empty error object as cli-missing', () => {
+    const r = formatGeminiError({});
+    expect(r.kind).toBe('cli-missing');
+    expect(r.message).toContain('@google/gemini-cli');
+  });
+
+  it('falls back to error.message when nothing else matches', () => {
+    const r = formatGeminiError({ message: 'something weird' });
+    expect(r.kind).toBe('unknown');
+    expect(r.message).toBe('something weird');
+  });
+
+  it('prefers details over message for unknown errors', () => {
+    const r = formatGeminiError({ message: 'msg', data: { details: 'detailed' } });
+    expect(r.message).toBe('detailed');
+  });
+
+  it('handles plain Error (no own keys) as cli-missing fallback', () => {
+    // WHY: `new Error('msg')` has no own enumerable keys; the original code
+    // path matches that against the empty-error-object branch and assumes
+    // the Gemini CLI binary is missing. Pinning the legacy behavior.
+    const r = formatGeminiError(new Error('generic'));
+    expect(r.kind).toBe('cli-missing');
+  });
+
+  it('handles primitives', () => {
+    const r = formatGeminiError('a string');
+    expect(r.kind).toBe('unknown');
+    expect(r.message).toBe('Process error occurred');
+  });
+});
+
+describe('classifyPromptError', () => {
+  it('flags quota errors and never marks them retryable', () => {
+    const r = classifyPromptError({ data: { details: 'quota exhausted reset after 2h' } });
+    expect(r.isQuotaError).toBe(true);
+    expect(r.isRetryable).toBe(false);
+    expect(r.quotaResetSuffix).toBe(' Quota resets in 2h.');
+  });
+
+  it('flags empty-response errors as retryable', () => {
+    const r = classifyPromptError({ message: 'Model stream ended' });
+    expect(r.isRetryable).toBe(true);
+    expect(r.isQuotaError).toBe(false);
+  });
+
+  it('flags -32603 as retryable', () => {
+    const r = classifyPromptError({ code: -32603, message: 'internal' });
+    expect(r.isRetryable).toBe(true);
+  });
+
+  it('does not flag random errors as retryable', () => {
+    const r = classifyPromptError({ message: 'something else' });
+    expect(r.isRetryable).toBe(false);
+    expect(r.isQuotaError).toBe(false);
+  });
+
+  it('handles undefined / null safely', () => {
+    expect(classifyPromptError(undefined).isRetryable).toBe(false);
+    expect(classifyPromptError(null).isRetryable).toBe(false);
+  });
+
+  it('reads details from nested data.details first', () => {
+    const r = classifyPromptError({ data: { details: 'empty response' }, message: 'fallback' });
+    expect(r.details).toBe('empty response');
+  });
+});

--- a/packages/styrby-cli/src/gemini/__tests__/finalMessageBuilder.test.ts
+++ b/packages/styrby-cli/src/gemini/__tests__/finalMessageBuilder.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for `buildFinalTurnMessage`.
+ *
+ * The mobile app contract for the per-turn payload format lives here —
+ * `type: 'message'`, `id`, `message`, optional `options[]`. Test the
+ * exact shape so the contract can't drift silently.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildFinalTurnMessage } from '@/gemini/utils/finalMessageBuilder';
+
+describe('buildFinalTurnMessage', () => {
+  const fixedId = () => 'fixed-id';
+
+  it('returns null for empty / whitespace-only response', () => {
+    expect(buildFinalTurnMessage('', fixedId)).toBeNull();
+    expect(buildFinalTurnMessage('   \n\t', fixedId)).toBeNull();
+  });
+
+  it('builds payload with no options for plain text', () => {
+    const r = buildFinalTurnMessage('Hello, world!', fixedId);
+    expect(r).not.toBeNull();
+    expect(r!.payload).toEqual({
+      type: 'message',
+      message: 'Hello, world!',
+      id: 'fixed-id',
+    });
+    expect(r!.options).toEqual([]);
+    expect(r!.historyText).toBe('Hello, world!');
+    expect(r!.incompleteOptions).toBe(false);
+  });
+
+  it('parses options + reattaches XML on payload', () => {
+    const text = 'Pick one:\n<options><option>A</option><option>B</option></options>';
+    const r = buildFinalTurnMessage(text, fixedId);
+    expect(r).not.toBeNull();
+    expect(r!.options).toEqual(['A', 'B']);
+    expect(r!.payload.options).toEqual(['A', 'B']);
+    // History text strips the options block
+    expect(r!.historyText).not.toContain('<options>');
+    // Payload message has options re-serialized
+    expect(r!.payload.message).toContain('<options>');
+    expect(r!.payload.message).toContain('A');
+    expect(r!.payload.message).toContain('B');
+  });
+
+  it('omits `options` field on payload when none parsed', () => {
+    const r = buildFinalTurnMessage('plain', fixedId);
+    expect('options' in r!.payload).toBe(false);
+  });
+
+  it('flags incomplete options block (opener with no closer)', () => {
+    const r = buildFinalTurnMessage('text <options><option>A</option>', fixedId);
+    expect(r).not.toBeNull();
+    expect(r!.options).toEqual([]);
+    expect(r!.incompleteOptions).toBe(true);
+  });
+
+  it('uses default randomUUID when no id generator provided', () => {
+    const r = buildFinalTurnMessage('hi');
+    expect(r!.payload.id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('id generator is invoked exactly once per build', () => {
+    let calls = 0;
+    const gen = () => `gen-${++calls}`;
+    const r = buildFinalTurnMessage('hi', gen);
+    expect(r!.payload.id).toBe('gen-1');
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/styrby-cli/src/gemini/__tests__/idTokenEmail.test.ts
+++ b/packages/styrby-cli/src/gemini/__tests__/idTokenEmail.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for `decodeEmailFromIdToken`.
+ *
+ * Covers happy path + every documented failure mode, since the helper
+ * MUST never throw (used in best-effort enrichment).
+ */
+import { describe, it, expect } from 'vitest';
+import { decodeEmailFromIdToken } from '@/gemini/utils/idTokenEmail';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  // Signature segment is meaningless for decode-only.
+  return `${header}.${body}.signaturepart`;
+}
+
+describe('decodeEmailFromIdToken', () => {
+  it('returns email when payload contains a string email', () => {
+    const token = makeJwt({ email: 'user@example.com', sub: '123' });
+    expect(decodeEmailFromIdToken(token)).toBe('user@example.com');
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(decodeEmailFromIdToken(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for null input', () => {
+    expect(decodeEmailFromIdToken(null)).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(decodeEmailFromIdToken('')).toBeUndefined();
+  });
+
+  it('returns undefined when payload omits email claim', () => {
+    const token = makeJwt({ sub: '123' });
+    expect(decodeEmailFromIdToken(token)).toBeUndefined();
+  });
+
+  it('returns undefined when email claim is non-string', () => {
+    const token = makeJwt({ email: 42 });
+    expect(decodeEmailFromIdToken(token)).toBeUndefined();
+  });
+
+  it('returns undefined for a token with wrong segment count', () => {
+    expect(decodeEmailFromIdToken('only.two')).toBeUndefined();
+    expect(decodeEmailFromIdToken('a.b.c.d')).toBeUndefined();
+  });
+
+  it('returns undefined for malformed base64', () => {
+    expect(decodeEmailFromIdToken('header.!!!notbase64!!!.sig')).toBeUndefined();
+  });
+
+  it('returns undefined when payload is not JSON', () => {
+    const bogus = Buffer.from('not json {{{').toString('base64url');
+    expect(decodeEmailFromIdToken(`h.${bogus}.s`)).toBeUndefined();
+  });
+
+  it('returns undefined when payload decodes to a non-object', () => {
+    const arr = Buffer.from(JSON.stringify(['email', 'x'])).toString('base64url');
+    expect(decodeEmailFromIdToken(`h.${arr}.s`)).toBeUndefined();
+  });
+
+  it('does not throw for non-string types passed at runtime', () => {
+    // @ts-expect-error - exercising runtime guard
+    expect(decodeEmailFromIdToken(42)).toBeUndefined();
+    // @ts-expect-error
+    expect(decodeEmailFromIdToken({})).toBeUndefined();
+  });
+});

--- a/packages/styrby-cli/src/gemini/__tests__/modeResolver.test.ts
+++ b/packages/styrby-cli/src/gemini/__tests__/modeResolver.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for `resolvePermissionMode` and `resolveModel`.
+ *
+ * These two helpers encode the per-message override semantics — getting
+ * them wrong would silently change the model or permission scope without
+ * the user noticing. Every documented branch is asserted here.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolvePermissionMode, resolveModel } from '@/gemini/utils/modeResolver';
+
+describe('resolvePermissionMode', () => {
+  it('initializes to default on first message with no meta', () => {
+    const r = resolvePermissionMode(undefined, undefined);
+    expect(r.forMessage).toBe('default');
+    expect(r.newCurrent).toBe('default');
+    expect(r.didChange).toBe(true);
+    expect(r.invalid).toBe(false);
+  });
+
+  it('keeps current when meta omits permissionMode', () => {
+    const r = resolvePermissionMode({}, 'yolo');
+    expect(r.forMessage).toBe('yolo');
+    expect(r.didChange).toBe(false);
+  });
+
+  it('accepts a valid override and marks change', () => {
+    const r = resolvePermissionMode({ permissionMode: 'read-only' }, 'default');
+    expect(r.forMessage).toBe('read-only');
+    expect(r.newCurrent).toBe('read-only');
+    expect(r.didChange).toBe(true);
+    expect(r.invalid).toBe(false);
+  });
+
+  it('rejects invalid override and keeps current', () => {
+    const r = resolvePermissionMode({ permissionMode: 'evil-mode' }, 'safe-yolo');
+    expect(r.forMessage).toBe('safe-yolo');
+    expect(r.invalid).toBe(true);
+  });
+
+  it('rejects invalid override but initializes when current is undefined', () => {
+    const r = resolvePermissionMode({ permissionMode: 'bad' }, undefined);
+    expect(r.forMessage).toBe('default');
+    expect(r.invalid).toBe(true);
+  });
+
+  it('accepts all four valid modes', () => {
+    for (const mode of ['default', 'read-only', 'safe-yolo', 'yolo'] as const) {
+      const r = resolvePermissionMode({ permissionMode: mode }, undefined);
+      expect(r.invalid).toBe(false);
+      expect(r.forMessage).toBe(mode);
+    }
+  });
+});
+
+describe('resolveModel', () => {
+  it('keeps current when meta is undefined', () => {
+    const r = resolveModel(undefined, 'gemini-2.5-pro');
+    expect(r.kind).toBe('keep');
+    expect(r.forMessage).toBe('gemini-2.5-pro');
+  });
+
+  it('keeps current when meta lacks model key', () => {
+    const r = resolveModel({}, 'gemini-2.5-flash');
+    expect(r.kind).toBe('keep');
+  });
+
+  it('returns "reset" when model is explicit null', () => {
+    const r = resolveModel({ model: null }, 'gemini-2.5-flash');
+    expect(r.kind).toBe('reset');
+    expect(r.forMessage).toBeUndefined();
+    expect(r.newCurrent).toBeUndefined();
+  });
+
+  it('returns "change" when model is a different string', () => {
+    const r = resolveModel({ model: 'gemini-2.5-flash-lite' }, 'gemini-2.5-pro');
+    expect(r.kind).toBe('change');
+    if (r.kind === 'change') {
+      expect(r.forMessage).toBe('gemini-2.5-flash-lite');
+      expect(r.previous).toBe('gemini-2.5-pro');
+    }
+  });
+
+  it('returns "change" when current is undefined and a model is supplied', () => {
+    const r = resolveModel({ model: 'gemini-2.5-pro' }, undefined);
+    expect(r.kind).toBe('change');
+  });
+
+  it('returns "noop" when model matches current', () => {
+    const r = resolveModel({ model: 'gemini-2.5-pro' }, 'gemini-2.5-pro');
+    expect(r.kind).toBe('noop');
+    expect(r.forMessage).toBe('gemini-2.5-pro');
+  });
+
+  it('treats meta.model === undefined (key present, value undefined) as keep', () => {
+    const r = resolveModel({ model: undefined }, 'gemini-2.5-flash');
+    expect(r.kind).toBe('keep');
+  });
+
+  it('treats empty string model as keep (falsy non-null)', () => {
+    const r = resolveModel({ model: '' }, 'gemini-2.5-flash');
+    // Empty string is falsy and not null — original code's `meta.model || null`
+    // path would fall to the keep branch in our resolver.
+    expect(r.kind).toBe('keep');
+  });
+});

--- a/packages/styrby-cli/src/gemini/__tests__/promptBuilder.test.ts
+++ b/packages/styrby-cli/src/gemini/__tests__/promptBuilder.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for `buildFirstMessagePrompt` and `promptContainsChangeTitle`.
+ *
+ * The first-message format must match Codex byte-for-byte (system prompt
+ * BEFORE user message, change_title instruction AFTER) — a regression here
+ * silently breaks mobile session-title generation.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildFirstMessagePrompt,
+  promptContainsChangeTitle,
+} from '@/gemini/utils/promptBuilder';
+import { CHANGE_TITLE_INSTRUCTION } from '@/gemini/constants';
+
+describe('buildFirstMessagePrompt', () => {
+  it('returns user message unchanged when no system prompt provided', () => {
+    expect(
+      buildFirstMessagePrompt({ userMessage: 'hi there' }),
+    ).toBe('hi there');
+  });
+
+  it('returns user message unchanged when system prompt is empty string', () => {
+    expect(
+      buildFirstMessagePrompt({ userMessage: 'hi', appendSystemPrompt: '' }),
+    ).toBe('hi');
+  });
+
+  it('orders parts as system + user + change_title with double-newlines', () => {
+    const r = buildFirstMessagePrompt({
+      userMessage: 'USERMSG',
+      appendSystemPrompt: 'SYSPROMPT',
+    });
+    expect(r).toBe(`SYSPROMPT\n\nUSERMSG\n\n${CHANGE_TITLE_INSTRUCTION}`);
+  });
+
+  it('places change_title AFTER the user message (Codex parity)', () => {
+    const r = buildFirstMessagePrompt({
+      userMessage: 'do thing',
+      appendSystemPrompt: 'be helpful',
+    });
+    expect(r.indexOf('do thing')).toBeLessThan(r.indexOf(CHANGE_TITLE_INSTRUCTION));
+    expect(r.indexOf('be helpful')).toBeLessThan(r.indexOf('do thing'));
+  });
+});
+
+describe('promptContainsChangeTitle', () => {
+  it('detects bare change_title', () => {
+    expect(promptContainsChangeTitle('please change_title now')).toBe(true);
+  });
+
+  it('detects MCP-prefixed happy__change_title', () => {
+    expect(promptContainsChangeTitle('use happy__change_title tool')).toBe(true);
+  });
+
+  it('returns false when neither token is present', () => {
+    expect(promptContainsChangeTitle('hello world')).toBe(false);
+  });
+
+  it('returns true for prompt built via buildFirstMessagePrompt with sysprompt', () => {
+    const built = buildFirstMessagePrompt({
+      userMessage: 'task',
+      appendSystemPrompt: 'sys',
+    });
+    expect(promptContainsChangeTitle(built)).toBe(true);
+  });
+});

--- a/packages/styrby-cli/src/gemini/__tests__/promptRetryLoop.test.ts
+++ b/packages/styrby-cli/src/gemini/__tests__/promptRetryLoop.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for `sendPromptWithRetry`.
+ *
+ * Mocks the AgentBackend interface so we can assert:
+ *   - Success on first attempt
+ *   - Retry on empty-response, succeed on second attempt
+ *   - Quota errors NEVER retry, always invoke onQuotaError + rethrow
+ *   - Non-retryable errors propagate immediately
+ *   - Max retries respected
+ *   - waitForResponseComplete is awaited when present
+ *   - Sleep delay scales linearly with attempt number
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { sendPromptWithRetry } from '@/gemini/promptRetryLoop';
+import type { AgentBackend } from '@/agent';
+
+function makeBackend(impl: Partial<AgentBackend>): AgentBackend {
+  // Cast — tests only need the methods we call.
+  return impl as AgentBackend;
+}
+
+describe('sendPromptWithRetry', () => {
+  it('succeeds on first attempt', async () => {
+    const sendPrompt = vi.fn().mockResolvedValue(undefined);
+    const onRetry = vi.fn();
+    const onQuota = vi.fn();
+    await sendPromptWithRetry({
+      backend: makeBackend({ sendPrompt }),
+      acpSessionId: 'sid',
+      prompt: 'hi',
+      onQuotaError: onQuota,
+      onRetryAttempt: onRetry,
+      sleep: async () => {},
+    });
+    expect(sendPrompt).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+    expect(onQuota).not.toHaveBeenCalled();
+  });
+
+  it('awaits waitForResponseComplete when backend provides it', async () => {
+    const sendPrompt = vi.fn().mockResolvedValue(undefined);
+    const waitForResponseComplete = vi.fn().mockResolvedValue(undefined);
+    await sendPromptWithRetry({
+      backend: makeBackend({ sendPrompt, waitForResponseComplete }),
+      acpSessionId: 'sid',
+      prompt: 'hi',
+      onQuotaError: () => {},
+      onRetryAttempt: () => {},
+      sleep: async () => {},
+    });
+    expect(waitForResponseComplete).toHaveBeenCalledWith(120000);
+  });
+
+  it('retries empty-response errors and eventually succeeds', async () => {
+    const sendPrompt = vi.fn()
+      .mockRejectedValueOnce({ data: { details: 'empty response' } })
+      .mockResolvedValueOnce(undefined);
+    const onRetry = vi.fn();
+    await sendPromptWithRetry({
+      backend: makeBackend({ sendPrompt }),
+      acpSessionId: 'sid',
+      prompt: 'hi',
+      onQuotaError: () => {},
+      onRetryAttempt: onRetry,
+      sleep: async () => {},
+    });
+    expect(sendPrompt).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith({ attempt: 1, max: 3, details: 'empty response' });
+  });
+
+  it('retries -32603 errors', async () => {
+    const sendPrompt = vi.fn()
+      .mockRejectedValueOnce({ code: -32603, message: 'internal' })
+      .mockResolvedValueOnce(undefined);
+    await sendPromptWithRetry({
+      backend: makeBackend({ sendPrompt }),
+      acpSessionId: 'sid',
+      prompt: 'hi',
+      onQuotaError: () => {},
+      onRetryAttempt: () => {},
+      sleep: async () => {},
+    });
+    expect(sendPrompt).toHaveBeenCalledTimes(2);
+  });
+
+  it('quota errors invoke onQuotaError and rethrow without retry', async () => {
+    const quotaErr = { data: { details: 'quota exhausted reset after 2h' } };
+    const sendPrompt = vi.fn().mockRejectedValue(quotaErr);
+    const onRetry = vi.fn();
+    const onQuota = vi.fn();
+    await expect(
+      sendPromptWithRetry({
+        backend: makeBackend({ sendPrompt }),
+        acpSessionId: 'sid',
+        prompt: 'hi',
+        onQuotaError: onQuota,
+        onRetryAttempt: onRetry,
+        sleep: async () => {},
+      }),
+    ).rejects.toBe(quotaErr);
+    expect(sendPrompt).toHaveBeenCalledTimes(1);
+    expect(onQuota).toHaveBeenCalledWith({ quotaResetSuffix: ' Quota resets in 2h.' });
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('non-retryable errors propagate immediately', async () => {
+    const err = { message: 'something else' };
+    const sendPrompt = vi.fn().mockRejectedValue(err);
+    await expect(
+      sendPromptWithRetry({
+        backend: makeBackend({ sendPrompt }),
+        acpSessionId: 'sid',
+        prompt: 'hi',
+        onQuotaError: () => {},
+        onRetryAttempt: () => {},
+        sleep: async () => {},
+      }),
+    ).rejects.toBe(err);
+    expect(sendPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects maxRetries cap', async () => {
+    const err = { data: { details: 'empty response' } };
+    const sendPrompt = vi.fn().mockRejectedValue(err);
+    await expect(
+      sendPromptWithRetry({
+        backend: makeBackend({ sendPrompt }),
+        acpSessionId: 'sid',
+        prompt: 'hi',
+        maxRetries: 2,
+        onQuotaError: () => {},
+        onRetryAttempt: () => {},
+        sleep: async () => {},
+      }),
+    ).rejects.toBe(err);
+    expect(sendPrompt).toHaveBeenCalledTimes(2);
+  });
+
+  it('sleep delay scales linearly with attempt number', async () => {
+    const sleeps: number[] = [];
+    const sendPrompt = vi.fn()
+      .mockRejectedValueOnce({ data: { details: 'empty response' } })
+      .mockRejectedValueOnce({ data: { details: 'empty response' } })
+      .mockResolvedValueOnce(undefined);
+    await sendPromptWithRetry({
+      backend: makeBackend({ sendPrompt }),
+      acpSessionId: 'sid',
+      prompt: 'hi',
+      retryDelayMs: 1000,
+      onQuotaError: () => {},
+      onRetryAttempt: () => {},
+      sleep: async (ms) => { sleeps.push(ms); },
+    });
+    expect(sleeps).toEqual([1000, 2000]); // attempt 1 -> 1000, attempt 2 -> 2000
+  });
+});

--- a/packages/styrby-cli/src/gemini/__tests__/turnState.test.ts
+++ b/packages/styrby-cli/src/gemini/__tests__/turnState.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for `createGeminiTurnState`.
+ *
+ * The state container exposes its mutable interior through getter/setter
+ * pairs on `handlerState` plus three reset helpers — those resets are
+ * timing-critical (called between every prompt and turn) so we pin them.
+ */
+import { describe, it, expect } from 'vitest';
+import { createGeminiTurnState } from '@/gemini/turnState';
+
+describe('createGeminiTurnState', () => {
+  it('initializes with all flags false / empty', () => {
+    const s = createGeminiTurnState();
+    expect(s.thinking()).toBe(false);
+    expect(s.isResponseInProgress()).toBe(false);
+    expect(s.accumulatedResponse()).toBe('');
+    expect(s.handlerState.getTaskStartedSent()).toBe(false);
+  });
+
+  it('handlerState getters and setters round-trip', () => {
+    const s = createGeminiTurnState();
+    s.handlerState.setThinking(true);
+    expect(s.thinking()).toBe(true);
+    expect(s.handlerState.getThinking()).toBe(true);
+
+    s.handlerState.setAccumulatedResponse('hello');
+    expect(s.accumulatedResponse()).toBe('hello');
+    expect(s.handlerState.getAccumulatedResponse()).toBe('hello');
+
+    s.handlerState.setIsResponseInProgress(true);
+    expect(s.isResponseInProgress()).toBe(true);
+
+    s.handlerState.setTaskStartedSent(true);
+    expect(s.handlerState.getTaskStartedSent()).toBe(true);
+  });
+
+  it('resetForNewPrompt clears accumulator + per-turn flags but NOT thinking', () => {
+    const s = createGeminiTurnState();
+    s.handlerState.setAccumulatedResponse('partial');
+    s.handlerState.setIsResponseInProgress(true);
+    s.handlerState.setTaskStartedSent(true);
+    s.handlerState.setThinking(true);
+
+    s.resetForNewPrompt();
+
+    expect(s.accumulatedResponse()).toBe('');
+    expect(s.isResponseInProgress()).toBe(false);
+    expect(s.handlerState.getTaskStartedSent()).toBe(false);
+    // WHY: thinking is cleared in resetAfterTurn, NOT resetForNewPrompt.
+    expect(s.thinking()).toBe(true);
+  });
+
+  it('resetAfterTurn clears thinking + tracking flags', () => {
+    const s = createGeminiTurnState();
+    s.handlerState.setThinking(true);
+    s.handlerState.setTaskStartedSent(true);
+
+    s.resetAfterTurn();
+
+    expect(s.thinking()).toBe(false);
+    expect(s.handlerState.getTaskStartedSent()).toBe(false);
+  });
+
+  it('clearAccumulatedAfterFlush clears accumulator + isResponseInProgress only', () => {
+    const s = createGeminiTurnState();
+    s.handlerState.setAccumulatedResponse('done');
+    s.handlerState.setIsResponseInProgress(true);
+    s.handlerState.setThinking(true);
+
+    s.clearAccumulatedAfterFlush();
+
+    expect(s.accumulatedResponse()).toBe('');
+    expect(s.isResponseInProgress()).toBe(false);
+    expect(s.thinking()).toBe(true); // unchanged
+  });
+
+  it('multiple instances do not share state', () => {
+    const a = createGeminiTurnState();
+    const b = createGeminiTurnState();
+    a.handlerState.setAccumulatedResponse('A');
+    b.handlerState.setAccumulatedResponse('B');
+    expect(a.accumulatedResponse()).toBe('A');
+    expect(b.accumulatedResponse()).toBe('B');
+  });
+});

--- a/packages/styrby-cli/src/gemini/abortHandler.ts
+++ b/packages/styrby-cli/src/gemini/abortHandler.ts
@@ -1,0 +1,76 @@
+/**
+ * Gemini Abort Handler Factory
+ *
+ * Builds the `handleAbort` function used by both the RPC abort handler and
+ * the kill-session sequence. Centralises the abort effects:
+ *   - Send `turn_aborted` to mobile
+ *   - Reset reasoning + diff processors
+ *   - Abort the current AbortController and reset to a fresh one
+ *   - Drain the message queue
+ *   - Cancel the active ACP session if any
+ *
+ * WHY split out: this was ~30 lines of pure orchestration that's invoked
+ * from two places (RPC handler + kill session). Promoting to a factory
+ * keeps the single-responsibility shape clean.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { logger } from '@/ui/logger';
+import type { ApiSessionClient } from '@/api/apiSession';
+import type { AgentBackend } from '@/agent';
+import type { MessageQueue2 } from '@/utils/MessageQueue2';
+import type { GeminiReasoningProcessor } from '@/gemini/utils/reasoningProcessor';
+import type { GeminiDiffProcessor } from '@/gemini/utils/diffProcessor';
+import type { GeminiMode } from '@/gemini/types';
+
+export interface AbortHandlerDeps {
+  getSession: () => ApiSessionClient;
+  getBackend: () => AgentBackend | null;
+  getAcpSessionId: () => string | null;
+  getAbortController: () => AbortController;
+  setAbortController: (ac: AbortController) => void;
+  reasoningProcessor: GeminiReasoningProcessor;
+  diffProcessor: GeminiDiffProcessor;
+  messageQueue: MessageQueue2<GeminiMode>;
+}
+
+/**
+ * Build the `handleAbort` async function used by RPC + kill flows.
+ *
+ * Behavior is identical to the pre-refactor inline `handleAbort`.
+ */
+export function buildAbortHandler(deps: AbortHandlerDeps): () => Promise<void> {
+  const {
+    getSession, getBackend, getAcpSessionId,
+    getAbortController, setAbortController,
+    reasoningProcessor, diffProcessor, messageQueue,
+  } = deps;
+
+  return async function handleAbort(): Promise<void> {
+    logger.debug('[Gemini] Abort requested - stopping current task');
+
+    // Send turn_aborted to mobile (Codex parity).
+    getSession().sendAgentMessage('gemini', {
+      type: 'turn_aborted',
+      id: randomUUID(),
+    });
+
+    reasoningProcessor.abort();
+    diffProcessor.reset();
+
+    try {
+      getAbortController().abort();
+      messageQueue.reset();
+      const backend = getBackend();
+      const acpId = getAcpSessionId();
+      if (backend && acpId) {
+        await backend.cancel(acpId);
+      }
+      logger.debug('[Gemini] Abort completed - session remains active');
+    } catch (error) {
+      logger.debug('[Gemini] Error during abort:', error);
+    } finally {
+      setAbortController(new AbortController());
+    }
+  };
+}

--- a/packages/styrby-cli/src/gemini/backendFactory.ts
+++ b/packages/styrby-cli/src/gemini/backendFactory.ts
@@ -1,0 +1,50 @@
+/**
+ * Gemini Backend Creation Helper
+ *
+ * Tiny wrapper that consolidates the duplicated `createGeminiBackend`
+ * invocation used in both the "first message" and "mode-changed" branches
+ * of `runGemini`'s main loop.
+ *
+ * WHY split out: the args object was identical in both call sites except
+ * for the `model` value, and both sites had the same odd `undefined vs
+ * null` mapping rule with a multiline WHY comment. DRYing this up keeps
+ * the rule documented in exactly one place.
+ */
+
+import { createGeminiBackend } from '@/agent/factories/gemini';
+import type { GeminiPermissionHandler } from '@/gemini/utils/permissionHandler';
+
+export interface CreateBackendArgs {
+  mcpServers: Record<string, { command: string; args: string[] }>;
+  permissionHandler: GeminiPermissionHandler;
+  cloudToken?: string;
+  currentUserEmail?: string;
+  /**
+   * Per-message model override.
+   *   - `undefined` => key not present in user-message meta; backend will
+   *     fall back to local config / env / default.
+   *   - explicit `null` => user explicitly reset model; backend should skip
+   *     local config and use env / default only.
+   *   - string => use this model.
+   */
+  messageModel: string | null | undefined;
+}
+
+/**
+ * Translate the `messageModel` semantics into the `model` arg expected by
+ * `createGeminiBackend`, and return the factory result unchanged.
+ */
+export function createBackendForMessage(args: CreateBackendArgs) {
+  const { mcpServers, permissionHandler, cloudToken, currentUserEmail, messageModel } = args;
+  // WHY: `undefined` -> pass undefined; otherwise coerce empty/null -> null
+  // so the factory knows "explicitly reset, skip local config".
+  const model = messageModel === undefined ? undefined : (messageModel || null);
+  return createGeminiBackend({
+    cwd: process.cwd(),
+    mcpServers,
+    permissionHandler,
+    cloudToken,
+    currentUserEmail,
+    model,
+  });
+}

--- a/packages/styrby-cli/src/gemini/bootstrap.ts
+++ b/packages/styrby-cli/src/gemini/bootstrap.ts
@@ -1,0 +1,148 @@
+/**
+ * Gemini Session Bootstrap
+ *
+ * Encapsulates the "before-the-main-loop" setup work that `runGemini` used
+ * to do inline: ApiClient creation, machine registration, cloud-token fetch
+ * (with email decoding), session metadata + offline reconnection wiring,
+ * and the daemon notification.
+ *
+ * WHY split out: This was ~120 lines of straight-line setup with no shared
+ * mutation, so it pulls out as a pure-ish async function that returns a
+ * struct of everything the orchestrator needs.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { ApiClient } from '@/api/api';
+import { logger } from '@/ui/logger';
+import { type Credentials, readSettings } from '@/persistence';
+import { createSessionMetadata } from '@/utils/createSessionMetadata';
+import { initialMachineMetadata } from '@/daemon/run';
+import { notifyDaemonSessionStarted } from '@/daemon/controlClient';
+import { connectionState } from '@/utils/serverConnectionErrors';
+import { setupOfflineReconnection } from '@/utils/setupOfflineReconnection';
+import type { ApiSessionClient } from '@/api/apiSession';
+
+import { decodeEmailFromIdToken } from '@/gemini/utils/idTokenEmail';
+
+export interface GeminiBootstrapResult {
+  api: ApiClient;
+  machineId: string;
+  cloudToken?: string;
+  currentUserEmail?: string;
+  sessionTag: string;
+  metadata: ReturnType<typeof createSessionMetadata>['metadata'];
+  state: ReturnType<typeof createSessionMetadata>['state'];
+  /** The initial session client (may be an offline stub). */
+  initialSession: ApiSessionClient;
+  /** Handle to cancel offline reconnection during cleanup. */
+  reconnectionHandle: { cancel: () => void } | undefined;
+}
+
+/**
+ * Run the full Gemini session bootstrap sequence.
+ *
+ * Side effects (matching pre-refactor behavior):
+ *   - Calls `connectionState.setBackend('Gemini')`
+ *   - Logs to debug logger
+ *   - May `process.exit(1)` if no machineId is in settings
+ *   - Notifies daemon (best effort)
+ *
+ * @param opts.credentials - Auth credentials passed by the CLI shell.
+ * @param opts.startedBy   - Whether this run came from 'daemon' or 'terminal'.
+ * @param opts.onSessionSwap - Callback invoked when offline reconnection
+ *   produces a new live `ApiSessionClient` (the orchestrator's swap logic).
+ */
+export async function bootstrapGeminiSession(opts: {
+  credentials: Credentials;
+  startedBy?: 'daemon' | 'terminal';
+  onSessionSwap: (newSession: ApiSessionClient) => void;
+}): Promise<GeminiBootstrapResult> {
+  const sessionTag = randomUUID();
+
+  // Set backend for offline warnings (before any API calls)
+  connectionState.setBackend('Gemini');
+
+  const api = await ApiClient.create(opts.credentials);
+
+  const settings = await readSettings();
+  const machineId = settings?.machineId;
+  if (!machineId) {
+    console.error(
+      `[START] No machine ID found in settings, which is unexpected since ` +
+      `authAndSetupMachineIfNeeded should have created it. ` +
+      `Please report this issue on https://github.com/slopus/happy-cli/issues`,
+    );
+    process.exit(1);
+  }
+  logger.debug(`Using machineId: ${machineId}`);
+  await api.getOrCreateMachine({
+    machineId,
+    metadata: initialMachineMetadata,
+  });
+
+  // Fetch Gemini cloud token (from 'happy connect gemini')
+  let cloudToken: string | undefined;
+  let currentUserEmail: string | undefined;
+  try {
+    const vendorToken = await api.getVendorToken('gemini');
+    if (vendorToken?.oauth?.access_token) {
+      cloudToken = vendorToken.oauth.access_token;
+      logger.debug('[Gemini] Using OAuth token from Happy cloud');
+
+      // WHY: Per-account project matching needs the Google identity. Decode
+      // the id_token (JWT) without verifying — used only for routing.
+      currentUserEmail = decodeEmailFromIdToken(vendorToken.oauth.id_token);
+      if (currentUserEmail) {
+        logger.debug(`[Gemini] Current user email: ${currentUserEmail}`);
+      } else if (vendorToken.oauth.id_token) {
+        logger.debug('[Gemini] Failed to decode id_token for email');
+      }
+    }
+  } catch (error) {
+    logger.debug('[Gemini] Failed to fetch cloud token:', error);
+  }
+
+  // Create session
+  const { state, metadata } = createSessionMetadata({
+    flavor: 'gemini',
+    machineId,
+    startedBy: opts.startedBy,
+  });
+  const response = await api.getOrCreateSession({ tag: sessionTag, metadata, state });
+
+  const { session: initialSession, reconnectionHandle } = setupOfflineReconnection({
+    api,
+    sessionTag,
+    metadata,
+    state,
+    response,
+    onSessionSwap: opts.onSessionSwap,
+  });
+
+  // Report to daemon (only if we have a real session)
+  if (response) {
+    try {
+      logger.debug(`[START] Reporting session ${response.id} to daemon`);
+      const result = await notifyDaemonSessionStarted(response.id, metadata);
+      if (result.error) {
+        logger.debug(`[START] Failed to report to daemon (may not be running):`, result.error);
+      } else {
+        logger.debug(`[START] Reported session ${response.id} to daemon`);
+      }
+    } catch (error) {
+      logger.debug('[START] Failed to report to daemon (may not be running):', error);
+    }
+  }
+
+  return {
+    api,
+    machineId,
+    cloudToken,
+    currentUserEmail,
+    sessionTag,
+    metadata,
+    state,
+    initialSession,
+    reconnectionHandle,
+  };
+}

--- a/packages/styrby-cli/src/gemini/displayedModelTracker.ts
+++ b/packages/styrby-cli/src/gemini/displayedModelTracker.ts
@@ -1,0 +1,88 @@
+/**
+ * Gemini Displayed Model Tracker
+ *
+ * Encapsulates the "currently displayed model in the Ink status bar" state
+ * + the helper that mutates it (and pushes [MODEL:...] markers into the
+ * message buffer for the UI to parse).
+ *
+ * WHY split out: the original `runGemini` had ~30 lines of declaration +
+ * `updateDisplayedModel` closure + `getInitialGeminiModel` debug logging
+ * tangled together. Pulling it out gives the orchestrator a clean
+ * `tracker.get()` / `tracker.update(model, save)` API.
+ */
+
+import { logger } from '@/ui/logger';
+import type { MessageBuffer } from '@/ui/ink/messageBuffer';
+import { GEMINI_MODEL_ENV } from '@/gemini/constants';
+import {
+  readGeminiLocalConfig,
+  saveGeminiModelToConfig,
+  getInitialGeminiModel,
+} from '@/gemini/utils/config';
+
+export interface DisplayedModelTracker {
+  /** Read the current displayed model (may be undefined before first set). */
+  get(): string | undefined;
+  /**
+   * Update the displayed model and (optionally) persist to local config.
+   *
+   * No-op when called with `undefined`. When called with the same value,
+   * still logs but skips the [MODEL:...] marker (UI doesn't need refresh).
+   *
+   * @param model - New model name; passing `undefined` is a no-op.
+   * @param saveToConfig - True for user-initiated changes; false for backend init.
+   */
+  update(model: string | undefined, saveToConfig?: boolean): void;
+}
+
+export interface CreateTrackerArgs {
+  messageBuffer: MessageBuffer;
+  /**
+   * Read whether we have a TTY (closure so the tracker can be constructed
+   * BEFORE Ink setup runs, which is when `hasTTY` becomes known).
+   */
+  getHasTTY: () => boolean;
+}
+
+/**
+ * Create the displayed-model tracker initialised from env / local config.
+ *
+ * Side effect: emits a debug log of the resolved init values, matching the
+ * pre-refactor behavior.
+ */
+export function createDisplayedModelTracker(args: CreateTrackerArgs): DisplayedModelTracker {
+  const { messageBuffer, getHasTTY } = args;
+  let displayedModel: string | undefined = getInitialGeminiModel();
+
+  const localConfig = readGeminiLocalConfig();
+  logger.debug(
+    `[gemini] Initial model setup: env[GEMINI_MODEL_ENV]=${process.env[GEMINI_MODEL_ENV] || 'not set'}, ` +
+    `localConfig=${localConfig.model || 'not set'}, displayedModel=${displayedModel}`,
+  );
+
+  return {
+    get: () => displayedModel,
+    update: (model: string | undefined, saveToConfig: boolean = false) => {
+      if (model === undefined) {
+        logger.debug('[gemini] updateDisplayedModel called with undefined, skipping update');
+        return;
+      }
+      const oldModel = displayedModel;
+      displayedModel = model;
+      logger.debug(`[gemini] updateDisplayedModel called: oldModel=${oldModel}, newModel=${model}, saveToConfig=${saveToConfig}`);
+
+      if (saveToConfig) {
+        saveGeminiModelToConfig(model);
+      }
+
+      if (getHasTTY() && oldModel !== model) {
+        // WHY: UI parses [MODEL:<name>] from system messages to populate
+        // the status bar. We only emit when value actually changes.
+        logger.debug(`[gemini] Adding model update message to buffer: [MODEL:${model}]`);
+        messageBuffer.addMessage(`[MODEL:${model}]`, 'system');
+      } else if (getHasTTY()) {
+        logger.debug('[gemini] Model unchanged, skipping update message');
+      }
+    },
+  };
+}

--- a/packages/styrby-cli/src/gemini/inkSetup.ts
+++ b/packages/styrby-cli/src/gemini/inkSetup.ts
@@ -1,0 +1,108 @@
+/**
+ * Gemini Ink TTY Setup
+ *
+ * Wraps the Ink/React UI mount used by `runGemini`. Handles:
+ *   - Detecting whether we have a TTY
+ *   - Switching stdin to raw mode for keyboard input
+ *   - Mounting the `GeminiDisplay` React tree with a closure-driven model getter
+ *   - Pushing the initial model marker into the message buffer
+ *
+ * WHY split out: ~80 lines of side-effecting UI setup that has nothing to
+ * do with the agent loop. Extracting keeps `runGemini.ts` focused on the
+ * loop. Returns the unmount handle + tty flag so the caller can clean up.
+ */
+
+import React from 'react';
+import { render } from 'ink';
+import { logger } from '@/ui/logger';
+import { GeminiDisplay } from '@/ui/ink/GeminiDisplay';
+import type { MessageBuffer } from '@/ui/ink/messageBuffer';
+
+export interface InkSetupArgs {
+  messageBuffer: MessageBuffer;
+  /** Read the latest displayed model on each render (closure getter). */
+  getDisplayedModel: () => string | undefined;
+  /** Called when the user hits Ctrl-C. */
+  onExit: () => void | Promise<void>;
+}
+
+export interface InkSetupResult {
+  hasTTY: boolean;
+  inkInstance: ReturnType<typeof render> | null;
+}
+
+/**
+ * Mount the Gemini Ink UI (only if we have a TTY) and configure stdin for
+ * raw keyboard input.
+ *
+ * Side effects:
+ *   - `console.clear()` when TTY present (matches pre-refactor behavior)
+ *   - Pushes `[MODEL:<name>]` marker into messageBuffer so the status bar
+ *     populates immediately
+ *   - Switches process.stdin to raw mode
+ */
+export function setupGeminiInkUI(args: InkSetupArgs): InkSetupResult {
+  const { messageBuffer, getDisplayedModel, onExit } = args;
+  const hasTTY = Boolean(process.stdout.isTTY && process.stdin.isTTY);
+  let inkInstance: ReturnType<typeof render> | null = null;
+
+  if (hasTTY) {
+    console.clear();
+
+    // WHY: Function component that re-reads `displayedModel` from the closure
+    // on every render. This way Ink picks up model changes without prop
+    // wiring — the parent `runGemini` mutates the variable directly.
+    const DisplayComponent = () => {
+      const currentModelValue = getDisplayedModel() || 'gemini-2.5-pro';
+      return React.createElement(GeminiDisplay, {
+        messageBuffer,
+        logPath: process.env.DEBUG ? logger.getLogPath() : undefined,
+        currentModel: currentModelValue,
+        onExit: async () => {
+          logger.debug('[gemini]: Exiting agent via Ctrl-C');
+          await onExit();
+        },
+      });
+    };
+
+    inkInstance = render(React.createElement(DisplayComponent), {
+      exitOnCtrlC: false,
+      patchConsole: false,
+    });
+
+    const initialModelName = getDisplayedModel() || 'gemini-2.5-pro';
+    logger.debug(`[gemini] Sending initial model to UI: ${initialModelName}`);
+    messageBuffer.addMessage(`[MODEL:${initialModelName}]`, 'system');
+
+    process.stdin.resume();
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+    process.stdin.setEncoding('utf8');
+  }
+
+  return { hasTTY, inkInstance };
+}
+
+/**
+ * Tear down the Ink UI: restore stdin, unmount React, clear buffer.
+ *
+ * Safe to call even if `setupGeminiInkUI` was a no-op (no TTY).
+ */
+export function teardownGeminiInkUI(args: {
+  hasTTY: boolean;
+  inkInstance: ReturnType<typeof render> | null;
+  messageBuffer: MessageBuffer;
+}): void {
+  const { hasTTY, inkInstance, messageBuffer } = args;
+  if (process.stdin.isTTY) {
+    try { process.stdin.setRawMode(false); } catch { /* ignore */ }
+  }
+  if (hasTTY) {
+    try { process.stdin.pause(); } catch { /* ignore */ }
+  }
+  if (inkInstance) {
+    inkInstance.unmount();
+  }
+  messageBuffer.clear();
+}

--- a/packages/styrby-cli/src/gemini/lifecycle.ts
+++ b/packages/styrby-cli/src/gemini/lifecycle.ts
@@ -1,0 +1,132 @@
+/**
+ * Gemini Session Lifecycle Helpers
+ *
+ * Two helpers that used to be inline closures inside `runGemini`:
+ *   - `buildKillSessionHandler` — the RPC handler for "kill session" that
+ *     archives the session, stops servers, disposes the backend, and exits.
+ *   - `finalCleanupGemini`     — the outer-finally cleanup block that
+ *     cancels offline reconnection, closes the session, and tears down Ink.
+ *
+ * WHY split out: each is ~30 lines of pure-effect orchestration with no
+ * loop-private state, so both lift cleanly.
+ */
+
+import { logger } from '@/ui/logger';
+import { stopCaffeinate } from '@/utils/caffeinate';
+import type { ApiSessionClient } from '@/api/apiSession';
+import type { AgentBackend } from '@/agent';
+import type { MessageBuffer } from '@/ui/ink/messageBuffer';
+import type { render } from 'ink';
+import { teardownGeminiInkUI } from '@/gemini/inkSetup';
+
+export interface KillSessionDeps {
+  /** Live session reference. */
+  getSession: () => ApiSessionClient | undefined;
+  /** Live backend reference (may be null before first message). */
+  getBackend: () => AgentBackend | null;
+  /** Stop the bundled Happy MCP server. */
+  stopHappyServer: () => void;
+  /** Run the abort sequence first (cancel current task etc). */
+  handleAbort: () => Promise<void>;
+}
+
+/**
+ * Build the RPC handler invoked when the mobile app requests "kill session".
+ *
+ * Behavior is identical to the pre-refactor inline handler in `runGemini`.
+ * On any unexpected throw it exits with code 1; on success exits with 0.
+ */
+export function buildKillSessionHandler(deps: KillSessionDeps): () => Promise<void> {
+  const { getSession, getBackend, stopHappyServer, handleAbort } = deps;
+  return async function handleKillSession(): Promise<void> {
+    logger.debug('[Gemini] Kill session requested - terminating process');
+    await handleAbort();
+    logger.debug('[Gemini] Abort completed, proceeding with termination');
+
+    try {
+      const session = getSession();
+      if (session) {
+        session.updateMetadata((currentMetadata) => ({
+          ...currentMetadata,
+          lifecycleState: 'archived',
+          lifecycleStateSince: Date.now(),
+          archivedBy: 'cli',
+          archiveReason: 'User terminated',
+        }));
+
+        session.sendSessionDeath();
+        await session.flush();
+        await session.close();
+      }
+
+      stopCaffeinate();
+      stopHappyServer();
+
+      const backend = getBackend();
+      if (backend) {
+        await backend.dispose();
+      }
+
+      logger.debug('[Gemini] Session termination complete, exiting');
+      process.exit(0);
+    } catch (error) {
+      logger.debug('[Gemini] Error during session termination:', error);
+      process.exit(1);
+    }
+  };
+}
+
+export interface FinalCleanupArgs {
+  reconnectionHandle: { cancel: () => void } | undefined;
+  session: ApiSessionClient;
+  backend: AgentBackend | null;
+  stopHappyServer: () => void;
+  keepAliveInterval: ReturnType<typeof setInterval>;
+  hasTTY: boolean;
+  inkInstance: ReturnType<typeof render> | null;
+  messageBuffer: MessageBuffer;
+}
+
+/**
+ * Run the full outer-finally cleanup sequence for `runGemini`.
+ *
+ * Best-effort: any error during one step is logged and the next step still
+ * runs (matches the pre-refactor try/catch granularity).
+ */
+export async function finalCleanupGemini(args: FinalCleanupArgs): Promise<void> {
+  const {
+    reconnectionHandle,
+    session,
+    backend,
+    stopHappyServer,
+    keepAliveInterval,
+    hasTTY,
+    inkInstance,
+    messageBuffer,
+  } = args;
+  logger.debug('[gemini]: Final cleanup start');
+
+  if (reconnectionHandle) {
+    logger.debug('[gemini]: Cancelling offline reconnection');
+    reconnectionHandle.cancel();
+  }
+
+  try {
+    session.sendSessionDeath();
+    await session.flush();
+    await session.close();
+  } catch (e) {
+    logger.debug('[gemini]: Error while closing session', e);
+  }
+
+  if (backend) {
+    await backend.dispose();
+  }
+
+  stopHappyServer();
+
+  clearInterval(keepAliveInterval);
+  teardownGeminiInkUI({ hasTTY, inkInstance, messageBuffer });
+
+  logger.debug('[gemini]: Final cleanup completed');
+}

--- a/packages/styrby-cli/src/gemini/messageHandler.ts
+++ b/packages/styrby-cli/src/gemini/messageHandler.ts
@@ -1,0 +1,363 @@
+/**
+ * Gemini Backend Message Handler Factory
+ *
+ * The big `switch (msg.type)` block that translates `AgentMessage` events
+ * coming OUT of the Gemini ACP backend into:
+ *   - terminal UI updates (via `messageBuffer`)
+ *   - mobile app messages (via `session.sendAgentMessage`)
+ *   - reasoning/diff processor calls
+ *   - per-turn state mutations (thinking, accumulator, etc.)
+ *
+ * WHY split out: this switch is ~340 lines on its own, dwarfing every
+ * other concern in `runGemini.ts`. It is also a single cohesive
+ * responsibility (translate backend events to outbound effects) so it
+ * extracts cleanly behind a deps object. The factory pattern preserves
+ * shared mutable state via getters/setters — identical behavior to the
+ * pre-refactor closure.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { logger } from '@/ui/logger';
+import type { ApiSessionClient } from '@/api/apiSession';
+import type { AgentBackend, AgentMessage } from '@/agent';
+import type { MessageBuffer } from '@/ui/ink/messageBuffer';
+import type { GeminiReasoningProcessor } from '@/gemini/utils/reasoningProcessor';
+import type { GeminiDiffProcessor } from '@/gemini/utils/diffProcessor';
+
+/**
+ * Mutable state shared between the message handler and the main loop.
+ * The handler reads + writes these via getters/setters so it sees the same
+ * latest values as the rest of `runGemini.ts`.
+ */
+export interface MessageHandlerState {
+  getThinking(): boolean;
+  setThinking(v: boolean): void;
+  getAccumulatedResponse(): string;
+  setAccumulatedResponse(v: string): void;
+  getIsResponseInProgress(): boolean;
+  setIsResponseInProgress(v: boolean): void;
+  setCurrentResponseMessageId(v: string | null): void;
+  setHadToolCallInTurn(v: boolean): void;
+  setChangeTitleCompleted(v: boolean): void;
+  getTaskStartedSent(): boolean;
+  setTaskStartedSent(v: boolean): void;
+}
+
+export interface MessageHandlerDeps {
+  /** Live session reference (may have been swapped via reconnect). */
+  getSession: () => ApiSessionClient;
+  messageBuffer: MessageBuffer;
+  reasoningProcessor: GeminiReasoningProcessor;
+  diffProcessor: GeminiDiffProcessor;
+  state: MessageHandlerState;
+}
+
+/**
+ * Wire a backend's `onMessage` to the full Gemini event-translation logic.
+ *
+ * Behavior is byte-for-byte identical to the pre-refactor inline switch
+ * in `runGemini.ts` — only the surrounding closure was extracted.
+ *
+ * @param backend - The newly-created Gemini ACP backend.
+ * @param deps - Live references to session + UI + processors + state.
+ */
+export function attachGeminiMessageHandler(
+  backend: AgentBackend,
+  deps: MessageHandlerDeps
+): void {
+  const { getSession, messageBuffer, reasoningProcessor, diffProcessor, state } = deps;
+
+  backend.onMessage((msg: AgentMessage) => {
+    const session = getSession();
+
+    switch (msg.type) {
+      case 'model-output':
+        if (msg.textDelta) {
+          if (!state.getIsResponseInProgress()) {
+            // Start of new response - create new assistant message.
+            // Remove "Thinking..." message if present (will be replaced).
+            messageBuffer.removeLastMessage('system');
+            messageBuffer.addMessage(msg.textDelta, 'assistant');
+            state.setIsResponseInProgress(true);
+            logger.debug(`[gemini] Started new response, first chunk length: ${msg.textDelta.length}`);
+          } else {
+            messageBuffer.updateLastMessage(msg.textDelta, 'assistant');
+            logger.debug(`[gemini] Updated response, chunk length: ${msg.textDelta.length}, total accumulated: ${state.getAccumulatedResponse().length + msg.textDelta.length}`);
+          }
+          state.setAccumulatedResponse(state.getAccumulatedResponse() + msg.textDelta);
+        }
+        break;
+
+      case 'status': {
+        const statusDetail = msg.detail
+          ? (typeof msg.detail === 'object' ? JSON.stringify(msg.detail) : String(msg.detail))
+          : '';
+        logger.debug(`[gemini] Status changed: ${msg.status}${statusDetail ? ` - ${statusDetail}` : ''}`);
+
+        if (msg.status === 'error') {
+          logger.debug(`[gemini] ⚠️ Error status received: ${statusDetail || 'Unknown error'}`);
+          session.sendAgentMessage('gemini', {
+            type: 'turn_aborted',
+            id: randomUUID(),
+          });
+        }
+
+        if (msg.status === 'running') {
+          state.setThinking(true);
+          session.keepAlive(true, 'remote');
+
+          // Send task_started ONCE per turn (Gemini may oscillate running<->idle).
+          if (!state.getTaskStartedSent()) {
+            session.sendAgentMessage('gemini', {
+              type: 'task_started',
+              id: randomUUID(),
+            });
+            state.setTaskStartedSent(true);
+          }
+
+          messageBuffer.addMessage('Thinking...', 'system');
+        } else if (msg.status === 'idle' || msg.status === 'stopped') {
+          // WHY: We deliberately do NOT toggle `thinking=false` here.
+          // Gemini emits multiple idle events per turn (between chunks).
+          // Toggling thinking here would cause UI status to flicker between
+          // "working" and "online". `thinking` is only cleared in the
+          // turn-completion finally block.
+          reasoningProcessor.complete();
+        } else if (msg.status === 'error') {
+          state.setThinking(false);
+          session.keepAlive(false, 'remote');
+          state.setAccumulatedResponse('');
+          state.setIsResponseInProgress(false);
+          state.setCurrentResponseMessageId(null);
+
+          let errorMessage = 'Unknown error';
+          if (msg.detail) {
+            if (typeof msg.detail === 'object') {
+              const detailObj = msg.detail as Record<string, unknown>;
+              errorMessage = (detailObj.message as string) ||
+                             (detailObj.details as string) ||
+                             JSON.stringify(detailObj);
+            } else {
+              errorMessage = String(msg.detail);
+            }
+          }
+
+          if (errorMessage.includes('Authentication required')) {
+            errorMessage = `Authentication required.\n` +
+              `For Google Workspace accounts, run: happy gemini project set <project-id>\n` +
+              `Or use a different Google account: happy connect gemini\n` +
+              `Guide: https://goo.gle/gemini-cli-auth-docs#workspace-gca`;
+          }
+
+          messageBuffer.addMessage(`Error: ${errorMessage}`, 'status');
+          session.sendAgentMessage('gemini', {
+            type: 'message',
+            message: `Error: ${errorMessage}`,
+          });
+        }
+        break;
+      }
+
+      case 'tool-call': {
+        state.setHadToolCallInTurn(true);
+
+        const toolArgs = msg.args ? JSON.stringify(msg.args).substring(0, 100) : '';
+        const isInvestigationTool = msg.toolName === 'codebase_investigator' ||
+                                    (typeof msg.toolName === 'string' && msg.toolName.includes('investigator'));
+
+        logger.debug(`[gemini] 🔧 Tool call received: ${msg.toolName} (${msg.callId})${isInvestigationTool ? ' [INVESTIGATION]' : ''}`);
+        if (isInvestigationTool && msg.args && typeof msg.args === 'object' && 'objective' in msg.args) {
+          logger.debug(`[gemini] 🔍 Investigation objective: ${String(msg.args.objective).substring(0, 150)}...`);
+        }
+
+        messageBuffer.addMessage(`Executing: ${msg.toolName}${toolArgs ? ` ${toolArgs}${toolArgs.length >= 100 ? '...' : ''}` : ''}`, 'tool');
+        session.sendAgentMessage('gemini', {
+          type: 'tool-call',
+          name: msg.toolName,
+          callId: msg.callId,
+          input: msg.args,
+          id: randomUUID(),
+        });
+        break;
+      }
+
+      case 'tool-result': {
+        if (msg.toolName === 'change_title' ||
+            msg.callId?.includes('change_title') ||
+            msg.toolName === 'happy__change_title') {
+          state.setChangeTitleCompleted(true);
+          logger.debug('[gemini] change_title completed');
+        }
+
+        const isError = msg.result && typeof msg.result === 'object' && 'error' in msg.result;
+        const resultText = typeof msg.result === 'string'
+          ? msg.result.substring(0, 200)
+          : JSON.stringify(msg.result).substring(0, 200);
+        const truncatedResult = resultText + (typeof msg.result === 'string' && msg.result.length > 200 ? '...' : '');
+
+        const resultSize = typeof msg.result === 'string'
+          ? msg.result.length
+          : JSON.stringify(msg.result).length;
+
+        logger.debug(`[gemini] ${isError ? '❌' : '✅'} Tool result received: ${msg.toolName} (${msg.callId}) - Size: ${resultSize} bytes${isError ? ' [ERROR]' : ''}`);
+
+        if (!isError) {
+          diffProcessor.processToolResult(msg.toolName, msg.result, msg.callId);
+        }
+
+        if (isError) {
+          const errorMsg = (msg.result as any).error || 'Tool call failed';
+          logger.debug(`[gemini] ❌ Tool call error: ${errorMsg.substring(0, 300)}`);
+          messageBuffer.addMessage(`Error: ${errorMsg}`, 'status');
+        } else {
+          if (resultSize > 1000) {
+            logger.debug(`[gemini] ✅ Large tool result (${resultSize} bytes) - first 200 chars: ${truncatedResult}`);
+          }
+          messageBuffer.addMessage(`Result: ${truncatedResult}`, 'result');
+        }
+
+        session.sendAgentMessage('gemini', {
+          type: 'tool-result',
+          callId: msg.callId,
+          output: msg.result,
+          id: randomUUID(),
+        });
+        break;
+      }
+
+      case 'fs-edit':
+        messageBuffer.addMessage(`File edit: ${msg.description}`, 'tool');
+        diffProcessor.processFsEdit(msg.path || '', msg.description, msg.diff);
+        session.sendAgentMessage('gemini', {
+          type: 'file-edit',
+          description: msg.description,
+          diff: msg.diff,
+          filePath: msg.path || 'unknown',
+          id: randomUUID(),
+        });
+        break;
+
+      case 'terminal-output':
+        messageBuffer.addMessage(msg.data, 'result');
+        session.sendAgentMessage('gemini', {
+          type: 'terminal-output',
+          data: msg.data,
+          callId: (msg as any).callId || randomUUID(),
+        });
+        break;
+
+      case 'permission-request': {
+        const payload = (msg as any).payload || {};
+        session.sendAgentMessage('gemini', {
+          type: 'permission-request',
+          permissionId: msg.id,
+          toolName: payload.toolName || (msg as any).reason || 'unknown',
+          description: (msg as any).reason || payload.toolName || '',
+          options: payload,
+        });
+        break;
+      }
+
+      case 'exec-approval-request': {
+        const execApprovalMsg = msg as any;
+        const callId = execApprovalMsg.call_id || execApprovalMsg.callId || randomUUID();
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { call_id, type, ...inputs } = execApprovalMsg;
+
+        logger.debug(`[gemini] Exec approval request received: ${callId}`);
+        messageBuffer.addMessage(`Exec approval requested: ${callId}`, 'tool');
+
+        session.sendAgentMessage('gemini', {
+          type: 'tool-call',
+          name: 'GeminiBash',
+          callId,
+          input: inputs,
+          id: randomUUID(),
+        });
+        break;
+      }
+
+      case 'patch-apply-begin': {
+        const patchBeginMsg = msg as any;
+        const patchCallId = patchBeginMsg.call_id || patchBeginMsg.callId || randomUUID();
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { call_id: _pId, type: _pType, auto_approved, changes } = patchBeginMsg;
+
+        const changeCount = changes ? Object.keys(changes).length : 0;
+        const filesMsg = changeCount === 1 ? '1 file' : `${changeCount} files`;
+        messageBuffer.addMessage(`Modifying ${filesMsg}...`, 'tool');
+        logger.debug(`[gemini] Patch apply begin: ${patchCallId}, files: ${changeCount}`);
+
+        session.sendAgentMessage('gemini', {
+          type: 'tool-call',
+          name: 'GeminiPatch',
+          callId: patchCallId,
+          input: { auto_approved, changes },
+          id: randomUUID(),
+        });
+        break;
+      }
+
+      case 'patch-apply-end': {
+        const patchEndMsg = msg as any;
+        const patchEndCallId = patchEndMsg.call_id || patchEndMsg.callId || randomUUID();
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { call_id: _peId, type: _peType, stdout, stderr, success } = patchEndMsg;
+
+        if (success) {
+          const message = stdout || 'Files modified successfully';
+          messageBuffer.addMessage(message.substring(0, 200), 'result');
+        } else {
+          const errorMsg = stderr || 'Failed to modify files';
+          messageBuffer.addMessage(`Error: ${errorMsg.substring(0, 200)}`, 'result');
+        }
+        logger.debug(`[gemini] Patch apply end: ${patchEndCallId}, success: ${success}`);
+
+        session.sendAgentMessage('gemini', {
+          type: 'tool-result',
+          callId: patchEndCallId,
+          output: { stdout, stderr, success },
+          id: randomUUID(),
+        });
+        break;
+      }
+
+      case 'event':
+        if (msg.name === 'thinking') {
+          const thinkingPayload = msg.payload as { text?: string } | undefined;
+          const thinkingText = (thinkingPayload && typeof thinkingPayload === 'object' && 'text' in thinkingPayload)
+            ? String(thinkingPayload.text || '')
+            : '';
+          if (thinkingText) {
+            // ReasoningProcessor identifies titled (**Title**) sections and
+            // converts them to tool calls.
+            reasoningProcessor.processChunk(thinkingText);
+            logger.debug(`[gemini] 💭 Thinking chunk received: ${thinkingText.length} chars - Preview: ${thinkingText.substring(0, 100)}...`);
+
+            if (!thinkingText.startsWith('**')) {
+              const thinkingPreview = thinkingText.substring(0, 100);
+              messageBuffer.updateLastMessage(`[Thinking] ${thinkingPreview}...`, 'system');
+            }
+            // For titled reasoning, ReasoningProcessor sends tool call but we
+            // keep "Thinking..." visible so user sees progress.
+          }
+          session.sendAgentMessage('gemini', {
+            type: 'thinking',
+            text: thinkingText,
+          });
+        }
+        break;
+
+      default:
+        // Forward token-count and any other unmodelled message types.
+        if ((msg as any).type === 'token-count') {
+          session.sendAgentMessage('gemini', {
+            type: 'token_count',
+            ...(msg as any),
+            id: randomUUID(),
+          });
+        }
+        break;
+    }
+  });
+}

--- a/packages/styrby-cli/src/gemini/promptRetryLoop.ts
+++ b/packages/styrby-cli/src/gemini/promptRetryLoop.ts
@@ -1,0 +1,104 @@
+/**
+ * Gemini sendPrompt Retry Loop
+ *
+ * The Gemini ACP backend occasionally returns transient errors that succeed
+ * on a second/third attempt:
+ *   - "empty response" / "Model stream ended"
+ *   - JSON-RPC internal error -32603
+ *
+ * This module wraps `geminiBackend.sendPrompt` (+ optional
+ * `waitForResponseComplete`) with the standard 3-attempt exponential delay
+ * loop that `runGemini.ts` used inline.
+ *
+ * Quota errors are NEVER retried — the caller passes a `onQuotaError`
+ * hook so it can surface the (formatted) message and decide what to do.
+ */
+
+import { logger } from '@/ui/logger';
+import type { AgentBackend } from '@/agent';
+import { classifyPromptError } from '@/gemini/utils/errorFormatter';
+
+export interface SendWithRetryArgs {
+  backend: AgentBackend;
+  acpSessionId: string;
+  prompt: string;
+  /** Max total attempts including the initial one. Defaults to 3. */
+  maxRetries?: number;
+  /** Base delay between attempts in ms (linearly scaled by attempt). Defaults to 2000. */
+  retryDelayMs?: number;
+  /**
+   * Called when classifier flags a quota error. Caller surfaces UI/mobile
+   * messages then we re-throw so the outer catch handles cleanup as before.
+   */
+  onQuotaError: (info: { quotaResetSuffix: string }) => void;
+  /**
+   * Called between retry attempts so the caller can render a "retrying X/Y"
+   * status banner.
+   */
+  onRetryAttempt: (info: { attempt: number; max: number; details: string }) => void;
+  /** Optional sleep override for tests. Defaults to setTimeout-based promise. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Send a prompt with retry-on-transient-failure semantics.
+ *
+ * Mirrors the original loop in `runGemini.ts` exactly: only "empty response"
+ * and -32603 errors are retried, quota errors are forwarded to the caller
+ * and rethrown immediately, and we wait for `waitForResponseComplete` (when
+ * available) inside each successful attempt before declaring success.
+ *
+ * @returns void on success. Throws the most-recent error on terminal failure.
+ */
+export async function sendPromptWithRetry(args: SendWithRetryArgs): Promise<void> {
+  const {
+    backend,
+    acpSessionId,
+    prompt,
+    maxRetries = 3,
+    retryDelayMs = 2000,
+    onQuotaError,
+    onRetryAttempt,
+    sleep = (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+  } = args;
+
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await backend.sendPrompt(acpSessionId, prompt);
+      logger.debug('[gemini] Prompt sent successfully');
+
+      if (backend.waitForResponseComplete) {
+        // WHY: Wait for full streaming completion (chunks + final idle) so we
+        // never declare task_complete before the model is actually done.
+        await backend.waitForResponseComplete(120000);
+        logger.debug('[gemini] Response complete');
+      }
+
+      return; // Success
+    } catch (promptError) {
+      lastError = promptError;
+      const cls = classifyPromptError(promptError);
+
+      if (cls.isQuotaError) {
+        onQuotaError({ quotaResetSuffix: cls.quotaResetSuffix });
+        throw promptError; // Don't retry quota errors
+      }
+
+      if (cls.isRetryable && attempt < maxRetries) {
+        logger.debug(`[gemini] Retryable error on attempt ${attempt}/${maxRetries}: ${cls.details}`);
+        onRetryAttempt({ attempt, max: maxRetries, details: cls.details });
+        await sleep(retryDelayMs * attempt);
+        continue;
+      }
+
+      // Not retryable or max retries reached
+      throw promptError;
+    }
+  }
+
+  // Should be unreachable — the loop either returns or throws.
+  // Rethrow last error defensively.
+  throw lastError ?? new Error('sendPromptWithRetry: exhausted without success or error');
+}

--- a/packages/styrby-cli/src/gemini/runGemini.ts
+++ b/packages/styrby-cli/src/gemini/runGemini.ts
@@ -1,148 +1,73 @@
 /**
- * Gemini CLI Entry Point
- * 
- * This module provides the main entry point for running the Gemini agent
- * through Happy CLI. It manages the agent lifecycle, session state, and
- * communication with the Happy server and mobile app.
+ * Gemini CLI Entry Point — orchestrator for `runGemini`.
+ *
+ * This file owns: session bootstrap, the main turn loop, and final cleanup.
+ * Cohesive concerns are extracted to sibling modules (see imports below).
+ * Public API is unchanged: `export async function runGemini(...)`.
  */
 
-import { render } from 'ink';
-import React from 'react';
 import { randomUUID } from 'node:crypto';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 
-import { ApiClient } from '@/api/api';
 import { logger } from '@/ui/logger';
-import { Credentials, readSettings } from '@/persistence';
-import { createSessionMetadata } from '@/utils/createSessionMetadata';
-import { initialMachineMetadata } from '@/daemon/run';
+import { type Credentials } from '@/persistence';
 import { MessageQueue2 } from '@/utils/MessageQueue2';
 import { hashObject } from '@/utils/deterministicJson';
 import { projectPath } from '@/projectPath';
 import { startHappyServer } from '@/claude/utils/startHappyServer';
 import { MessageBuffer } from '@/ui/ink/messageBuffer';
-import { notifyDaemonSessionStarted } from '@/daemon/controlClient';
 import { registerKillSessionHandler } from '@/claude/registerKillSessionHandler';
-import { stopCaffeinate } from '@/utils/caffeinate';
-import { connectionState } from '@/utils/serverConnectionErrors';
-import { setupOfflineReconnection } from '@/utils/setupOfflineReconnection';
 import type { ApiSessionClient } from '@/api/apiSession';
 
-import { createGeminiBackend } from '@/agent/factories/gemini';
-import type { AgentBackend, AgentMessage } from '@/agent';
-import { GeminiDisplay } from '@/ui/ink/GeminiDisplay';
+import type { AgentBackend } from '@/agent';
 import { GeminiPermissionHandler } from '@/gemini/utils/permissionHandler';
 import { GeminiReasoningProcessor } from '@/gemini/utils/reasoningProcessor';
 import { GeminiDiffProcessor } from '@/gemini/utils/diffProcessor';
-import type { GeminiMode, CodexMessagePayload } from '@/gemini/types';
+import type { GeminiMode } from '@/gemini/types';
 import type { PermissionMode } from '@/api/types';
-import { GEMINI_MODEL_ENV, CHANGE_TITLE_INSTRUCTION } from '@/gemini/constants';
-import {
-  readGeminiLocalConfig,
-  saveGeminiModelToConfig,
-  getInitialGeminiModel
-} from '@/gemini/utils/config';
-import {
-  parseOptionsFromText,
-  hasIncompleteOptions,
-  formatOptionsXml,
-} from '@/gemini/utils/optionsParser';
 import { ConversationHistory } from '@/gemini/utils/conversationHistory';
 
+import { promptContainsChangeTitle } from '@/gemini/utils/promptBuilder';
+import { attachGeminiMessageHandler } from '@/gemini/messageHandler';
+import { bootstrapGeminiSession } from '@/gemini/bootstrap';
+import { setupGeminiInkUI } from '@/gemini/inkSetup';
+import { sendTurnPrompt } from '@/gemini/sendTurnPrompt';
+import { buildUserMessageRouter } from '@/gemini/userMessageRouter';
+import { finalizeGeminiTurn } from '@/gemini/turnFinalize';
+import { buildKillSessionHandler, finalCleanupGemini } from '@/gemini/lifecycle';
+import { prepareTurnBackend } from '@/gemini/turnPrep';
+import { createDisplayedModelTracker } from '@/gemini/displayedModelTracker';
+import { createGeminiTurnState } from '@/gemini/turnState';
+import { buildAbortHandler } from '@/gemini/abortHandler';
+
+// Re-export extracted helpers so existing callers (and any future ones) can
+// import them via the canonical `@/gemini/runGemini` path used pre-refactor.
+export { decodeEmailFromIdToken } from '@/gemini/utils/idTokenEmail';
+export { formatGeminiError, classifyPromptError } from '@/gemini/utils/errorFormatter';
+export { resolvePermissionMode, resolveModel } from '@/gemini/utils/modeResolver';
+export { buildFinalTurnMessage } from '@/gemini/utils/finalMessageBuilder';
+export { buildFirstMessagePrompt, promptContainsChangeTitle } from '@/gemini/utils/promptBuilder';
+export { attachGeminiMessageHandler } from '@/gemini/messageHandler';
 
 /**
- * Main entry point for the gemini command with ink UI
+ * Main entry point for the gemini command with ink UI.
  */
 export async function runGemini(opts: {
   credentials: Credentials;
   startedBy?: 'daemon' | 'terminal';
 }): Promise<void> {
-  //
-  // Define session
-  //
-
-  
-  const sessionTag = randomUUID();
-
-  // Set backend for offline warnings (before any API calls)
-  connectionState.setBackend('Gemini');
-
-  const api = await ApiClient.create(opts.credentials);
-
-
-  //
-  // Machine
-  //
-
-  const settings = await readSettings();
-  const machineId = settings?.machineId;
-  if (!machineId) {
-    console.error(`[START] No machine ID found in settings, which is unexpected since authAndSetupMachineIfNeeded should have created it. Please report this issue on https://github.com/slopus/happy-cli/issues`);
-    process.exit(1);
-  }
-  logger.debug(`Using machineId: ${machineId}`);
-  await api.getOrCreateMachine({
-    machineId,
-    metadata: initialMachineMetadata
-  });
-
-  //
-  // Fetch Gemini cloud token (from 'happy connect gemini')
-  //
-  let cloudToken: string | undefined = undefined;
-  let currentUserEmail: string | undefined = undefined;
-  try {
-    const vendorToken = await api.getVendorToken('gemini');
-    if (vendorToken?.oauth?.access_token) {
-      cloudToken = vendorToken.oauth.access_token;
-      logger.debug('[Gemini] Using OAuth token from Happy cloud');
-      
-      // Extract email from id_token for per-account project matching
-      if (vendorToken.oauth.id_token) {
-        try {
-          const parts = vendorToken.oauth.id_token.split('.');
-          if (parts.length === 3) {
-            const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
-            if (payload.email) {
-              currentUserEmail = payload.email;
-              logger.debug(`[Gemini] Current user email: ${currentUserEmail}`);
-            }
-          }
-        } catch {
-          logger.debug('[Gemini] Failed to decode id_token for email');
-        }
-      }
-    }
-  } catch (error) {
-    logger.debug('[Gemini] Failed to fetch cloud token:', error);
-  }
-
-  //
-  // Create session
-  //
-
-  const { state, metadata } = createSessionMetadata({
-    flavor: 'gemini',
-    machineId,
-    startedBy: opts.startedBy
-  });
-  const response = await api.getOrCreateSession({ tag: sessionTag, metadata, state });
-
-  // Handle server unreachable case - create offline stub with hot reconnection
+  // Live session reference (may be hot-swapped by offline reconnection).
   let session: ApiSessionClient;
-  // Permission handler declared here so it can be updated in onSessionSwap callback
-  // (assigned later after Happy server setup)
+  // Permission handler declared here so it can be updated in onSessionSwap
+  // callback (assigned later after Happy server setup).
   let permissionHandler: GeminiPermissionHandler;
 
-  // Session swap synchronization to prevent race conditions during message processing
-  // When a swap is requested during processing, it's queued and applied after the current cycle
+  // Session swap synchronization to prevent race conditions during message
+  // processing.
   let isProcessingMessage = false;
   let pendingSessionSwap: ApiSessionClient | null = null;
 
-  /**
-   * Apply a pending session swap. Called between message processing cycles.
-   * This ensures session swaps happen at safe points, not during message processing.
-   */
+  /** Apply a pending session swap. Called between message processing cycles. */
   const applyPendingSessionSwap = () => {
     if (pendingSessionSwap) {
       logger.debug('[gemini] Applying pending session swap');
@@ -154,43 +79,24 @@ export async function runGemini(opts: {
     }
   };
 
-  const { session: initialSession, reconnectionHandle } = setupOfflineReconnection({
-    api,
-    sessionTag,
-    metadata,
-    state,
-    response,
-    onSessionSwap: (newSession) => {
-      // If we're processing a message, queue the swap for later
-      // This prevents race conditions where session changes mid-processing
-      if (isProcessingMessage) {
-        logger.debug('[gemini] Session swap requested during message processing - queueing');
-        pendingSessionSwap = newSession;
-      } else {
-        // Safe to swap immediately
-        session = newSession;
-        if (permissionHandler) {
-          permissionHandler.updateSession(newSession);
+  const { api, cloudToken, currentUserEmail, initialSession, reconnectionHandle } =
+    await bootstrapGeminiSession({
+      credentials: opts.credentials,
+      startedBy: opts.startedBy,
+      onSessionSwap: (newSession) => {
+        // If processing, queue swap for between-cycles application.
+        if (isProcessingMessage) {
+          logger.debug('[gemini] Session swap requested during message processing - queueing');
+          pendingSessionSwap = newSession;
+        } else {
+          session = newSession;
+          if (permissionHandler) {
+            permissionHandler.updateSession(newSession);
+          }
         }
-      }
-    }
-  });
+      },
+    });
   session = initialSession;
-
-  // Report to daemon (only if we have a real session)
-  if (response) {
-    try {
-      logger.debug(`[START] Reporting session ${response.id} to daemon`);
-      const result = await notifyDaemonSessionStarted(response.id, metadata);
-      if (result.error) {
-        logger.debug(`[START] Failed to report to daemon (may not be running):`, result.error);
-      } else {
-        logger.debug(`[START] Reported session ${response.id} to daemon`);
-      }
-    } catch (error) {
-      logger.debug('[START] Failed to report to daemon (may not be running):', error);
-    }
-  }
 
   const messageQueue = new MessageQueue2<GeminiMode>((mode) => hashObject({
     permissionMode: mode.permissionMode,
@@ -201,93 +107,34 @@ export async function runGemini(opts: {
   const conversationHistory = new ConversationHistory({ maxMessages: 20, maxCharacters: 50000 });
 
   // Track current overrides to apply per message
-  let currentPermissionMode: PermissionMode | undefined = undefined;
-  let currentModel: string | undefined = undefined;
-
-  session.onUserMessage((message) => {
-    // Resolve permission mode (validate) - same as Codex
-    let messagePermissionMode = currentPermissionMode;
-    if (message.meta?.permissionMode) {
-      const validModes: PermissionMode[] = ['default', 'read-only', 'safe-yolo', 'yolo'];
-      if (validModes.includes(message.meta.permissionMode as PermissionMode)) {
-        messagePermissionMode = message.meta.permissionMode as PermissionMode;
-        currentPermissionMode = messagePermissionMode;
-        // Update permission handler with new mode
-        updatePermissionMode(messagePermissionMode);
-        logger.debug(`[Gemini] Permission mode updated from user message to: ${currentPermissionMode}`);
-      } else {
-        logger.debug(`[Gemini] Invalid permission mode received: ${message.meta.permissionMode}`);
-      }
-    } else {
-      logger.debug(`[Gemini] User message received with no permission mode override, using current: ${currentPermissionMode ?? 'default (effective)'}`);
-    }
-    
-    // Initialize permission mode if not set yet
-    if (currentPermissionMode === undefined) {
-      currentPermissionMode = 'default';
-      updatePermissionMode('default');
-    }
-
-    // Resolve model; explicit null resets to default (undefined)
-    let messageModel = currentModel;
-    if (message.meta?.hasOwnProperty('model')) {
-      // If model is explicitly null, reset internal state but don't update displayed model
-      // If model is provided, use it and update displayed model
-      // Otherwise keep current model
-      if (message.meta.model === null) {
-        messageModel = undefined; // Explicitly reset - will use default/env/config
-        currentModel = undefined;
-        // Don't call updateDisplayedModel here - keep current displayed model
-        // The backend will use the correct model from env/config/default
-      } else if (message.meta.model) {
-        const previousModel = currentModel;
-        messageModel = message.meta.model;
-        currentModel = messageModel;
-        // Only update UI and show message if model actually changed
-        if (previousModel !== messageModel) {
-          // Save model to config file so it persists across sessions
-          updateDisplayedModel(messageModel, true); // Update UI and save to config
-          // Show model change message in UI (this will trigger UI re-render)
-          messageBuffer.addMessage(`Model changed to: ${messageModel}`, 'system');
-          logger.debug(`[Gemini] Model changed from ${previousModel} to ${messageModel}`);
-        }
-      }
-      // If message.meta.model is undefined, keep currentModel
-    }
-
-    // Build the full prompt with appendSystemPrompt if provided
-    // Only include system prompt for the first message to avoid forcing tool usage on every message
-    const originalUserMessage = message.content.text;
-    let fullPrompt = originalUserMessage;
-    if (isFirstMessage && message.meta?.appendSystemPrompt) {
-      // Prepend system prompt to user message only for first message
-      // Also add change_title instruction (like Codex does)
-      // Use EXACT same format as Codex: add instruction AFTER user message
-      // This matches Codex's approach exactly - instruction comes after user message
-      // Codex format: system prompt + user message + change_title instruction
-      fullPrompt = message.meta.appendSystemPrompt + '\n\n' + originalUserMessage + '\n\n' + CHANGE_TITLE_INSTRUCTION;
-      isFirstMessage = false;
-    }
-
-    const mode: GeminiMode = {
-      permissionMode: messagePermissionMode || 'default',
-      model: messageModel,
-      originalUserMessage, // Store original message separately
-    };
-    messageQueue.push(fullPrompt, mode);
-    
-    // Record user message in conversation history for context preservation
-    conversationHistory.addUserMessage(originalUserMessage);
-  });
-
-  let thinking = false;
-  session.keepAlive(thinking, 'remote');
-  const keepAliveInterval = setInterval(() => {
-    session.keepAlive(thinking, 'remote');
-  }, 2000);
+  let currentPermissionMode: PermissionMode | undefined;
+  let currentModel: string | undefined;
 
   // Track if this is the first message to include system prompt only once
   let isFirstMessage = true;
+
+  session.onUserMessage(buildUserMessageRouter({
+    messageQueue,
+    messageBuffer,
+    conversationHistory,
+    updatePermissionMode: (mode) => updatePermissionMode(mode),
+    updateDisplayedModel: (model, save) => updateDisplayedModel(model, save),
+    getCurrentPermissionMode: () => currentPermissionMode,
+    setCurrentPermissionMode: (m) => { currentPermissionMode = m; },
+    getCurrentModel: () => currentModel,
+    setCurrentModel: (m) => { currentModel = m; },
+    getIsFirstMessage: () => isFirstMessage,
+    setIsFirstMessage: (v) => { isFirstMessage = v; },
+  }));
+
+  // Per-turn mutable state container (accumulator, thinking flag, etc).
+  // Created early so keep-alive ticks can read its `thinking()` flag.
+  const turnState = createGeminiTurnState();
+
+  session.keepAlive(turnState.thinking(), 'remote');
+  const keepAliveInterval = setInterval(() => {
+    session.keepAlive(turnState.thinking(), 'remote');
+  }, 2000);
 
   const sendReady = () => {
     session.sendSessionEvent({ type: 'ready' });
@@ -303,23 +150,13 @@ export async function runGemini(opts: {
   };
 
   /**
-   * Check if we can emit ready event
-   * * Returns true when ready event was emitted
+   * Check if we can emit ready event. Returns true when emitted.
    */
   const emitReadyIfIdle = (): boolean => {
-    if (shouldExit) {
-      return false;
-    }
-    if (thinking) {
-      return false;
-    }
-    if (isResponseInProgress) {
-      return false;
-    }
-    if (messageQueue.size() > 0) {
-      return false;
-    }
-
+    if (shouldExit) return false;
+    if (turnState.thinking()) return false;
+    if (turnState.isResponseInProgress()) return false;
+    if (messageQueue.size() > 0) return false;
     sendReady();
     return true;
   };
@@ -334,67 +171,33 @@ export async function runGemini(opts: {
   let acpSessionId: string | null = null;
   let wasSessionCreated = false;
 
-  async function handleAbort() {
-    logger.debug('[Gemini] Abort requested - stopping current task');
-    
-    // Send turn_aborted event (like Codex) when abort is requested
-    session.sendAgentMessage('gemini', {
-      type: 'turn_aborted',
-      id: randomUUID(),
-    });
-    
-    // Abort reasoning processor and reset diff processor
-    reasoningProcessor.abort();
-    diffProcessor.reset();
-    
-    try {
-      abortController.abort();
-      messageQueue.reset();
-      if (geminiBackend && acpSessionId) {
-        await geminiBackend.cancel(acpSessionId);
-      }
-      logger.debug('[Gemini] Abort completed - session remains active');
-    } catch (error) {
-      logger.debug('[Gemini] Error during abort:', error);
-    } finally {
-      abortController = new AbortController();
-    }
-  }
+  // Reasoning + diff processors are created up-front so the abort/kill
+  // handlers can reference them. They emit messages via the live session.
+  permissionHandler = new GeminiPermissionHandler(session);
+  const reasoningProcessor = new GeminiReasoningProcessor((msg) => {
+    session.sendAgentMessage('gemini', msg);
+  });
+  const diffProcessor = new GeminiDiffProcessor((msg) => {
+    session.sendAgentMessage('gemini', msg);
+  });
 
-  const handleKillSession = async () => {
-    logger.debug('[Gemini] Kill session requested - terminating process');
-    await handleAbort();
-    logger.debug('[Gemini] Abort completed, proceeding with termination');
+  const handleAbort = buildAbortHandler({
+    getSession: () => session,
+    getBackend: () => geminiBackend,
+    getAcpSessionId: () => acpSessionId,
+    getAbortController: () => abortController,
+    setAbortController: (ac) => { abortController = ac; },
+    reasoningProcessor,
+    diffProcessor,
+    messageQueue,
+  });
 
-    try {
-      if (session) {
-        session.updateMetadata((currentMetadata) => ({
-          ...currentMetadata,
-          lifecycleState: 'archived',
-          lifecycleStateSince: Date.now(),
-          archivedBy: 'cli',
-          archiveReason: 'User terminated'
-        }));
-
-        session.sendSessionDeath();
-        await session.flush();
-        await session.close();
-      }
-
-      stopCaffeinate();
-      happyServer.stop();
-
-      if (geminiBackend) {
-        await geminiBackend.dispose();
-      }
-
-      logger.debug('[Gemini] Session termination complete, exiting');
-      process.exit(0);
-    } catch (error) {
-      logger.debug('[Gemini] Error during session termination:', error);
-      process.exit(1);
-    }
-  };
+  const handleKillSession = buildKillSessionHandler({
+    getSession: () => session,
+    getBackend: () => geminiBackend,
+    stopHappyServer: () => happyServer.stop(),
+    handleAbort,
+  });
 
   session.rpcHandlerManager.registerHandler('abort', handleAbort);
   registerKillSessionHandler(session.rpcHandlerManager, handleKillSession);
@@ -404,85 +207,24 @@ export async function runGemini(opts: {
   //
 
   const messageBuffer = new MessageBuffer();
-  const hasTTY = process.stdout.isTTY && process.stdin.isTTY;
-  let inkInstance: ReturnType<typeof render> | null = null;
 
-  // Track current model for UI display
-  // Initialize with env var or default to show correct model from start
-  let displayedModel: string | undefined = getInitialGeminiModel();
-  
-  // Log initial values
-  const localConfig = readGeminiLocalConfig();
-  logger.debug(`[gemini] Initial model setup: env[GEMINI_MODEL_ENV]=${process.env[GEMINI_MODEL_ENV] || 'not set'}, localConfig=${localConfig.model || 'not set'}, displayedModel=${displayedModel}`);
+  // Track displayed model (env -> local config -> default). The tracker
+  // gets `hasTTY` lazily because Ink isn't set up yet.
+  const modelTracker = createDisplayedModelTracker({
+    messageBuffer,
+    getHasTTY: () => hasTTY,
+  });
+  const updateDisplayedModel = (model: string | undefined, saveToConfig: boolean = false) =>
+    modelTracker.update(model, saveToConfig);
 
-  // Function to update displayed model and notify UI
-  const updateDisplayedModel = (model: string | undefined, saveToConfig: boolean = false) => {
-    // Only update if model is actually provided (not undefined)
-    if (model === undefined) {
-      logger.debug(`[gemini] updateDisplayedModel called with undefined, skipping update`);
-      return;
-    }
-    
-    const oldModel = displayedModel;
-    displayedModel = model;
-    logger.debug(`[gemini] updateDisplayedModel called: oldModel=${oldModel}, newModel=${model}, saveToConfig=${saveToConfig}`);
-    
-    // Save to config file if requested (when user changes model via mobile app)
-    if (saveToConfig) {
-      saveGeminiModelToConfig(model);
-    }
-    
-    // Trigger UI update by adding a system message with model info
-    // The message will be parsed by UI to extract model name
-    if (hasTTY && oldModel !== model) {
-      // Add a system message that includes model info - UI will parse it
-      // Format: [MODEL:gemini-2.5-pro] to make it easy to extract
-      logger.debug(`[gemini] Adding model update message to buffer: [MODEL:${model}]`);
-      messageBuffer.addMessage(`[MODEL:${model}]`, 'system');
-    } else if (hasTTY) {
-      logger.debug(`[gemini] Model unchanged, skipping update message`);
-    }
-  };
-
-  if (hasTTY) {
-    console.clear();
-    // Create a React component that reads displayedModel from closure
-    // Model will update when UI re-renders (on messageBuffer updates)
-    // We use a function component that reads displayedModel on each render
-    const DisplayComponent = () => {
-      // Read displayedModel from closure - it will have latest value on each render
-      const currentModelValue = displayedModel || 'gemini-2.5-pro';
-      // Don't log on every render to avoid spam - only log when model changes
-      return React.createElement(GeminiDisplay, {
-        messageBuffer,
-        logPath: process.env.DEBUG ? logger.getLogPath() : undefined,
-        currentModel: currentModelValue,
-        onExit: async () => {
-          logger.debug('[gemini]: Exiting agent via Ctrl-C');
-          shouldExit = true;
-          await handleAbort();
-        }
-      });
-    };
-    
-    inkInstance = render(React.createElement(DisplayComponent), {
-      exitOnCtrlC: false,
-      patchConsole: false
-    });
-    
-    // Send initial model to UI so it displays correctly from start
-    const initialModelName = displayedModel || 'gemini-2.5-pro';
-    logger.debug(`[gemini] Sending initial model to UI: ${initialModelName}`);
-    messageBuffer.addMessage(`[MODEL:${initialModelName}]`, 'system');
-  }
-
-  if (hasTTY) {
-    process.stdin.resume();
-    if (process.stdin.isTTY) {
-      process.stdin.setRawMode(true);
-    }
-    process.stdin.setEncoding('utf8');
-  }
+  const { hasTTY, inkInstance } = setupGeminiInkUI({
+    messageBuffer,
+    getDisplayedModel: () => modelTracker.get(),
+    onExit: async () => {
+      shouldExit = true;
+      await handleAbort();
+    },
+  });
 
   //
   // Start Happy MCP server and create Gemini backend
@@ -493,391 +235,33 @@ export async function runGemini(opts: {
   const mcpServers = {
     happy: {
       command: bridgeCommand,
-      args: ['--url', happyServer.url]
-    }
+      args: ['--url', happyServer.url],
+    },
   };
 
-  // Create permission handler for tool approval (variable declared earlier for onSessionSwap)
-  permissionHandler = new GeminiPermissionHandler(session);
-  
-  // Create reasoning processor for handling thinking/reasoning chunks
-  const reasoningProcessor = new GeminiReasoningProcessor((message) => {
-    // Callback to send messages directly from the processor
-    session.sendAgentMessage('gemini', message);
-  });
-  
-  // Create diff processor for handling file edit events and diff tracking
-  const diffProcessor = new GeminiDiffProcessor((message) => {
-    // Callback to send messages directly from the processor
-    session.sendAgentMessage('gemini', message);
-  });
-  
-  // Update permission handler when permission mode changes
+  /** Update permission handler when permission mode changes. */
   const updatePermissionMode = (mode: PermissionMode) => {
     permissionHandler.setPermissionMode(mode);
   };
 
-  // Accumulate Gemini response text for sending complete message to mobile
-  let accumulatedResponse = '';
-  let isResponseInProgress = false;
-  let currentResponseMessageId: string | null = null; // Track the message ID for current response
-  let hadToolCallInTurn = false; // Track if any tool calls happened in this turn (for task_complete)
-  let pendingChangeTitle = false; // Track if we're waiting for change_title to complete
-  let changeTitleCompleted = false; // Track if change_title was completed in this turn
-  let taskStartedSent = false; // Track if task_started was sent this turn (prevent duplicates)
 
   /**
-   * Set up message handler for Gemini backend
-   * This function is called when backend is created or recreated
+   * Set up message handler for Gemini backend.
+   * Called when backend is created or recreated.
    */
   function setupGeminiMessageHandler(backend: AgentBackend): void {
-    backend.onMessage((msg: AgentMessage) => {
-
-    switch (msg.type) {
-      case 'model-output':
-        if (msg.textDelta) {
-          // If this is the first delta of a new response, create a new message
-          // Otherwise, update the existing message for this response
-          if (!isResponseInProgress) {
-            // Start of new response - create new assistant message
-            // Remove "Thinking..." message if it exists (it will be replaced by actual response)
-            messageBuffer.removeLastMessage('system'); // Remove "Thinking..." if present
-            messageBuffer.addMessage(msg.textDelta, 'assistant');
-            isResponseInProgress = true;
-            logger.debug(`[gemini] Started new response, first chunk length: ${msg.textDelta.length}`);
-          } else {
-            // Continue existing response - update last assistant message
-            messageBuffer.updateLastMessage(msg.textDelta, 'assistant');
-            logger.debug(`[gemini] Updated response, chunk length: ${msg.textDelta.length}, total accumulated: ${accumulatedResponse.length + msg.textDelta.length}`);
-          }
-          accumulatedResponse += msg.textDelta;
-        }
-        break;
-
-      case 'status':
-        // Log status changes for debugging - stringify object details
-        const statusDetail = msg.detail 
-          ? (typeof msg.detail === 'object' ? JSON.stringify(msg.detail) : String(msg.detail))
-          : '';
-        logger.debug(`[gemini] Status changed: ${msg.status}${statusDetail ? ` - ${statusDetail}` : ''}`);
-        
-        // Log error status with details
-        if (msg.status === 'error') {
-          logger.debug(`[gemini] ⚠️ Error status received: ${statusDetail || 'Unknown error'}`);
-          
-          // Send turn_aborted event (like Codex) when error occurs
-          session.sendAgentMessage('gemini', {
-            type: 'turn_aborted',
-            id: randomUUID(),
-          });
-        }
-        
-        if (msg.status === 'running') {
-          thinking = true;
-          session.keepAlive(thinking, 'remote');
-          
-          // Send task_started event ONCE per turn (like Codex) when agent starts working
-          // Gemini may go running -> idle -> running multiple times during a turn
-          if (!taskStartedSent) {
-            session.sendAgentMessage('gemini', {
-              type: 'task_started',
-              id: randomUUID(),
-            });
-            taskStartedSent = true;
-          }
-          
-          // Show thinking indicator in UI when agent starts working (like Codex)
-          // This will be updated with actual thinking text when agent_thought_chunk events arrive
-          // Always show thinking indicator when status becomes 'running' to give user feedback
-          // Even if response is in progress, we want to show thinking for new operations
-          messageBuffer.addMessage('Thinking...', 'system');
-          
-          // Don't reset accumulator here - tool calls can happen during a response
-          // Accumulator will be reset when a new prompt is sent (in the main loop)
-        } else if (msg.status === 'idle' || msg.status === 'stopped') {
-          // DON'T change thinking state here - Gemini makes pauses between chunks
-          // which causes multiple idle events. thinking will be set to false ONCE
-          // in the finally block when the turn is complete.
-          // This prevents UI status flickering between "working" and "online"
-          
-          // Complete reasoning processor when status becomes idle (like Codex)
-          // Only complete if there's actually reasoning content to complete
-          // Skip if this is just the initial idle status after session creation
-          reasoningProcessor.complete();
-        } else if (msg.status === 'error') {
-          thinking = false;
-          session.keepAlive(thinking, 'remote');
-          accumulatedResponse = '';
-          isResponseInProgress = false;
-          currentResponseMessageId = null;
-          
-          // Show error in CLI UI - handle object errors properly
-          let errorMessage = 'Unknown error';
-          if (msg.detail) {
-            if (typeof msg.detail === 'object') {
-              // Extract message from error object
-              const detailObj = msg.detail as Record<string, unknown>;
-              errorMessage = (detailObj.message as string) || 
-                           (detailObj.details as string) || 
-                           JSON.stringify(detailObj);
-            } else {
-              errorMessage = String(msg.detail);
-            }
-          }
-          
-          // Check for authentication error and provide helpful message
-          if (errorMessage.includes('Authentication required')) {
-            errorMessage = `Authentication required.\n` +
-              `For Google Workspace accounts, run: happy gemini project set <project-id>\n` +
-              `Or use a different Google account: happy connect gemini\n` +
-              `Guide: https://goo.gle/gemini-cli-auth-docs#workspace-gca`;
-          }
-          
-          messageBuffer.addMessage(`Error: ${errorMessage}`, 'status');
-          
-          // Use sendAgentMessage for consistency with ACP format
-          session.sendAgentMessage('gemini', {
-            type: 'message',
-            message: `Error: ${errorMessage}`,
-          });
-        }
-        break;
-
-      case 'tool-call':
-        // Track that we had tool calls in this turn (for task_complete)
-        hadToolCallInTurn = true;
-        
-        // Show tool call in UI like Codex does
-        const toolArgs = msg.args ? JSON.stringify(msg.args).substring(0, 100) : '';
-        const isInvestigationTool = msg.toolName === 'codebase_investigator' || 
-                                    (typeof msg.toolName === 'string' && msg.toolName.includes('investigator'));
-        
-        logger.debug(`[gemini] 🔧 Tool call received: ${msg.toolName} (${msg.callId})${isInvestigationTool ? ' [INVESTIGATION]' : ''}`);
-        if (isInvestigationTool && msg.args && typeof msg.args === 'object' && 'objective' in msg.args) {
-          logger.debug(`[gemini] 🔍 Investigation objective: ${String(msg.args.objective).substring(0, 150)}...`);
-        }
-        
-        messageBuffer.addMessage(`Executing: ${msg.toolName}${toolArgs ? ` ${toolArgs}${toolArgs.length >= 100 ? '...' : ''}` : ''}`, 'tool');
-        session.sendAgentMessage('gemini', {
-          type: 'tool-call',
-          name: msg.toolName,
-          callId: msg.callId,
-          input: msg.args,
-          id: randomUUID(),
-        });
-        break;
-
-      case 'tool-result':
-        // Track change_title completion
-        if (msg.toolName === 'change_title' || 
-            msg.callId?.includes('change_title') ||
-            msg.toolName === 'happy__change_title') {
-          changeTitleCompleted = true;
-          logger.debug('[gemini] change_title completed');
-        }
-        
-        // Show tool result in UI like Codex does
-        // Check if result contains error information
-        const isError = msg.result && typeof msg.result === 'object' && 'error' in msg.result;
-        const resultText = typeof msg.result === 'string' 
-          ? msg.result.substring(0, 200)
-          : JSON.stringify(msg.result).substring(0, 200);
-        const truncatedResult = resultText + (typeof msg.result === 'string' && msg.result.length > 200 ? '...' : '');
-        
-        const resultSize = typeof msg.result === 'string' 
-          ? msg.result.length 
-          : JSON.stringify(msg.result).length;
-        
-        logger.debug(`[gemini] ${isError ? '❌' : '✅'} Tool result received: ${msg.toolName} (${msg.callId}) - Size: ${resultSize} bytes${isError ? ' [ERROR]' : ''}`);
-        
-        // Process tool result through diff processor to check for diff information (like Codex)
-        if (!isError) {
-          diffProcessor.processToolResult(msg.toolName, msg.result, msg.callId);
-        }
-        
-        if (isError) {
-          const errorMsg = (msg.result as any).error || 'Tool call failed';
-          logger.debug(`[gemini] ❌ Tool call error: ${errorMsg.substring(0, 300)}`);
-          messageBuffer.addMessage(`Error: ${errorMsg}`, 'status');
-        } else {
-          // Log summary for large results (like investigation tools)
-          if (resultSize > 1000) {
-            logger.debug(`[gemini] ✅ Large tool result (${resultSize} bytes) - first 200 chars: ${truncatedResult}`);
-          }
-          messageBuffer.addMessage(`Result: ${truncatedResult}`, 'result');
-        }
-        
-        session.sendAgentMessage('gemini', {
-          type: 'tool-result',
-          callId: msg.callId,
-          output: msg.result,
-          id: randomUUID(),
-        });
-        break;
-
-      case 'fs-edit':
-        messageBuffer.addMessage(`File edit: ${msg.description}`, 'tool');
-        
-        // Process fs-edit through diff processor (like Codex)
-        // msg.diff is optional (diff?: string), so it can be undefined
-        diffProcessor.processFsEdit(msg.path || '', msg.description, msg.diff);
-        
-        session.sendAgentMessage('gemini', {
-          type: 'file-edit',
-          description: msg.description,
-          diff: msg.diff,
-          filePath: msg.path || 'unknown',
-          id: randomUUID(),
-        });
-        break;
-
-      default:
-        // Handle token-count and other potential message types
-        if ((msg as any).type === 'token-count') {
-          // Forward token count to mobile app (like Codex)
-          // Note: Gemini ACP may not provide token_count events directly,
-          // but we handle them if they come from the backend
-          session.sendAgentMessage('gemini', {
-            type: 'token_count',
-            ...(msg as any),
-            id: randomUUID(),
-          });
-        }
-        break;
-
-      case 'terminal-output':
-        messageBuffer.addMessage(msg.data, 'result');
-        session.sendAgentMessage('gemini', {
-          type: 'terminal-output',
-          data: msg.data,
-          callId: (msg as any).callId || randomUUID(),
-        });
-        break;
-
-      case 'permission-request':
-        // Forward permission request to mobile app
-        // Note: toolName is in msg.payload.toolName (from AcpBackend), 
-        // msg.reason also contains the tool name
-        const payload = (msg as any).payload || {};
-        session.sendAgentMessage('gemini', {
-          type: 'permission-request',
-          permissionId: msg.id,
-          toolName: payload.toolName || (msg as any).reason || 'unknown',
-          description: (msg as any).reason || payload.toolName || '',
-          options: payload,
-        });
-        break;
-
-      case 'exec-approval-request':
-        // Handle exec approval request (like Codex exec_approval_request)
-        // Convert to tool call for mobile app compatibility
-        const execApprovalMsg = msg as any;
-        const callId = execApprovalMsg.call_id || execApprovalMsg.callId || randomUUID();
-        const { call_id, type, ...inputs } = execApprovalMsg;
-        
-        logger.debug(`[gemini] Exec approval request received: ${callId}`);
-        messageBuffer.addMessage(`Exec approval requested: ${callId}`, 'tool');
-        
-        session.sendAgentMessage('gemini', {
-          type: 'tool-call',
-          name: 'GeminiBash', // Similar to Codex's CodexBash
-          callId: callId,
-          input: inputs,
-          id: randomUUID(),
-        });
-        break;
-
-      case 'patch-apply-begin':
-        // Handle patch operation begin (like Codex patch_apply_begin)
-        const patchBeginMsg = msg as any;
-        const patchCallId = patchBeginMsg.call_id || patchBeginMsg.callId || randomUUID();
-        const { call_id: patchCallIdVar, type: patchType, auto_approved, changes } = patchBeginMsg;
-        
-        // Add UI feedback for patch operation
-        const changeCount = changes ? Object.keys(changes).length : 0;
-        const filesMsg = changeCount === 1 ? '1 file' : `${changeCount} files`;
-        messageBuffer.addMessage(`Modifying ${filesMsg}...`, 'tool');
-        logger.debug(`[gemini] Patch apply begin: ${patchCallId}, files: ${changeCount}`);
-        
-        session.sendAgentMessage('gemini', {
-          type: 'tool-call',
-          name: 'GeminiPatch', // Similar to Codex's CodexPatch
-          callId: patchCallId,
-          input: {
-            auto_approved,
-            changes
-          },
-          id: randomUUID(),
-        });
-        break;
-
-      case 'patch-apply-end':
-        // Handle patch operation end (like Codex patch_apply_end)
-        const patchEndMsg = msg as any;
-        const patchEndCallId = patchEndMsg.call_id || patchEndMsg.callId || randomUUID();
-        const { call_id: patchEndCallIdVar, type: patchEndType, stdout, stderr, success } = patchEndMsg;
-        
-        // Add UI feedback for completion
-        if (success) {
-          const message = stdout || 'Files modified successfully';
-          messageBuffer.addMessage(message.substring(0, 200), 'result');
-        } else {
-          const errorMsg = stderr || 'Failed to modify files';
-          messageBuffer.addMessage(`Error: ${errorMsg.substring(0, 200)}`, 'result');
-        }
-        logger.debug(`[gemini] Patch apply end: ${patchEndCallId}, success: ${success}`);
-        
-        session.sendAgentMessage('gemini', {
-          type: 'tool-result',
-          callId: patchEndCallId,
-          output: {
-            stdout,
-            stderr,
-            success
-          },
-          id: randomUUID(),
-        });
-        break;
-
-      case 'event':
-        // Handle thinking events - process through ReasoningProcessor like Codex
-        if (msg.name === 'thinking') {
-          const thinkingPayload = msg.payload as { text?: string } | undefined;
-          const thinkingText = (thinkingPayload && typeof thinkingPayload === 'object' && 'text' in thinkingPayload)
-            ? String(thinkingPayload.text || '')
-            : '';
-          if (thinkingText) {
-            // Process thinking chunk through reasoning processor
-            // This will identify titled reasoning sections (**Title**) and convert them to tool calls
-            reasoningProcessor.processChunk(thinkingText);
-            
-            // Log thinking chunks (especially useful for investigation tools)
-            logger.debug(`[gemini] 💭 Thinking chunk received: ${thinkingText.length} chars - Preview: ${thinkingText.substring(0, 100)}...`);
-            
-            // Show thinking message in UI (truncated like Codex)
-            // For titled reasoning (starts with **), ReasoningProcessor will show it as tool call
-            // But we still show progress for long operations
-            if (!thinkingText.startsWith('**')) {
-              // Update existing "Thinking..." message or add new one for untitled reasoning
-              const thinkingPreview = thinkingText.substring(0, 100);
-              messageBuffer.updateLastMessage(`[Thinking] ${thinkingPreview}...`, 'system');
-            }
-            // For titled reasoning, ReasoningProcessor will send tool call, but we keep "Thinking..." visible
-            // This ensures user sees progress during long reasoning operations
-          }
-          // Also forward to mobile for UI feedback
-          session.sendAgentMessage('gemini', {
-            type: 'thinking',
-            text: thinkingText,
-          });
-        }
-        break;
-    }
+    attachGeminiMessageHandler(backend, {
+      getSession: () => session,
+      messageBuffer,
+      reasoningProcessor,
+      diffProcessor,
+      state: turnState.handlerState,
     });
   }
 
-  // Note: Backend will be created dynamically in the main loop based on model from first message
-  // This allows us to support model changes by recreating the backend
+  // Note: Backend will be created dynamically in the main loop based on
+  // model from first message. This allows us to support model changes by
+  // recreating the backend.
 
   let first = true;
 
@@ -909,77 +293,37 @@ export async function runGemini(opts: {
         break;
       }
 
-      // Track if we need to inject conversation history (after model change)
-      let injectHistoryContext = false;
-      
-      // Handle mode change (like Codex) - restart session if permission mode or model changed
-      if (wasSessionCreated && currentModeHash && message.hash !== currentModeHash) {
-        logger.debug('[Gemini] Mode changed – restarting Gemini session');
-        messageBuffer.addMessage('═'.repeat(40), 'status');
-        
-        // Check if we have conversation history to preserve
-        if (conversationHistory.hasHistory()) {
-          messageBuffer.addMessage(`Switching model (preserving ${conversationHistory.size()} messages of context)...`, 'status');
-          injectHistoryContext = true;
-          logger.debug(`[Gemini] Will inject conversation history: ${conversationHistory.getSummary()}`);
-        } else {
-          messageBuffer.addMessage('Starting new Gemini session (mode changed)...', 'status');
-        }
-        
-        // Reset permission handler and reasoning processor on mode change (like Codex)
-        permissionHandler.reset();
-        reasoningProcessor.abort();
-        
-        // Dispose old backend and create new one with new model
-        if (geminiBackend) {
-          await geminiBackend.dispose();
-          geminiBackend = null;
-        }
-
-        // Create new backend with new model
-        const modelToUse = message.mode?.model === undefined ? undefined : (message.mode.model || null);
-        const backendResult = createGeminiBackend({
-          cwd: process.cwd(),
+      // Prepare backend + ACP session for this turn (handles mode change + first turn)
+      const prep = await prepareTurnBackend(
+        {
           mcpServers,
           permissionHandler,
+          reasoningProcessor,
+          conversationHistory,
+          messageBuffer,
           cloudToken,
           currentUserEmail,
-          // Pass model from message - if undefined, will use local config/env/default
-          // If explicitly null, will skip local config and use env/default
-          model: modelToUse,
-        });
-        geminiBackend = backendResult.backend;
+          setupGeminiMessageHandler,
+          updateDisplayedModel,
+          updatePermissionMode,
+        },
+        {
+          message,
+          backend: geminiBackend,
+          acpSessionId,
+          currentModeHash,
+          wasSessionCreated,
+          isFirstTurn: first,
+        },
+      );
+      geminiBackend = prep.backend;
+      acpSessionId = prep.acpSessionId;
+      wasSessionCreated = prep.wasSessionCreated;
+      currentModeHash = prep.newModeHash;
+      first = prep.isFirstTurn;
+      const injectHistoryContext = prep.injectHistoryContext;
 
-        // Set up message handler again
-        setupGeminiMessageHandler(geminiBackend);
-
-        // Use model from factory result (single source of truth - no duplicate resolution)
-        const actualModel = backendResult.model;
-        logger.debug(`[gemini] Model change - modelToUse=${modelToUse}, actualModel=${actualModel} (from ${backendResult.modelSource})`);
-        
-        // Update conversation history with new model
-        conversationHistory.setCurrentModel(actualModel);
-        
-        logger.debug('[gemini] Starting new ACP session with model:', actualModel);
-        const { sessionId } = await geminiBackend.startSession();
-        acpSessionId = sessionId;
-        logger.debug(`[gemini] New ACP session started: ${acpSessionId}`);
-        
-        // Update displayed model in UI (don't save to config - this is backend initialization)
-        logger.debug(`[gemini] Calling updateDisplayedModel with: ${actualModel}`);
-        updateDisplayedModel(actualModel, false);
-        // Don't add "Using model" message - model is shown in status bar
-        
-        // Update permission handler with current permission mode
-        updatePermissionMode(message.mode.permissionMode);
-        
-        wasSessionCreated = true;
-        currentModeHash = message.hash;
-        first = false; // Not first message anymore
-      }
-
-      currentModeHash = message.hash;
-      // Show only original user message in UI, not the full prompt with system prompt
+      // Show only the original user message in UI (not the system-prompt-laced full prompt)
       const userMessageToShow = message.mode?.originalUserMessage || message.message;
       messageBuffer.addMessage(userMessageToShow, 'user');
 
@@ -987,290 +331,42 @@ export async function runGemini(opts: {
       isProcessingMessage = true;
 
       try {
-        if (first || !wasSessionCreated) {
-          // First message or session not created yet - create backend and start session
-          if (!geminiBackend) {
-            const modelToUse = message.mode?.model === undefined ? undefined : (message.mode.model || null);
-            const backendResult = createGeminiBackend({
-              cwd: process.cwd(),
-              mcpServers,
-              permissionHandler,
-              cloudToken,
-              currentUserEmail,
-              // Pass model from message - if undefined, will use local config/env/default
-              // If explicitly null, will skip local config and use env/default
-              model: modelToUse,
-            });
-            geminiBackend = backendResult.backend;
+        turnState.resetForNewPrompt();
+        // WHY: Pre-refactor code computed `pendingChangeTitle` here for symmetry
+        // with Codex even though it was never read downstream. Preserved as a
+        // call to keep behavior parity (and so future code can plumb it through).
+        promptContainsChangeTitle(message.message);
 
-            // Set up message handler
-            setupGeminiMessageHandler(geminiBackend);
+        await sendTurnPrompt({
+          session,
+          backend: geminiBackend,
+          acpSessionId,
+          baseMessage: message.message,
+          injectHistoryContext,
+          conversationHistory,
+          messageBuffer,
+          getDisplayedModel: () => modelTracker.get(),
+        });
 
-            // Use model from factory result (single source of truth - no duplicate resolution)
-            const actualModel = backendResult.model;
-            logger.debug(`[gemini] Backend created, model will be: ${actualModel} (from ${backendResult.modelSource})`);
-            logger.debug(`[gemini] Calling updateDisplayedModel with: ${actualModel}`);
-            updateDisplayedModel(actualModel, false); // Don't save - this is backend initialization
-            
-            // Track current model in conversation history
-            conversationHistory.setCurrentModel(actualModel);
-          }
-          
-          // Start session if not started
-          if (!acpSessionId) {
-            logger.debug('[gemini] Starting ACP session...');
-            // Update permission handler with current permission mode before starting session
-            updatePermissionMode(message.mode.permissionMode);
-            const { sessionId } = await geminiBackend.startSession();
-            acpSessionId = sessionId;
-            logger.debug(`[gemini] ACP session started: ${acpSessionId}`);
-            wasSessionCreated = true;
-            currentModeHash = message.hash;
-            
-            // Model info is already shown in status bar via updateDisplayedModel
-            logger.debug(`[gemini] Displaying model in UI: ${displayedModel || 'gemini-2.5-pro'}, displayedModel: ${displayedModel}`);
-          }
-        }
-        
-        if (!acpSessionId) {
-          throw new Error('ACP session not started');
-        }
-         
-        // Reset accumulator when sending a new prompt (not when tool calls start)
-        // Reset accumulated response for new prompt
-        // This ensures a new assistant message will be created (not updating previous one)
-        accumulatedResponse = '';
-        isResponseInProgress = false;
-        hadToolCallInTurn = false;
-        taskStartedSent = false; // Reset so new turn can send task_started
-        
-        // Track if this prompt contains change_title instruction
-        // If so, don't send task_complete until change_title is completed
-        pendingChangeTitle = message.message.includes('change_title') || 
-                             message.message.includes('happy__change_title');
-        changeTitleCompleted = false;
-        
-        if (!geminiBackend || !acpSessionId) {
-          throw new Error('Gemini backend or session not initialized');
-        }
-        
-        // The prompt already includes system prompt and change_title instruction (added in onUserMessage handler)
-        // This is done in the message queue, so message.message already contains everything
-        let promptToSend = message.message;
-        
-        // Inject conversation history context if model was just changed
-        if (injectHistoryContext && conversationHistory.hasHistory()) {
-          const historyContext = conversationHistory.getContextForNewSession();
-          promptToSend = historyContext + promptToSend;
-          logger.debug(`[gemini] Injected conversation history context (${historyContext.length} chars)`);
-          // Don't clear history - keep accumulating for future model changes
-        }
-        
-        logger.debug(`[gemini] Sending prompt to Gemini (length: ${promptToSend.length}): ${promptToSend.substring(0, 100)}...`);
-        logger.debug(`[gemini] Full prompt: ${promptToSend}`);
-        
-        // Retry logic for transient Gemini API errors (empty response, internal errors)
-        const MAX_RETRIES = 3;
-        const RETRY_DELAY_MS = 2000;
-        let lastError: unknown = null;
-        
-        for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-          try {
-            await geminiBackend.sendPrompt(acpSessionId, promptToSend);
-            logger.debug('[gemini] Prompt sent successfully');
-            
-            // Wait for Gemini to finish responding (all chunks received + final idle)
-            // This ensures we don't send task_complete until response is truly done
-            if (geminiBackend.waitForResponseComplete) {
-              await geminiBackend.waitForResponseComplete(120000);
-              logger.debug('[gemini] Response complete');
-            }
-            
-            break; // Success, exit retry loop
-          } catch (promptError) {
-            lastError = promptError;
-            const errObj = promptError as any;
-            const errorDetails = errObj?.data?.details || errObj?.details || errObj?.message || '';
-            const errorCode = errObj?.code;
-            
-            // Check for quota exhausted - this is NOT retryable
-            const isQuotaError = errorDetails.includes('exhausted') || 
-                                 errorDetails.includes('quota') ||
-                                 errorDetails.includes('capacity');
-            if (isQuotaError) {
-              // Extract reset time from error message like "Your quota will reset after 3h20m35s."
-              const resetTimeMatch = errorDetails.match(/reset after (\d+h)?(\d+m)?(\d+s)?/i);
-              let resetTimeMsg = '';
-              if (resetTimeMatch) {
-                const parts = resetTimeMatch.slice(1).filter(Boolean).join('');
-                resetTimeMsg = ` Quota resets in ${parts}.`;
-              }
-              const quotaMsg = `Gemini quota exceeded.${resetTimeMsg} Try using a different model (gemini-2.5-flash-lite) or wait for quota reset.`;
-              messageBuffer.addMessage(quotaMsg, 'status');
-              session.sendAgentMessage('gemini', { type: 'message', message: quotaMsg });
-              throw promptError; // Don't retry quota errors
-            }
-            
-            // Check if this is a retryable error (empty response, internal error -32603)
-            const isEmptyResponseError = errorDetails.includes('empty response') || 
-                                         errorDetails.includes('Model stream ended');
-            const isInternalError = errorCode === -32603;
-            const isRetryable = isEmptyResponseError || isInternalError;
-            
-            if (isRetryable && attempt < MAX_RETRIES) {
-              logger.debug(`[gemini] Retryable error on attempt ${attempt}/${MAX_RETRIES}: ${errorDetails}`);
-              messageBuffer.addMessage(`Gemini returned empty response, retrying (${attempt}/${MAX_RETRIES})...`, 'status');
-              await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS * attempt));
-              continue;
-            }
-            
-            // Not retryable or max retries reached
-            throw promptError;
-          }
-        }
-        
-        if (lastError && MAX_RETRIES > 1) {
-          // If we had errors but eventually succeeded, log it
-          logger.debug('[gemini] Prompt succeeded after retries');
-        }
-        
-        // Mark as not first message after sending prompt
         if (first) {
           first = false;
         }
-      } catch (error) {
-        logger.debug('[gemini] Error in gemini session:', error);
-        const isAbortError = error instanceof Error && error.name === 'AbortError';
-
-        if (isAbortError) {
-          messageBuffer.addMessage('Aborted by user', 'status');
-          session.sendSessionEvent({ type: 'message', message: 'Aborted by user' });
-        } else {
-          // Parse error message
-          let errorMsg = 'Process error occurred';
-          
-          if (typeof error === 'object' && error !== null) {
-            const errObj = error as any;
-            
-            // Extract error information from various possible formats
-            const errorDetails = errObj.data?.details || errObj.details || '';
-            const errorCode = errObj.code || errObj.status || (errObj.response?.status);
-            const errorMessage = errObj.message || errObj.error?.message || '';
-            const errorString = String(error);
-            
-            // Check for 404 error (model not found)
-            if (errorCode === 404 || errorDetails.includes('notFound') || errorDetails.includes('404') || 
-                errorMessage.includes('not found') || errorMessage.includes('404')) {
-              const currentModel = displayedModel || 'gemini-2.5-pro';
-              errorMsg = `Model "${currentModel}" not found. Available models: gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite`;
-            }
-            // Check for empty response / internal error after retries exhausted
-            else if (errorCode === -32603 || 
-                     errorDetails.includes('empty response') || errorDetails.includes('Model stream ended')) {
-              errorMsg = 'Gemini API returned empty response after retries. This is a temporary issue - please try again.';
-            }
-            // Check for rate limit error (429) - multiple possible formats
-            else if (errorCode === 429 || 
-                     errorDetails.includes('429') || errorMessage.includes('429') || errorString.includes('429') ||
-                     errorDetails.includes('rateLimitExceeded') || errorDetails.includes('RESOURCE_EXHAUSTED') ||
-                     errorMessage.includes('Rate limit exceeded') || errorMessage.includes('Resource exhausted') ||
-                     errorString.includes('rateLimitExceeded') || errorString.includes('RESOURCE_EXHAUSTED')) {
-              errorMsg = 'Gemini API rate limit exceeded. Please wait a moment and try again. The API will retry automatically.';
-            }
-            // Check for quota/capacity exceeded error
-            else if (errorDetails.includes('quota') || errorMessage.includes('quota') || errorString.includes('quota') ||
-                     errorDetails.includes('exhausted') || errorDetails.includes('capacity')) {
-              // Extract reset time from error message like "Your quota will reset after 3h20m35s."
-              const resetTimeMatch = (errorDetails + errorMessage + errorString).match(/reset after (\d+h)?(\d+m)?(\d+s)?/i);
-              let resetTimeMsg = '';
-              if (resetTimeMatch) {
-                const parts = resetTimeMatch.slice(1).filter(Boolean).join('');
-                resetTimeMsg = ` Quota resets in ${parts}.`;
-              }
-              errorMsg = `Gemini quota exceeded.${resetTimeMsg} Try using a different model (gemini-2.5-flash-lite) or wait for quota reset.`;
-            }
-            // Check for authentication error (Google Workspace accounts need project ID)
-            else if (errorMessage.includes('Authentication required') || 
-                     errorDetails.includes('Authentication required') ||
-                     errorCode === -32000) {
-              errorMsg = `Authentication required. For Google Workspace accounts, you need to set a Google Cloud Project:\n` +
-                         `  happy gemini project set <your-project-id>\n` +
-                         `Or use a different Google account: happy connect gemini\n` +
-                         `Guide: https://goo.gle/gemini-cli-auth-docs#workspace-gca`;
-            }
-            // Check for empty error (command not found)
-            else if (Object.keys(error).length === 0) {
-              errorMsg = 'Failed to start Gemini. Is "gemini" CLI installed? Run: npm install -g @google/gemini-cli';
-            }
-            // Use message from error object
-            else if (errObj.message || errorMessage) {
-              errorMsg = errorDetails || errorMessage || errObj.message;
-            }
-          } else if (error instanceof Error) {
-            errorMsg = error.message;
-          }
-          
-          messageBuffer.addMessage(errorMsg, 'status');
-          // Use sendAgentMessage for consistency with ACP format
-          session.sendAgentMessage('gemini', {
-            type: 'message',
-            message: errorMsg,
-          });
-        }
       } finally {
-        // Reset permission handler, reasoning processor, and diff processor after turn (like Codex)
-        permissionHandler.reset();
-        reasoningProcessor.abort(); // Use abort to properly finish any in-progress tool calls
-        diffProcessor.reset(); // Reset diff processor on turn completion
-        
-        // Send accumulated response to mobile app ONLY when turn is complete
-        // This prevents message fragmentation from Gemini's chunked responses
-        if (accumulatedResponse.trim()) {
-          const { text: messageText, options } = parseOptionsFromText(accumulatedResponse);
-          
-          // Record assistant response in conversation history for context preservation
-          conversationHistory.addAssistantMessage(messageText);
-          
-          // Mobile app parses options from text via parseMarkdown
-          let finalMessageText = messageText;
-          if (options.length > 0) {
-            const optionsXml = formatOptionsXml(options);
-            finalMessageText = messageText + optionsXml;
-            logger.debug(`[gemini] Found ${options.length} options in response:`, options);
-          } else if (hasIncompleteOptions(accumulatedResponse)) {
-            logger.debug(`[gemini] Warning: Incomplete options block detected`);
-          }
-          
-          const messagePayload: CodexMessagePayload = {
-            type: 'message',
-            message: finalMessageText,
-            id: randomUUID(),
-            ...(options.length > 0 && { options }),
-          };
-          
-          logger.debug(`[gemini] Sending complete message to mobile (length: ${finalMessageText.length}): ${finalMessageText.substring(0, 100)}...`);
-          session.sendAgentMessage('gemini', messagePayload);
-          accumulatedResponse = '';
-          isResponseInProgress = false;
-        }
-        
-        // Send task_complete ONCE at the end of turn (not on every idle)
-        // This signals to the UI that the agent has finished processing
-        session.sendAgentMessage('gemini', {
-          type: 'task_complete',
-          id: randomUUID(),
+        const { sentFinalMessage } = finalizeGeminiTurn({
+          session,
+          permissionHandler,
+          reasoningProcessor,
+          diffProcessor,
+          conversationHistory,
+          accumulatedResponse: turnState.accumulatedResponse(),
         });
-        
-        // Reset tracking flags
-        hadToolCallInTurn = false;
-        pendingChangeTitle = false;
-        changeTitleCompleted = false;
-        taskStartedSent = false;
-        
-        thinking = false;
-        session.keepAlive(thinking, 'remote');
-        
-        // Use same logic as Codex - emit ready if idle (no pending operations, no queue)
+        if (sentFinalMessage) {
+          turnState.clearAccumulatedAfterFlush();
+        }
+
+        turnState.resetAfterTurn();
+        session.keepAlive(turnState.thinking(), 'remote');
+
         emitReadyIfIdle();
 
         // Message processing complete - safe to apply any pending session swap
@@ -1282,43 +378,15 @@ export async function runGemini(opts: {
     }
 
   } finally {
-    // Clean up resources
-    logger.debug('[gemini]: Final cleanup start');
-
-    // Cancel offline reconnection if still running
-    if (reconnectionHandle) {
-      logger.debug('[gemini]: Cancelling offline reconnection');
-      reconnectionHandle.cancel();
-    }
-
-    try {
-      session.sendSessionDeath();
-      await session.flush();
-      await session.close();
-    } catch (e) {
-      logger.debug('[gemini]: Error while closing session', e);
-    }
-
-    if (geminiBackend) {
-      await geminiBackend.dispose();
-    }
-
-    happyServer.stop();
-
-    if (process.stdin.isTTY) {
-      try { process.stdin.setRawMode(false); } catch { /* ignore */ }
-    }
-    if (hasTTY) {
-      try { process.stdin.pause(); } catch { /* ignore */ }
-    }
-
-    clearInterval(keepAliveInterval);
-    if (inkInstance) {
-      inkInstance.unmount();
-    }
-    messageBuffer.clear();
-
-    logger.debug('[gemini]: Final cleanup completed');
+    await finalCleanupGemini({
+      reconnectionHandle,
+      session,
+      backend: geminiBackend,
+      stopHappyServer: () => happyServer.stop(),
+      keepAliveInterval,
+      hasTTY,
+      inkInstance,
+      messageBuffer,
+    });
   }
 }
-

--- a/packages/styrby-cli/src/gemini/sendTurnPrompt.ts
+++ b/packages/styrby-cli/src/gemini/sendTurnPrompt.ts
@@ -1,0 +1,91 @@
+/**
+ * Gemini Per-Turn Prompt Send + Error Handling
+ *
+ * Wraps the inner try/catch around `sendPromptWithRetry` for a single turn.
+ * Responsibilities:
+ *   1. Inject conversation history context if model just changed
+ *   2. Log + dispatch the prompt with retry semantics
+ *   3. On error, format with `formatGeminiError` and surface to UI + mobile
+ *
+ * WHY split out: this was 50 lines of mixed concerns inside the main loop.
+ * Extracting it leaves the orchestrator with a single `await sendTurnPrompt(...)`
+ * call plus its own resetForNewPrompt + finalize bookends.
+ */
+
+import { logger } from '@/ui/logger';
+import type { ApiSessionClient } from '@/api/apiSession';
+import type { AgentBackend } from '@/agent';
+import type { MessageBuffer } from '@/ui/ink/messageBuffer';
+import type { ConversationHistory } from '@/gemini/utils/conversationHistory';
+
+import { sendPromptWithRetry } from '@/gemini/promptRetryLoop';
+import { formatGeminiError } from '@/gemini/utils/errorFormatter';
+
+export interface SendTurnPromptArgs {
+  session: ApiSessionClient;
+  backend: AgentBackend;
+  acpSessionId: string;
+  /** Original message text from the queue (already includes system prompt + change_title). */
+  baseMessage: string;
+  /** When true, prepend `conversationHistory.getContextForNewSession()` to the prompt. */
+  injectHistoryContext: boolean;
+  conversationHistory: ConversationHistory;
+  messageBuffer: MessageBuffer;
+  /** Used by error formatter for "model not found" messages. */
+  getDisplayedModel: () => string | undefined;
+}
+
+/**
+ * Send the per-turn prompt with retry, surface errors, and return when done.
+ *
+ * Never throws — caller's `finally` block runs regardless. Errors are
+ * formatted into UI + mobile messages internally.
+ */
+export async function sendTurnPrompt(args: SendTurnPromptArgs): Promise<void> {
+  const {
+    session, backend, acpSessionId, baseMessage,
+    injectHistoryContext, conversationHistory, messageBuffer, getDisplayedModel,
+  } = args;
+
+  // Inject conversation history context if model was just changed.
+  // WHY: don't clear history afterward — keep accumulating for future model changes.
+  let promptToSend = baseMessage;
+  if (injectHistoryContext && conversationHistory.hasHistory()) {
+    const historyContext = conversationHistory.getContextForNewSession();
+    promptToSend = historyContext + promptToSend;
+    logger.debug(`[gemini] Injected conversation history context (${historyContext.length} chars)`);
+  }
+
+  logger.debug(`[gemini] Sending prompt to Gemini (length: ${promptToSend.length}): ${promptToSend.substring(0, 100)}...`);
+  logger.debug(`[gemini] Full prompt: ${promptToSend}`);
+
+  try {
+    await sendPromptWithRetry({
+      backend,
+      acpSessionId,
+      prompt: promptToSend,
+      onQuotaError: ({ quotaResetSuffix }) => {
+        const quotaMsg = `Gemini quota exceeded.${quotaResetSuffix} Try using a different model (gemini-2.5-flash-lite) or wait for quota reset.`;
+        messageBuffer.addMessage(quotaMsg, 'status');
+        session.sendAgentMessage('gemini', { type: 'message', message: quotaMsg });
+      },
+      onRetryAttempt: ({ attempt, max }) => {
+        messageBuffer.addMessage(`Gemini returned empty response, retrying (${attempt}/${max})...`, 'status');
+      },
+    });
+  } catch (error) {
+    logger.debug('[gemini] Error in gemini session:', error);
+    const formatted = formatGeminiError(error, { displayedModel: getDisplayedModel() });
+
+    if (formatted.kind === 'abort') {
+      messageBuffer.addMessage(formatted.message, 'status');
+      session.sendSessionEvent({ type: 'message', message: formatted.message });
+    } else {
+      messageBuffer.addMessage(formatted.message, 'status');
+      session.sendAgentMessage('gemini', {
+        type: 'message',
+        message: formatted.message,
+      });
+    }
+  }
+}

--- a/packages/styrby-cli/src/gemini/turnFinalize.ts
+++ b/packages/styrby-cli/src/gemini/turnFinalize.ts
@@ -1,0 +1,87 @@
+/**
+ * Gemini Turn Finalization
+ *
+ * Encapsulates the side-effects that run in the main loop's `finally` block
+ * after each user turn completes (regardless of success or thrown error):
+ *   1. Reset permission/reasoning/diff processors
+ *   2. Build + send the per-turn final assistant message to mobile
+ *   3. Send `task_complete` event
+ *   4. Clear keepalive thinking flag
+ *
+ * WHY split out: the finally block was 50 lines mixing many independent
+ * effects, and `buildFinalTurnMessage` already had its own pure helper —
+ * pairing it with this orchestrator keeps the run loop focused.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { logger } from '@/ui/logger';
+import type { ApiSessionClient } from '@/api/apiSession';
+import type { GeminiPermissionHandler } from '@/gemini/utils/permissionHandler';
+import type { GeminiReasoningProcessor } from '@/gemini/utils/reasoningProcessor';
+import type { GeminiDiffProcessor } from '@/gemini/utils/diffProcessor';
+import type { ConversationHistory } from '@/gemini/utils/conversationHistory';
+import { buildFinalTurnMessage } from '@/gemini/utils/finalMessageBuilder';
+
+export interface FinalizeTurnArgs {
+  session: ApiSessionClient;
+  permissionHandler: GeminiPermissionHandler;
+  reasoningProcessor: GeminiReasoningProcessor;
+  diffProcessor: GeminiDiffProcessor;
+  conversationHistory: ConversationHistory;
+  /** The text accumulated by the message handler over the turn. */
+  accumulatedResponse: string;
+}
+
+export interface FinalizeTurnResult {
+  /** True when we sent a per-turn message to mobile (caller should clear accumulator). */
+  sentFinalMessage: boolean;
+}
+
+/**
+ * Run all per-turn cleanup + final-message dispatch.
+ *
+ * Behavior matches the pre-refactor inline finally block exactly. The
+ * caller is still responsible for clearing accumulator state vars,
+ * resetting per-turn flags (hadToolCallInTurn, etc), `keepAlive`, and
+ * `emitReadyIfIdle`. We keep those in the orchestrator since they touch
+ * its loop-private state.
+ */
+export function finalizeGeminiTurn(args: FinalizeTurnArgs): FinalizeTurnResult {
+  const {
+    session,
+    permissionHandler,
+    reasoningProcessor,
+    diffProcessor,
+    conversationHistory,
+    accumulatedResponse,
+  } = args;
+
+  // Reset per-turn processors
+  permissionHandler.reset();
+  reasoningProcessor.abort();
+  diffProcessor.reset();
+
+  // Send accumulated response to mobile app ONLY when turn is complete.
+  // WHY: prevents fragmentation from Gemini's chunked streaming responses.
+  const built = buildFinalTurnMessage(accumulatedResponse);
+  let sentFinalMessage = false;
+  if (built) {
+    conversationHistory.addAssistantMessage(built.historyText);
+    if (built.options.length > 0) {
+      logger.debug(`[gemini] Found ${built.options.length} options in response:`, built.options);
+    } else if (built.incompleteOptions) {
+      logger.debug('[gemini] Warning: Incomplete options block detected');
+    }
+    logger.debug(`[gemini] Sending complete message to mobile (length: ${built.payload.message.length}): ${built.payload.message.substring(0, 100)}...`);
+    session.sendAgentMessage('gemini', built.payload);
+    sentFinalMessage = true;
+  }
+
+  // Send task_complete ONCE at end of turn (not on every idle).
+  session.sendAgentMessage('gemini', {
+    type: 'task_complete',
+    id: randomUUID(),
+  });
+
+  return { sentFinalMessage };
+}

--- a/packages/styrby-cli/src/gemini/turnPrep.ts
+++ b/packages/styrby-cli/src/gemini/turnPrep.ts
@@ -1,0 +1,184 @@
+/**
+ * Gemini Per-Turn Backend / Session Preparation
+ *
+ * Handles two cases that both run before each turn's `sendPrompt`:
+ *   1. **Mode change**: previous message used a different permission mode
+ *      or model => dispose backend, recreate with new model, start a fresh
+ *      ACP session (preserving conversation history if any).
+ *   2. **First message** (no backend yet) => create the backend lazily,
+ *      then start the ACP session.
+ *
+ * WHY split out: this was 90 lines of branching at the top of each loop
+ * iteration. Both branches share the same backend-create-then-start-session
+ * shape; isolating them into a single helper documents the model-change
+ * contract in one place.
+ */
+
+import { logger } from '@/ui/logger';
+import type { AgentBackend } from '@/agent';
+import type { MessageBuffer } from '@/ui/ink/messageBuffer';
+import type { GeminiPermissionHandler } from '@/gemini/utils/permissionHandler';
+import type { GeminiReasoningProcessor } from '@/gemini/utils/reasoningProcessor';
+import type { ConversationHistory } from '@/gemini/utils/conversationHistory';
+import type { PermissionMode } from '@/api/types';
+import type { GeminiMode } from '@/gemini/types';
+
+import { createBackendForMessage } from '@/gemini/backendFactory';
+
+export interface TurnPrepDeps {
+  mcpServers: Record<string, { command: string; args: string[] }>;
+  permissionHandler: GeminiPermissionHandler;
+  reasoningProcessor: GeminiReasoningProcessor;
+  conversationHistory: ConversationHistory;
+  messageBuffer: MessageBuffer;
+  cloudToken?: string;
+  currentUserEmail?: string;
+  /** Wire the message handler onto the new backend. */
+  setupGeminiMessageHandler: (backend: AgentBackend) => void;
+  /** Update displayed model in UI (don't save to config). */
+  updateDisplayedModel: (model: string | undefined, saveToConfig?: boolean) => void;
+  updatePermissionMode: (mode: PermissionMode) => void;
+}
+
+export interface TurnPrepInput {
+  message: { mode: GeminiMode; hash: string };
+  /** Existing backend or null if not created yet. */
+  backend: AgentBackend | null;
+  /** Existing ACP session id or null. */
+  acpSessionId: string | null;
+  /** Hash of the current session-wide mode (for change detection). */
+  currentModeHash: string | null;
+  wasSessionCreated: boolean;
+  /** True if this is the first turn of the run. */
+  isFirstTurn: boolean;
+}
+
+export interface TurnPrepResult {
+  backend: AgentBackend;
+  acpSessionId: string;
+  /** True if we restarted the session due to mode change. */
+  modeChanged: boolean;
+  /** True if conversation history should be injected into this turn's prompt. */
+  injectHistoryContext: boolean;
+  /** New session-wide mode hash (== message.hash). */
+  newModeHash: string;
+  wasSessionCreated: true;
+  /** New value of "first turn" flag (false unless we made no changes). */
+  isFirstTurn: boolean;
+}
+
+/**
+ * Prepare the Gemini backend + ACP session for the next turn.
+ *
+ * Returns the (possibly new) backend, ACP session id, and metadata flags
+ * the orchestrator needs (modeChanged, injectHistoryContext, etc).
+ */
+export async function prepareTurnBackend(
+  deps: TurnPrepDeps,
+  input: TurnPrepInput,
+): Promise<TurnPrepResult> {
+  const {
+    mcpServers, permissionHandler, reasoningProcessor, conversationHistory,
+    messageBuffer, cloudToken, currentUserEmail,
+    setupGeminiMessageHandler, updateDisplayedModel, updatePermissionMode,
+  } = deps;
+  const { message } = input;
+
+  let backend = input.backend;
+  let acpSessionId = input.acpSessionId;
+  let injectHistoryContext = false;
+  let modeChanged = false;
+  let isFirstTurn = input.isFirstTurn;
+  let wasSessionCreated = input.wasSessionCreated;
+
+  // 1) Mode change branch (Codex-parity): restart Gemini session
+  if (input.wasSessionCreated && input.currentModeHash && message.hash !== input.currentModeHash) {
+    modeChanged = true;
+    logger.debug('[Gemini] Mode changed – restarting Gemini session');
+    messageBuffer.addMessage('═'.repeat(40), 'status');
+
+    if (conversationHistory.hasHistory()) {
+      messageBuffer.addMessage(
+        `Switching model (preserving ${conversationHistory.size()} messages of context)...`,
+        'status',
+      );
+      injectHistoryContext = true;
+      logger.debug(`[Gemini] Will inject conversation history: ${conversationHistory.getSummary()}`);
+    } else {
+      messageBuffer.addMessage('Starting new Gemini session (mode changed)...', 'status');
+    }
+
+    permissionHandler.reset();
+    reasoningProcessor.abort();
+
+    if (backend) {
+      await backend.dispose();
+      backend = null;
+    }
+
+    const result = createBackendForMessage({
+      mcpServers, permissionHandler, cloudToken, currentUserEmail,
+      messageModel: message.mode?.model,
+    });
+    backend = result.backend;
+    setupGeminiMessageHandler(backend);
+
+    const actualModel = result.model;
+    logger.debug(`[gemini] Model change - messageModel=${message.mode?.model}, actualModel=${actualModel} (from ${result.modelSource})`);
+    conversationHistory.setCurrentModel(actualModel);
+
+    logger.debug('[gemini] Starting new ACP session with model:', actualModel);
+    const { sessionId } = await backend.startSession();
+    acpSessionId = sessionId;
+    logger.debug(`[gemini] New ACP session started: ${acpSessionId}`);
+
+    // Update displayed model (don't save - this is backend init).
+    logger.debug(`[gemini] Calling updateDisplayedModel with: ${actualModel}`);
+    updateDisplayedModel(actualModel, false);
+    updatePermissionMode(message.mode.permissionMode);
+
+    wasSessionCreated = true;
+    isFirstTurn = false;
+  }
+
+  // 2) First-turn branch: create backend lazily
+  if (isFirstTurn || !wasSessionCreated) {
+    if (!backend) {
+      const result = createBackendForMessage({
+        mcpServers, permissionHandler, cloudToken, currentUserEmail,
+        messageModel: message.mode?.model,
+      });
+      backend = result.backend;
+      setupGeminiMessageHandler(backend);
+
+      const actualModel = result.model;
+      logger.debug(`[gemini] Backend created, model will be: ${actualModel} (from ${result.modelSource})`);
+      logger.debug(`[gemini] Calling updateDisplayedModel with: ${actualModel}`);
+      updateDisplayedModel(actualModel, false);
+      conversationHistory.setCurrentModel(actualModel);
+    }
+
+    if (!acpSessionId) {
+      logger.debug('[gemini] Starting ACP session...');
+      updatePermissionMode(message.mode.permissionMode);
+      const { sessionId } = await backend.startSession();
+      acpSessionId = sessionId;
+      logger.debug(`[gemini] ACP session started: ${acpSessionId}`);
+      wasSessionCreated = true;
+    }
+  }
+
+  if (!acpSessionId || !backend) {
+    throw new Error('ACP session not started');
+  }
+
+  return {
+    backend,
+    acpSessionId,
+    modeChanged,
+    injectHistoryContext,
+    newModeHash: message.hash,
+    wasSessionCreated: true,
+    isFirstTurn,
+  };
+}

--- a/packages/styrby-cli/src/gemini/turnState.ts
+++ b/packages/styrby-cli/src/gemini/turnState.ts
@@ -1,0 +1,87 @@
+/**
+ * Gemini Per-Turn Mutable State Container
+ *
+ * Encapsulates the cluster of `let` variables `runGemini` previously held
+ * inline (accumulated response, response-in-progress flag, change-title
+ * tracking, task_started dedup, etc) plus the `MessageHandlerState`
+ * adapter the extracted message handler needs.
+ *
+ * WHY split out: 8 mutable locals + 11 getter/setter wiring lines is real
+ * line count for zero domain logic. Extracting clarifies what "the per-turn
+ * state" actually is and lets the orchestrator just call `state.resetForNewPrompt()`
+ * instead of remembering 5 separate assignments.
+ */
+
+import type { MessageHandlerState } from '@/gemini/messageHandler';
+
+export interface GeminiTurnState {
+  /** Accessors for the message handler. */
+  handlerState: MessageHandlerState;
+  /** True while the agent is running (drives keep-alive + ready emission). */
+  thinking(): boolean;
+  setThinking(v: boolean): void;
+  /** Read whether a streaming response is currently being built. */
+  isResponseInProgress(): boolean;
+  /** Read accumulated response text for end-of-turn flush. */
+  accumulatedResponse(): string;
+  /** Reset accumulator + per-turn flags before a new sendPrompt. */
+  resetForNewPrompt(): void;
+  /** Reset all turn-completion flags after finalize. */
+  resetAfterTurn(): void;
+  /** Clear accumulated response after final-message dispatch. */
+  clearAccumulatedAfterFlush(): void;
+}
+
+/**
+ * Create a fresh per-turn state container for a single `runGemini` invocation.
+ */
+export function createGeminiTurnState(): GeminiTurnState {
+  let thinking = false;
+  let accumulatedResponse = '';
+  let isResponseInProgress = false;
+  let currentResponseMessageId: string | null = null;
+  let hadToolCallInTurn = false;
+  let changeTitleCompleted = false;
+  let taskStartedSent = false;
+
+  const handlerState: MessageHandlerState = {
+    getThinking: () => thinking,
+    setThinking: (v) => { thinking = v; },
+    getAccumulatedResponse: () => accumulatedResponse,
+    setAccumulatedResponse: (v) => { accumulatedResponse = v; },
+    getIsResponseInProgress: () => isResponseInProgress,
+    setIsResponseInProgress: (v) => { isResponseInProgress = v; },
+    setCurrentResponseMessageId: (v) => { currentResponseMessageId = v; },
+    setHadToolCallInTurn: (v) => { hadToolCallInTurn = v; },
+    setChangeTitleCompleted: (v) => { changeTitleCompleted = v; },
+    getTaskStartedSent: () => taskStartedSent,
+    setTaskStartedSent: (v) => { taskStartedSent = v; },
+  };
+
+  return {
+    handlerState,
+    thinking: () => thinking,
+    setThinking: (v) => { thinking = v; },
+    isResponseInProgress: () => isResponseInProgress,
+    accumulatedResponse: () => accumulatedResponse,
+    resetForNewPrompt: () => {
+      // WHY: Reset accumulator state for new prompt — ensures a NEW assistant
+      // message is started (rather than appending to previous).
+      accumulatedResponse = '';
+      isResponseInProgress = false;
+      hadToolCallInTurn = false;
+      taskStartedSent = false;
+      changeTitleCompleted = false;
+    },
+    resetAfterTurn: () => {
+      hadToolCallInTurn = false;
+      changeTitleCompleted = false;
+      taskStartedSent = false;
+      thinking = false;
+    },
+    clearAccumulatedAfterFlush: () => {
+      accumulatedResponse = '';
+      isResponseInProgress = false;
+    },
+  };
+}

--- a/packages/styrby-cli/src/gemini/userMessageRouter.ts
+++ b/packages/styrby-cli/src/gemini/userMessageRouter.ts
@@ -1,0 +1,155 @@
+/**
+ * Gemini Inbound User Message Router
+ *
+ * Builds the `onUserMessage` callback that `runGemini` registers on the
+ * session. The callback's job is to:
+ *   1. Resolve permission mode (validate + persist)
+ *   2. Resolve model (handle keep / change / reset / noop semantics)
+ *   3. Inject system prompt + change_title instruction on the FIRST message
+ *   4. Push the resulting prompt + GeminiMode onto the message queue
+ *   5. Record the original user message into ConversationHistory
+ *
+ * WHY split out: this was ~80 lines of branching inside `runGemini.ts`
+ * that mixed pure decisions (handled by `modeResolver` / `promptBuilder`)
+ * with side effects (queue.push, UI banner, debug logs). Extracting the
+ * coordinator lets the orchestrator stay focused on lifecycle.
+ */
+
+import { logger } from '@/ui/logger';
+import type { PermissionMode } from '@/api/types';
+import type { MessageBuffer } from '@/ui/ink/messageBuffer';
+import type { MessageQueue2 } from '@/utils/MessageQueue2';
+import type { GeminiMode } from '@/gemini/types';
+import type { ConversationHistory } from '@/gemini/utils/conversationHistory';
+
+import { resolvePermissionMode, resolveModel } from '@/gemini/utils/modeResolver';
+import { buildFirstMessagePrompt } from '@/gemini/utils/promptBuilder';
+
+/**
+ * Mutable state and side-effect callbacks the router needs from the
+ * orchestrator. Mirrors the closure variables `runGemini` previously
+ * captured directly.
+ */
+export interface UserMessageRouterDeps {
+  messageQueue: MessageQueue2<GeminiMode>;
+  messageBuffer: MessageBuffer;
+  conversationHistory: ConversationHistory;
+  /** Refresh the live permission handler when mode changes. */
+  updatePermissionMode: (mode: PermissionMode) => void;
+  /** Refresh the displayed model in the UI; pass `saveToConfig=true` for user-initiated changes. */
+  updateDisplayedModel: (model: string | undefined, saveToConfig?: boolean) => void;
+  /** Read/write current session-wide permission mode override. */
+  getCurrentPermissionMode: () => PermissionMode | undefined;
+  setCurrentPermissionMode: (mode: PermissionMode | undefined) => void;
+  /** Read/write current session-wide model override. */
+  getCurrentModel: () => string | undefined;
+  setCurrentModel: (model: string | undefined) => void;
+  /** Read/write the "have we sent the first message?" flag. */
+  getIsFirstMessage: () => boolean;
+  setIsFirstMessage: (v: boolean) => void;
+}
+
+/**
+ * The structural type of an incoming user message we read from. We avoid
+ * importing the full `ApiSessionClient` types here so this module stays
+ * easy to test with a fixture.
+ */
+export interface IncomingUserMessage {
+  content: { text: string };
+  meta?: {
+    permissionMode?: string;
+    model?: string | null;
+    appendSystemPrompt?: string;
+  };
+}
+
+/**
+ * Build the handler function to pass to `session.onUserMessage(...)`.
+ *
+ * Behavior is identical to the pre-refactor inline handler in `runGemini.ts`.
+ */
+export function buildUserMessageRouter(deps: UserMessageRouterDeps) {
+  const {
+    messageQueue,
+    messageBuffer,
+    conversationHistory,
+    updatePermissionMode,
+    updateDisplayedModel,
+    getCurrentPermissionMode,
+    setCurrentPermissionMode,
+    getCurrentModel,
+    setCurrentModel,
+    getIsFirstMessage,
+    setIsFirstMessage,
+  } = deps;
+
+  return function onUserMessage(message: IncomingUserMessage): void {
+    // 1) Permission mode resolution (validate)
+    const permResolution = resolvePermissionMode(
+      message.meta,
+      getCurrentPermissionMode(),
+    );
+    if (message.meta?.permissionMode && permResolution.invalid) {
+      logger.debug(`[Gemini] Invalid permission mode received: ${message.meta.permissionMode}`);
+    }
+    if (permResolution.didChange && !permResolution.invalid && message.meta?.permissionMode) {
+      setCurrentPermissionMode(permResolution.newCurrent);
+      updatePermissionMode(permResolution.forMessage);
+      logger.debug(`[Gemini] Permission mode updated from user message to: ${permResolution.newCurrent}`);
+    } else if (!message.meta?.permissionMode) {
+      logger.debug(`[Gemini] User message received with no permission mode override, using current: ${getCurrentPermissionMode() ?? 'default (effective)'}`);
+    }
+    if (getCurrentPermissionMode() === undefined) {
+      // Initialize permission mode on first message ever
+      setCurrentPermissionMode('default');
+      updatePermissionMode('default');
+    }
+    const messagePermissionMode = permResolution.forMessage;
+
+    // 2) Model resolution
+    const modelAction = resolveModel(message.meta, getCurrentModel());
+    let messageModel = getCurrentModel();
+    switch (modelAction.kind) {
+      case 'reset':
+        // WHY: Don't update displayed model — backend picks env/config/default.
+        messageModel = undefined;
+        setCurrentModel(undefined);
+        break;
+      case 'change':
+        messageModel = modelAction.forMessage;
+        setCurrentModel(modelAction.newCurrent);
+        // Save to config so it persists, refresh UI, announce change.
+        updateDisplayedModel(modelAction.forMessage, true);
+        messageBuffer.addMessage(`Model changed to: ${modelAction.forMessage}`, 'system');
+        logger.debug(`[Gemini] Model changed from ${modelAction.previous} to ${modelAction.forMessage}`);
+        break;
+      case 'noop':
+      case 'keep':
+        // Keep current — nothing to do.
+        messageModel = modelAction.forMessage;
+        break;
+    }
+
+    // 3) Build prompt (system prompt + change_title only on first message)
+    const originalUserMessage = message.content.text;
+    let fullPrompt = originalUserMessage;
+    if (getIsFirstMessage() && message.meta?.appendSystemPrompt) {
+      fullPrompt = buildFirstMessagePrompt({
+        userMessage: originalUserMessage,
+        appendSystemPrompt: message.meta.appendSystemPrompt,
+      });
+      setIsFirstMessage(false);
+    }
+
+    // 4) Push onto queue
+    const mode: GeminiMode = {
+      permissionMode: messagePermissionMode || 'default',
+      model: messageModel,
+      originalUserMessage, // store original separately for UI display
+    };
+    messageQueue.push(fullPrompt, mode);
+
+    // 5) Record into ConversationHistory for context preservation across model changes
+    conversationHistory.addUserMessage(originalUserMessage);
+  };
+}

--- a/packages/styrby-cli/src/gemini/utils/errorFormatter.ts
+++ b/packages/styrby-cli/src/gemini/utils/errorFormatter.ts
@@ -1,0 +1,235 @@
+/**
+ * Gemini Error Formatter
+ *
+ * Pure helpers that normalize raw Gemini-CLI / ACP errors into user-facing
+ * strings shown both in the terminal UI and forwarded to the mobile app.
+ *
+ * WHY split out: the original `runGemini.ts` had ~70 lines of nested
+ * if/else conditions inside its main loop's catch block, which was both
+ * untested AND impossible to test (it required throwing arbitrary errors
+ * through a real Gemini subprocess). This module is fully pure and unit-
+ * testable.
+ *
+ * Categories handled:
+ *   - 404 / model-not-found
+ *   - empty response / internal -32603
+ *   - 429 rate limit (multiple shapes)
+ *   - quota / capacity exhausted (with optional reset-time extraction)
+ *   - authentication required (Workspace project setup)
+ *   - empty error object (CLI not installed)
+ *   - generic fallback
+ */
+
+/**
+ * Categorized error kind for branching in callers (for analytics, retries,
+ * UI styling, etc).
+ */
+export type GeminiErrorKind =
+  | 'abort'
+  | 'model-not-found'
+  | 'empty-response'
+  | 'rate-limit'
+  | 'quota-exceeded'
+  | 'auth-required'
+  | 'cli-missing'
+  | 'unknown';
+
+export interface FormattedGeminiError {
+  /** Human-readable message safe to surface in UI / push to mobile. */
+  message: string;
+  /** Stable category for branching/analytics. */
+  kind: GeminiErrorKind;
+}
+
+/**
+ * Extract a quota-reset suffix like " Quota resets in 3h20m35s." from any
+ * Gemini error string that contains the phrase "reset after Xh Ym Zs".
+ *
+ * @param haystack - Combined error text (details + message + string repr)
+ * @returns The suffix sentence (with leading space), or '' if no match.
+ */
+export function extractResetTimeSuffix(haystack: string): string {
+  const resetTimeMatch = haystack.match(/reset after (\d+h)?(\d+m)?(\d+s)?/i);
+  if (!resetTimeMatch) return '';
+  const parts = resetTimeMatch.slice(1).filter(Boolean).join('');
+  if (!parts) return '';
+  return ` Quota resets in ${parts}.`;
+}
+
+/**
+ * Classify and format an arbitrary error thrown by the Gemini backend during
+ * `sendPrompt`/`waitForResponseComplete`.
+ *
+ * Behavior matches the pre-refactor inline logic in `runGemini.ts` exactly.
+ *
+ * @param error - The unknown thrown value (Error, JSON-RPC error object, etc).
+ * @param ctx - Caller-supplied context for richer messages (currently the
+ *   active model name for "model not found" errors).
+ * @returns A formatted message + classification.
+ */
+export function formatGeminiError(
+  error: unknown,
+  ctx: { displayedModel?: string } = {}
+): FormattedGeminiError {
+  if (error instanceof Error && error.name === 'AbortError') {
+    return { message: 'Aborted by user', kind: 'abort' };
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const errObj = error as Record<string, any>;
+    const errorDetails: string =
+      errObj.data?.details || errObj.details || '';
+    const errorCode = errObj.code || errObj.status || errObj.response?.status;
+    const errorMessage: string =
+      errObj.message || errObj.error?.message || '';
+    const errorString = String(error);
+    const haystack = errorDetails + errorMessage + errorString;
+
+    // 404 / model not found
+    if (
+      errorCode === 404 ||
+      errorDetails.includes('notFound') ||
+      errorDetails.includes('404') ||
+      errorMessage.includes('not found') ||
+      errorMessage.includes('404')
+    ) {
+      const currentModel = ctx.displayedModel || 'gemini-2.5-pro';
+      return {
+        message: `Model "${currentModel}" not found. Available models: gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite`,
+        kind: 'model-not-found',
+      };
+    }
+
+    // Empty response / internal -32603 after retries exhausted
+    if (
+      errorCode === -32603 ||
+      errorDetails.includes('empty response') ||
+      errorDetails.includes('Model stream ended')
+    ) {
+      return {
+        message:
+          'Gemini API returned empty response after retries. This is a temporary issue - please try again.',
+        kind: 'empty-response',
+      };
+    }
+
+    // 429 / rate limit (multiple possible shapes)
+    if (
+      errorCode === 429 ||
+      errorDetails.includes('429') ||
+      errorMessage.includes('429') ||
+      errorString.includes('429') ||
+      errorDetails.includes('rateLimitExceeded') ||
+      errorDetails.includes('RESOURCE_EXHAUSTED') ||
+      errorMessage.includes('Rate limit exceeded') ||
+      errorMessage.includes('Resource exhausted') ||
+      errorString.includes('rateLimitExceeded') ||
+      errorString.includes('RESOURCE_EXHAUSTED')
+    ) {
+      return {
+        message:
+          'Gemini API rate limit exceeded. Please wait a moment and try again. The API will retry automatically.',
+        kind: 'rate-limit',
+      };
+    }
+
+    // Quota / capacity exhausted
+    if (
+      errorDetails.includes('quota') ||
+      errorMessage.includes('quota') ||
+      errorString.includes('quota') ||
+      errorDetails.includes('exhausted') ||
+      errorDetails.includes('capacity')
+    ) {
+      const resetTimeMsg = extractResetTimeSuffix(haystack);
+      return {
+        message: `Gemini quota exceeded.${resetTimeMsg} Try using a different model (gemini-2.5-flash-lite) or wait for quota reset.`,
+        kind: 'quota-exceeded',
+      };
+    }
+
+    // Auth required (Workspace accounts need project ID)
+    if (
+      errorMessage.includes('Authentication required') ||
+      errorDetails.includes('Authentication required') ||
+      errorCode === -32000
+    ) {
+      return {
+        message:
+          `Authentication required. For Google Workspace accounts, you need to set a Google Cloud Project:\n` +
+          `  happy gemini project set <your-project-id>\n` +
+          `Or use a different Google account: happy connect gemini\n` +
+          `Guide: https://goo.gle/gemini-cli-auth-docs#workspace-gca`,
+        kind: 'auth-required',
+      };
+    }
+
+    // Empty error object => CLI binary missing
+    if (Object.keys(error).length === 0) {
+      return {
+        message:
+          'Failed to start Gemini. Is "gemini" CLI installed? Run: npm install -g @google/gemini-cli',
+        kind: 'cli-missing',
+      };
+    }
+
+    // Generic object error - prefer details > message > raw .message
+    if (errObj.message || errorMessage) {
+      return {
+        message: errorDetails || errorMessage || errObj.message,
+        kind: 'unknown',
+      };
+    }
+  }
+
+  if (error instanceof Error) {
+    return { message: error.message, kind: 'unknown' };
+  }
+
+  return { message: 'Process error occurred', kind: 'unknown' };
+}
+
+/**
+ * Classify a `sendPrompt` error to decide whether the caller should retry,
+ * surface a quota error immediately, or rethrow.
+ *
+ * Mirrors the original retry-loop classification in `runGemini.ts`.
+ */
+export interface PromptRetryClassification {
+  /** True if this looks like a transient empty/internal error worth retrying. */
+  isRetryable: boolean;
+  /** True if quota is exhausted - must NOT retry; surface to user. */
+  isQuotaError: boolean;
+  /** Optional " Quota resets in ..." suffix when `isQuotaError`. */
+  quotaResetSuffix: string;
+  /** The raw details string we extracted (for logging). */
+  details: string;
+}
+
+/**
+ * Inspect an error thrown by `geminiBackend.sendPrompt` and classify it for
+ * the in-loop retry handler.
+ *
+ * @param error - Unknown thrown value from sendPrompt / waitForResponseComplete.
+ */
+export function classifyPromptError(error: unknown): PromptRetryClassification {
+  const errObj = (error as any) || {};
+  const details: string =
+    errObj?.data?.details || errObj?.details || errObj?.message || '';
+  const errorCode = errObj?.code;
+
+  const isQuotaError =
+    details.includes('exhausted') ||
+    details.includes('quota') ||
+    details.includes('capacity');
+
+  const isEmptyResponseError =
+    details.includes('empty response') ||
+    details.includes('Model stream ended');
+  const isInternalError = errorCode === -32603;
+  const isRetryable = !isQuotaError && (isEmptyResponseError || isInternalError);
+
+  const quotaResetSuffix = isQuotaError ? extractResetTimeSuffix(details) : '';
+
+  return { isRetryable, isQuotaError, quotaResetSuffix, details };
+}

--- a/packages/styrby-cli/src/gemini/utils/finalMessageBuilder.ts
+++ b/packages/styrby-cli/src/gemini/utils/finalMessageBuilder.ts
@@ -1,0 +1,79 @@
+/**
+ * Gemini Final-Turn Message Builder
+ *
+ * Pure helper that takes the accumulated assistant response collected over
+ * a full turn and produces the `CodexMessagePayload` we send to mobile,
+ * including parsed `<options>` (a Happy/Codex convention used to render
+ * tappable choice buttons in the mobile UI).
+ *
+ * WHY split out: the original `runGemini.ts` finally block built this
+ * payload inline alongside session side effects (history recording, push
+ * sending). Pulling the construction into a pure builder lets us assert on
+ * the EXACT shape of the payload — which is the contract with the mobile
+ * app — without spinning up a real session.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  parseOptionsFromText,
+  hasIncompleteOptions,
+  formatOptionsXml,
+} from '@/gemini/utils/optionsParser';
+import type { CodexMessagePayload } from '@/gemini/types';
+
+export interface BuiltFinalMessage {
+  /** The full payload to forward to mobile via `sendAgentMessage`. */
+  payload: CodexMessagePayload;
+  /** Plain-text portion (no options XML), recorded into ConversationHistory. */
+  historyText: string;
+  /** Parsed options (empty if none). Exposed for callers that want to log. */
+  options: string[];
+  /** True if accumulator had a `<options>` opener but no closer (warn-worthy). */
+  incompleteOptions: boolean;
+}
+
+/**
+ * Build the final per-turn assistant message payload from the accumulated
+ * Gemini response text.
+ *
+ * @param accumulatedResponse - The full text streamed for this turn.
+ * @param idGenerator - Optional ID generator (DI for tests). Defaults to
+ *   `node:crypto.randomUUID`.
+ * @returns A built payload, or `null` if the accumulated text is whitespace-
+ *   only (caller should skip sending — matches original `.trim()` guard).
+ */
+export function buildFinalTurnMessage(
+  accumulatedResponse: string,
+  idGenerator: () => string = randomUUID
+): BuiltFinalMessage | null {
+  if (!accumulatedResponse.trim()) {
+    return null;
+  }
+
+  const { text: messageText, options } = parseOptionsFromText(accumulatedResponse);
+
+  let finalMessageText = messageText;
+  if (options.length > 0) {
+    // WHY: Mobile app's `parseMarkdown` expects options re-serialized as an
+    // <options> XML block appended to the message body. We strip-then-reattach
+    // so any extra whitespace inside the original block is normalized.
+    finalMessageText = messageText + formatOptionsXml(options);
+  }
+
+  const incompleteOptions =
+    options.length === 0 && hasIncompleteOptions(accumulatedResponse);
+
+  const payload: CodexMessagePayload = {
+    type: 'message',
+    message: finalMessageText,
+    id: idGenerator(),
+    ...(options.length > 0 && { options }),
+  };
+
+  return {
+    payload,
+    historyText: messageText,
+    options,
+    incompleteOptions,
+  };
+}

--- a/packages/styrby-cli/src/gemini/utils/idTokenEmail.ts
+++ b/packages/styrby-cli/src/gemini/utils/idTokenEmail.ts
@@ -1,0 +1,48 @@
+/**
+ * Gemini ID Token Email Decoder
+ *
+ * Pure helper that extracts the user's email from a Google OAuth `id_token`
+ * (a standard JWT). Used so per-account Gemini Cloud project lookups can
+ * scope to the active Google identity.
+ *
+ * WHY a dedicated helper: `runGemini.ts` previously inlined manual JWT
+ * parsing inside a try/catch. Pulling it out lets us unit-test the (many)
+ * failure modes of malformed tokens without booting the full Gemini stack.
+ */
+
+/**
+ * Decode the `email` claim from a Google OAuth id_token JWT.
+ *
+ * The JWT is NOT verified — Google already issued it, and we only use the
+ * email for local routing (project selection). Never trust this for auth.
+ *
+ * @param idToken - The raw `id_token` string (3 base64url segments, dot-separated)
+ * @returns The decoded email if present, or `undefined` for any malformed
+ *   token, missing claim, or decode failure. Never throws.
+ *
+ * @example
+ *   const email = decodeEmailFromIdToken(vendorToken.oauth.id_token);
+ *   if (email) logger.debug(`User: ${email}`);
+ */
+export function decodeEmailFromIdToken(idToken: string | undefined | null): string | undefined {
+  if (!idToken || typeof idToken !== 'string') {
+    return undefined;
+  }
+  try {
+    const parts = idToken.split('.');
+    // WHY: A valid JWT has exactly 3 parts (header.payload.signature).
+    // Anything else is malformed and unsafe to decode.
+    if (parts.length !== 3) {
+      return undefined;
+    }
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    if (payload && typeof payload === 'object' && typeof payload.email === 'string') {
+      return payload.email;
+    }
+    return undefined;
+  } catch {
+    // WHY: Any parse error (bad base64, bad JSON) just means "no email" —
+    // never propagate to caller because email is best-effort enrichment.
+    return undefined;
+  }
+}

--- a/packages/styrby-cli/src/gemini/utils/modeResolver.ts
+++ b/packages/styrby-cli/src/gemini/utils/modeResolver.ts
@@ -1,0 +1,150 @@
+/**
+ * Gemini Per-Message Mode Resolver
+ *
+ * Pure helpers that take an incoming user message's `meta` and the current
+ * session-wide overrides, and return the resolved permission mode + model
+ * for THIS message — plus what the new session-wide overrides should be
+ * after this message is consumed.
+ *
+ * WHY split out: the original `onUserMessage` handler in `runGemini.ts`
+ * mixed business logic (which mode/model to use) with side effects (UI
+ * updates, debug logs, queue pushes). Pulling the pure decision into a
+ * helper makes it unit-testable AND lets the side-effecting handler stay
+ * thin.
+ */
+
+import type { PermissionMode } from '@/api/types';
+
+const VALID_PERMISSION_MODES: PermissionMode[] = [
+  'default',
+  'read-only',
+  'safe-yolo',
+  'yolo',
+];
+
+export interface IncomingMessageMeta {
+  permissionMode?: string;
+  /** Use `null` to explicitly reset to default; `undefined` to inherit. */
+  model?: string | null;
+}
+
+export interface ResolvedPermission {
+  /** Permission mode to apply to THIS message. */
+  forMessage: PermissionMode;
+  /** New session-wide override. */
+  newCurrent: PermissionMode;
+  /**
+   * True if the override changed (caller should refresh permission handler
+   * and emit a debug log).
+   */
+  didChange: boolean;
+  /**
+   * True if the meta carried a value but it failed validation (caller
+   * should log a warning).
+   */
+  invalid: boolean;
+}
+
+/**
+ * Resolve which permission mode to use for an incoming user message.
+ *
+ * Mirrors the pre-refactor logic exactly:
+ *   - If meta has a valid mode -> use it AND update the session-wide override
+ *   - If meta has an invalid mode -> keep current, signal `invalid: true`
+ *   - If meta omits the field -> use current
+ *   - If current is undefined -> default to 'default'
+ *
+ * @param meta - The optional `meta` field from the incoming user message.
+ * @param current - The session-wide override before this message (or undefined
+ *   if none has been set yet).
+ */
+export function resolvePermissionMode(
+  meta: IncomingMessageMeta | undefined,
+  current: PermissionMode | undefined
+): ResolvedPermission {
+  if (meta?.permissionMode) {
+    if (VALID_PERMISSION_MODES.includes(meta.permissionMode as PermissionMode)) {
+      const next = meta.permissionMode as PermissionMode;
+      return {
+        forMessage: next,
+        newCurrent: next,
+        didChange: true,
+        invalid: false,
+      };
+    }
+    // Invalid -> don't update; fall through to default-init below
+    const fallback: PermissionMode = current ?? 'default';
+    return {
+      forMessage: fallback,
+      newCurrent: fallback,
+      didChange: current === undefined,
+      invalid: true,
+    };
+  }
+
+  // No override in this message
+  if (current === undefined) {
+    // WHY: First message ever — initialize to 'default'.
+    return {
+      forMessage: 'default',
+      newCurrent: 'default',
+      didChange: true,
+      invalid: false,
+    };
+  }
+  return {
+    forMessage: current,
+    newCurrent: current,
+    didChange: false,
+    invalid: false,
+  };
+}
+
+export type ModelResolutionAction =
+  /** Meta omitted `model` field entirely — keep current. */
+  | { kind: 'keep'; forMessage: string | undefined; newCurrent: string | undefined }
+  /** Meta sent `model: null` — reset session override but DON'T touch UI. */
+  | { kind: 'reset'; forMessage: undefined; newCurrent: undefined }
+  /** Meta sent a string AND it differs from current — apply + persist + UI. */
+  | { kind: 'change'; forMessage: string; newCurrent: string; previous: string | undefined }
+  /** Meta sent the same string we already have — no-op. */
+  | { kind: 'noop'; forMessage: string; newCurrent: string };
+
+/**
+ * Resolve which model to use for an incoming user message.
+ *
+ * Returns a discriminated action so the side-effecting caller knows whether
+ * to update the UI / save to local config / show a "Model changed" banner.
+ *
+ * @param meta - The optional `meta` field from the incoming user message.
+ * @param current - The session-wide override before this message.
+ */
+export function resolveModel(
+  meta: IncomingMessageMeta | undefined,
+  current: string | undefined
+): ModelResolutionAction {
+  // Use `in`-check (matches original `hasOwnProperty`) - the 'model' key
+  // being PRESENT is meaningful, even when its value is undefined/null.
+  if (!meta || !('model' in meta)) {
+    return { kind: 'keep', forMessage: current, newCurrent: current };
+  }
+
+  if (meta.model === null) {
+    return { kind: 'reset', forMessage: undefined, newCurrent: undefined };
+  }
+
+  if (typeof meta.model === 'string' && meta.model.length > 0) {
+    if (current === meta.model) {
+      return { kind: 'noop', forMessage: meta.model, newCurrent: meta.model };
+    }
+    return {
+      kind: 'change',
+      forMessage: meta.model,
+      newCurrent: meta.model,
+      previous: current,
+    };
+  }
+
+  // meta.model === undefined (key present but value undefined) — keep current
+  return { kind: 'keep', forMessage: current, newCurrent: current };
+}

--- a/packages/styrby-cli/src/gemini/utils/promptBuilder.ts
+++ b/packages/styrby-cli/src/gemini/utils/promptBuilder.ts
@@ -1,0 +1,54 @@
+/**
+ * Gemini Prompt Builder
+ *
+ * Pure helpers for constructing the prompt text we send to Gemini per turn.
+ *
+ * Two concerns split out from `runGemini.ts`:
+ *   1. First-message system-prompt injection (Codex-parity formatting)
+ *   2. Detection of pending `change_title` instructions
+ *
+ * WHY: Both are pure string transforms with subtle ordering rules
+ * (system prompt BEFORE the user message, change_title instruction AFTER
+ * the user message — matching Codex behavior exactly). Bugs in either
+ * silently break mobile UX, so they deserve unit tests.
+ */
+
+import { CHANGE_TITLE_INSTRUCTION } from '@/gemini/constants';
+
+export interface BuildFirstPromptArgs {
+  /** The original text the user typed. */
+  userMessage: string;
+  /** Optional system-prompt prefix (from `meta.appendSystemPrompt`). */
+  appendSystemPrompt?: string;
+}
+
+/**
+ * Build the prompt for the FIRST message of a Gemini session.
+ *
+ * Format (matches Codex exactly):
+ *   <system prompt>\n\n<user message>\n\n<CHANGE_TITLE_INSTRUCTION>
+ *
+ * If no system prompt is provided, returns the user message unchanged.
+ *
+ * @param args - User message and optional system prompt.
+ */
+export function buildFirstMessagePrompt(args: BuildFirstPromptArgs): string {
+  const { userMessage, appendSystemPrompt } = args;
+  if (!appendSystemPrompt) return userMessage;
+  return `${appendSystemPrompt}\n\n${userMessage}\n\n${CHANGE_TITLE_INSTRUCTION}`;
+}
+
+/**
+ * Detect whether a prompt being sent contains the `change_title` instruction
+ * (either the bare tool name or the MCP-prefixed `happy__change_title`).
+ *
+ * Used by the main loop so the turn-completion handler can wait for title
+ * change to finish before emitting `task_complete`.
+ *
+ * @param prompt - The full prompt string being sent to Gemini.
+ */
+export function promptContainsChangeTitle(prompt: string): boolean {
+  return (
+    prompt.includes('change_title') || prompt.includes('happy__change_title')
+  );
+}

--- a/packages/styrby-cli/src/utils/serverConnectionErrors.test.ts
+++ b/packages/styrby-cli/src/utils/serverConnectionErrors.test.ts
@@ -198,13 +198,17 @@ describe('startOfflineReconnection', () => {
             const { handle } = createTestHandle({ healthCheck });
 
             // With real exponential backoff (5s + 10s delays with jitter),
-            // we need ~20s to reach attempt 3
-            await waitForReconnection(handle, 25000);
+            // we need ~20s to reach attempt 3. CI runners can be slow under
+            // load — the prior 25s budget flaked in CI (the 3rd retry missed
+            // its window by ~1-2s). Bumped to 35s in-test + 40s test timeout
+            // so we only fail if the reconnect logic is genuinely broken,
+            // not on CI scheduling jitter.
+            await waitForReconnection(handle, 35000);
 
             expect(attemptCount).toBe(3);
 
             handle.cancel();
-        }, 30000);
+        }, 40000);
     });
 
     describe('cancellation', () => {

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertCard.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertCard.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+/**
+ * AlertCard — single budget alert tile in the grid.
+ *
+ * Renders the name, period/agent badges, enable toggle, spend progress
+ * bar, action badge, and edit/delete controls for one alert.
+ *
+ * WHY split out: Each card is a self-contained presentation unit.
+ * Extracting it lets the orchestrator's render loop stay short and
+ * makes future per-card features (drag-to-reorder, bulk select) easy
+ * to add without touching the parent.
+ */
+
+import {
+  ACTION_DESCRIPTIONS,
+  AGENT_COLORS,
+  getActionBadgeColor,
+  getPercentageTextColor,
+  getPeriodBadgeColor,
+  getProgressColor,
+} from './helpers';
+import type { BudgetAlertWithSpend } from './types';
+
+interface AlertCardProps {
+  /** The alert to render. */
+  alert: BudgetAlertWithSpend;
+  /** True while a delete request for this alert is in flight. */
+  isDeleting: boolean;
+  /** True while a toggle request for this alert is in flight. */
+  isToggling: boolean;
+  /** Toggles the alert's enabled state. */
+  onToggle: (alert: BudgetAlertWithSpend) => void;
+  /** Opens the edit modal for this alert. */
+  onEdit: (alert: BudgetAlertWithSpend) => void;
+  /** Deletes this alert (after user confirmation). */
+  onDelete: (alertId: string) => void;
+}
+
+/**
+ * Renders a single budget alert card with progress, badges, and controls.
+ *
+ * @param props - See {@link AlertCardProps}.
+ */
+export function AlertCard({
+  alert,
+  isDeleting,
+  isToggling,
+  onToggle,
+  onEdit,
+  onDelete,
+}: AlertCardProps) {
+  const progressColor = getProgressColor(alert.percentage_used);
+  const percentTextColor = getPercentageTextColor(alert.percentage_used);
+  const actionBadge = getActionBadgeColor(alert.action);
+  const periodBadge = getPeriodBadgeColor(alert.period);
+
+  return (
+    <div
+      className={`rounded-xl bg-zinc-900 border border-zinc-800 p-4 transition-opacity ${
+        !alert.is_enabled ? 'opacity-60' : ''
+      } ${isDeleting ? 'opacity-30 pointer-events-none' : ''}`}
+    >
+      {/* Header row: name, period badge, toggle */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex-1 min-w-0 mr-3">
+          <h3 className="text-sm font-semibold text-zinc-100 truncate">
+            {alert.name}
+          </h3>
+          <div className="flex items-center gap-2 mt-1">
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${periodBadge.bg} ${periodBadge.text}`}
+            >
+              {alert.period}
+            </span>
+            {alert.agent_type && (
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${AGENT_COLORS[alert.agent_type].bg} ${AGENT_COLORS[alert.agent_type].text}`}
+              >
+                {alert.agent_type}
+              </span>
+            )}
+          </div>
+        </div>
+        <label className="relative inline-flex cursor-pointer items-center flex-shrink-0">
+          <input
+            type="checkbox"
+            className="peer sr-only"
+            checked={alert.is_enabled}
+            onChange={() => onToggle(alert)}
+            disabled={isToggling}
+            aria-label={`${alert.is_enabled ? 'Disable' : 'Enable'} ${alert.name} alert`}
+          />
+          <div className="h-5 w-9 rounded-full bg-zinc-700 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all peer-checked:bg-orange-500 peer-checked:after:translate-x-full" />
+        </label>
+      </div>
+
+      {/* Progress bar */}
+      <div className="mb-3">
+        <div className="flex items-baseline justify-between mb-1">
+          <span className="text-sm text-zinc-300">
+            ${alert.current_spend_usd.toFixed(2)}{' '}
+            <span className="text-zinc-500">
+              / ${Number(alert.threshold_usd).toFixed(2)}
+            </span>
+          </span>
+          <span className={`text-xs font-medium ${percentTextColor}`}>
+            {alert.percentage_used.toFixed(0)}%
+          </span>
+        </div>
+        <div
+          className="h-2 rounded-full bg-zinc-800 overflow-hidden"
+          role="progressbar"
+          aria-valuenow={Math.min(Math.round(alert.percentage_used), 100)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Budget usage: ${alert.percentage_used.toFixed(0)}% of $${alert.threshold_usd}`}
+        >
+          <div
+            className={`h-full rounded-full transition-all duration-500 ${progressColor}`}
+            style={{ width: `${Math.min(alert.percentage_used, 100)}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Action badge + edit/delete buttons */}
+      <div className="flex items-center justify-between">
+        <span
+          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${actionBadge.bg} ${actionBadge.text}`}
+        >
+          <svg
+            className="h-3 w-3"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d={ACTION_DESCRIPTIONS[alert.action].icon}
+            />
+          </svg>
+          {ACTION_DESCRIPTIONS[alert.action].label}
+        </span>
+
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => onEdit(alert)}
+            className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
+            aria-label={`Edit ${alert.name} alert`}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+              />
+            </svg>
+          </button>
+          <button
+            onClick={() => onDelete(alert.id)}
+            className="p-1.5 rounded-lg text-zinc-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+            disabled={isDeleting}
+            aria-label={`Delete ${alert.name} alert`}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Last triggered */}
+      {alert.last_triggered_at && (
+        <p className="text-xs text-zinc-500 mt-2">
+          Last triggered:{' '}
+          {new Date(alert.last_triggered_at).toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+          })}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertModal.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertModal.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+/**
+ * AlertModal — create/edit dialog for a budget alert.
+ *
+ * Owns the form-field layout and selector UI. Form state is owned by
+ * the parent orchestrator so submit/cancel logic stays centralized.
+ *
+ * WHY split out: This is the largest visual chunk of the page (~225
+ * LOC of fields, fieldsets, and the action grid). Extracting it keeps
+ * the orchestrator within the 400-LOC budget and makes the form's
+ * accessibility wiring (focus trap, aria-pressed, fieldset/legend)
+ * easier to reason about in isolation.
+ */
+
+import {
+  ACTION_DESCRIPTIONS,
+  AGENT_TYPES,
+  ALERT_ACTIONS,
+  ALERT_PERIODS,
+} from './helpers';
+import { OptionPill } from './OptionPill';
+import type { AlertFormData, AgentType, BudgetAlertWithSpend } from './types';
+
+interface AlertModalProps {
+  /**
+   * The alert being edited, or `null` when creating.
+   * Used only to flip the modal title and submit-button label.
+   */
+  editingAlert: BudgetAlertWithSpend | null;
+  /** Current form values. Controlled by the orchestrator. */
+  formData: AlertFormData;
+  /** Updates the form values. */
+  onFormChange: (next: AlertFormData) => void;
+  /** Server-returned error message, or `null` for none. */
+  error: string | null;
+  /** True while a create/update request is in flight. */
+  isSubmitting: boolean;
+  /** Closes the modal without saving. */
+  onClose: () => void;
+  /** Submits the form (create or update). */
+  onSubmit: () => void;
+  /**
+   * Focus-trap container ref. Provided by the orchestrator so the trap
+   * can outlive the modal mount and restore focus to the trigger.
+   */
+  focusTrapRef: React.RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * Renders the create/edit modal dialog.
+ *
+ * @param props - See {@link AlertModalProps}.
+ */
+export function AlertModal({
+  editingAlert,
+  formData,
+  onFormChange,
+  error,
+  isSubmitting,
+  onClose,
+  onSubmit,
+  focusTrapRef,
+}: AlertModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center p-0 md:p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={editingAlert ? 'Edit budget alert' : 'Create budget alert'}
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Modal content */}
+      <div
+        ref={focusTrapRef}
+        className="relative w-full md:w-auto md:min-w-[32rem] max-w-lg max-h-[85vh] overflow-y-auto rounded-t-xl md:rounded-xl bg-zinc-900 border border-zinc-800 p-6 shadow-xl"
+      >
+        <h2 className="text-lg font-semibold text-zinc-100 mb-6">
+          {editingAlert ? 'Edit Budget Alert' : 'Create Budget Alert'}
+        </h2>
+
+        {error && (
+          <div
+            role="alert"
+            className="mb-4 rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3"
+          >
+            <p className="text-sm text-red-400">{error}</p>
+          </div>
+        )}
+
+        <div className="space-y-5">
+          {/* Name */}
+          <div>
+            <label
+              htmlFor="alert-name"
+              className="block text-sm font-medium text-zinc-300 mb-1.5"
+            >
+              Alert Name
+            </label>
+            <input
+              id="alert-name"
+              type="text"
+              value={formData.name}
+              onChange={(e) =>
+                onFormChange({ ...formData, name: e.target.value })
+              }
+              placeholder="e.g., Daily Claude limit"
+              className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
+              maxLength={100}
+            />
+          </div>
+
+          {/* Threshold */}
+          <div>
+            <label
+              htmlFor="alert-threshold"
+              className="block text-sm font-medium text-zinc-300 mb-1.5"
+            >
+              Threshold Amount
+            </label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-zinc-500">
+                $
+              </span>
+              <input
+                id="alert-threshold"
+                type="number"
+                value={formData.threshold_usd}
+                onChange={(e) =>
+                  onFormChange({
+                    ...formData,
+                    threshold_usd: parseFloat(e.target.value) || 0,
+                  })
+                }
+                min={0.01}
+                step={0.01}
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 pl-7 pr-3 py-2 text-sm text-zinc-100 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
+              />
+            </div>
+          </div>
+
+          {/* Period selector */}
+          <fieldset className="border-0 p-0 m-0">
+            <legend className="block text-sm font-medium text-zinc-300 mb-1.5">
+              Period
+            </legend>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {ALERT_PERIODS.map((period) => (
+                <OptionPill
+                  key={period}
+                  isSelected={formData.period === period}
+                  onClick={() => onFormChange({ ...formData, period })}
+                >
+                  {period.charAt(0).toUpperCase() + period.slice(1)}
+                </OptionPill>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* Agent filter */}
+          <fieldset className="border-0 p-0 m-0">
+            <legend className="block text-sm font-medium text-zinc-300 mb-1.5">
+              Agent Filter
+              <span className="text-zinc-500 font-normal ml-1">(optional)</span>
+            </legend>
+            <div className="grid grid-cols-4 gap-2">
+              <OptionPill
+                isSelected={formData.agent_type === null}
+                onClick={() => onFormChange({ ...formData, agent_type: null })}
+              >
+                All
+              </OptionPill>
+              {AGENT_TYPES.map((agent: AgentType) => (
+                <OptionPill
+                  key={agent}
+                  isSelected={formData.agent_type === agent}
+                  onClick={() =>
+                    onFormChange({ ...formData, agent_type: agent })
+                  }
+                  className="capitalize"
+                >
+                  {agent}
+                </OptionPill>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* Action selector */}
+          <fieldset className="border-0 p-0 m-0">
+            <legend className="block text-sm font-medium text-zinc-300 mb-1.5">
+              Action When Triggered
+            </legend>
+            <div className="space-y-2">
+              {ALERT_ACTIONS.map((action) => {
+                const info = ACTION_DESCRIPTIONS[action];
+                const isSelected = formData.action === action;
+                return (
+                  <button
+                    key={action}
+                    type="button"
+                    onClick={() => onFormChange({ ...formData, action })}
+                    className={`w-full rounded-lg px-4 py-3 text-left transition-colors ${
+                      isSelected
+                        ? 'bg-orange-500/10 border-orange-500/50 border'
+                        : 'bg-zinc-800 border border-zinc-700 hover:bg-zinc-700'
+                    }`}
+                    aria-pressed={isSelected}
+                  >
+                    <div className="flex items-center gap-3">
+                      <svg
+                        className={`h-5 w-5 flex-shrink-0 ${
+                          isSelected ? 'text-orange-400' : 'text-zinc-500'
+                        }`}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        aria-hidden="true"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d={info.icon}
+                        />
+                      </svg>
+                      <div>
+                        <p
+                          className={`text-sm font-medium ${
+                            isSelected ? 'text-orange-300' : 'text-zinc-300'
+                          }`}
+                        >
+                          {info.label}
+                        </p>
+                        <p className="text-xs text-zinc-500">
+                          {info.description}
+                        </p>
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+        </div>
+
+        {/* Modal actions */}
+        <div className="flex items-center justify-end gap-3 mt-6 pt-4 border-t border-zinc-800">
+          <button
+            onClick={onClose}
+            className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 transition-colors"
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onSubmit}
+            disabled={
+              isSubmitting ||
+              !formData.name.trim() ||
+              formData.threshold_usd <= 0
+            }
+            className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {isSubmitting && (
+              <div
+                className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
+                aria-hidden="true"
+              />
+            )}
+            {editingAlert ? 'Save Changes' : 'Create Alert'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertsHeader.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertsHeader.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+/**
+ * AlertsHeader — top bar of the Budget Alerts page.
+ *
+ * Shows tier usage ("3 / 5 alerts used (Pro plan)") and the right-side
+ * action: either a "Create Alert" button (when under the limit) or an
+ * upgrade CTA (when at the limit).
+ *
+ * WHY split out: The header has three mutually exclusive right-side
+ * states (create / upgrade-from-free / upgrade-for-more). Co-locating
+ * the branching here keeps the orchestrator focused on data flow.
+ */
+
+import Link from 'next/link';
+
+interface AlertsHeaderProps {
+  /** Current number of alerts the user has. */
+  alertCount: number;
+  /** Maximum alerts allowed for the user's tier. */
+  alertLimit: number;
+  /** Subscription tier label (e.g. "Free", "Pro"). */
+  tier: string;
+  /** Invoked when the user clicks "Create Alert". */
+  onCreate: () => void;
+}
+
+/**
+ * Renders the page header with usage stats and the primary CTA.
+ *
+ * @param props - See {@link AlertsHeaderProps}.
+ */
+export function AlertsHeader({
+  alertCount,
+  alertLimit,
+  tier,
+  onCreate,
+}: AlertsHeaderProps) {
+  const canCreateAlert = alertCount < alertLimit;
+
+  return (
+    <div className="flex items-center justify-between mb-6">
+      <div>
+        <p className="text-sm text-zinc-400">
+          {alertCount} / {alertLimit} alerts used
+          <span className="text-zinc-500 ml-2">({tier} plan)</span>
+        </p>
+      </div>
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard/costs"
+          className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 transition-colors"
+        >
+          Back to Costs
+        </Link>
+        {canCreateAlert ? (
+          <button
+            onClick={onCreate}
+            className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors flex items-center gap-2"
+            aria-label="Create a new budget alert"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            Create Alert
+          </button>
+        ) : alertLimit === 0 ? (
+          <Link
+            href="/pricing"
+            className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
+          >
+            Upgrade to Pro
+          </Link>
+        ) : (
+          <Link
+            href="/pricing"
+            className="rounded-lg border border-orange-500/50 px-4 py-2 text-sm font-medium text-orange-400 hover:bg-orange-500/10 transition-colors"
+          >
+            Upgrade for More
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/EmptyState.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/EmptyState.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+/**
+ * EmptyState — shown when the user has zero budget alerts.
+ *
+ * Two variants:
+ * - alertLimit > 0: "Create your first alert" CTA
+ * - alertLimit === 0: Upgrade-to-Pro CTA (Free tier has no alert quota)
+ */
+
+import Link from 'next/link';
+
+interface EmptyStateProps {
+  /** Maximum alerts allowed for the user's tier. */
+  alertLimit: number;
+  /** Invoked when the user clicks "Create Your First Alert". */
+  onCreate: () => void;
+}
+
+/**
+ * Renders the zero-alerts empty state with a tier-appropriate CTA.
+ *
+ * @param props - See {@link EmptyStateProps}.
+ */
+export function EmptyState({ alertLimit, onCreate }: EmptyStateProps) {
+  return (
+    <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
+      <div className="mx-auto h-16 w-16 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
+        <svg
+          className="h-8 w-8 text-zinc-500"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+          />
+        </svg>
+      </div>
+      <h3 className="text-lg font-medium text-zinc-100 mb-2">No budget alerts</h3>
+      {alertLimit > 0 ? (
+        <>
+          <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
+            Set up budget alerts to get notified when your AI spending reaches
+            your thresholds.
+          </p>
+          <button
+            onClick={onCreate}
+            className="rounded-lg bg-orange-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
+            aria-label="Create your first budget alert"
+          >
+            Create Your First Alert
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
+            Budget alerts help you control AI spending. Upgrade to Pro to
+            create up to 3 budget alerts.
+          </p>
+          <Link
+            href="/pricing"
+            className="inline-block rounded-lg bg-orange-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
+          >
+            Upgrade to Pro
+          </Link>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/OptionPill.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/OptionPill.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * OptionPill — shared toggleable pill button used in the modal selectors.
+ *
+ * WHY extracted: The Period and Agent grids in the alert modal both
+ * render the same orange-when-selected, zinc-when-not pill pattern.
+ * Centralizing avoids drift if the design system updates the pill
+ * styling.
+ */
+
+import type { ReactNode } from 'react';
+
+interface OptionPillProps {
+  /** Whether this pill represents the currently selected option. */
+  isSelected: boolean;
+  /** Click handler — called when the pill is activated. */
+  onClick: () => void;
+  /** Pill label content. */
+  children: ReactNode;
+  /** Additional classes appended to the base pill style. */
+  className?: string;
+}
+
+/**
+ * Renders a single selectable pill button.
+ *
+ * @param props - See {@link OptionPillProps}.
+ */
+export function OptionPill({
+  isSelected,
+  onClick,
+  children,
+  className = '',
+}: OptionPillProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={isSelected}
+      className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+        isSelected
+          ? 'bg-orange-500 text-white'
+          : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 border border-zinc-700'
+      } ${className}`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/__tests__/helpers.test.ts
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/__tests__/helpers.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for budget-alerts presentational helpers.
+ *
+ * WHY: These pure functions encode the visual urgency thresholds that
+ * users rely on to spot over-budget alerts. Regressions in the threshold
+ * boundaries would silently change which alerts look "safe" vs "danger".
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getProgressColor,
+  getPercentageTextColor,
+  getActionBadgeColor,
+  getPeriodBadgeColor,
+} from '../helpers';
+
+describe('getProgressColor', () => {
+  it('returns green below 50%', () => {
+    expect(getProgressColor(0)).toBe('bg-green-500');
+    expect(getProgressColor(49.9)).toBe('bg-green-500');
+  });
+
+  it('returns yellow at 50% boundary and below 80%', () => {
+    expect(getProgressColor(50)).toBe('bg-yellow-500');
+    expect(getProgressColor(79.9)).toBe('bg-yellow-500');
+  });
+
+  it('returns orange at 80% boundary and below 100%', () => {
+    expect(getProgressColor(80)).toBe('bg-orange-500');
+    expect(getProgressColor(99.9)).toBe('bg-orange-500');
+  });
+
+  it('returns red at 100% and above', () => {
+    expect(getProgressColor(100)).toBe('bg-red-500');
+    expect(getProgressColor(250)).toBe('bg-red-500');
+  });
+});
+
+describe('getPercentageTextColor', () => {
+  it('mirrors progress color thresholds', () => {
+    expect(getPercentageTextColor(0)).toBe('text-green-400');
+    expect(getPercentageTextColor(50)).toBe('text-yellow-400');
+    expect(getPercentageTextColor(80)).toBe('text-orange-400');
+    expect(getPercentageTextColor(100)).toBe('text-red-400');
+  });
+});
+
+describe('getActionBadgeColor', () => {
+  it('returns blue palette for notify', () => {
+    expect(getActionBadgeColor('notify')).toEqual({
+      bg: 'bg-blue-500/10',
+      text: 'text-blue-400',
+    });
+  });
+
+  it('returns yellow palette for warn_and_slowdown', () => {
+    expect(getActionBadgeColor('warn_and_slowdown')).toEqual({
+      bg: 'bg-yellow-500/10',
+      text: 'text-yellow-400',
+    });
+  });
+
+  it('returns red palette for hard_stop', () => {
+    expect(getActionBadgeColor('hard_stop')).toEqual({
+      bg: 'bg-red-500/10',
+      text: 'text-red-400',
+    });
+  });
+});
+
+describe('getPeriodBadgeColor', () => {
+  it('assigns a distinct palette per period', () => {
+    expect(getPeriodBadgeColor('daily').text).toBe('text-purple-400');
+    expect(getPeriodBadgeColor('weekly').text).toBe('text-cyan-400');
+    expect(getPeriodBadgeColor('monthly').text).toBe('text-indigo-400');
+  });
+});

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/helpers.ts
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/helpers.ts
@@ -1,0 +1,156 @@
+/**
+ * Pure presentational helpers for the Budget Alerts feature.
+ *
+ * WHY pure functions: All visual classification (progress color, badge
+ * color, percentage color) is deterministic from inputs. Keeping these
+ * pure makes them trivially unit-testable and avoids re-rendering
+ * concerns inside React components.
+ */
+
+import type { AlertAction, AlertPeriod, AgentType } from './types';
+
+/**
+ * Human-readable descriptions for each alert action.
+ *
+ * WHY: Shown both in the modal (decision-making context) and on alert
+ * cards (badge label). Centralized so wording stays consistent if
+ * marketing/legal updates copy.
+ */
+export const ACTION_DESCRIPTIONS: Record<
+  AlertAction,
+  { label: string; description: string; icon: string }
+> = {
+  notify: {
+    label: 'Notify Only',
+    description: 'Send a notification when the threshold is reached',
+    icon: 'M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9',
+  },
+  warn_and_slowdown: {
+    label: 'Warn & Slowdown',
+    description: 'Notify and throttle agent activity to reduce spending',
+    icon: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
+  },
+  hard_stop: {
+    label: 'Hard Stop',
+    description: 'Notify and immediately stop all agent usage',
+    icon: 'M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636',
+  },
+};
+
+/**
+ * Color configuration for agent type badges.
+ *
+ * WHY: Matches the color scheme used throughout the Styrby dashboard so
+ * agents are visually consistent across cost charts, alert cards, and
+ * session lists.
+ */
+export const AGENT_COLORS: Record<AgentType, { bg: string; text: string }> = {
+  claude: { bg: 'bg-orange-500/10', text: 'text-orange-400' },
+  codex: { bg: 'bg-green-500/10', text: 'text-green-400' },
+  gemini: { bg: 'bg-blue-500/10', text: 'text-blue-400' },
+  opencode: { bg: 'bg-purple-500/10', text: 'text-purple-400' },
+  aider: { bg: 'bg-pink-500/10', text: 'text-pink-400' },
+  goose: { bg: 'bg-teal-500/10', text: 'text-teal-400' },
+  amp: { bg: 'bg-amber-500/10', text: 'text-amber-400' },
+  crush: { bg: 'bg-rose-500/10', text: 'text-rose-400' },
+  kilo: { bg: 'bg-sky-500/10', text: 'text-sky-400' },
+  kiro: { bg: 'bg-orange-500/10', text: 'text-orange-400' },
+  droid: { bg: 'bg-slate-500/10', text: 'text-slate-400' },
+};
+
+/** Ordered list of agent types for rendering the agent filter grid. */
+export const AGENT_TYPES: AgentType[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'opencode',
+  'aider',
+  'goose',
+  'amp',
+  'crush',
+  'kilo',
+  'kiro',
+  'droid',
+];
+
+/** Ordered list of alert periods for rendering the period selector. */
+export const ALERT_PERIODS: AlertPeriod[] = ['daily', 'weekly', 'monthly'];
+
+/** Ordered list of alert actions for rendering the action selector. */
+export const ALERT_ACTIONS: AlertAction[] = [
+  'notify',
+  'warn_and_slowdown',
+  'hard_stop',
+];
+
+/**
+ * Returns the Tailwind CSS color class for a progress bar based on usage
+ * percentage.
+ *
+ * WHY: Visual urgency helps users quickly identify alerts that need
+ * attention.
+ * - Green (<50%): Safe, well within budget
+ * - Yellow (50-80%): Approaching threshold, be aware
+ * - Orange (80-100%): Close to threshold, take action soon
+ * - Red (>=100%): Over budget, immediate attention needed
+ *
+ * @param percentage - The percentage of the threshold used (0-100+)
+ * @returns Tailwind CSS background color class
+ */
+export function getProgressColor(percentage: number): string {
+  if (percentage >= 100) return 'bg-red-500';
+  if (percentage >= 80) return 'bg-orange-500';
+  if (percentage >= 50) return 'bg-yellow-500';
+  return 'bg-green-500';
+}
+
+/**
+ * Returns the Tailwind CSS text color class for a usage percentage.
+ *
+ * @param percentage - The percentage of the threshold used (0-100+)
+ * @returns Tailwind CSS text color class
+ */
+export function getPercentageTextColor(percentage: number): string {
+  if (percentage >= 100) return 'text-red-400';
+  if (percentage >= 80) return 'text-orange-400';
+  if (percentage >= 50) return 'text-yellow-400';
+  return 'text-green-400';
+}
+
+/**
+ * Returns the badge color classes for an alert action.
+ *
+ * @param action - The alert action type
+ * @returns Object with bg and text Tailwind classes
+ */
+export function getActionBadgeColor(
+  action: AlertAction
+): { bg: string; text: string } {
+  switch (action) {
+    case 'notify':
+      return { bg: 'bg-blue-500/10', text: 'text-blue-400' };
+    case 'warn_and_slowdown':
+      return { bg: 'bg-yellow-500/10', text: 'text-yellow-400' };
+    case 'hard_stop':
+      return { bg: 'bg-red-500/10', text: 'text-red-400' };
+  }
+}
+
+/**
+ * Returns the badge color classes for a period.
+ *
+ * @param period - The alert period
+ * @returns Object with bg and text Tailwind classes
+ */
+export function getPeriodBadgeColor(
+  period: AlertPeriod
+): { bg: string; text: string } {
+  switch (period) {
+    case 'daily':
+      return { bg: 'bg-purple-500/10', text: 'text-purple-400' };
+    case 'weekly':
+      return { bg: 'bg-cyan-500/10', text: 'text-cyan-400' };
+    case 'monthly':
+      return { bg: 'bg-indigo-500/10', text: 'text-indigo-400' };
+  }
+}

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/index.ts
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Barrel exports for the Budget Alerts feature sub-components.
+ *
+ * WHY narrow surface: Only the symbols the orchestrator imports are
+ * re-exported here. Helpers, OptionPill, and AGENT_COLORS stay
+ * intentionally absent so callers cannot reach into internals from
+ * outside the feature folder.
+ */
+
+export { AlertsHeader } from './AlertsHeader';
+export { EmptyState } from './EmptyState';
+export { AlertCard } from './AlertCard';
+export { AlertModal } from './AlertModal';
+export type { BudgetAlertWithSpend, AlertFormData } from './types';

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/types.ts
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared types for the Budget Alerts feature.
+ *
+ * WHY co-located: These types are only consumed by files inside
+ * `dashboard/costs/budget-alerts/**`. Keeping them next to the feature
+ * avoids polluting a global `src/types` namespace with feature-specific
+ * shapes and matches the file-collocation pattern used elsewhere
+ * (e.g., `src/components/costs/`).
+ */
+
+/** Valid agent types matching the Postgres enum. */
+export type AgentType =
+  | 'claude'
+  | 'codex'
+  | 'gemini'
+  | 'opencode'
+  | 'aider'
+  | 'goose'
+  | 'amp'
+  | 'crush'
+  | 'kilo'
+  | 'kiro'
+  | 'droid';
+
+/** Valid alert periods matching the database CHECK constraint. */
+export type AlertPeriod = 'daily' | 'weekly' | 'monthly';
+
+/** Valid alert actions matching the database CHECK constraint. */
+export type AlertAction = 'notify' | 'warn_and_slowdown' | 'hard_stop';
+
+/** Valid notification channels. */
+export type NotificationChannel = 'push' | 'in_app' | 'email';
+
+/**
+ * Budget alert from the database, enriched with computed spend data.
+ *
+ * The server calculates `current_spend_usd` and `percentage_used` by
+ * querying the cost_records table for the alert's period and agent scope.
+ */
+export interface BudgetAlertWithSpend {
+  id: string;
+  user_id: string;
+  name: string;
+  threshold_usd: number;
+  period: AlertPeriod;
+  agent_type: AgentType | null;
+  action: AlertAction;
+  notification_channels: NotificationChannel[];
+  is_enabled: boolean;
+  last_triggered_at: string | null;
+  created_at: string;
+  updated_at: string;
+  current_spend_usd: number;
+  percentage_used: number;
+}
+
+/**
+ * Form data for creating or editing a budget alert.
+ *
+ * Matches the shape expected by the POST/PATCH `/api/budget-alerts`
+ * endpoints (minus the `id`, which is appended for PATCH).
+ */
+export interface AlertFormData {
+  name: string;
+  threshold_usd: number;
+  period: AlertPeriod;
+  agent_type: AgentType | null;
+  action: AlertAction;
+  notification_channels: NotificationChannel[];
+}

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/budget-alerts-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/budget-alerts-client.tsx
@@ -1,204 +1,54 @@
 'use client';
 
 /**
- * Budget Alerts Client Component
+ * Budget Alerts Client Component (orchestrator).
  *
- * Interactive UI for managing budget alerts. Displays alert cards in a grid
- * with progress bars, action badges, and controls for creating, editing,
- * enabling/disabling, and deleting alerts.
+ * Owns state, server I/O, and top-level layout for the Budget Alerts
+ * page. Delegates presentation to focused sub-components in
+ * `./_components`:
+ * - {@link AlertsHeader}: tier usage line + Create CTA
+ * - {@link EmptyState}: zero-alerts onboarding
+ * - {@link AlertCard}: a single alert tile in the grid
+ * - {@link AlertModal}: create/edit form dialog
  *
- * WHY this is a client component: It requires interactive state management
- * for the create/edit modal, toggle switches, and optimistic UI updates
- * when toggling or deleting alerts.
+ * WHY this is a client component: Modal state, optimistic toggle/delete
+ * updates, and form interactions all require interactive React state.
+ * The parent server component pre-fetches the alert list and pricing
+ * tier so the first paint is data-complete.
  */
 
 import { useState, useCallback } from 'react';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
+import {
+  AlertCard,
+  AlertModal,
+  AlertsHeader,
+  EmptyState,
+  type AlertFormData,
+  type BudgetAlertWithSpend,
+} from './_components';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/** Valid agent types matching the Postgres enum */
-type AgentType = 'claude' | 'codex' | 'gemini' | 'opencode' | 'aider' | 'goose' | 'amp' | 'crush' | 'kilo' | 'kiro' | 'droid';
-
-/** Valid alert periods matching the database CHECK constraint */
-type AlertPeriod = 'daily' | 'weekly' | 'monthly';
-
-/** Valid alert actions matching the database CHECK constraint */
-type AlertAction = 'notify' | 'warn_and_slowdown' | 'hard_stop';
-
-/** Valid notification channels */
-type NotificationChannel = 'push' | 'in_app' | 'email';
-
-/**
- * Budget alert from the database, enriched with computed spend data.
- * The server calculates current_spend_usd and percentage_used by querying
- * the cost_records table for the alert's period and agent scope.
- */
-interface BudgetAlertWithSpend {
-  id: string;
-  user_id: string;
-  name: string;
-  threshold_usd: number;
-  period: AlertPeriod;
-  agent_type: AgentType | null;
-  action: AlertAction;
-  notification_channels: NotificationChannel[];
-  is_enabled: boolean;
-  last_triggered_at: string | null;
-  created_at: string;
-  updated_at: string;
-  current_spend_usd: number;
-  percentage_used: number;
-}
-
-/** Props passed from the server component page */
+/** Props passed from the server component page. */
 interface BudgetAlertsClientProps {
-  /** List of budget alerts with computed spend data */
+  /** List of budget alerts with computed spend data. */
   initialAlerts: BudgetAlertWithSpend[];
-  /** The user's subscription tier */
+  /** The user's subscription tier (e.g. "Free", "Pro"). */
   tier: string;
-  /** Maximum number of alerts allowed by the user's tier */
+  /** Maximum number of alerts allowed by the user's tier. */
   alertLimit: number;
-  /** Current number of alerts the user has */
+  /** Current number of alerts the user has. */
   alertCount: number;
 }
 
 /**
- * Form data for creating or editing a budget alert.
- * Matches the shape expected by the POST/PATCH API endpoints.
- */
-interface AlertFormData {
-  name: string;
-  threshold_usd: number;
-  period: AlertPeriod;
-  agent_type: AgentType | null;
-  action: AlertAction;
-  notification_channels: NotificationChannel[];
-}
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/**
- * Human-readable descriptions for each alert action.
- * Shown in the create/edit form to help users understand consequences.
- */
-const ACTION_DESCRIPTIONS: Record<AlertAction, { label: string; description: string; icon: string }> = {
-  notify: {
-    label: 'Notify Only',
-    description: 'Send a notification when the threshold is reached',
-    icon: 'M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9',
-  },
-  warn_and_slowdown: {
-    label: 'Warn & Slowdown',
-    description: 'Notify and throttle agent activity to reduce spending',
-    icon: 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
-  },
-  hard_stop: {
-    label: 'Hard Stop',
-    description: 'Notify and immediately stop all agent usage',
-    icon: 'M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636',
-  },
-};
-
-/**
- * Color configuration for agent type badges.
- * Matches the color scheme used throughout the Styrby dashboard.
- */
-const AGENT_COLORS: Record<AgentType, { bg: string; text: string }> = {
-  claude: { bg: 'bg-orange-500/10', text: 'text-orange-400' },
-  codex: { bg: 'bg-green-500/10', text: 'text-green-400' },
-  gemini: { bg: 'bg-blue-500/10', text: 'text-blue-400' },
-  opencode: { bg: 'bg-purple-500/10', text: 'text-purple-400' },
-  aider: { bg: 'bg-pink-500/10', text: 'text-pink-400' },
-  goose: { bg: 'bg-teal-500/10', text: 'text-teal-400' },
-  amp: { bg: 'bg-amber-500/10', text: 'text-amber-400' },
-  crush: { bg: 'bg-rose-500/10', text: 'text-rose-400' },
-  kilo: { bg: 'bg-sky-500/10', text: 'text-sky-400' },
-  kiro: { bg: 'bg-orange-500/10', text: 'text-orange-400' },
-  droid: { bg: 'bg-slate-500/10', text: 'text-slate-400' },
-};
-
-// ---------------------------------------------------------------------------
-// Helper Functions
-// ---------------------------------------------------------------------------
-
-/**
- * Returns the Tailwind CSS color class for a progress bar based on usage percentage.
+ * Default values for the alert creation form.
  *
- * WHY: Visual urgency helps users quickly identify alerts that need attention.
- * - Green (<50%): Safe, well within budget
- * - Yellow (50-80%): Approaching threshold, be aware
- * - Orange (80-100%): Close to threshold, take action soon
- * - Red (>100%): Over budget, immediate attention needed
- *
- * @param percentage - The percentage of the threshold used (0-100+)
- * @returns Tailwind CSS background color class
+ * WHY these defaults: Daily/$10/notify is the safest "training wheels"
+ * configuration — low impact (notify-only), short window (1 day), and
+ * a small enough threshold that most users will see it trigger
+ * organically and learn how alerts behave.
  */
-function getProgressColor(percentage: number): string {
-  if (percentage >= 100) return 'bg-red-500';
-  if (percentage >= 80) return 'bg-orange-500';
-  if (percentage >= 50) return 'bg-yellow-500';
-  return 'bg-green-500';
-}
-
-/**
- * Returns the Tailwind CSS text color class for a usage percentage.
- *
- * @param percentage - The percentage of the threshold used (0-100+)
- * @returns Tailwind CSS text color class
- */
-function getPercentageTextColor(percentage: number): string {
-  if (percentage >= 100) return 'text-red-400';
-  if (percentage >= 80) return 'text-orange-400';
-  if (percentage >= 50) return 'text-yellow-400';
-  return 'text-green-400';
-}
-
-/**
- * Returns the badge color classes for an alert action.
- *
- * @param action - The alert action type
- * @returns Object with bg and text Tailwind classes
- */
-function getActionBadgeColor(action: AlertAction): { bg: string; text: string } {
-  switch (action) {
-    case 'notify':
-      return { bg: 'bg-blue-500/10', text: 'text-blue-400' };
-    case 'warn_and_slowdown':
-      return { bg: 'bg-yellow-500/10', text: 'text-yellow-400' };
-    case 'hard_stop':
-      return { bg: 'bg-red-500/10', text: 'text-red-400' };
-  }
-}
-
-/**
- * Returns the badge color classes for a period.
- *
- * @param period - The alert period
- * @returns Object with bg and text Tailwind classes
- */
-function getPeriodBadgeColor(period: AlertPeriod): { bg: string; text: string } {
-  switch (period) {
-    case 'daily':
-      return { bg: 'bg-purple-500/10', text: 'text-purple-400' };
-    case 'weekly':
-      return { bg: 'bg-cyan-500/10', text: 'text-cyan-400' };
-    case 'monthly':
-      return { bg: 'bg-indigo-500/10', text: 'text-indigo-400' };
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Default Form Values
-// ---------------------------------------------------------------------------
-
-/** Default values for the alert creation form */
 const DEFAULT_FORM_DATA: AlertFormData = {
   name: '',
   threshold_usd: 10,
@@ -208,20 +58,10 @@ const DEFAULT_FORM_DATA: AlertFormData = {
   notification_channels: ['push', 'in_app'],
 };
 
-// ---------------------------------------------------------------------------
-// Main Component
-// ---------------------------------------------------------------------------
-
 /**
  * Budget alerts management interface.
  *
- * Renders a grid of alert cards with progress bars and controls,
- * plus a modal form for creating and editing alerts.
- *
- * @param initialAlerts - Pre-fetched alert data from the server component
- * @param tier - The user's subscription tier ID
- * @param alertLimit - Maximum alerts allowed for the user's tier
- * @param alertCount - Current number of alerts
+ * @param props - See {@link BudgetAlertsClientProps}.
  */
 export function BudgetAlertsClient({
   initialAlerts,
@@ -233,22 +73,20 @@ export function BudgetAlertsClient({
   const [alerts, setAlerts] = useState<BudgetAlertWithSpend[]>(initialAlerts);
   const [alertCount, setAlertCount] = useState(initialAlertCount);
   const [showModal, setShowModal] = useState(false);
-  const [editingAlert, setEditingAlert] = useState<BudgetAlertWithSpend | null>(null);
+  const [editingAlert, setEditingAlert] = useState<BudgetAlertWithSpend | null>(
+    null
+  );
   const [formData, setFormData] = useState<AlertFormData>(DEFAULT_FORM_DATA);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [togglingId, setTogglingId] = useState<string | null>(null);
 
-  const canCreateAlert = alertCount < alertLimit;
-
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------
   // Modal Handlers
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------
 
-  /**
-   * Opens the create modal with default form values.
-   */
+  /** Opens the create modal with default form values. */
   const handleOpenCreate = useCallback(() => {
     setEditingAlert(null);
     setFormData(DEFAULT_FORM_DATA);
@@ -256,11 +94,7 @@ export function BudgetAlertsClient({
     setShowModal(true);
   }, []);
 
-  /**
-   * Opens the edit modal pre-populated with the alert's current values.
-   *
-   * @param alert - The alert to edit
-   */
+  /** Opens the edit modal pre-populated with the alert's current values. */
   const handleOpenEdit = useCallback((alert: BudgetAlertWithSpend) => {
     setEditingAlert(alert);
     setFormData({
@@ -275,9 +109,7 @@ export function BudgetAlertsClient({
     setShowModal(true);
   }, []);
 
-  /**
-   * Closes the modal and resets form state.
-   */
+  /** Closes the modal and resets form state. */
   const handleCloseModal = useCallback(() => {
     setShowModal(false);
     setEditingAlert(null);
@@ -285,18 +117,19 @@ export function BudgetAlertsClient({
     setError(null);
   }, []);
 
-  // WHY: WCAG 2.1.2 requires focus to not be trapped unless the trap is intentional
-  // (i.e., a modal dialog). The focus trap keeps keyboard users inside the modal
-  // and restores focus to the trigger element when the modal closes.
+  // WHY: WCAG 2.1.2 requires focus to not be trapped unless the trap is
+  // intentional (i.e., a modal dialog). The focus trap keeps keyboard
+  // users inside the modal and restores focus to the trigger element
+  // when the modal closes.
   const focusTrapRef = useFocusTrap<HTMLDivElement>(showModal, handleCloseModal);
 
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------
   // CRUD Operations
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------
 
   /**
-   * Submits the form to create or update a budget alert.
-   * Calls the POST or PATCH endpoint and refreshes the page on success.
+   * Submits the form to create or update a budget alert. Calls the
+   * POST or PATCH endpoint and refreshes the page on success.
    */
   const handleSubmit = useCallback(async () => {
     setIsSubmitting(true);
@@ -320,17 +153,23 @@ export function BudgetAlertsClient({
       }
 
       handleCloseModal();
-      // WHY: Revalidate the server component data so the page shows fresh
-      // spend calculations. Client-side state alone would show stale spend.
+      // WHY: Revalidate the server component data so the page shows
+      // fresh spend calculations. Client-side state alone would show
+      // stale spend.
       router.refresh();
 
       // Optimistic update for immediate feedback
       if (isEdit) {
         setAlerts((prev) =>
-          prev.map((a) => (a.id === editingAlert.id ? { ...a, ...data.alert } : a))
+          prev.map((a) =>
+            a.id === editingAlert.id ? { ...a, ...data.alert } : a
+          )
         );
       } else {
-        setAlerts((prev) => [{ ...data.alert, current_spend_usd: 0, percentage_used: 0 }, ...prev]);
+        setAlerts((prev) => [
+          { ...data.alert, current_spend_usd: 0, percentage_used: 0 },
+          ...prev,
+        ]);
         setAlertCount((prev) => prev + 1);
       }
     } catch {
@@ -341,56 +180,47 @@ export function BudgetAlertsClient({
   }, [editingAlert, formData, handleCloseModal, router]);
 
   /**
-   * Toggles an alert's enabled/disabled state.
-   * Uses optimistic update for instant UI feedback.
-   *
-   * @param alert - The alert to toggle
+   * Toggles an alert's enabled/disabled state. Uses an optimistic
+   * update for instant UI feedback, reverting on failure.
    */
-  const handleToggle = useCallback(
-    async (alert: BudgetAlertWithSpend) => {
-      setTogglingId(alert.id);
+  const handleToggle = useCallback(async (alert: BudgetAlertWithSpend) => {
+    setTogglingId(alert.id);
 
-      // Optimistic update
-      setAlerts((prev) =>
-        prev.map((a) =>
-          a.id === alert.id ? { ...a, is_enabled: !a.is_enabled } : a
-        )
-      );
+    // Optimistic update
+    setAlerts((prev) =>
+      prev.map((a) =>
+        a.id === alert.id ? { ...a, is_enabled: !a.is_enabled } : a
+      )
+    );
 
-      try {
-        const response = await fetch('/api/budget-alerts', {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: alert.id, is_enabled: !alert.is_enabled }),
-        });
+    try {
+      const response = await fetch('/api/budget-alerts', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: alert.id, is_enabled: !alert.is_enabled }),
+      });
 
-        if (!response.ok) {
-          // Revert optimistic update on failure
-          setAlerts((prev) =>
-            prev.map((a) =>
-              a.id === alert.id ? { ...a, is_enabled: alert.is_enabled } : a
-            )
-          );
-        }
-      } catch {
-        // Revert on network error
+      if (!response.ok) {
+        // Revert optimistic update on failure
         setAlerts((prev) =>
           prev.map((a) =>
             a.id === alert.id ? { ...a, is_enabled: alert.is_enabled } : a
           )
         );
-      } finally {
-        setTogglingId(null);
       }
-    },
-    []
-  );
+    } catch {
+      // Revert on network error
+      setAlerts((prev) =>
+        prev.map((a) =>
+          a.id === alert.id ? { ...a, is_enabled: alert.is_enabled } : a
+        )
+      );
+    } finally {
+      setTogglingId(null);
+    }
+  }, []);
 
-  /**
-   * Deletes a budget alert after confirmation.
-   *
-   * @param alertId - UUID of the alert to delete
-   */
+  /** Deletes a budget alert after user confirmation. */
   const handleDelete = useCallback(
     async (alertId: string) => {
       if (!confirm('Are you sure you want to delete this budget alert?')) {
@@ -412,7 +242,7 @@ export function BudgetAlertsClient({
           router.refresh();
         }
       } catch {
-        // Silently fail - the alert remains visible so the user can retry
+        // Silently fail - the alert remains visible so the user can retry.
       } finally {
         setDeletingId(null);
       }
@@ -420,488 +250,50 @@ export function BudgetAlertsClient({
     [router]
   );
 
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------
   // Render
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------
 
   return (
     <div>
-      {/* Header with create button and tier indicator */}
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <p className="text-sm text-zinc-400">
-            {alertCount} / {alertLimit} alerts used
-            <span className="text-zinc-500 ml-2">({tier} plan)</span>
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          <Link
-            href="/dashboard/costs"
-            className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 transition-colors"
-          >
-            Back to Costs
-          </Link>
-          {canCreateAlert ? (
-            <button
-              onClick={handleOpenCreate}
-              className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors flex items-center gap-2"
-              aria-label="Create a new budget alert"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-              Create Alert
-            </button>
-          ) : alertLimit === 0 ? (
-            <Link
-              href="/pricing"
-              className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
-            >
-              Upgrade to Pro
-            </Link>
-          ) : (
-            <Link
-              href="/pricing"
-              className="rounded-lg border border-orange-500/50 px-4 py-2 text-sm font-medium text-orange-400 hover:bg-orange-500/10 transition-colors"
-            >
-              Upgrade for More
-            </Link>
-          )}
-        </div>
-      </div>
+      <AlertsHeader
+        alertCount={alertCount}
+        alertLimit={alertLimit}
+        tier={tier}
+        onCreate={handleOpenCreate}
+      />
 
-      {/* Empty State */}
       {alerts.length === 0 && (
-        <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
-          <div className="mx-auto h-16 w-16 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
-            <svg
-              className="h-8 w-8 text-zinc-500"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-              />
-            </svg>
-          </div>
-          <h3 className="text-lg font-medium text-zinc-100 mb-2">No budget alerts</h3>
-          {alertLimit > 0 ? (
-            <>
-              <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
-                Set up budget alerts to get notified when your AI spending
-                reaches your thresholds.
-              </p>
-              <button
-                onClick={handleOpenCreate}
-                className="rounded-lg bg-orange-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
-                aria-label="Create your first budget alert"
-              >
-                Create Your First Alert
-              </button>
-            </>
-          ) : (
-            <>
-              <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
-                Budget alerts help you control AI spending. Upgrade to Pro to
-                create up to 3 budget alerts.
-              </p>
-              <Link
-                href="/pricing"
-                className="inline-block rounded-lg bg-orange-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
-              >
-                Upgrade to Pro
-              </Link>
-            </>
-          )}
-        </div>
+        <EmptyState alertLimit={alertLimit} onCreate={handleOpenCreate} />
       )}
 
-      {/* Alert Cards Grid */}
       {alerts.length > 0 && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {alerts.map((alert) => {
-            const progressColor = getProgressColor(alert.percentage_used);
-            const percentTextColor = getPercentageTextColor(alert.percentage_used);
-            const actionBadge = getActionBadgeColor(alert.action);
-            const periodBadge = getPeriodBadgeColor(alert.period);
-            const isDeleting = deletingId === alert.id;
-            const isToggling = togglingId === alert.id;
-
-            return (
-              <div
-                key={alert.id}
-                className={`rounded-xl bg-zinc-900 border border-zinc-800 p-4 transition-opacity ${
-                  !alert.is_enabled ? 'opacity-60' : ''
-                } ${isDeleting ? 'opacity-30 pointer-events-none' : ''}`}
-              >
-                {/* Header row: name, period badge, toggle */}
-                <div className="flex items-start justify-between mb-3">
-                  <div className="flex-1 min-w-0 mr-3">
-                    <h3 className="text-sm font-semibold text-zinc-100 truncate">
-                      {alert.name}
-                    </h3>
-                    <div className="flex items-center gap-2 mt-1">
-                      {/* Period badge */}
-                      <span
-                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${periodBadge.bg} ${periodBadge.text}`}
-                      >
-                        {alert.period}
-                      </span>
-                      {/* Agent filter badge */}
-                      {alert.agent_type && (
-                        <span
-                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${AGENT_COLORS[alert.agent_type].bg} ${AGENT_COLORS[alert.agent_type].text}`}
-                        >
-                          {alert.agent_type}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  {/* Toggle switch */}
-                  <label className="relative inline-flex cursor-pointer items-center flex-shrink-0">
-                    <input
-                      type="checkbox"
-                      className="peer sr-only"
-                      checked={alert.is_enabled}
-                      onChange={() => handleToggle(alert)}
-                      disabled={isToggling}
-                      aria-label={`${alert.is_enabled ? 'Disable' : 'Enable'} ${alert.name} alert`}
-                    />
-                    <div className="h-5 w-9 rounded-full bg-zinc-700 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all peer-checked:bg-orange-500 peer-checked:after:translate-x-full" />
-                  </label>
-                </div>
-
-                {/* Progress bar */}
-                <div className="mb-3">
-                  <div className="flex items-baseline justify-between mb-1">
-                    <span className="text-sm text-zinc-300">
-                      ${alert.current_spend_usd.toFixed(2)}{' '}
-                      <span className="text-zinc-500">
-                        / ${Number(alert.threshold_usd).toFixed(2)}
-                      </span>
-                    </span>
-                    <span className={`text-xs font-medium ${percentTextColor}`}>
-                      {alert.percentage_used.toFixed(0)}%
-                    </span>
-                  </div>
-                  <div
-                    className="h-2 rounded-full bg-zinc-800 overflow-hidden"
-                    role="progressbar"
-                    aria-valuenow={Math.min(Math.round(alert.percentage_used), 100)}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    aria-label={`Budget usage: ${alert.percentage_used.toFixed(0)}% of $${alert.threshold_usd}`}
-                  >
-                    <div
-                      className={`h-full rounded-full transition-all duration-500 ${progressColor}`}
-                      style={{ width: `${Math.min(alert.percentage_used, 100)}%` }}
-                    />
-                  </div>
-                </div>
-
-                {/* Action badge */}
-                <div className="flex items-center justify-between">
-                  <span
-                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${actionBadge.bg} ${actionBadge.text}`}
-                  >
-                    <svg
-                      className="h-3 w-3"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      aria-hidden="true"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d={ACTION_DESCRIPTIONS[alert.action].icon}
-                      />
-                    </svg>
-                    {ACTION_DESCRIPTIONS[alert.action].label}
-                  </span>
-
-                  {/* Edit / Delete buttons */}
-                  <div className="flex items-center gap-1">
-                    <button
-                      onClick={() => handleOpenEdit(alert)}
-                      className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
-                      aria-label={`Edit ${alert.name} alert`}
-                    >
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                        />
-                      </svg>
-                    </button>
-                    <button
-                      onClick={() => handleDelete(alert.id)}
-                      className="p-1.5 rounded-lg text-zinc-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
-                      disabled={isDeleting}
-                      aria-label={`Delete ${alert.name} alert`}
-                    >
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-
-                {/* Last triggered */}
-                {alert.last_triggered_at && (
-                  <p className="text-xs text-zinc-500 mt-2">
-                    Last triggered:{' '}
-                    {new Date(alert.last_triggered_at).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                      hour: 'numeric',
-                      minute: '2-digit',
-                    })}
-                  </p>
-                )}
-              </div>
-            );
-          })}
+          {alerts.map((alert) => (
+            <AlertCard
+              key={alert.id}
+              alert={alert}
+              isDeleting={deletingId === alert.id}
+              isToggling={togglingId === alert.id}
+              onToggle={handleToggle}
+              onEdit={handleOpenEdit}
+              onDelete={handleDelete}
+            />
+          ))}
         </div>
       )}
 
-      {/* Create/Edit Modal */}
       {showModal && (
-        <div
-          className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center p-0 md:p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-label={editingAlert ? 'Edit budget alert' : 'Create budget alert'}
-        >
-          {/* Backdrop */}
-          <div
-            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-            onClick={handleCloseModal}
-            aria-hidden="true"
-          />
-
-          {/* Modal content */}
-          <div ref={focusTrapRef} className="relative w-full md:w-auto md:min-w-[32rem] max-w-lg max-h-[85vh] overflow-y-auto rounded-t-xl md:rounded-xl bg-zinc-900 border border-zinc-800 p-6 shadow-xl">
-            <h2 className="text-lg font-semibold text-zinc-100 mb-6">
-              {editingAlert ? 'Edit Budget Alert' : 'Create Budget Alert'}
-            </h2>
-
-            {/* Error message */}
-            {error && (
-              <div role="alert" className="mb-4 rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3">
-                <p className="text-sm text-red-400">{error}</p>
-              </div>
-            )}
-
-            {/* Form fields */}
-            <div className="space-y-5">
-              {/* Name */}
-              <div>
-                <label
-                  htmlFor="alert-name"
-                  className="block text-sm font-medium text-zinc-300 mb-1.5"
-                >
-                  Alert Name
-                </label>
-                <input
-                  id="alert-name"
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  placeholder="e.g., Daily Claude limit"
-                  className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-                  maxLength={100}
-                />
-              </div>
-
-              {/* Threshold */}
-              <div>
-                <label
-                  htmlFor="alert-threshold"
-                  className="block text-sm font-medium text-zinc-300 mb-1.5"
-                >
-                  Threshold Amount
-                </label>
-                <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-zinc-500">
-                    $
-                  </span>
-                  <input
-                    id="alert-threshold"
-                    type="number"
-                    value={formData.threshold_usd}
-                    onChange={(e) =>
-                      setFormData({
-                        ...formData,
-                        threshold_usd: parseFloat(e.target.value) || 0,
-                      })
-                    }
-                    min={0.01}
-                    step={0.01}
-                    className="w-full rounded-lg border border-zinc-700 bg-zinc-800 pl-7 pr-3 py-2 text-sm text-zinc-100 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-                  />
-                </div>
-              </div>
-
-              {/* Period selector */}
-              <fieldset className="border-0 p-0 m-0">
-                <legend className="block text-sm font-medium text-zinc-300 mb-1.5">
-                  Period
-                </legend>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-                  {(['daily', 'weekly', 'monthly'] as AlertPeriod[]).map(
-                    (period) => (
-                      <button
-                        key={period}
-                        type="button"
-                        onClick={() => setFormData({ ...formData, period })}
-                        className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                          formData.period === period
-                            ? 'bg-orange-500 text-white'
-                            : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 border border-zinc-700'
-                        }`}
-                        aria-pressed={formData.period === period}
-                      >
-                        {period.charAt(0).toUpperCase() + period.slice(1)}
-                      </button>
-                    )
-                  )}
-                </div>
-              </fieldset>
-
-              {/* Agent filter */}
-              <fieldset className="border-0 p-0 m-0">
-                <legend className="block text-sm font-medium text-zinc-300 mb-1.5">
-                  Agent Filter
-                  <span className="text-zinc-500 font-normal ml-1">(optional)</span>
-                </legend>
-                <div className="grid grid-cols-4 gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setFormData({ ...formData, agent_type: null })}
-                    className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                      formData.agent_type === null
-                        ? 'bg-orange-500 text-white'
-                        : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 border border-zinc-700'
-                    }`}
-                    aria-pressed={formData.agent_type === null}
-                  >
-                    All
-                  </button>
-                  {(['claude', 'codex', 'gemini', 'opencode', 'aider', 'goose', 'amp', 'crush', 'kilo', 'kiro', 'droid'] as AgentType[]).map((agent) => (
-                    <button
-                      key={agent}
-                      type="button"
-                      onClick={() => setFormData({ ...formData, agent_type: agent })}
-                      className={`rounded-lg px-3 py-2 text-sm font-medium capitalize transition-colors ${
-                        formData.agent_type === agent
-                          ? 'bg-orange-500 text-white'
-                          : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 border border-zinc-700'
-                      }`}
-                      aria-pressed={formData.agent_type === agent}
-                    >
-                      {agent}
-                    </button>
-                  ))}
-                </div>
-              </fieldset>
-
-              {/* Action selector */}
-              <fieldset className="border-0 p-0 m-0">
-                <legend className="block text-sm font-medium text-zinc-300 mb-1.5">
-                  Action When Triggered
-                </legend>
-                <div className="space-y-2">
-                  {(
-                    ['notify', 'warn_and_slowdown', 'hard_stop'] as AlertAction[]
-                  ).map((action) => {
-                    const info = ACTION_DESCRIPTIONS[action];
-                    const isSelected = formData.action === action;
-                    return (
-                      <button
-                        key={action}
-                        type="button"
-                        onClick={() => setFormData({ ...formData, action })}
-                        className={`w-full rounded-lg px-4 py-3 text-left transition-colors ${
-                          isSelected
-                            ? 'bg-orange-500/10 border-orange-500/50 border'
-                            : 'bg-zinc-800 border border-zinc-700 hover:bg-zinc-700'
-                        }`}
-                        aria-pressed={isSelected}
-                      >
-                        <div className="flex items-center gap-3">
-                          <svg
-                            className={`h-5 w-5 flex-shrink-0 ${
-                              isSelected ? 'text-orange-400' : 'text-zinc-500'
-                            }`}
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            aria-hidden="true"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d={info.icon}
-                            />
-                          </svg>
-                          <div>
-                            <p
-                              className={`text-sm font-medium ${
-                                isSelected ? 'text-orange-300' : 'text-zinc-300'
-                              }`}
-                            >
-                              {info.label}
-                            </p>
-                            <p className="text-xs text-zinc-500">{info.description}</p>
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </fieldset>
-            </div>
-
-            {/* Modal actions */}
-            <div className="flex items-center justify-end gap-3 mt-6 pt-4 border-t border-zinc-800">
-              <button
-                onClick={handleCloseModal}
-                className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 transition-colors"
-                disabled={isSubmitting}
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSubmit}
-                disabled={isSubmitting || !formData.name.trim() || formData.threshold_usd <= 0}
-                className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-              >
-                {isSubmitting && (
-                  <div
-                    className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
-                    aria-hidden="true"
-                  />
-                )}
-                {editingAlert ? 'Save Changes' : 'Create Alert'}
-              </button>
-            </div>
-          </div>
-        </div>
+        <AlertModal
+          editingAlert={editingAlert}
+          formData={formData}
+          onFormChange={setFormData}
+          error={error}
+          isSubmitting={isSubmitting}
+          onClose={handleCloseModal}
+          onSubmit={handleSubmit}
+          focusTrapRef={focusTrapRef}
+        />
       )}
     </div>
   );

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/__tests__/webhook-helpers.test.ts
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/__tests__/webhook-helpers.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for webhook helper pure functions.
+ *
+ * WHY co-located: These helpers are folder-local utilities; tests sit next
+ * to them so a future refactor of `_components/` keeps tests in lockstep
+ * with implementation.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatLastSuccess,
+  getDeliveryStatusClasses,
+  getEventColors,
+  isFormSubmittable,
+  toggleEvent,
+} from '../webhook-helpers';
+import { EVENT_COLORS, FALLBACK_EVENT_COLORS, type WebhookEvent } from '../webhook-types';
+
+describe('getEventColors', () => {
+  it('returns the mapped colors for known events', () => {
+    expect(getEventColors('session.started')).toEqual(EVENT_COLORS['session.started']);
+    expect(getEventColors('session.completed')).toEqual(EVENT_COLORS['session.completed']);
+    expect(getEventColors('budget.exceeded')).toEqual(EVENT_COLORS['budget.exceeded']);
+    expect(getEventColors('permission.requested')).toEqual(
+      EVENT_COLORS['permission.requested'],
+    );
+  });
+
+  it('returns the neutral fallback for unknown events', () => {
+    expect(getEventColors('unknown.event')).toEqual(FALLBACK_EVENT_COLORS);
+    expect(getEventColors('')).toEqual(FALLBACK_EVENT_COLORS);
+  });
+});
+
+describe('formatLastSuccess', () => {
+  it('returns the empty-state copy when null', () => {
+    expect(formatLastSuccess(null)).toBe('No deliveries yet');
+  });
+
+  it('formats a valid ISO timestamp into a short locale string', () => {
+    const formatted = formatLastSuccess('2026-04-20T15:30:00.000Z');
+    // Just assert non-empty + not the empty-state string. Locale formatting
+    // can vary across CI nodes — we don't pin TZ in vitest.setup.
+    expect(formatted).not.toBe('No deliveries yet');
+    expect(formatted.length).toBeGreaterThan(0);
+  });
+});
+
+describe('toggleEvent', () => {
+  it('adds an event when not present', () => {
+    const result = toggleEvent(['session.started'], 'budget.exceeded');
+    expect(result).toEqual(['session.started', 'budget.exceeded']);
+  });
+
+  it('removes an event when present', () => {
+    const result = toggleEvent(
+      ['session.started', 'budget.exceeded'],
+      'session.started',
+    );
+    expect(result).toEqual(['budget.exceeded']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input: WebhookEvent[] = ['session.started'];
+    toggleEvent(input, 'session.completed');
+    expect(input).toEqual(['session.started']);
+  });
+
+  it('handles toggling on an empty list', () => {
+    expect(toggleEvent([], 'session.started')).toEqual(['session.started']);
+  });
+});
+
+describe('isFormSubmittable', () => {
+  it('returns true when name + url + at least one event are present', () => {
+    expect(
+      isFormSubmittable({
+        name: 'Slack',
+        url: 'https://example.com',
+        events: ['session.started'],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when name is whitespace only', () => {
+    expect(
+      isFormSubmittable({
+        name: '   ',
+        url: 'https://example.com',
+        events: ['session.started'],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when url is whitespace only', () => {
+    expect(
+      isFormSubmittable({
+        name: 'Slack',
+        url: '   ',
+        events: ['session.started'],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when no events are selected', () => {
+    expect(
+      isFormSubmittable({ name: 'Slack', url: 'https://example.com', events: [] }),
+    ).toBe(false);
+  });
+});
+
+describe('getDeliveryStatusClasses', () => {
+  it('returns green classes for success', () => {
+    expect(getDeliveryStatusClasses('success')).toContain('green');
+  });
+
+  it('returns yellow classes for pending', () => {
+    expect(getDeliveryStatusClasses('pending')).toContain('yellow');
+  });
+
+  it('returns red classes for any other status (treated as failure)', () => {
+    expect(getDeliveryStatusClasses('failed')).toContain('red');
+    expect(getDeliveryStatusClasses('timeout')).toContain('red');
+    expect(getDeliveryStatusClasses('')).toContain('red');
+  });
+});

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/delivery-log-modal.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/delivery-log-modal.tsx
@@ -1,0 +1,176 @@
+/**
+ * DeliveryLogModal
+ *
+ * Modal that fetches and displays recent webhook delivery attempts for the
+ * selected webhook. Limited to the last 20 deliveries server-side.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { getDeliveryStatusClasses } from './webhook-helpers';
+import type { Webhook, WebhookDelivery } from './webhook-types';
+
+interface DeliveryLogModalProps {
+  webhook: Webhook;
+  onClose: () => void;
+}
+
+/**
+ * Renders the delivery log modal.
+ *
+ * WHY useEffect (not useState initializer): The original implementation
+ * fired the fetch from `useState(() => { ... })`, which technically works
+ * but abuses useState's initializer for side effects. Switched to
+ * useEffect so the intent (run-on-mount side effect) is explicit and
+ * compatible with React Strict Mode's expectations.
+ */
+export function DeliveryLogModal({ webhook, onClose }: DeliveryLogModalProps) {
+  const [deliveries, setDeliveries] = useState<WebhookDelivery[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    /**
+     * Fetch the latest 20 delivery attempts for the selected webhook.
+     * Cancellation guard avoids state writes after unmount.
+     */
+    async function fetchDeliveries() {
+      try {
+        const response = await fetch(
+          `/api/webhooks/user/deliveries?webhookId=${webhook.id}&limit=20`,
+        );
+        const data = await response.json();
+
+        if (cancelled) return;
+
+        if (response.ok) {
+          setDeliveries(data.deliveries || []);
+        } else {
+          setError(data.error || 'Failed to load deliveries');
+        }
+      } catch {
+        if (!cancelled) setError('Network error');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchDeliveries();
+    return () => {
+      cancelled = true;
+    };
+  }, [webhook.id]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center p-0 md:p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Webhook delivery log"
+    >
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative w-full md:w-auto md:min-w-[40rem] max-w-2xl max-h-[85vh] overflow-hidden rounded-t-xl md:rounded-xl bg-zinc-900 border border-zinc-800 shadow-xl flex flex-col">
+        <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-zinc-100">Delivery Log</h2>
+            <p className="text-sm text-zinc-500">{webhook.name}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
+            aria-label="Close delivery log"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          {loading && (
+            <div className="flex items-center justify-center py-8">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-zinc-600 border-t-orange-500" />
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3">
+              <p className="text-sm text-red-400">{error}</p>
+            </div>
+          )}
+
+          {!loading && !error && deliveries.length === 0 && (
+            <div className="text-center py-8">
+              <p className="text-zinc-500">No deliveries yet</p>
+              <p className="text-sm text-zinc-500 mt-1">
+                Deliveries will appear here once events are triggered
+              </p>
+            </div>
+          )}
+
+          {!loading && !error && deliveries.length > 0 && (
+            <div className="space-y-3">
+              {deliveries.map((delivery) => (
+                <DeliveryRow key={delivery.id} delivery={delivery} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renders a single delivery attempt row.
+ */
+function DeliveryRow({ delivery }: { delivery: WebhookDelivery }) {
+  return (
+    <div className="rounded-lg bg-zinc-800 border border-zinc-700 p-4">
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${getDeliveryStatusClasses(delivery.status)}`}
+          >
+            {delivery.status}
+          </span>
+          <span className="text-sm text-zinc-300">{delivery.event}</span>
+        </div>
+        <span className="text-xs text-zinc-500">
+          {new Date(delivery.created_at).toLocaleString()}
+        </span>
+      </div>
+      <div className="text-xs text-zinc-500 flex items-center gap-3">
+        {delivery.response_status && <span>HTTP {delivery.response_status}</span>}
+        {delivery.duration_ms !== null && <span>{delivery.duration_ms}ms</span>}
+        <span>Attempts: {delivery.attempts}</span>
+      </div>
+      {delivery.error_message && (
+        <p
+          className="mt-2 text-xs text-red-400 truncate"
+          title={delivery.error_message}
+        >
+          {delivery.error_message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/index.ts
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Barrel of public symbols for the webhooks orchestrator.
+ *
+ * WHY narrow surface: Only the orchestrator should reach into this folder,
+ * and it only needs the top-level components + the domain types it threads
+ * through props. Helpers and the icon-button primitive stay private to
+ * this folder so future refactors don't have to track external consumers.
+ */
+
+export { DeliveryLogModal } from './delivery-log-modal';
+export { WebhookCard } from './webhook-card';
+export { WebhookEmptyState } from './webhook-empty-state';
+export { WebhookFormModal } from './webhook-form-modal';
+export { WebhookHeader } from './webhook-header';
+export { WebhookTestToast } from './webhook-test-toast';
+
+export type {
+  Webhook,
+  WebhookEvent,
+  WebhookFormData,
+  WebhookTestMessage,
+} from './webhook-types';
+export { DEFAULT_FORM_DATA } from './webhook-types';
+
+// WHY exposed: orchestrator's submit handler toggles event-set membership
+// with this pure helper. Exporting it via the barrel keeps the orchestrator's
+// import surface uniform — see PR #97 reviewer NIT #8.
+export { toggleEvent } from './webhook-helpers';

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-card.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-card.tsx
@@ -1,0 +1,211 @@
+/**
+ * WebhookCard
+ *
+ * Single webhook row on the management page. Owns the per-card layout
+ * (header, event badges, footer/actions) and forwards intent to the
+ * orchestrator via callback props. Owns no state.
+ */
+
+import { formatLastSuccess, getEventColors } from './webhook-helpers';
+import { WebhookIconButton } from './webhook-icon-button';
+import type { Webhook } from './webhook-types';
+
+interface WebhookCardProps {
+  webhook: Webhook;
+  /** True when a delete request is in-flight for this webhook. */
+  isDeleting: boolean;
+  /** True when an enable/disable toggle is in-flight. */
+  isToggling: boolean;
+  /** True when a test event is being dispatched. */
+  isTesting: boolean;
+  onToggle: (webhook: Webhook) => void;
+  onTest: (webhook: Webhook) => void;
+  onOpenDeliveries: (webhook: Webhook) => void;
+  onEdit: (webhook: Webhook) => void;
+  onDelete: (webhookId: string) => void;
+}
+
+/**
+ * Renders one webhook card.
+ *
+ * Visual cues:
+ *   - Disabled webhooks render at 60% opacity.
+ *   - Cards being deleted go to 30% opacity and stop accepting clicks.
+ *   - Webhooks with consecutive failures show a red "N failures" pill.
+ */
+export function WebhookCard({
+  webhook,
+  isDeleting,
+  isToggling,
+  isTesting,
+  onToggle,
+  onTest,
+  onOpenDeliveries,
+  onEdit,
+  onDelete,
+}: WebhookCardProps) {
+  const hasFailures = webhook.consecutive_failures > 0;
+
+  return (
+    <div
+      className={`rounded-xl bg-zinc-900 border border-zinc-800 p-4 transition-opacity ${
+        !webhook.is_active ? 'opacity-60' : ''
+      } ${isDeleting ? 'opacity-30 pointer-events-none' : ''}`}
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex-1 min-w-0 mr-4">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-zinc-100">{webhook.name}</h3>
+            {hasFailures && (
+              <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-red-500/10 text-red-400">
+                {webhook.consecutive_failures} failures
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-zinc-500 mt-1 truncate" title={webhook.url}>
+            {webhook.url}
+          </p>
+        </div>
+        {/* Toggle switch */}
+        <label className="relative inline-flex cursor-pointer items-center flex-shrink-0">
+          <input
+            type="checkbox"
+            className="peer sr-only"
+            checked={webhook.is_active}
+            onChange={() => onToggle(webhook)}
+            disabled={isToggling}
+            aria-label={`${webhook.is_active ? 'Disable' : 'Enable'} ${webhook.name}`}
+          />
+          <div className="h-5 w-9 rounded-full bg-zinc-700 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all peer-checked:bg-orange-500 peer-checked:after:translate-x-full" />
+        </label>
+      </div>
+
+      {/* Event badges */}
+      <div className="flex flex-wrap gap-2 mb-3">
+        {webhook.events.map((event) => {
+          const colors = getEventColors(event);
+          return (
+            <span
+              key={event}
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colors.bg} ${colors.text}`}
+            >
+              {event}
+            </span>
+          );
+        })}
+      </div>
+
+      {/* Footer with status and actions */}
+      <div className="flex items-center justify-between">
+        <div className="text-xs text-zinc-500">
+          {webhook.last_success_at ? (
+            <span className="text-green-400">
+              Last success: {formatLastSuccess(webhook.last_success_at)}
+            </span>
+          ) : (
+            <span>{formatLastSuccess(null)}</span>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-1">
+          <WebhookIconButton
+            onClick={() => onTest(webhook)}
+            disabled={isTesting || !webhook.is_active}
+            ariaLabel={`Test ${webhook.name}`}
+            title="Send test event"
+          >
+            {isTesting ? (
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-500 border-t-zinc-300" />
+            ) : (
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            )}
+          </WebhookIconButton>
+
+          <WebhookIconButton
+            onClick={() => onOpenDeliveries(webhook)}
+            ariaLabel={`View delivery log for ${webhook.name}`}
+            title="View delivery log"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+              />
+            </svg>
+          </WebhookIconButton>
+
+          <WebhookIconButton
+            onClick={() => onEdit(webhook)}
+            ariaLabel={`Edit ${webhook.name}`}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+              />
+            </svg>
+          </WebhookIconButton>
+
+          <WebhookIconButton
+            onClick={() => onDelete(webhook.id)}
+            disabled={isDeleting}
+            ariaLabel={`Delete ${webhook.name}`}
+            variant="danger"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </WebhookIconButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-empty-state.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-empty-state.tsx
@@ -1,0 +1,74 @@
+/**
+ * Webhook Empty State
+ *
+ * Shown when the user has no webhooks. Two variants based on tier:
+ *   - tier supports webhooks → invite the user to create their first
+ *   - tier does not (limit === 0) → invite the user to upgrade
+ */
+
+import Link from 'next/link';
+
+interface WebhookEmptyStateProps {
+  /** Tier limit; 0 means the user must upgrade before creating any. */
+  webhookLimit: number;
+  /** Open the create modal (only used when webhookLimit > 0). */
+  onCreate: () => void;
+}
+
+/**
+ * Renders the empty-state card for the webhooks page.
+ *
+ * When the tier has zero quota, the CTA links to /pricing instead of
+ * opening the create modal — there's nothing to create until they upgrade.
+ */
+export function WebhookEmptyState({ webhookLimit, onCreate }: WebhookEmptyStateProps) {
+  return (
+    <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
+      <div className="mx-auto h-16 w-16 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
+        <svg
+          className="h-8 w-8 text-zinc-500"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+          />
+        </svg>
+      </div>
+      <h3 className="text-lg font-medium text-zinc-100 mb-2">No webhooks</h3>
+      {webhookLimit > 0 ? (
+        <>
+          <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
+            Create webhooks to receive event notifications in Slack, Discord,
+            or any custom endpoint.
+          </p>
+          <button
+            onClick={onCreate}
+            className="rounded-lg bg-orange-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
+            aria-label="Create your first webhook"
+          >
+            Create Your First Webhook
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
+            Webhooks let you integrate Styrby with Slack, Discord, and more.
+            Upgrade to Pro to create webhooks.
+          </p>
+          <Link
+            href="/pricing"
+            className="inline-block rounded-lg bg-orange-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
+          >
+            Upgrade to Pro
+          </Link>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-form-modal.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-form-modal.tsx
@@ -1,0 +1,286 @@
+/**
+ * WebhookFormModal
+ *
+ * Bottom-sheet / centered modal for creating or editing a webhook, plus a
+ * post-create state that surfaces the freshly-generated signing secret.
+ *
+ * WHY one component, two states: The "form" and "secret" panels share the
+ * same backdrop, container, and close behavior. Splitting them would
+ * duplicate the chrome and risk the two halves drifting visually.
+ */
+
+import { EVENT_OPTIONS, type WebhookFormData, type WebhookEvent } from './webhook-types';
+import { isFormSubmittable } from './webhook-helpers';
+
+interface WebhookFormModalProps {
+  /** True when editing an existing webhook (changes title + button label). */
+  isEditing: boolean;
+  formData: WebhookFormData;
+  /** Validation/server error to display above the form. */
+  error: string | null;
+  /** Whether a create/edit request is in flight. */
+  isSubmitting: boolean;
+  /**
+   * If non-null, the modal switches to the "secret created" panel. The
+   * close handler is suppressed on backdrop click in this state to prevent
+   * accidental loss of the secret.
+   */
+  createdSecret: string | null;
+  onClose: () => void;
+  onSubmit: () => void;
+  onChangeName: (name: string) => void;
+  onChangeUrl: (url: string) => void;
+  onToggleEvent: (event: WebhookEvent) => void;
+}
+
+/**
+ * Renders the create/edit modal or the post-create secret reveal.
+ */
+export function WebhookFormModal({
+  isEditing,
+  formData,
+  error,
+  isSubmitting,
+  createdSecret,
+  onClose,
+  onSubmit,
+  onChangeName,
+  onChangeUrl,
+  onToggleEvent,
+}: WebhookFormModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center p-0 md:p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={isEditing ? 'Edit webhook' : 'Create webhook'}
+    >
+      {/* Backdrop — disabled while showing the secret to prevent loss */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={createdSecret ? undefined : onClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative w-full md:w-auto md:min-w-[32rem] max-w-lg max-h-[85vh] overflow-y-auto rounded-t-xl md:rounded-xl bg-zinc-900 border border-zinc-800 p-6 shadow-xl">
+        {createdSecret ? (
+          <SecretRevealPanel secret={createdSecret} onClose={onClose} />
+        ) : (
+          <CreateEditPanel
+            isEditing={isEditing}
+            formData={formData}
+            error={error}
+            isSubmitting={isSubmitting}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            onChangeName={onChangeName}
+            onChangeUrl={onChangeUrl}
+            onToggleEvent={onToggleEvent}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internal panels
+// ---------------------------------------------------------------------------
+
+interface SecretRevealPanelProps {
+  secret: string;
+  onClose: () => void;
+}
+
+/**
+ * One-time reveal of the newly-minted webhook signing secret.
+ *
+ * The user MUST copy this now — it is hashed at rest server-side and we
+ * cannot show it again. The "Done" CTA confirms acknowledgement.
+ */
+function SecretRevealPanel({ secret, onClose }: SecretRevealPanelProps) {
+  return (
+    <>
+      <h2 className="text-lg font-semibold text-zinc-100 mb-4">Webhook Created!</h2>
+      <div className="mb-4 rounded-lg bg-yellow-500/10 border border-yellow-500/30 px-4 py-3">
+        <p className="text-sm text-yellow-400 mb-2">
+          Save this signing secret now. You will not be able to see it again!
+        </p>
+        <code className="block p-3 bg-zinc-800 rounded text-sm text-zinc-100 font-mono break-all">
+          {secret}
+        </code>
+      </div>
+      <p className="text-sm text-zinc-400 mb-6">
+        Use this secret to verify webhook signatures. Store it securely in your environment variables.
+      </p>
+      <div className="flex justify-end">
+        <button
+          onClick={onClose}
+          className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
+        >
+          Done
+        </button>
+      </div>
+    </>
+  );
+}
+
+interface CreateEditPanelProps {
+  isEditing: boolean;
+  formData: WebhookFormData;
+  error: string | null;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  onChangeName: (name: string) => void;
+  onChangeUrl: (url: string) => void;
+  onToggleEvent: (event: WebhookEvent) => void;
+}
+
+/**
+ * Form panel for create/edit. Renders the three fields (name, URL,
+ * event picker) and the submit/cancel actions.
+ */
+function CreateEditPanel({
+  isEditing,
+  formData,
+  error,
+  isSubmitting,
+  onClose,
+  onSubmit,
+  onChangeName,
+  onChangeUrl,
+  onToggleEvent,
+}: CreateEditPanelProps) {
+  const submittable = isFormSubmittable(formData);
+
+  return (
+    <>
+      <h2 className="text-lg font-semibold text-zinc-100 mb-6">
+        {isEditing ? 'Edit Webhook' : 'Create Webhook'}
+      </h2>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+
+      <div className="space-y-5">
+        <div>
+          <label htmlFor="webhook-name" className="block text-sm font-medium text-zinc-300 mb-1.5">
+            Name
+          </label>
+          <input
+            id="webhook-name"
+            type="text"
+            value={formData.name}
+            onChange={(e) => onChangeName(e.target.value)}
+            placeholder="e.g., Slack Notifications"
+            className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
+            maxLength={100}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="webhook-url" className="block text-sm font-medium text-zinc-300 mb-1.5">
+            Endpoint URL
+          </label>
+          <input
+            id="webhook-url"
+            type="url"
+            value={formData.url}
+            onChange={(e) => onChangeUrl(e.target.value)}
+            placeholder="https://..."
+            className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
+          />
+          <p className="mt-1 text-xs text-zinc-500">Must be HTTPS for production use</p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+            Events to Subscribe
+          </label>
+          <div className="space-y-2">
+            {EVENT_OPTIONS.map((event) => {
+              const isSelected = formData.events.includes(event.value);
+              return (
+                <button
+                  key={event.value}
+                  type="button"
+                  onClick={() => onToggleEvent(event.value)}
+                  className={`w-full rounded-lg px-4 py-3 text-left transition-colors ${
+                    isSelected
+                      ? 'bg-orange-500/10 border-orange-500/50 border'
+                      : 'bg-zinc-800 border border-zinc-700 hover:bg-zinc-700'
+                  }`}
+                  aria-pressed={isSelected}
+                >
+                  <div className="flex items-center gap-3">
+                    <div
+                      className={`h-4 w-4 rounded border-2 flex items-center justify-center ${
+                        isSelected
+                          ? 'bg-orange-500 border-orange-500'
+                          : 'border-zinc-500'
+                      }`}
+                    >
+                      {isSelected && (
+                        <svg
+                          className="h-3 w-3 text-white"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={3}
+                            d="M5 13l4 4L19 7"
+                          />
+                        </svg>
+                      )}
+                    </div>
+                    <div>
+                      <p
+                        className={`text-sm font-medium ${
+                          isSelected ? 'text-orange-300' : 'text-zinc-300'
+                        }`}
+                      >
+                        {event.label}
+                      </p>
+                      <p className="text-xs text-zinc-500">{event.description}</p>
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-3 mt-6 pt-4 border-t border-zinc-800">
+        <button
+          onClick={onClose}
+          className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 transition-colors"
+          disabled={isSubmitting}
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onSubmit}
+          disabled={isSubmitting || !submittable}
+          className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+        >
+          {isSubmitting && (
+            <div
+              className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
+              aria-hidden="true"
+            />
+          )}
+          {isEditing ? 'Save Changes' : 'Create Webhook'}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-header.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-header.tsx
@@ -1,0 +1,100 @@
+/**
+ * Webhook Header
+ *
+ * Top bar of the webhooks settings page: usage indicator, docs link, back
+ * link, and the create-or-upgrade CTA.
+ *
+ * WHY split: Decouples the orchestrator from the tier/quota CTA branching,
+ * which has three states (can-create / locked-on-free / hit-limit-on-paid).
+ */
+
+import Link from 'next/link';
+
+interface WebhookHeaderProps {
+  /** Active webhook count for the user. */
+  webhookCount: number;
+  /** Hard limit by tier. 0 means tier has no webhook access. */
+  webhookLimit: number;
+  /** User's plan name shown in parentheses. */
+  tier: string;
+  /** Whether the user is below their limit. */
+  canCreateWebhook: boolean;
+  /** Open the create modal. */
+  onCreate: () => void;
+}
+
+/**
+ * Renders the top header strip for the webhooks page.
+ *
+ * Shows quota usage on the left and the primary CTA on the right. The CTA
+ * routes to /pricing when the user is at or above their tier limit.
+ */
+export function WebhookHeader({
+  webhookCount,
+  webhookLimit,
+  tier,
+  canCreateWebhook,
+  onCreate,
+}: WebhookHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center gap-4">
+        <p className="text-sm text-zinc-400">
+          {webhookCount} / {webhookLimit} webhooks used
+          <span className="text-zinc-500 ml-2">({tier} plan)</span>
+        </p>
+        <Link
+          href="/dashboard/settings/webhooks/docs"
+          className="text-sm text-orange-400 hover:text-orange-300 transition-colors"
+        >
+          View Documentation
+        </Link>
+      </div>
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard/settings"
+          className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 transition-colors"
+        >
+          Back to Settings
+        </Link>
+        {canCreateWebhook ? (
+          <button
+            onClick={onCreate}
+            className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors flex items-center gap-2"
+            aria-label="Create a new webhook"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            Create Webhook
+          </button>
+        ) : webhookLimit === 0 ? (
+          <Link
+            href="/pricing"
+            className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
+          >
+            Upgrade to Pro
+          </Link>
+        ) : (
+          <Link
+            href="/pricing"
+            className="rounded-lg border border-orange-500/50 px-4 py-2 text-sm font-medium text-orange-400 hover:bg-orange-500/10 transition-colors"
+          >
+            Upgrade for More
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-helpers.ts
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-helpers.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure helper functions for the webhooks UI.
+ *
+ * WHY split out: Each helper is deterministic and side-effect free, so we
+ * can unit test them in isolation rather than dragging the React tree into
+ * every assertion. Also keeps the orchestrator and presentation components
+ * free of formatting noise.
+ */
+
+import {
+  EVENT_COLORS,
+  FALLBACK_EVENT_COLORS,
+  type WebhookEvent,
+} from './webhook-types';
+
+/**
+ * Resolve the badge color pair for an arbitrary event string.
+ *
+ * Falls back to neutral zinc when the event is not in the known map, which
+ * happens if the backend introduces a new event type before the client is
+ * updated. We render the badge instead of crashing or hiding the event.
+ *
+ * @param event - Event identifier from `webhook.events`.
+ * @returns `{ bg, text }` Tailwind class pair for the badge.
+ */
+export function getEventColors(event: string): { bg: string; text: string } {
+  return EVENT_COLORS[event as WebhookEvent] ?? FALLBACK_EVENT_COLORS;
+}
+
+/**
+ * Format a webhook's last-success timestamp for the card footer.
+ *
+ * @param iso - ISO 8601 timestamp or null.
+ * @returns Human-friendly string, or `'No deliveries yet'` when null.
+ */
+export function formatLastSuccess(iso: string | null): string {
+  if (!iso) return 'No deliveries yet';
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Toggle membership of `event` inside the `events` array.
+ *
+ * Used by the form's event picker. Order is preserved on remove; appended
+ * to the end on add. Idempotent for missing events (returns a fresh copy).
+ *
+ * @param events - Current selected events.
+ * @param event - Event to toggle in/out of selection.
+ * @returns A new array; never mutates the input.
+ */
+export function toggleEvent(
+  events: WebhookEvent[],
+  event: WebhookEvent,
+): WebhookEvent[] {
+  return events.includes(event)
+    ? events.filter((e) => e !== event)
+    : [...events, event];
+}
+
+/**
+ * Whether the create/edit form is ready for submission.
+ *
+ * All three fields are required: trimmed name + trimmed URL + at least one
+ * event. Centralised so the submit button and an upcoming form-level
+ * validation message stay in sync.
+ *
+ * @param form - Current form state.
+ * @returns true when the user can hit submit.
+ */
+export function isFormSubmittable(form: {
+  name: string;
+  url: string;
+  events: readonly WebhookEvent[];
+}): boolean {
+  return (
+    form.name.trim().length > 0 &&
+    form.url.trim().length > 0 &&
+    form.events.length > 0
+  );
+}
+
+/**
+ * Color classes for a delivery row's status badge.
+ *
+ * Treats anything other than `success` / `pending` as a failure (red),
+ * matching the backend's three-state model in the `webhook_deliveries`
+ * table.
+ */
+export function getDeliveryStatusClasses(status: string): string {
+  if (status === 'success') return 'bg-green-500/10 text-green-400';
+  if (status === 'pending') return 'bg-yellow-500/10 text-yellow-400';
+  return 'bg-red-500/10 text-red-400';
+}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-icon-button.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-icon-button.tsx
@@ -1,0 +1,61 @@
+/**
+ * WebhookIconButton
+ *
+ * A small icon-only button used by the action row on every webhook card.
+ *
+ * WHY a primitive: Each card has 4 nearly-identical action buttons (test,
+ * deliveries, edit, delete). Extracting a primitive prevents copy-paste
+ * drift in their styling and aria handling.
+ */
+
+import type { ReactNode } from 'react';
+
+interface WebhookIconButtonProps {
+  /** Icon content (an SVG). */
+  children: ReactNode;
+  /** Click handler. */
+  onClick: () => void;
+  /** Accessible label for screen readers. */
+  ariaLabel: string;
+  /** Optional native title (tooltip on hover). */
+  title?: string;
+  /** Disable the button (e.g., while a request is in flight). */
+  disabled?: boolean;
+  /**
+   * Visual variant. `danger` highlights the button red on hover, used by
+   * the delete action.
+   */
+  variant?: 'default' | 'danger';
+}
+
+/**
+ * Small icon button used in webhook card action rows.
+ *
+ * Centralises padding, hover, and disabled styling so all four buttons in
+ * a card stay visually consistent.
+ */
+export function WebhookIconButton({
+  children,
+  onClick,
+  ariaLabel,
+  title,
+  disabled,
+  variant = 'default',
+}: WebhookIconButtonProps) {
+  const hoverClasses =
+    variant === 'danger'
+      ? 'hover:text-red-400 hover:bg-red-500/10'
+      : 'hover:text-zinc-300 hover:bg-zinc-800';
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`p-1.5 rounded-lg text-zinc-500 transition-colors disabled:opacity-50 ${hoverClasses}`}
+      aria-label={ariaLabel}
+      title={title}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-test-toast.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-test-toast.tsx
@@ -1,0 +1,32 @@
+/**
+ * WebhookTestToast
+ *
+ * Inline success/error banner displayed above the webhook list after the
+ * user dispatches a test event. Auto-clears after 5s in the orchestrator.
+ */
+
+import type { WebhookTestMessage } from './webhook-types';
+
+interface WebhookTestToastProps {
+  message: WebhookTestMessage;
+}
+
+/**
+ * Renders the test event result banner.
+ */
+export function WebhookTestToast({ message }: WebhookTestToastProps) {
+  const isSuccess = message.type === 'success';
+  return (
+    <div
+      className={`mb-4 rounded-lg px-4 py-3 ${
+        isSuccess
+          ? 'bg-green-500/10 border border-green-500/30'
+          : 'bg-red-500/10 border border-red-500/30'
+      }`}
+    >
+      <p className={`text-sm ${isSuccess ? 'text-green-400' : 'text-red-400'}`}>
+        {message.text}
+      </p>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-types.ts
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-types.ts
@@ -1,0 +1,142 @@
+/**
+ * Webhook Domain Types and Constants
+ *
+ * Co-located with the webhooks settings page since these types are only
+ * consumed by the webhooks client tree. If/when other features (e.g. mobile
+ * client, edge functions) need them, promote to packages/styrby-shared.
+ *
+ * WHY co-location: Avoids cross-app type drift while these UI shapes are
+ * still in flux. The DB row shape itself lives in the Supabase schema and
+ * is mirrored here for the client component layer.
+ */
+
+// ---------------------------------------------------------------------------
+// Domain Types
+// ---------------------------------------------------------------------------
+
+/** Valid webhook event types emitted by the Styrby backend. */
+export type WebhookEvent =
+  | 'session.started'
+  | 'session.completed'
+  | 'budget.exceeded'
+  | 'permission.requested';
+
+/**
+ * Webhook row as returned from the Supabase `webhooks` table.
+ *
+ * Mirrors the DB schema shape — keep in sync with
+ * supabase/migrations defining the `webhooks` table.
+ */
+export interface Webhook {
+  /** Unique identifier (UUID). */
+  id: string;
+  /** Human-readable name shown in the UI. */
+  name: string;
+  /** HTTPS endpoint receiving signed payloads. */
+  url: string;
+  /** Subscribed events; stored as `text[]` in Postgres. */
+  events: string[];
+  /** Whether the webhook actively delivers events. */
+  is_active: boolean;
+  /** ISO timestamp of last 2xx delivery, null if never. */
+  last_success_at: string | null;
+  /** ISO timestamp of last failed delivery, null if never. */
+  last_failure_at: string | null;
+  /** Consecutive failures since the last success; drives the failure badge. */
+  consecutive_failures: number;
+  /** ISO timestamp when the webhook was created. */
+  created_at: string;
+  /** ISO timestamp when the webhook was last modified. */
+  updated_at: string;
+}
+
+/**
+ * A single delivery attempt log row used by the delivery log modal.
+ */
+export interface WebhookDelivery {
+  id: string;
+  event: string;
+  status: string;
+  attempts: number;
+  response_status: number | null;
+  error_message: string | null;
+  duration_ms: number | null;
+  created_at: string;
+}
+
+/** Form state for the create/edit modal. */
+export interface WebhookFormData {
+  name: string;
+  url: string;
+  events: WebhookEvent[];
+}
+
+/** Inline toast for test-event feedback. */
+export interface WebhookTestMessage {
+  type: 'success' | 'error';
+  text: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Event metadata shown in the create/edit form.
+ *
+ * WHY array (not map): Render order is significant in the UI — showing
+ * session lifecycle events before alert events matches the user's mental
+ * model of "what happens, then what to alert on".
+ */
+export const EVENT_OPTIONS: ReadonlyArray<{
+  value: WebhookEvent;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'session.started',
+    label: 'Session Started',
+    description: 'When an agent session begins',
+  },
+  {
+    value: 'session.completed',
+    label: 'Session Completed',
+    description: 'When an agent session ends',
+  },
+  {
+    value: 'budget.exceeded',
+    label: 'Budget Exceeded',
+    description: 'When a budget alert threshold is crossed',
+  },
+  {
+    value: 'permission.requested',
+    label: 'Permission Requested',
+    description: 'When an agent requests permission for an action',
+  },
+];
+
+/**
+ * Tailwind color classes for each event badge.
+ *
+ * WHY paired bg/text: Each badge needs both a tinted background and an
+ * accent text color. Bundling them prevents typo drift between the two.
+ */
+export const EVENT_COLORS: Record<WebhookEvent, { bg: string; text: string }> = {
+  'session.started': { bg: 'bg-green-500/10', text: 'text-green-400' },
+  'session.completed': { bg: 'bg-blue-500/10', text: 'text-blue-400' },
+  'budget.exceeded': { bg: 'bg-orange-500/10', text: 'text-orange-400' },
+  'permission.requested': { bg: 'bg-purple-500/10', text: 'text-purple-400' },
+};
+
+/** Fallback colors for any unknown event string in `webhook.events`. */
+export const FALLBACK_EVENT_COLORS = {
+  bg: 'bg-zinc-500/10',
+  text: 'text-zinc-400',
+} as const;
+
+/** Initial value for the create/edit form. */
+export const DEFAULT_FORM_DATA: WebhookFormData = {
+  name: '',
+  url: '',
+  events: [],
+};

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/webhooks-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/webhooks-client.tsx
@@ -1,45 +1,43 @@
 'use client';
 
 /**
- * Webhooks Client Component
+ * Webhooks Client (orchestrator)
  *
- * Interactive UI for managing webhooks. Displays webhook cards with status,
- * event badges, and controls for creating, editing, testing, and deleting webhooks.
+ * Owns webhook state, network calls, and modal coordination. All
+ * presentation lives in `./_components/*`.
  *
- * WHY this is a client component: It requires interactive state management
- * for modals, toggle switches, and optimistic UI updates.
+ * WHY a client component: Interactive state management — modals, toggle
+ * switches, optimistic UI updates — none of which can run on the server.
+ *
+ * WHY orchestrator pattern: The previous monolith mixed list rendering,
+ * card layout, two modals, and four mutation flows in a single 920-line
+ * file. Splitting into one orchestrator + focused presentation children
+ * makes each concern testable, reusable, and below the 400-LOC ceiling.
  */
 
-import { useState, useCallback } from 'react';
-import Link from 'next/link';
+import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
+import {
+  DEFAULT_FORM_DATA,
+  DeliveryLogModal,
+  WebhookCard,
+  WebhookEmptyState,
+  WebhookFormModal,
+  WebhookHeader,
+  WebhookTestToast,
+  toggleEvent,
+  type Webhook,
+  type WebhookEvent,
+  type WebhookFormData,
+  type WebhookTestMessage,
+} from './_components';
+
 // ---------------------------------------------------------------------------
-// Types
+// Props
 // ---------------------------------------------------------------------------
 
-/** Valid webhook event types */
-type WebhookEvent =
-  | 'session.started'
-  | 'session.completed'
-  | 'budget.exceeded'
-  | 'permission.requested';
-
-/** Webhook from the database */
-interface Webhook {
-  id: string;
-  name: string;
-  url: string;
-  events: string[];
-  is_active: boolean;
-  last_success_at: string | null;
-  last_failure_at: string | null;
-  consecutive_failures: number;
-  created_at: string;
-  updated_at: string;
-}
-
-/** Props from server component */
+/** Props from the server component (initial render data). */
 interface WebhooksClientProps {
   initialWebhooks: Webhook[];
   tier: string;
@@ -47,62 +45,8 @@ interface WebhooksClientProps {
   webhookCount: number;
 }
 
-/** Form data for creating/editing webhook */
-interface WebhookFormData {
-  name: string;
-  url: string;
-  events: WebhookEvent[];
-}
-
 // ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/**
- * Event descriptions for the create/edit form.
- */
-const EVENT_OPTIONS: { value: WebhookEvent; label: string; description: string }[] = [
-  {
-    value: 'session.started',
-    label: 'Session Started',
-    description: 'When an agent session begins',
-  },
-  {
-    value: 'session.completed',
-    label: 'Session Completed',
-    description: 'When an agent session ends',
-  },
-  {
-    value: 'budget.exceeded',
-    label: 'Budget Exceeded',
-    description: 'When a budget alert threshold is crossed',
-  },
-  {
-    value: 'permission.requested',
-    label: 'Permission Requested',
-    description: 'When an agent requests permission for an action',
-  },
-];
-
-/**
- * Color scheme for event badges.
- */
-const EVENT_COLORS: Record<WebhookEvent, { bg: string; text: string }> = {
-  'session.started': { bg: 'bg-green-500/10', text: 'text-green-400' },
-  'session.completed': { bg: 'bg-blue-500/10', text: 'text-blue-400' },
-  'budget.exceeded': { bg: 'bg-orange-500/10', text: 'text-orange-400' },
-  'permission.requested': { bg: 'bg-purple-500/10', text: 'text-purple-400' },
-};
-
-/** Default form values */
-const DEFAULT_FORM_DATA: WebhookFormData = {
-  name: '',
-  url: '',
-  events: [],
-};
-
-// ---------------------------------------------------------------------------
-// Main Component
+// Component
 // ---------------------------------------------------------------------------
 
 /**
@@ -110,6 +54,11 @@ const DEFAULT_FORM_DATA: WebhookFormData = {
  *
  * Renders a list of webhook cards with status indicators and controls,
  * plus modals for creating/editing webhooks and viewing delivery logs.
+ *
+ * @param initialWebhooks - SSR-fetched webhooks for the user.
+ * @param tier - User's plan tier (e.g., "Free", "Power").
+ * @param webhookLimit - Maximum webhooks the user can create on their tier.
+ * @param webhookCount - Initial count of active webhooks for the user.
  */
 export function WebhooksClient({
   initialWebhooks,
@@ -118,25 +67,33 @@ export function WebhooksClient({
   webhookCount: initialCount,
 }: WebhooksClientProps) {
   const router = useRouter();
+
+  // List + quota state
   const [webhooks, setWebhooks] = useState<Webhook[]>(initialWebhooks);
   const [webhookCount, setWebhookCount] = useState(initialCount);
+
+  // Modal state
   const [showModal, setShowModal] = useState(false);
   const [showDeliveryModal, setShowDeliveryModal] = useState(false);
   const [editingWebhook, setEditingWebhook] = useState<Webhook | null>(null);
   const [selectedWebhook, setSelectedWebhook] = useState<Webhook | null>(null);
+
+  // Form state
   const [formData, setFormData] = useState<WebhookFormData>(DEFAULT_FORM_DATA);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createdSecret, setCreatedSecret] = useState<string | null>(null);
+
+  // Per-row pending state
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [testingId, setTestingId] = useState<string | null>(null);
-  const [testMessage, setTestMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [testMessage, setTestMessage] = useState<WebhookTestMessage | null>(null);
 
   const canCreateWebhook = webhookCount < webhookLimit;
 
   // -------------------------------------------------------------------------
-  // Modal Handlers
+  // Modal handlers
   // -------------------------------------------------------------------------
 
   const handleOpenCreate = useCallback(() => {
@@ -178,22 +135,30 @@ export function WebhooksClient({
   }, []);
 
   // -------------------------------------------------------------------------
-  // Event Toggle Handler
+  // Form change handlers
   // -------------------------------------------------------------------------
 
+  const handleChangeName = useCallback((name: string) => {
+    setFormData((prev) => ({ ...prev, name }));
+  }, []);
+
+  const handleChangeUrl = useCallback((url: string) => {
+    setFormData((prev) => ({ ...prev, url }));
+  }, []);
+
   const handleEventToggle = useCallback((event: WebhookEvent) => {
-    setFormData((prev) => ({
-      ...prev,
-      events: prev.events.includes(event)
-        ? prev.events.filter((e) => e !== event)
-        : [...prev.events, event],
-    }));
+    setFormData((prev) => ({ ...prev, events: toggleEvent(prev.events, event) }));
   }, []);
 
   // -------------------------------------------------------------------------
-  // CRUD Operations
+  // CRUD operations
   // -------------------------------------------------------------------------
 
+  /**
+   * Submit create or edit. On create with a returned secret, switches the
+   * modal into the secret-reveal panel; on edit, optimistically updates
+   * the list and refreshes the route to re-fetch SSR state.
+   */
   const handleSubmit = useCallback(async () => {
     setIsSubmitting(true);
     setError(null);
@@ -204,7 +169,7 @@ export function WebhooksClient({
         method: isEdit ? 'PATCH' : 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(
-          isEdit ? { id: editingWebhook.id, ...formData } : formData
+          isEdit ? { id: editingWebhook.id, ...formData } : formData,
         ),
       });
 
@@ -216,7 +181,8 @@ export function WebhooksClient({
       }
 
       if (!isEdit && data.secret) {
-        // Show the secret to the user (only on creation)
+        // WHY: Show signing secret only once at creation — it is hashed
+        // server-side and cannot be re-derived afterwards.
         setCreatedSecret(data.secret);
         setWebhooks((prev) => [data.webhook, ...prev]);
         setWebhookCount((prev) => prev + 1);
@@ -225,7 +191,9 @@ export function WebhooksClient({
         router.refresh();
         if (isEdit) {
           setWebhooks((prev) =>
-            prev.map((w) => (w.id === editingWebhook.id ? { ...w, ...data.webhook } : w))
+            prev.map((w) =>
+              w.id === editingWebhook.id ? { ...w, ...data.webhook } : w,
+            ),
           );
         }
       }
@@ -236,15 +204,25 @@ export function WebhooksClient({
     }
   }, [editingWebhook, formData, handleCloseModal, router]);
 
+  /**
+   * Optimistically toggle is_active and revert on any failure so the user
+   * sees instant feedback while still tolerating network errors.
+   */
   const handleToggle = useCallback(async (webhook: Webhook) => {
     setTogglingId(webhook.id);
 
-    // Optimistic update
     setWebhooks((prev) =>
       prev.map((w) =>
-        w.id === webhook.id ? { ...w, is_active: !w.is_active } : w
-      )
+        w.id === webhook.id ? { ...w, is_active: !w.is_active } : w,
+      ),
     );
+
+    const revert = () =>
+      setWebhooks((prev) =>
+        prev.map((w) =>
+          w.id === webhook.id ? { ...w, is_active: webhook.is_active } : w,
+        ),
+      );
 
     try {
       const response = await fetch('/api/webhooks/user', {
@@ -252,53 +230,53 @@ export function WebhooksClient({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: webhook.id, is_active: !webhook.is_active }),
       });
-
-      if (!response.ok) {
-        // Revert on failure
-        setWebhooks((prev) =>
-          prev.map((w) =>
-            w.id === webhook.id ? { ...w, is_active: webhook.is_active } : w
-          )
-        );
-      }
+      if (!response.ok) revert();
     } catch {
-      // Revert on error
-      setWebhooks((prev) =>
-        prev.map((w) =>
-          w.id === webhook.id ? { ...w, is_active: webhook.is_active } : w
-        )
-      );
+      revert();
     } finally {
       setTogglingId(null);
     }
   }, []);
 
-  const handleDelete = useCallback(async (webhookId: string) => {
-    if (!confirm('Are you sure you want to delete this webhook? All delivery history will be lost.')) {
-      return;
-    }
-
-    setDeletingId(webhookId);
-
-    try {
-      const response = await fetch('/api/webhooks/user', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: webhookId }),
-      });
-
-      if (response.ok) {
-        setWebhooks((prev) => prev.filter((w) => w.id !== webhookId));
-        setWebhookCount((prev) => prev - 1);
-        router.refresh();
+  const handleDelete = useCallback(
+    async (webhookId: string) => {
+      // WHY confirm(): Webhook deletion drops all associated delivery
+      // history and cannot be undone. Native confirm is the lightest
+      // possible "are you sure?" guard.
+      if (
+        !confirm(
+          'Are you sure you want to delete this webhook? All delivery history will be lost.',
+        )
+      ) {
+        return;
       }
-    } catch {
-      // Silent fail - webhook remains visible
-    } finally {
-      setDeletingId(null);
-    }
-  }, [router]);
 
+      setDeletingId(webhookId);
+
+      try {
+        const response = await fetch('/api/webhooks/user', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: webhookId }),
+        });
+
+        if (response.ok) {
+          setWebhooks((prev) => prev.filter((w) => w.id !== webhookId));
+          setWebhookCount((prev) => prev - 1);
+          router.refresh();
+        }
+      } catch {
+        // Silent fail - webhook remains visible; user can retry
+      } finally {
+        setDeletingId(null);
+      }
+    },
+    [router],
+  );
+
+  /**
+   * Dispatch a synthetic event to the webhook URL. Toast clears after 5s.
+   */
   const handleTest = useCallback(async (webhook: Webhook) => {
     setTestingId(webhook.id);
     setTestMessage(null);
@@ -313,15 +291,20 @@ export function WebhooksClient({
       const data = await response.json();
 
       if (response.ok) {
-        setTestMessage({ type: 'success', text: data.message || 'Test event sent!' });
+        setTestMessage({
+          type: 'success',
+          text: data.message || 'Test event sent!',
+        });
       } else {
-        setTestMessage({ type: 'error', text: data.error || 'Failed to send test' });
+        setTestMessage({
+          type: 'error',
+          text: data.error || 'Failed to send test',
+        });
       }
     } catch {
       setTestMessage({ type: 'error', text: 'Network error' });
     } finally {
       setTestingId(null);
-      // Clear message after 5 seconds
       setTimeout(() => setTestMessage(null), 5000);
     }
   }, []);
@@ -332,590 +315,57 @@ export function WebhooksClient({
 
   return (
     <div>
-      {/* Header with create button and tier indicator */}
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-4">
-          <p className="text-sm text-zinc-400">
-            {webhookCount} / {webhookLimit} webhooks used
-            <span className="text-zinc-500 ml-2">({tier} plan)</span>
-          </p>
-          <Link
-            href="/dashboard/settings/webhooks/docs"
-            className="text-sm text-orange-400 hover:text-orange-300 transition-colors"
-          >
-            View Documentation
-          </Link>
-        </div>
-        <div className="flex items-center gap-3">
-          <Link
-            href="/dashboard/settings"
-            className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 transition-colors"
-          >
-            Back to Settings
-          </Link>
-          {canCreateWebhook ? (
-            <button
-              onClick={handleOpenCreate}
-              className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors flex items-center gap-2"
-              aria-label="Create a new webhook"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-              Create Webhook
-            </button>
-          ) : webhookLimit === 0 ? (
-            <Link
-              href="/pricing"
-              className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
-            >
-              Upgrade to Pro
-            </Link>
-          ) : (
-            <Link
-              href="/pricing"
-              className="rounded-lg border border-orange-500/50 px-4 py-2 text-sm font-medium text-orange-400 hover:bg-orange-500/10 transition-colors"
-            >
-              Upgrade for More
-            </Link>
-          )}
-        </div>
-      </div>
-
-      {/* Test message toast */}
-      {testMessage && (
-        <div
-          className={`mb-4 rounded-lg px-4 py-3 ${
-            testMessage.type === 'success'
-              ? 'bg-green-500/10 border border-green-500/30'
-              : 'bg-red-500/10 border border-red-500/30'
-          }`}
-        >
-          <p className={`text-sm ${testMessage.type === 'success' ? 'text-green-400' : 'text-red-400'}`}>
-            {testMessage.text}
-          </p>
-        </div>
-      )}
-
-      {/* Empty State */}
-      {webhooks.length === 0 && (
-        <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
-          <div className="mx-auto h-16 w-16 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
-            <svg
-              className="h-8 w-8 text-zinc-500"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-              />
-            </svg>
-          </div>
-          <h3 className="text-lg font-medium text-zinc-100 mb-2">No webhooks</h3>
-          {webhookLimit > 0 ? (
-            <>
-              <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
-                Create webhooks to receive event notifications in Slack, Discord,
-                or any custom endpoint.
-              </p>
-              <button
-                onClick={handleOpenCreate}
-                className="rounded-lg bg-orange-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
-                aria-label="Create your first webhook"
-              >
-                Create Your First Webhook
-              </button>
-            </>
-          ) : (
-            <>
-              <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
-                Webhooks let you integrate Styrby with Slack, Discord, and more.
-                Upgrade to Pro to create webhooks.
-              </p>
-              <Link
-                href="/pricing"
-                className="inline-block rounded-lg bg-orange-500 px-6 py-2.5 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
-              >
-                Upgrade to Pro
-              </Link>
-            </>
-          )}
-        </div>
-      )}
-
-      {/* Webhook Cards */}
-      {webhooks.length > 0 && (
-        <div className="space-y-4">
-          {webhooks.map((webhook) => {
-            const isDeleting = deletingId === webhook.id;
-            const isToggling = togglingId === webhook.id;
-            const isTesting = testingId === webhook.id;
-            const hasFailures = webhook.consecutive_failures > 0;
-
-            return (
-              <div
-                key={webhook.id}
-                className={`rounded-xl bg-zinc-900 border border-zinc-800 p-4 transition-opacity ${
-                  !webhook.is_active ? 'opacity-60' : ''
-                } ${isDeleting ? 'opacity-30 pointer-events-none' : ''}`}
-              >
-                {/* Header row */}
-                <div className="flex items-start justify-between mb-3">
-                  <div className="flex-1 min-w-0 mr-4">
-                    <div className="flex items-center gap-2">
-                      <h3 className="text-sm font-semibold text-zinc-100">
-                        {webhook.name}
-                      </h3>
-                      {hasFailures && (
-                        <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-red-500/10 text-red-400">
-                          {webhook.consecutive_failures} failures
-                        </span>
-                      )}
-                    </div>
-                    <p className="text-xs text-zinc-500 mt-1 truncate" title={webhook.url}>
-                      {webhook.url}
-                    </p>
-                  </div>
-                  {/* Toggle switch */}
-                  <label className="relative inline-flex cursor-pointer items-center flex-shrink-0">
-                    <input
-                      type="checkbox"
-                      className="peer sr-only"
-                      checked={webhook.is_active}
-                      onChange={() => handleToggle(webhook)}
-                      disabled={isToggling}
-                      aria-label={`${webhook.is_active ? 'Disable' : 'Enable'} ${webhook.name}`}
-                    />
-                    <div className="h-5 w-9 rounded-full bg-zinc-700 after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all peer-checked:bg-orange-500 peer-checked:after:translate-x-full" />
-                  </label>
-                </div>
-
-                {/* Event badges */}
-                <div className="flex flex-wrap gap-2 mb-3">
-                  {webhook.events.map((event) => {
-                    const colors = EVENT_COLORS[event as WebhookEvent] || {
-                      bg: 'bg-zinc-500/10',
-                      text: 'text-zinc-400',
-                    };
-                    return (
-                      <span
-                        key={event}
-                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${colors.bg} ${colors.text}`}
-                      >
-                        {event}
-                      </span>
-                    );
-                  })}
-                </div>
-
-                {/* Footer with status and actions */}
-                <div className="flex items-center justify-between">
-                  <div className="text-xs text-zinc-500">
-                    {webhook.last_success_at ? (
-                      <span className="text-green-400">
-                        Last success: {new Date(webhook.last_success_at).toLocaleDateString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          hour: 'numeric',
-                          minute: '2-digit',
-                        })}
-                      </span>
-                    ) : (
-                      <span>No deliveries yet</span>
-                    )}
-                  </div>
-
-                  {/* Action buttons */}
-                  <div className="flex items-center gap-1">
-                    {/* Test */}
-                    <button
-                      onClick={() => handleTest(webhook)}
-                      disabled={isTesting || !webhook.is_active}
-                      className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors disabled:opacity-50"
-                      aria-label={`Test ${webhook.name}`}
-                      title="Send test event"
-                    >
-                      {isTesting ? (
-                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-500 border-t-zinc-300" />
-                      ) : (
-                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
-                      )}
-                    </button>
-                    {/* Delivery log */}
-                    <button
-                      onClick={() => handleOpenDeliveries(webhook)}
-                      className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
-                      aria-label={`View delivery log for ${webhook.name}`}
-                      title="View delivery log"
-                    >
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-                      </svg>
-                    </button>
-                    {/* Edit */}
-                    <button
-                      onClick={() => handleOpenEdit(webhook)}
-                      className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
-                      aria-label={`Edit ${webhook.name}`}
-                    >
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                      </svg>
-                    </button>
-                    {/* Delete */}
-                    <button
-                      onClick={() => handleDelete(webhook.id)}
-                      disabled={isDeleting}
-                      className="p-1.5 rounded-lg text-zinc-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
-                      aria-label={`Delete ${webhook.name}`}
-                    >
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-      {/* Create/Edit Modal */}
-      {showModal && (
-        <div
-          className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center p-0 md:p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-label={editingWebhook ? 'Edit webhook' : 'Create webhook'}
-        >
-          {/* Backdrop */}
-          <div
-            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-            onClick={createdSecret ? undefined : handleCloseModal}
-            aria-hidden="true"
-          />
-
-          {/* Modal content */}
-          <div className="relative w-full md:w-auto md:min-w-[32rem] max-w-lg max-h-[85vh] overflow-y-auto rounded-t-xl md:rounded-xl bg-zinc-900 border border-zinc-800 p-6 shadow-xl">
-            {createdSecret ? (
-              // Secret display after creation
-              <>
-                <h2 className="text-lg font-semibold text-zinc-100 mb-4">
-                  Webhook Created!
-                </h2>
-                <div className="mb-4 rounded-lg bg-yellow-500/10 border border-yellow-500/30 px-4 py-3">
-                  <p className="text-sm text-yellow-400 mb-2">
-                    Save this signing secret now. You will not be able to see it again!
-                  </p>
-                  <code className="block p-3 bg-zinc-800 rounded text-sm text-zinc-100 font-mono break-all">
-                    {createdSecret}
-                  </code>
-                </div>
-                <p className="text-sm text-zinc-400 mb-6">
-                  Use this secret to verify webhook signatures. Store it securely in your environment variables.
-                </p>
-                <div className="flex justify-end">
-                  <button
-                    onClick={handleCloseModal}
-                    className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors"
-                  >
-                    Done
-                  </button>
-                </div>
-              </>
-            ) : (
-              // Create/Edit form
-              <>
-                <h2 className="text-lg font-semibold text-zinc-100 mb-6">
-                  {editingWebhook ? 'Edit Webhook' : 'Create Webhook'}
-                </h2>
-
-                {/* Error message */}
-                {error && (
-                  <div className="mb-4 rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3">
-                    <p className="text-sm text-red-400">{error}</p>
-                  </div>
-                )}
-
-                {/* Form fields */}
-                <div className="space-y-5">
-                  {/* Name */}
-                  <div>
-                    <label htmlFor="webhook-name" className="block text-sm font-medium text-zinc-300 mb-1.5">
-                      Name
-                    </label>
-                    <input
-                      id="webhook-name"
-                      type="text"
-                      value={formData.name}
-                      onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                      placeholder="e.g., Slack Notifications"
-                      className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-                      maxLength={100}
-                    />
-                  </div>
-
-                  {/* URL */}
-                  <div>
-                    <label htmlFor="webhook-url" className="block text-sm font-medium text-zinc-300 mb-1.5">
-                      Endpoint URL
-                    </label>
-                    <input
-                      id="webhook-url"
-                      type="url"
-                      value={formData.url}
-                      onChange={(e) => setFormData({ ...formData, url: e.target.value })}
-                      placeholder="https://..."
-                      className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-                    />
-                    <p className="mt-1 text-xs text-zinc-500">
-                      Must be HTTPS for production use
-                    </p>
-                  </div>
-
-                  {/* Events */}
-                  <div>
-                    <label className="block text-sm font-medium text-zinc-300 mb-1.5">
-                      Events to Subscribe
-                    </label>
-                    <div className="space-y-2">
-                      {EVENT_OPTIONS.map((event) => {
-                        const isSelected = formData.events.includes(event.value);
-                        return (
-                          <button
-                            key={event.value}
-                            type="button"
-                            onClick={() => handleEventToggle(event.value)}
-                            className={`w-full rounded-lg px-4 py-3 text-left transition-colors ${
-                              isSelected
-                                ? 'bg-orange-500/10 border-orange-500/50 border'
-                                : 'bg-zinc-800 border border-zinc-700 hover:bg-zinc-700'
-                            }`}
-                            aria-pressed={isSelected}
-                          >
-                            <div className="flex items-center gap-3">
-                              <div
-                                className={`h-4 w-4 rounded border-2 flex items-center justify-center ${
-                                  isSelected
-                                    ? 'bg-orange-500 border-orange-500'
-                                    : 'border-zinc-500'
-                                }`}
-                              >
-                                {isSelected && (
-                                  <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-                                  </svg>
-                                )}
-                              </div>
-                              <div>
-                                <p className={`text-sm font-medium ${isSelected ? 'text-orange-300' : 'text-zinc-300'}`}>
-                                  {event.label}
-                                </p>
-                                <p className="text-xs text-zinc-500">{event.description}</p>
-                              </div>
-                            </div>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-
-                {/* Modal actions */}
-                <div className="flex items-center justify-end gap-3 mt-6 pt-4 border-t border-zinc-800">
-                  <button
-                    onClick={handleCloseModal}
-                    className="rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 transition-colors"
-                    disabled={isSubmitting}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    onClick={handleSubmit}
-                    disabled={isSubmitting || !formData.name.trim() || !formData.url.trim() || formData.events.length === 0}
-                    className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white hover:bg-orange-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-                  >
-                    {isSubmitting && (
-                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" aria-hidden="true" />
-                    )}
-                    {editingWebhook ? 'Save Changes' : 'Create Webhook'}
-                  </button>
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Delivery Log Modal */}
-      {showDeliveryModal && selectedWebhook && (
-        <DeliveryLogModal
-          webhook={selectedWebhook}
-          onClose={handleCloseDeliveries}
-        />
-      )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Delivery Log Modal Component
-// ---------------------------------------------------------------------------
-
-interface DeliveryLogModalProps {
-  webhook: Webhook;
-  onClose: () => void;
-}
-
-function DeliveryLogModal({ webhook, onClose }: DeliveryLogModalProps) {
-  const [deliveries, setDeliveries] = useState<Array<{
-    id: string;
-    event: string;
-    status: string;
-    attempts: number;
-    response_status: number | null;
-    error_message: string | null;
-    duration_ms: number | null;
-    created_at: string;
-  }>>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // Fetch deliveries on mount
-  useState(() => {
-    async function fetchDeliveries() {
-      try {
-        const response = await fetch(
-          `/api/webhooks/user/deliveries?webhookId=${webhook.id}&limit=20`
-        );
-        const data = await response.json();
-
-        if (response.ok) {
-          setDeliveries(data.deliveries || []);
-        } else {
-          setError(data.error || 'Failed to load deliveries');
-        }
-      } catch {
-        setError('Network error');
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchDeliveries();
-  });
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center p-0 md:p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Webhook delivery log"
-    >
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        onClick={onClose}
-        aria-hidden="true"
+      <WebhookHeader
+        webhookCount={webhookCount}
+        webhookLimit={webhookLimit}
+        tier={tier}
+        canCreateWebhook={canCreateWebhook}
+        onCreate={handleOpenCreate}
       />
 
-      {/* Modal content */}
-      <div className="relative w-full md:w-auto md:min-w-[40rem] max-w-2xl max-h-[85vh] overflow-hidden rounded-t-xl md:rounded-xl bg-zinc-900 border border-zinc-800 shadow-xl flex flex-col">
-        {/* Header */}
-        <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
-          <div>
-            <h2 className="text-lg font-semibold text-zinc-100">Delivery Log</h2>
-            <p className="text-sm text-zinc-500">{webhook.name}</p>
-          </div>
-          <button
-            onClick={onClose}
-            className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
-            aria-label="Close delivery log"
-          >
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+      {testMessage && <WebhookTestToast message={testMessage} />}
+
+      {webhooks.length === 0 && (
+        <WebhookEmptyState webhookLimit={webhookLimit} onCreate={handleOpenCreate} />
+      )}
+
+      {webhooks.length > 0 && (
+        <div className="space-y-4">
+          {webhooks.map((webhook) => (
+            <WebhookCard
+              key={webhook.id}
+              webhook={webhook}
+              isDeleting={deletingId === webhook.id}
+              isToggling={togglingId === webhook.id}
+              isTesting={testingId === webhook.id}
+              onToggle={handleToggle}
+              onTest={handleTest}
+              onOpenDeliveries={handleOpenDeliveries}
+              onEdit={handleOpenEdit}
+              onDelete={handleDelete}
+            />
+          ))}
         </div>
+      )}
 
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
-          {loading && (
-            <div className="flex items-center justify-center py-8">
-              <div className="h-6 w-6 animate-spin rounded-full border-2 border-zinc-600 border-t-orange-500" />
-            </div>
-          )}
+      {showModal && (
+        <WebhookFormModal
+          isEditing={editingWebhook !== null}
+          formData={formData}
+          error={error}
+          isSubmitting={isSubmitting}
+          createdSecret={createdSecret}
+          onClose={handleCloseModal}
+          onSubmit={handleSubmit}
+          onChangeName={handleChangeName}
+          onChangeUrl={handleChangeUrl}
+          onToggleEvent={handleEventToggle}
+        />
+      )}
 
-          {error && (
-            <div className="rounded-lg bg-red-500/10 border border-red-500/30 px-4 py-3">
-              <p className="text-sm text-red-400">{error}</p>
-            </div>
-          )}
-
-          {!loading && !error && deliveries.length === 0 && (
-            <div className="text-center py-8">
-              <p className="text-zinc-500">No deliveries yet</p>
-              <p className="text-sm text-zinc-500 mt-1">
-                Deliveries will appear here once events are triggered
-              </p>
-            </div>
-          )}
-
-          {!loading && !error && deliveries.length > 0 && (
-            <div className="space-y-3">
-              {deliveries.map((delivery) => (
-                <div
-                  key={delivery.id}
-                  className="rounded-lg bg-zinc-800 border border-zinc-700 p-4"
-                >
-                  <div className="flex items-start justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                          delivery.status === 'success'
-                            ? 'bg-green-500/10 text-green-400'
-                            : delivery.status === 'pending'
-                            ? 'bg-yellow-500/10 text-yellow-400'
-                            : 'bg-red-500/10 text-red-400'
-                        }`}
-                      >
-                        {delivery.status}
-                      </span>
-                      <span className="text-sm text-zinc-300">{delivery.event}</span>
-                    </div>
-                    <span className="text-xs text-zinc-500">
-                      {new Date(delivery.created_at).toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="text-xs text-zinc-500 flex items-center gap-3">
-                    {delivery.response_status && (
-                      <span>HTTP {delivery.response_status}</span>
-                    )}
-                    {delivery.duration_ms !== null && (
-                      <span>{delivery.duration_ms}ms</span>
-                    )}
-                    <span>Attempts: {delivery.attempts}</span>
-                  </div>
-                  {delivery.error_message && (
-                    <p className="mt-2 text-xs text-red-400 truncate" title={delivery.error_message}>
-                      {delivery.error_message}
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
+      {showDeliveryModal && selectedWebhook && (
+        <DeliveryLogModal webhook={selectedWebhook} onClose={handleCloseDeliveries} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Phase 1 item #4 batch 3. Continues PRs #95 (batch 1) + #96 (batch 2).

| File | Before → After | Sub-files | Helper tests |
|------|----------------|-----------|--------------|
| `web/dashboard/settings/webhooks/webhooks-client.tsx` | 921 → 371 | 11 | 15 |
| `web/dashboard/costs/budget-alerts/budget-alerts-client.tsx` | 908 → 300 | 9 | 9 |
| `cli/agent/acp/AcpBackend.ts` | 1,088 → 391 | 8 | 33 |
| `cli/gemini/runGemini.ts` | 1,324 → 392 | 18 | 82 |

**4,241 LOC of god-files → 1,454 orchestrators + 46 sub-files + 139 new tests.**

## Reviewer verdict: ship-ready. **No BLOCKERs.**

The cumulative learning loop worked — agents avoided the failure modes flagged in batches 1+2. All four splits confirmed clean on behavior preservation, barrel discipline, type co-location, and helper test coverage of the smaller extracts.

Batch 3 also produced a bonus bug fix: webhooks agent caught an existing `useState(initializer-that-fetches)` anti-pattern in `delivery-log-modal.tsx` and replaced it with `useEffect + cancellation guard` (Strict-Mode safe).

**Resolved in this PR:** NIT #8 — webhooks-client deep-imported `toggleEvent`, now exported via barrel.

**Deferred to test-debt cleanup PR** (consolidating batch 1+2+3 test deferrals): runGemini's larger extracts (`messageHandler`, `turnPrep`, `userMessageRouter`, `lifecycle`, `bootstrap`) are factory-shaped with dep injection so they're test-ready, just not tested. Joins the existing queue of deferred hook tests.

## Test plan

- [x] `pnpm typecheck` (cli + web + mobile) — green
- [x] CLI vitest — **1313/1313 pass** (was 1198; +115 new tests)
- [x] Web vitest — **1457/1457 pass** (was 1433; +24 new tests)
- [ ] CI passes
- [ ] Manual QA: webhooks CRUD, budget alerts CRUD, Crush ACP agent session, Gemini CLI session

## Phase 1 #4 progress

| Done | Remaining |
|------|-----------|
| settings.tsx (PR #80) | 2 files, 2 separate PRs: |
| chat/sessions/webhooks/agent-config (PR #95) | `web/settings-client.tsx` (1,717 — biggest blast radius) |
| costs/review/account/tmux (PR #96) | `cli/src/index.ts` (1,188 — CLI command router) |
| webhooks-client/budget-alerts/AcpBackend/runGemini (this PR) | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)