### PR TITLE
test(coverage): +124 tests — CLI parsers/costs + mobile lib (Phase 1.5 kickoff)

### DIFF
--- a/packages/styrby-cli/src/costs/__tests__/jsonl-parser.test.ts
+++ b/packages/styrby-cli/src/costs/__tests__/jsonl-parser.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Unit tests for `jsonl-parser.ts`.
+ *
+ * Covers the synchronous helpers (`calculateCost`, `calculateInputCost`,
+ * `getAgentTypeForModel`) and the pure-JS JSONL file parser
+ * (`parseJsonlFile`). File-system-dependent tests use `tmp` directories
+ * created via Node's `fs.mkdtempSync` so they never pollute `~/.claude`.
+ *
+ * WHY: These parsers are on the hot path — every session cost displayed in
+ * the app flows through them. Regressions here silently mis-bill users.
+ */
+
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ============================================================================
+// Mock @styrby/shared/pricing
+// WHY: litellm-pricing uses Node.js builtins (node:path, node:os, node:fs,
+// node:crypto) that are not available in the Vitest environment. We return
+// static Sonnet-4 pricing for deterministic math in tests.
+// ============================================================================
+
+vi.mock('@styrby/shared/pricing', () => ({
+  getModelPriceSync: vi.fn(() => ({
+    inputPer1k: 0.003,     // $3.00 / 1M
+    outputPer1k: 0.015,    // $15.00 / 1M
+    cachePer1k: 0.0003,    // $0.30 / 1M
+    cacheWritePer1k: 0.00375, // $3.75 / 1M
+  })),
+  getModelPrice: vi.fn(async () => ({
+    inputPer1k: 0.003,
+    outputPer1k: 0.015,
+    cachePer1k: 0.0003,
+    cacheWritePer1k: 0.00375,
+  })),
+}));
+
+import {
+  calculateCost,
+  calculateInputCost,
+  getAgentTypeForModel,
+  parseJsonlFile,
+  aggregateCosts,
+  getCostsForDateRange,
+  type TokenUsage,
+} from '../jsonl-parser.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+/**
+ * Builds a minimal TokenUsage fixture, allowing field overrides.
+ */
+function makeUsage(overrides: Partial<TokenUsage> = {}): TokenUsage {
+  return {
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    model: 'claude-sonnet-4-20250514',
+    timestamp: new Date('2026-03-01T12:00:00Z'),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// getAgentTypeForModel
+// ============================================================================
+
+describe('getAgentTypeForModel', () => {
+  it('maps claude- prefix to "claude"', () => {
+    expect(getAgentTypeForModel('claude-sonnet-4-20250514')).toBe('claude');
+    expect(getAgentTypeForModel('claude-opus-4-5-20251101')).toBe('claude');
+    expect(getAgentTypeForModel('claude-3-5-haiku-20241022')).toBe('claude');
+  });
+
+  it('maps gpt- prefix to "codex"', () => {
+    expect(getAgentTypeForModel('gpt-4o')).toBe('codex');
+    expect(getAgentTypeForModel('gpt-4o-mini')).toBe('codex');
+    expect(getAgentTypeForModel('gpt-4-turbo')).toBe('codex');
+  });
+
+  it('maps o1- prefix to "codex"', () => {
+    expect(getAgentTypeForModel('o1-preview')).toBe('codex');
+    expect(getAgentTypeForModel('o1-mini')).toBe('codex');
+  });
+
+  it('maps o3- prefix to "codex"', () => {
+    expect(getAgentTypeForModel('o3-mini')).toBe('codex');
+  });
+
+  it('maps gemini- prefix to "gemini"', () => {
+    expect(getAgentTypeForModel('gemini-2.0-flash')).toBe('gemini');
+    expect(getAgentTypeForModel('gemini-1.5-pro')).toBe('gemini');
+  });
+
+  it('returns null for unknown model names', () => {
+    expect(getAgentTypeForModel('unknown-model-xyz')).toBeNull();
+    expect(getAgentTypeForModel('')).toBeNull();
+    expect(getAgentTypeForModel('llama-3')).toBeNull();
+  });
+
+  it('is case-insensitive (lowercases before matching)', () => {
+    // WHY: Model names from different providers may arrive mixed-case.
+    expect(getAgentTypeForModel('Claude-Sonnet-4')).toBe('claude');
+    expect(getAgentTypeForModel('GPT-4o')).toBe('codex');
+    expect(getAgentTypeForModel('Gemini-2.0-Flash')).toBe('gemini');
+  });
+});
+
+// ============================================================================
+// calculateCost
+// ============================================================================
+
+describe('calculateCost', () => {
+  it('computes cost from input + output tokens only when no cache', () => {
+    const usage = makeUsage({ inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 });
+    // 1M input @ $3.00/1M = $3.00
+    const cost = calculateCost(usage);
+    expect(cost).toBeCloseTo(3.0, 4);
+  });
+
+  it('adds output cost component', () => {
+    const usage = makeUsage({ inputTokens: 0, outputTokens: 1_000_000, cacheReadTokens: 0, cacheWriteTokens: 0 });
+    // 1M output @ $15.00/1M = $15.00
+    expect(calculateCost(usage)).toBeCloseTo(15.0, 4);
+  });
+
+  it('adds cache-read cost when present', () => {
+    const usage = makeUsage({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 1_000_000, cacheWriteTokens: 0 });
+    // 1M cache read @ $0.30/1M = $0.30
+    expect(calculateCost(usage)).toBeCloseTo(0.30, 4);
+  });
+
+  it('adds cache-write cost when present', () => {
+    const usage = makeUsage({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 1_000_000 });
+    // 1M cache write @ $3.75/1M = $3.75
+    expect(calculateCost(usage)).toBeCloseTo(3.75, 4);
+  });
+
+  it('returns zero cost for all-zero token counts', () => {
+    const usage = makeUsage({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 });
+    expect(calculateCost(usage)).toBe(0);
+  });
+
+  it('sums all four cost components correctly', () => {
+    const usage = makeUsage({
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheWriteTokens: 1_000_000,
+    });
+    // 3.00 + 15.00 + 0.30 + 3.75 = 22.05
+    expect(calculateCost(usage)).toBeCloseTo(22.05, 4);
+  });
+
+  it('uses STYRBY_MODEL_PRICING_JSON env override when valid JSON', () => {
+    const override = JSON.stringify({
+      'test-model': { input: 100.0, output: 200.0 },
+    });
+    process.env.STYRBY_MODEL_PRICING_JSON = override;
+
+    const usage = makeUsage({ model: 'test-model', inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 });
+    const cost = calculateCost(usage);
+    // 1M input @ $100.00/1M = $100.00
+    expect(cost).toBeCloseTo(100.0, 4);
+
+    delete process.env.STYRBY_MODEL_PRICING_JSON;
+  });
+
+  it('falls back to dynamic pricing when STYRBY_MODEL_PRICING_JSON is invalid JSON', () => {
+    process.env.STYRBY_MODEL_PRICING_JSON = 'not-valid-json{{{';
+
+    const usage = makeUsage({ inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 });
+    // Should not throw; falls through to getModelPriceSync mock ($3.00/1M)
+    expect(() => calculateCost(usage)).not.toThrow();
+
+    delete process.env.STYRBY_MODEL_PRICING_JSON;
+  });
+});
+
+// ============================================================================
+// calculateInputCost
+// ============================================================================
+
+describe('calculateInputCost', () => {
+  it('returns only input + cache costs, not output costs', () => {
+    const usage = makeUsage({
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000, // should NOT be included
+      cacheReadTokens: 1_000_000,
+      cacheWriteTokens: 0,
+    });
+    // input ($3.00) + cacheRead ($0.30) = $3.30
+    expect(calculateInputCost(usage)).toBeCloseTo(3.30, 4);
+  });
+
+  it('excludes output tokens entirely', () => {
+    const withOutput = makeUsage({ inputTokens: 0, outputTokens: 1_000_000, cacheReadTokens: 0, cacheWriteTokens: 0 });
+    expect(calculateInputCost(withOutput)).toBe(0);
+  });
+
+  it('includes cache-write cost', () => {
+    const usage = makeUsage({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 1_000_000,
+    });
+    // 1M cache write @ $3.75/1M = $3.75
+    expect(calculateInputCost(usage)).toBeCloseTo(3.75, 4);
+  });
+
+  it('returns zero for all-zero token usage', () => {
+    const usage = makeUsage({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 });
+    expect(calculateInputCost(usage)).toBe(0);
+  });
+});
+
+// ============================================================================
+// parseJsonlFile — pure JS readline path
+// ============================================================================
+
+/** Temp directories created during tests — cleaned up in afterEach. */
+const tmpDirs: string[] = [];
+
+/**
+ * Creates a temp directory and returns its path.
+ * Registered for cleanup in afterEach.
+ */
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'styrby-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Writes lines to a `.jsonl` temp file and returns the file path.
+ *
+ * @param lines - Array of raw strings (one per JSONL line).
+ * @param dir - Optional temp directory to write into.
+ */
+function writeJsonlFile(lines: string[], dir?: string): string {
+  const tmpDir = dir ?? makeTmpDir();
+  const filePath = path.join(tmpDir, 'session.jsonl');
+  fs.writeFileSync(filePath, lines.join('\n'));
+  return filePath;
+}
+
+afterEach(() => {
+  // Clean up all temp dirs created during this test
+  for (const dir of tmpDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup — don't fail the test on cleanup errors
+    }
+  }
+  tmpDirs.length = 0;
+});
+
+describe('parseJsonlFile', () => {
+  it('returns empty array for a non-existent file', async () => {
+    const result = await parseJsonlFile('/tmp/does-not-exist-styrby-test.jsonl');
+    expect(result).toEqual([]);
+  });
+
+  it('parses a Claude Code assistant message with usage', async () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-01T12:00:00.000Z',
+      message: {
+        model: 'claude-sonnet-4-20250514',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 20,
+          cache_creation_input_tokens: 5,
+        },
+      },
+    });
+    const file = writeJsonlFile([line]);
+    const usages = await parseJsonlFile(file);
+    expect(usages).toHaveLength(1);
+    expect(usages[0].inputTokens).toBe(100);
+    expect(usages[0].outputTokens).toBe(50);
+    expect(usages[0].cacheReadTokens).toBe(20);
+    expect(usages[0].cacheWriteTokens).toBe(5);
+    expect(usages[0].model).toBe('claude-sonnet-4-20250514');
+    expect(usages[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  it('parses a cost_info format line', async () => {
+    const line = JSON.stringify({
+      cost_info: {
+        model: 'gpt-4o',
+        input_tokens: 200,
+        output_tokens: 80,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+      },
+      timestamp: '2026-03-01T13:00:00.000Z',
+    });
+    const file = writeJsonlFile([line]);
+    const usages = await parseJsonlFile(file);
+    expect(usages).toHaveLength(1);
+    expect(usages[0].inputTokens).toBe(200);
+    expect(usages[0].model).toBe('gpt-4o');
+  });
+
+  it('skips non-assistant message lines silently', async () => {
+    const lines = [
+      JSON.stringify({ type: 'user', message: 'hello' }),
+      JSON.stringify({ type: 'summary', text: 'session summary' }),
+      JSON.stringify({ type: 'system', content: 'context' }),
+    ];
+    const file = writeJsonlFile(lines);
+    const usages = await parseJsonlFile(file);
+    expect(usages).toEqual([]);
+  });
+
+  it('skips malformed (non-JSON) lines without throwing', async () => {
+    const lines = [
+      'not json at all}}}',
+      '',
+      '{"broken":',
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-03-01T12:00:00.000Z',
+        message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 10, output_tokens: 5 } },
+      }),
+    ];
+    const file = writeJsonlFile(lines);
+    const usages = await parseJsonlFile(file);
+    // Only the valid assistant line should parse
+    expect(usages).toHaveLength(1);
+    expect(usages[0].inputTokens).toBe(10);
+  });
+
+  it('skips blank lines silently', async () => {
+    const lines = ['', '   ', '\t'];
+    const file = writeJsonlFile(lines);
+    const usages = await parseJsonlFile(file);
+    expect(usages).toEqual([]);
+  });
+
+  it('handles missing usage fields by defaulting to 0', async () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-01T12:00:00.000Z',
+      message: {
+        model: 'claude-sonnet-4-20250514',
+        usage: {
+          // intentionally missing: output_tokens, cache fields
+          input_tokens: 42,
+        },
+      },
+    });
+    const file = writeJsonlFile([line]);
+    const usages = await parseJsonlFile(file);
+    expect(usages[0].inputTokens).toBe(42);
+    expect(usages[0].outputTokens).toBe(0);
+    expect(usages[0].cacheReadTokens).toBe(0);
+    expect(usages[0].cacheWriteTokens).toBe(0);
+  });
+
+  it('defaults model to "unknown" when absent', async () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { usage: { input_tokens: 1 } },
+    });
+    const file = writeJsonlFile([line]);
+    const usages = await parseJsonlFile(file);
+    expect(usages[0].model).toBe('unknown');
+  });
+
+  it('parses multiple valid lines from one file', async () => {
+    const lines = [1, 2, 3].map((i) =>
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: `2026-03-0${i}T12:00:00.000Z`,
+        message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: i * 10, output_tokens: i * 5 } },
+      }),
+    );
+    const file = writeJsonlFile(lines);
+    const usages = await parseJsonlFile(file);
+    expect(usages).toHaveLength(3);
+    expect(usages[0].inputTokens).toBe(10);
+    expect(usages[1].inputTokens).toBe(20);
+    expect(usages[2].inputTokens).toBe(30);
+  });
+});
+
+// ============================================================================
+// aggregateCosts
+// ============================================================================
+
+describe('aggregateCosts', () => {
+  it('returns a zeroed summary for an empty file list', async () => {
+    const summary = await aggregateCosts([]);
+    expect(summary.totalInputTokens).toBe(0);
+    expect(summary.totalOutputTokens).toBe(0);
+    expect(summary.totalCostUsd).toBe(0);
+    expect(summary.sessionCount).toBe(0);
+    expect(summary.byModel).toEqual({});
+  });
+
+  it('aggregates tokens across multiple files', async () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-01T12:00:00.000Z',
+      message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 50 } },
+    });
+    const dir = makeTmpDir();
+    const file1 = path.join(dir, 'session1.jsonl');
+    const file2 = path.join(dir, 'session2.jsonl');
+    fs.writeFileSync(file1, line);
+    fs.writeFileSync(file2, line);
+
+    const summary = await aggregateCosts([file1, file2]);
+    expect(summary.sessionCount).toBe(2);
+    expect(summary.totalInputTokens).toBe(200);
+    expect(summary.totalOutputTokens).toBe(100);
+    expect(summary.totalCostUsd).toBeGreaterThan(0);
+  });
+
+  it('tracks byModel breakdown', async () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-01T12:00:00.000Z',
+      message: { model: 'gpt-4o', usage: { input_tokens: 50, output_tokens: 25 } },
+    });
+    const file = writeJsonlFile([line]);
+    const summary = await aggregateCosts([file]);
+    expect(summary.byModel['gpt-4o']).toBeDefined();
+    expect(summary.byModel['gpt-4o'].inputTokens).toBe(50);
+  });
+
+  it('sets firstTimestamp and lastTimestamp across entries', async () => {
+    const lines = [
+      JSON.stringify({ type: 'assistant', timestamp: '2026-03-01T10:00:00.000Z', message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 1, output_tokens: 0 } } }),
+      JSON.stringify({ type: 'assistant', timestamp: '2026-03-01T12:00:00.000Z', message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 2, output_tokens: 0 } } }),
+    ];
+    const file = writeJsonlFile(lines);
+    const summary = await aggregateCosts([file]);
+    expect(summary.firstTimestamp).toBeDefined();
+    expect(summary.lastTimestamp).toBeDefined();
+    expect(summary.firstTimestamp!.toISOString()).toBe('2026-03-01T10:00:00.000Z');
+    expect(summary.lastTimestamp!.toISOString()).toBe('2026-03-01T12:00:00.000Z');
+  });
+});
+
+// ============================================================================
+// getCostsForDateRange
+// ============================================================================
+
+describe('getCostsForDateRange', () => {
+  it('returns zeroed summary when no files are in range', async () => {
+    const start = new Date('2026-01-01T00:00:00Z');
+    const end = new Date('2026-01-02T00:00:00Z');
+    const summary = await getCostsForDateRange(start, end, []);
+    expect(summary.totalInputTokens).toBe(0);
+    expect(summary.sessionCount).toBe(0);
+  });
+
+  it('includes entries within the date range', async () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-03-15T12:00:00.000Z',
+      message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 50 } },
+    });
+    const file = writeJsonlFile([line]);
+    const start = new Date('2026-03-15T00:00:00Z');
+    const end = new Date('2026-03-16T00:00:00Z');
+    const summary = await getCostsForDateRange(start, end, [file]);
+    expect(summary.totalInputTokens).toBe(100);
+    expect(summary.sessionCount).toBe(1);
+  });
+
+  it('excludes entries outside the date range', async () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-02-01T12:00:00.000Z',
+      message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 50 } },
+    });
+    const file = writeJsonlFile([line]);
+    const start = new Date('2026-03-15T00:00:00Z');
+    const end = new Date('2026-03-16T00:00:00Z');
+    const summary = await getCostsForDateRange(start, end, [file]);
+    expect(summary.totalInputTokens).toBe(0);
+    expect(summary.sessionCount).toBe(0);
+  });
+
+  it('filters by agentType when provided', async () => {
+    const lines = [
+      JSON.stringify({ type: 'assistant', timestamp: '2026-03-15T12:00:00.000Z', message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 50 } } }),
+      JSON.stringify({ type: 'assistant', timestamp: '2026-03-15T12:01:00.000Z', message: { model: 'gpt-4o', usage: { input_tokens: 200, output_tokens: 100 } } }),
+    ];
+    const file = writeJsonlFile(lines);
+    const start = new Date('2026-03-15T00:00:00Z');
+    const end = new Date('2026-03-16T00:00:00Z');
+
+    // Filter to claude only
+    const summary = await getCostsForDateRange(start, end, [file], 'claude');
+    expect(summary.totalInputTokens).toBe(100);
+    expect(summary.byModel['claude-sonnet-4-20250514']).toBeDefined();
+    expect(summary.byModel['gpt-4o']).toBeUndefined();
+  });
+
+  it('does not increment sessionCount for a file with no in-range entries', async () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      timestamp: '2025-01-01T12:00:00.000Z',
+      message: { model: 'claude-sonnet-4-20250514', usage: { input_tokens: 100, output_tokens: 50 } },
+    });
+    const file = writeJsonlFile([line]);
+    const start = new Date('2026-03-15T00:00:00Z');
+    const end = new Date('2026-03-16T00:00:00Z');
+    const summary = await getCostsForDateRange(start, end, [file]);
+    expect(summary.sessionCount).toBe(0);
+  });
+});

--- a/packages/styrby-cli/src/gemini/utils/__tests__/optionsParser.test.ts
+++ b/packages/styrby-cli/src/gemini/utils/__tests__/optionsParser.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for `optionsParser` utilities.
+ *
+ * These helpers are the contract between Gemini's streaming output and the
+ * mobile app's tappable-options UI. Tests pin every branch of the state
+ * machine so a regex tweak can't silently break option rendering.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  hasIncompleteOptions,
+  parseOptionsFromText,
+  formatOptionsXml,
+} from '@/gemini/utils/optionsParser';
+
+// ============================================================================
+// hasIncompleteOptions
+// ============================================================================
+
+describe('hasIncompleteOptions', () => {
+  it('returns false for plain text with no options tags', () => {
+    expect(hasIncompleteOptions('just some plain text')).toBe(false);
+  });
+
+  it('returns false for a complete <options> block', () => {
+    const text = 'Pick one:\n<options><option>A</option></options>';
+    expect(hasIncompleteOptions(text)).toBe(false);
+  });
+
+  it('returns true when <options> opener has no closer', () => {
+    expect(hasIncompleteOptions('text <options><option>A</option>')).toBe(true);
+  });
+
+  it('returns false for empty string', () => {
+    expect(hasIncompleteOptions('')).toBe(false);
+  });
+
+  it('is case-insensitive for the tag match', () => {
+    // WHY: The regex uses the /i flag so ALLCAPS won't sneak through undetected.
+    expect(hasIncompleteOptions('<OPTIONS><option>X</option>')).toBe(true);
+    expect(hasIncompleteOptions('<OPTIONS><option>X</option></OPTIONS>')).toBe(false);
+  });
+});
+
+// ============================================================================
+// parseOptionsFromText
+// ============================================================================
+
+describe('parseOptionsFromText', () => {
+  it('returns original text and empty options when no options block exists', () => {
+    const input = 'Hello world';
+    const result = parseOptionsFromText(input);
+    expect(result.text).toBe('Hello world');
+    expect(result.options).toEqual([]);
+  });
+
+  it('parses a single option', () => {
+    const input = '<options><option>Yes</option></options>';
+    const result = parseOptionsFromText(input);
+    expect(result.options).toEqual(['Yes']);
+    expect(result.text).toBe('');
+  });
+
+  it('parses multiple options in order', () => {
+    const input =
+      'What would you like?\n<options><option>A</option><option>B</option><option>C</option></options>';
+    const result = parseOptionsFromText(input);
+    expect(result.options).toEqual(['A', 'B', 'C']);
+    expect(result.text).toBe('What would you like?');
+  });
+
+  it('strips the options block from the returned text', () => {
+    const input = 'Preamble\n<options><option>X</option></options>\nSuffix';
+    const result = parseOptionsFromText(input);
+    expect(result.text).not.toContain('<options>');
+    expect(result.text).not.toContain('<option>');
+  });
+
+  it('trims whitespace inside option tags', () => {
+    const input = '<options><option>  spaced  </option></options>';
+    const result = parseOptionsFromText(input);
+    expect(result.options).toEqual(['spaced']);
+  });
+
+  it('ignores empty option tags', () => {
+    // WHY: Empty options would render as blank buttons in the mobile UI.
+    const input = '<options><option></option><option>Valid</option></options>';
+    const result = parseOptionsFromText(input);
+    expect(result.options).toEqual(['Valid']);
+  });
+
+  it('handles multiline option content', () => {
+    const input = '<options>\n  <option>First choice</option>\n  <option>Second choice</option>\n</options>';
+    const result = parseOptionsFromText(input);
+    expect(result.options).toEqual(['First choice', 'Second choice']);
+  });
+
+  it('returns text trimmed even without options', () => {
+    const result = parseOptionsFromText('  hello  ');
+    expect(result.text).toBe('hello');
+    expect(result.options).toEqual([]);
+  });
+
+  it('handles text that contains angle brackets but no options tag', () => {
+    const input = 'Use <componentName> for rendering';
+    const result = parseOptionsFromText(input);
+    expect(result.text).toBe('Use <componentName> for rendering');
+    expect(result.options).toEqual([]);
+  });
+
+  it('handles incomplete options block gracefully — returns no options', () => {
+    // WHY: Gemini may stream a partial turn; incomplete blocks must not crash.
+    const input = 'Here: <options><option>Partial';
+    const result = parseOptionsFromText(input);
+    expect(result.options).toEqual([]);
+    // Text is returned unchanged since no complete block was found
+    expect(result.text).toContain('Partial');
+  });
+});
+
+// ============================================================================
+// formatOptionsXml
+// ============================================================================
+
+describe('formatOptionsXml', () => {
+  it('returns empty string for an empty array', () => {
+    expect(formatOptionsXml([])).toBe('');
+  });
+
+  it('wraps a single option in <options> XML', () => {
+    const xml = formatOptionsXml(['Yes']);
+    expect(xml).toContain('<options>');
+    expect(xml).toContain('<option>Yes</option>');
+    expect(xml).toContain('</options>');
+  });
+
+  it('formats multiple options as individual <option> tags', () => {
+    const xml = formatOptionsXml(['A', 'B', 'C']);
+    expect(xml).toContain('<option>A</option>');
+    expect(xml).toContain('<option>B</option>');
+    expect(xml).toContain('<option>C</option>');
+  });
+
+  it('round-trips through parseOptionsFromText', () => {
+    // WHY: The mobile app receives text + re-serialized XML. This round-trip
+    // test ensures serialize → parse produces the same options array.
+    const original = ['Option 1', 'Option 2', 'Option 3'];
+    const xml = formatOptionsXml(original);
+    const { options } = parseOptionsFromText(xml);
+    expect(options).toEqual(original);
+  });
+
+  it('preserves option text exactly including spaces', () => {
+    const xml = formatOptionsXml(['Go back to main menu']);
+    expect(xml).toContain('<option>Go back to main menu</option>');
+  });
+});

--- a/packages/styrby-cli/src/parsers/specialCommands.test.ts
+++ b/packages/styrby-cli/src/parsers/specialCommands.test.ts
@@ -72,10 +72,76 @@ describe('parseSpecialCommand', () => {
         // Test with extra whitespace
         expect(parseSpecialCommand('  /compact test  ').type).toBe('compact');
         expect(parseSpecialCommand('  /clear  ').type).toBe('clear');
-        
+
         // Test partial matches should not trigger
         expect(parseSpecialCommand('some /compact text').type).toBeNull();
         expect(parseSpecialCommand('/compactor').type).toBeNull();
         expect(parseSpecialCommand('/clearing').type).toBeNull();
+    });
+});
+
+// ============================================================================
+// Additional edge-case coverage
+// ============================================================================
+
+describe('parseCompact — additional edge cases', () => {
+    it('preserves multi-word arguments verbatim', () => {
+        const result = parseCompact('/compact summarize and keep all tool calls');
+        expect(result.isCompact).toBe(true);
+        expect(result.originalMessage).toBe('/compact summarize and keep all tool calls');
+    });
+
+    it('handles empty string as non-compact', () => {
+        const result = parseCompact('');
+        expect(result.isCompact).toBe(false);
+        expect(result.originalMessage).toBe('');
+    });
+
+    it('handles string with only whitespace as non-compact', () => {
+        // WHY: trim() collapses whitespace-only strings to '', which won't
+        // match '/compact', so isCompact must be false.
+        const result = parseCompact('   ');
+        expect(result.isCompact).toBe(false);
+    });
+
+    it('does not match /compactor (no space after /compact)', () => {
+        // Must start with "/compact " (trailing space) or be exactly "/compact"
+        expect(parseCompact('/compactor').isCompact).toBe(false);
+    });
+
+    it('returns trimmed originalMessage for bare /compact', () => {
+        const result = parseCompact('  /compact  ');
+        expect(result.isCompact).toBe(true);
+        // originalMessage is set to trimmed value
+        expect(result.originalMessage).toBe('/compact');
+    });
+});
+
+describe('parseClear — additional edge cases', () => {
+    it('handles empty string', () => {
+        expect(parseClear('').isClear).toBe(false);
+    });
+
+    it('does not match /clear followed by slash (e.g., /clear/context)', () => {
+        expect(parseClear('/clear/context').isClear).toBe(false);
+    });
+
+    it('does not match prefix substring (e.g., /clea)', () => {
+        expect(parseClear('/clea').isClear).toBe(false);
+    });
+});
+
+describe('parseSpecialCommand — priority ordering', () => {
+    it('compact takes priority and is checked before clear', () => {
+        // Sanity check: the /compact branch runs before the /clear branch,
+        // so a message like "/compact /clear test" resolves as compact.
+        const result = parseSpecialCommand('/compact /clear test');
+        expect(result.type).toBe('compact');
+    });
+
+    it('returns null type and no originalMessage for truly unrecognised input', () => {
+        const result = parseSpecialCommand('/unknown-command');
+        expect(result.type).toBeNull();
+        expect(result.originalMessage).toBeUndefined();
     });
 });

--- a/packages/styrby-mobile/src/lib/__tests__/platform-billing.test.ts
+++ b/packages/styrby-mobile/src/lib/__tests__/platform-billing.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Platform Billing Utility Tests
+ *
+ * Tests the Apple App Store §3.1.3(a) Reader App compliance helpers.
+ * The helpers gate upgrade CTA visibility and messaging by platform (iOS vs Android).
+ *
+ * Covers:
+ * - canShowUpgradePrompt() returns false on iOS, true on Android
+ * - getUpgradeMessage() returns iOS-safe (no price) vs Android (with price)
+ * - getUpgradeButtonLabel() returns null on iOS, label string on Android
+ * - getIosManageNote() returns note on iOS, null on Android
+ * - Default tier argument behaviour ('pro' is default)
+ * - 'power' tier produces correct pricing strings
+ *
+ * WHY Platform.OS is set in jest.setup.js:
+ * react-native is mocked globally with Platform.OS = 'ios'. To test Android
+ * behaviour we use jest.replaceProperty on the Platform mock.
+ */
+
+import { Platform } from 'react-native';
+import {
+  canShowUpgradePrompt,
+  getUpgradeMessage,
+  getUpgradeButtonLabel,
+  getIosManageNote,
+  POLAR_CUSTOMER_PORTAL_URL,
+} from '../platform-billing';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Temporarily overrides Platform.OS for the scope of a single test block.
+ * Uses jest.replaceProperty so the original value is restored after each test.
+ */
+function setPlatform(os: 'ios' | 'android') {
+  jest.replaceProperty(Platform, 'OS', os);
+}
+
+// ============================================================================
+// Test Suite
+// ============================================================================
+
+describe('Platform Billing Utilities', () => {
+  // Reset Platform.OS back to the jest.setup.js default ('ios') after each test.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // Constants
+  // --------------------------------------------------------------------------
+
+  describe('POLAR_CUSTOMER_PORTAL_URL', () => {
+    it('exports the Polar portal URL', () => {
+      expect(POLAR_CUSTOMER_PORTAL_URL).toBe('https://polar.sh/styrby/portal');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // canShowUpgradePrompt()
+  // --------------------------------------------------------------------------
+
+  describe('canShowUpgradePrompt()', () => {
+    it('returns false on iOS (App Store Reader App rules prohibit upgrade UI)', () => {
+      setPlatform('ios');
+      expect(canShowUpgradePrompt()).toBe(false);
+    });
+
+    it('returns true on Android (no equivalent App Store restriction)', () => {
+      setPlatform('android');
+      expect(canShowUpgradePrompt()).toBe(true);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // getUpgradeMessage()
+  // --------------------------------------------------------------------------
+
+  describe('getUpgradeMessage()', () => {
+    describe('on iOS', () => {
+      beforeEach(() => setPlatform('ios'));
+
+      it('returns informational text without price for pro tier', () => {
+        const msg = getUpgradeMessage('Budget Alerts', 'pro');
+        expect(msg).toBe('Budget Alerts requires a Pro subscription');
+        // WHY no price: Apple §3.1.3(a) prohibits in-app pricing display
+        expect(msg).not.toContain('$');
+      });
+
+      it('returns informational text without price for power tier', () => {
+        const msg = getUpgradeMessage('Session Replay', 'power');
+        expect(msg).toBe('Session Replay requires a Power subscription');
+        expect(msg).not.toContain('$');
+      });
+
+      it('defaults to pro tier when no tier argument is provided', () => {
+        const msg = getUpgradeMessage('Some Feature');
+        expect(msg).toBe('Some Feature requires a Pro subscription');
+      });
+
+      it('includes the feature name in the message', () => {
+        const msg = getUpgradeMessage('Webhook Notifications', 'pro');
+        expect(msg).toContain('Webhook Notifications');
+      });
+    });
+
+    describe('on Android', () => {
+      beforeEach(() => setPlatform('android'));
+
+      it('returns upgrade CTA with price for pro tier', () => {
+        const msg = getUpgradeMessage('Budget Alerts', 'pro');
+        expect(msg).toBe('Budget Alerts requires Pro — Upgrade for $29/mo');
+        expect(msg).toContain('$29/mo');
+      });
+
+      it('returns upgrade CTA with price for power tier', () => {
+        const msg = getUpgradeMessage('Session Replay', 'power');
+        expect(msg).toBe('Session Replay requires Power — Upgrade for $59/mo');
+        expect(msg).toContain('$59/mo');
+      });
+
+      it('defaults to pro tier on Android', () => {
+        const msg = getUpgradeMessage('Some Feature');
+        expect(msg).toBe('Some Feature requires Pro — Upgrade for $29/mo');
+      });
+
+      it('includes the feature name in the Android CTA', () => {
+        const msg = getUpgradeMessage('API Keys', 'power');
+        expect(msg).toContain('API Keys');
+      });
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // getUpgradeButtonLabel()
+  // --------------------------------------------------------------------------
+
+  describe('getUpgradeButtonLabel()', () => {
+    describe('on iOS', () => {
+      beforeEach(() => setPlatform('ios'));
+
+      it('returns null for pro tier (no button on iOS)', () => {
+        expect(getUpgradeButtonLabel('pro')).toBeNull();
+      });
+
+      it('returns null for power tier (no button on iOS)', () => {
+        expect(getUpgradeButtonLabel('power')).toBeNull();
+      });
+
+      it('returns null with default tier argument', () => {
+        expect(getUpgradeButtonLabel()).toBeNull();
+      });
+    });
+
+    describe('on Android', () => {
+      beforeEach(() => setPlatform('android'));
+
+      it('returns "Upgrade to Pro" label for pro tier', () => {
+        expect(getUpgradeButtonLabel('pro')).toBe('Upgrade to Pro');
+      });
+
+      it('returns "Upgrade to Power" label for power tier', () => {
+        expect(getUpgradeButtonLabel('power')).toBe('Upgrade to Power');
+      });
+
+      it('defaults to pro label when no tier is provided', () => {
+        expect(getUpgradeButtonLabel()).toBe('Upgrade to Pro');
+      });
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // getIosManageNote()
+  // --------------------------------------------------------------------------
+
+  describe('getIosManageNote()', () => {
+    it('returns the manage note on iOS', () => {
+      setPlatform('ios');
+      const note = getIosManageNote();
+      expect(note).toBe('Manage your subscription at styrbyapp.com');
+    });
+
+    it('returns null on Android (button is shown instead)', () => {
+      setPlatform('android');
+      expect(getIosManageNote()).toBeNull();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Integration — typical gating pattern
+  // --------------------------------------------------------------------------
+
+  describe('typical gating pattern', () => {
+    it('iOS: prompt disabled, note visible, no button', () => {
+      setPlatform('ios');
+
+      expect(canShowUpgradePrompt()).toBe(false);
+      expect(getUpgradeButtonLabel('pro')).toBeNull();
+      expect(getIosManageNote()).not.toBeNull();
+      // Message is safe for iOS (no price)
+      const msg = getUpgradeMessage('Dashboard', 'pro');
+      expect(msg).not.toMatch(/\$\d+/);
+    });
+
+    it('Android: prompt enabled, button visible, no manage note', () => {
+      setPlatform('android');
+
+      expect(canShowUpgradePrompt()).toBe(true);
+      expect(getUpgradeButtonLabel('pro')).toBe('Upgrade to Pro');
+      expect(getIosManageNote()).toBeNull();
+      // Message includes price
+      const msg = getUpgradeMessage('Dashboard', 'pro');
+      expect(msg).toMatch(/\$\d+/);
+    });
+  });
+});

--- a/packages/styrby-mobile/src/lib/__tests__/rate-limit.test.ts
+++ b/packages/styrby-mobile/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Rate Limiter Utility Tests
+ *
+ * Tests the sliding-window rate limiter used to prevent Supabase API flooding
+ * from rapid mobile UI interactions. Covers:
+ * - Allowing calls within the rate limit
+ * - Blocking calls that exceed maxCalls within windowMs
+ * - Returning correct retryAfterMs when rate limited
+ * - Resetting the limiter via reset()
+ * - remaining() count decrements and recovers after window expiry
+ * - createRateLimitedFetch convenience wrapper
+ * - Error propagation from the wrapped function
+ * - Sliding window semantics (old timestamps expire and free up slots)
+ */
+
+import { createRateLimiter, createRateLimitedFetch } from '../rate-limit';
+
+// ============================================================================
+// Test Suite
+// ============================================================================
+
+describe('createRateLimiter()', () => {
+  // Use fake timers so we can advance time without waiting
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // --------------------------------------------------------------------------
+  // Happy path — calls within the limit
+  // --------------------------------------------------------------------------
+
+  describe('within the rate limit', () => {
+    it('allows calls up to maxCalls within the window', async () => {
+      const fn = jest.fn(async () => 'result');
+      const limiter = createRateLimiter(fn, { maxCalls: 3, windowMs: 1000 });
+
+      const r1 = await limiter.call();
+      const r2 = await limiter.call();
+      const r3 = await limiter.call();
+
+      expect(r1.allowed).toBe(true);
+      expect(r2.allowed).toBe(true);
+      expect(r3.allowed).toBe(true);
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns the wrapped function result in allowed calls', async () => {
+      const fn = jest.fn(async (x: number) => x * 2);
+      const limiter = createRateLimiter(fn, { maxCalls: 5, windowMs: 1000 });
+
+      const result = await limiter.call(7);
+
+      expect(result.allowed).toBe(true);
+      expect(result.result).toBe(14);
+      expect(result.retryAfterMs).toBe(0);
+    });
+
+    it('passes arguments through to the wrapped function', async () => {
+      const fn = jest.fn(async (a: string, b: number) => `${a}-${b}`);
+      const limiter = createRateLimiter(fn, { maxCalls: 5, windowMs: 1000 });
+
+      const result = await limiter.call('hello', 42);
+
+      expect(fn).toHaveBeenCalledWith('hello', 42);
+      expect(result.result).toBe('hello-42');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Rate limiting — calls that exceed maxCalls
+  // --------------------------------------------------------------------------
+
+  describe('exceeding the rate limit', () => {
+    it('blocks calls once maxCalls is reached within the window', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 2, windowMs: 5000 });
+
+      await limiter.call();
+      await limiter.call();
+      const blocked = await limiter.call();
+
+      expect(blocked.allowed).toBe(false);
+      expect(blocked.result).toBeUndefined();
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns retryAfterMs > 0 when rate limited', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 1, windowMs: 5000 });
+
+      await limiter.call();
+      const blocked = await limiter.call();
+
+      expect(blocked.allowed).toBe(false);
+      // WHY > 0: The first call was recorded at ~now, so retryAfterMs should
+      // be approximately windowMs (5000ms) since the window hasn't expired.
+      expect(blocked.retryAfterMs).toBeGreaterThan(0);
+      expect(blocked.retryAfterMs).toBeLessThanOrEqual(5000);
+    });
+
+    it('does not call the wrapped function when rate limited', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 1, windowMs: 1000 });
+
+      await limiter.call();
+      await limiter.call(); // blocked
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Sliding window — old timestamps expire
+  // --------------------------------------------------------------------------
+
+  describe('sliding window expiry', () => {
+    it('allows new calls after the window expires', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 2, windowMs: 1000 });
+
+      // Exhaust the limit
+      await limiter.call();
+      await limiter.call();
+
+      // Blocked before window expires
+      const blocked = await limiter.call();
+      expect(blocked.allowed).toBe(false);
+
+      // Advance time past the window
+      jest.advanceTimersByTime(1001);
+
+      // Now calls should be allowed again
+      const allowed = await limiter.call();
+      expect(allowed.allowed).toBe(true);
+    });
+
+    it('only clears expired timestamps (partial window expiry)', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 3, windowMs: 2000 });
+
+      // First call at t=0
+      await limiter.call();
+
+      // Advance 1500ms — first call is still within the 2000ms window
+      jest.advanceTimersByTime(1500);
+
+      // Two more calls at t=1500 — now at limit
+      await limiter.call();
+      await limiter.call();
+
+      // Advance another 600ms (t=2100) — first call at t=0 is now expired
+      jest.advanceTimersByTime(600);
+
+      // The first slot is freed, allowing one more call
+      const result = await limiter.call();
+      expect(result.allowed).toBe(true);
+      expect(fn).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // reset()
+  // --------------------------------------------------------------------------
+
+  describe('reset()', () => {
+    it('clears all timestamps so calls are immediately allowed', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 2, windowMs: 5000 });
+
+      await limiter.call();
+      await limiter.call();
+
+      // Confirm blocked before reset
+      const blocked = await limiter.call();
+      expect(blocked.allowed).toBe(false);
+
+      // Reset
+      limiter.reset();
+
+      // Should be allowed again
+      const allowed = await limiter.call();
+      expect(allowed.allowed).toBe(true);
+    });
+
+    it('restores remaining() to maxCalls after reset', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 5, windowMs: 1000 });
+
+      await limiter.call();
+      await limiter.call();
+      expect(limiter.remaining()).toBe(3);
+
+      limiter.reset();
+
+      expect(limiter.remaining()).toBe(5);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // remaining()
+  // --------------------------------------------------------------------------
+
+  describe('remaining()', () => {
+    it('returns maxCalls when no calls have been made', () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 10, windowMs: 5000 });
+
+      expect(limiter.remaining()).toBe(10);
+    });
+
+    it('decrements as calls are made', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 5, windowMs: 5000 });
+
+      await limiter.call();
+      expect(limiter.remaining()).toBe(4);
+
+      await limiter.call();
+      expect(limiter.remaining()).toBe(3);
+    });
+
+    it('returns 0 when the limit is exhausted', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 2, windowMs: 5000 });
+
+      await limiter.call();
+      await limiter.call();
+
+      expect(limiter.remaining()).toBe(0);
+    });
+
+    it('increases again as old timestamps expire', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 2, windowMs: 1000 });
+
+      await limiter.call();
+      await limiter.call();
+      expect(limiter.remaining()).toBe(0);
+
+      // Wait for the window to expire
+      jest.advanceTimersByTime(1001);
+      expect(limiter.remaining()).toBe(2);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Error propagation
+  // --------------------------------------------------------------------------
+
+  describe('error propagation', () => {
+    it('propagates errors thrown by the wrapped function', async () => {
+      const fn = jest.fn(async () => {
+        throw new Error('Supabase timeout');
+      });
+      const limiter = createRateLimiter(fn, { maxCalls: 5, windowMs: 1000 });
+
+      await expect(limiter.call()).rejects.toThrow('Supabase timeout');
+    });
+
+    it('still consumes a slot even if the wrapped function throws', async () => {
+      // WHY: A failed call that reached the network still counts against
+      // the rate limit. We don't want retries to bypass rate limiting.
+      const fn = jest.fn(async () => {
+        throw new Error('fail');
+      });
+      const limiter = createRateLimiter(fn, { maxCalls: 1, windowMs: 1000 });
+
+      // First call: throws but slot is consumed
+      await expect(limiter.call()).rejects.toThrow();
+
+      // Second call: rate limited
+      const blocked = await limiter.call();
+      expect(blocked.allowed).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Edge cases
+  // --------------------------------------------------------------------------
+
+  describe('edge cases', () => {
+    it('handles maxCalls = 1 correctly', async () => {
+      const fn = jest.fn(async () => 'single');
+      const limiter = createRateLimiter(fn, { maxCalls: 1, windowMs: 1000 });
+
+      const first = await limiter.call();
+      expect(first.allowed).toBe(true);
+
+      const second = await limiter.call();
+      expect(second.allowed).toBe(false);
+    });
+
+    it('handles a very large maxCalls without issue', async () => {
+      const fn = jest.fn(async () => 'ok');
+      const limiter = createRateLimiter(fn, { maxCalls: 10000, windowMs: 60000 });
+
+      const result = await limiter.call();
+      expect(result.allowed).toBe(true);
+      expect(limiter.remaining()).toBe(9999);
+    });
+  });
+});
+
+// ============================================================================
+// createRateLimitedFetch convenience wrapper
+// ============================================================================
+
+describe('createRateLimitedFetch()', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('creates a rate limiter with 10 calls per 5 seconds', async () => {
+    let callCount = 0;
+    const fn = jest.fn(async () => ++callCount);
+    const limiter = createRateLimitedFetch(fn);
+
+    // 10 calls should all be allowed
+    for (let i = 0; i < 10; i++) {
+      const result = await limiter.call();
+      expect(result.allowed).toBe(true);
+    }
+
+    // 11th call should be blocked
+    const blocked = await limiter.call();
+    expect(blocked.allowed).toBe(false);
+
+    expect(fn).toHaveBeenCalledTimes(10);
+  });
+
+  it('resets after 5 seconds', async () => {
+    const fn = jest.fn(async () => 'ok');
+    const limiter = createRateLimitedFetch(fn);
+
+    // Exhaust the limit
+    for (let i = 0; i < 10; i++) {
+      await limiter.call();
+    }
+
+    // Advance 5 seconds + 1ms
+    jest.advanceTimersByTime(5001);
+
+    const result = await limiter.call();
+    expect(result.allowed).toBe(true);
+  });
+
+  it('wraps a zero-argument function and passes no args', async () => {
+    const fn = jest.fn(async () => ({ data: 'sessions' }));
+    const limiter = createRateLimitedFetch(fn);
+
+    const result = await limiter.call();
+
+    expect(fn).toHaveBeenCalledWith();
+    expect(result.result).toEqual({ data: 'sessions' });
+  });
+
+  it('remaining() starts at 10', () => {
+    const fn = jest.fn(async () => 'ok');
+    const limiter = createRateLimitedFetch(fn);
+
+    expect(limiter.remaining()).toBe(10);
+  });
+});

--- a/packages/styrby-mobile/src/lib/__tests__/supabase.test.ts
+++ b/packages/styrby-mobile/src/lib/__tests__/supabase.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Supabase Client Helper Tests
+ *
+ * Tests the thin wrapper functions (getCurrentUser, signInWithEmail, signOut)
+ * that sit on top of the Supabase client singleton in src/lib/supabase.ts.
+ *
+ * WHY jest.isolateModules + mock-then-import:
+ * src/lib/supabase.ts calls createClient() at module-load time. A top-level
+ * jest.mock('@supabase/supabase-js') is hoisted BEFORE that import, so the
+ * createClient factory receives our mock and populates supabase.auth with
+ * our jest.fn() instances. Tests then spy directly on the exported `supabase`
+ * object for assertions.
+ *
+ * WHY we do NOT mock '../../lib/supabase' itself:
+ * We want to exercise the real getCurrentUser/signInWithEmail/signOut
+ * implementations. We only mock the underlying Supabase SDK.
+ */
+
+// ============================================================================
+// Mock the Supabase SDK (hoisted before any imports)
+// ============================================================================
+
+const mockGetUser = jest.fn();
+const mockSignInWithOtp = jest.fn();
+const mockSignOut = jest.fn();
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    auth: {
+      getUser: mockGetUser,
+      signInWithOtp: mockSignInWithOtp,
+      signOut: mockSignOut,
+    },
+    from: jest.fn(),
+  })),
+}));
+
+// ============================================================================
+// Import helpers AFTER mock is in place
+// ============================================================================
+
+// WHY: We need `supabase` exported object to spy/patch in tests where the
+// module-level mock needs per-test behaviour.
+let getCurrentUser: typeof import('../supabase').getCurrentUser;
+let signInWithEmail: typeof import('../supabase').signInWithEmail;
+let signOut: typeof import('../supabase').signOut;
+let supabase: typeof import('../supabase').supabase;
+
+beforeAll(() => {
+  // Fresh import after jest.mock has been registered
+  const mod = require('../supabase') as typeof import('../supabase');
+  getCurrentUser = mod.getCurrentUser;
+  signInWithEmail = mod.signInWithEmail;
+  signOut = mod.signOut;
+  supabase = mod.supabase;
+});
+
+// ============================================================================
+// Test Suite
+// ============================================================================
+
+describe('Supabase helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // getCurrentUser()
+  // --------------------------------------------------------------------------
+
+  describe('getCurrentUser()', () => {
+    it('returns the user when authenticated', async () => {
+      const mockUser = { id: 'user-123', email: 'test@example.com' };
+      mockGetUser.mockResolvedValueOnce({
+        data: { user: mockUser },
+        error: null,
+      });
+
+      const result = await getCurrentUser();
+
+      expect(result).toEqual(mockUser);
+      expect(mockGetUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when no user is authenticated (data.user is null)', async () => {
+      mockGetUser.mockResolvedValueOnce({
+        data: { user: null },
+        error: null,
+      });
+
+      const result = await getCurrentUser();
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null and logs error when getUser returns an auth error', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockGetUser.mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: 'JWT expired' },
+      });
+
+      const result = await getCurrentUser();
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Error getting user:',
+        'JWT expired',
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('returns null when error message is a network error', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockGetUser.mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: 'Failed to fetch' },
+      });
+
+      const result = await getCurrentUser();
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Error getting user:',
+        'Failed to fetch',
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('does not log when no error (successful response)', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockGetUser.mockResolvedValueOnce({
+        data: { user: { id: 'u1' } },
+        error: null,
+      });
+
+      await getCurrentUser();
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // signInWithEmail()
+  // --------------------------------------------------------------------------
+
+  describe('signInWithEmail()', () => {
+    it('calls signInWithOtp with the email and magic link redirect', async () => {
+      mockSignInWithOtp.mockResolvedValueOnce({ error: null });
+
+      const result = await signInWithEmail('user@example.com');
+
+      expect(mockSignInWithOtp).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        options: {
+          emailRedirectTo: 'styrby://auth/callback',
+        },
+      });
+      expect(result.error).toBeNull();
+    });
+
+    it('returns the error from Supabase when OTP sending fails', async () => {
+      const mockError = { message: 'Rate limit exceeded' };
+      mockSignInWithOtp.mockResolvedValueOnce({ error: mockError });
+
+      const result = await signInWithEmail('user@example.com');
+
+      expect(result.error).toBe(mockError);
+    });
+
+    it('uses the correct styrby deep link callback URL', async () => {
+      mockSignInWithOtp.mockResolvedValueOnce({ error: null });
+
+      await signInWithEmail('another@example.com');
+
+      const callArgs = mockSignInWithOtp.mock.calls[0][0] as {
+        email: string;
+        options: { emailRedirectTo: string };
+      };
+      expect(callArgs.options.emailRedirectTo).toBe('styrby://auth/callback');
+    });
+
+    it('passes through email without modification', async () => {
+      mockSignInWithOtp.mockResolvedValueOnce({ error: null });
+
+      await signInWithEmail('CAPS@Example.COM');
+
+      const callArgs = mockSignInWithOtp.mock.calls[0][0] as { email: string };
+      // WHY: Email normalisation is Supabase's responsibility
+      expect(callArgs.email).toBe('CAPS@Example.COM');
+    });
+
+    it('handles empty string email (Supabase validates)', async () => {
+      mockSignInWithOtp.mockResolvedValueOnce({
+        error: { message: 'Invalid email' },
+      });
+
+      const result = await signInWithEmail('');
+
+      expect(mockSignInWithOtp).toHaveBeenCalledWith(
+        expect.objectContaining({ email: '' }),
+      );
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // signOut()
+  // --------------------------------------------------------------------------
+
+  describe('signOut()', () => {
+    it('calls supabase.auth.signOut and returns the result', async () => {
+      mockSignOut.mockResolvedValueOnce({ error: null });
+
+      const result = await signOut();
+
+      expect(mockSignOut).toHaveBeenCalledTimes(1);
+      expect(result.error).toBeNull();
+    });
+
+    it('returns the error object when sign out fails', async () => {
+      const mockError = { message: 'Session already invalidated' };
+      mockSignOut.mockResolvedValueOnce({ error: mockError });
+
+      const result = await signOut();
+
+      expect(result.error).toBe(mockError);
+    });
+
+    it('is a pure pass-through — calls no other auth methods', async () => {
+      mockSignOut.mockResolvedValueOnce({ error: null });
+
+      await signOut();
+
+      // Confirm no unintended side effects (e.g., getUser is not called)
+      expect(mockGetUser).not.toHaveBeenCalled();
+      expect(mockSignInWithOtp).not.toHaveBeenCalled();
+      expect(mockSignOut).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // supabase singleton is exported
+  // --------------------------------------------------------------------------
+
+  describe('supabase singleton', () => {
+    it('exports a supabase client object with auth methods', () => {
+      // WHY: Verifying the export contract so consumers can import the singleton
+      // directly without re-instantiating.
+      expect(supabase).toBeDefined();
+      expect(supabase.auth).toBeDefined();
+      expect(typeof supabase.auth.getUser).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
First parallel-agent pass on the Phase 1.5 coverage push to 70%+. Test-only — no source modifications.

### CLI (+67 tests)
- **`costs/__tests__/jsonl-parser.test.ts`** (new, 37 tests) — `getAgentTypeForModel`, `calculateCost`/`calculateInputCost` (each token component independently, env-var pricing override, invalid-JSON fallback), `parseJsonlFile` (Claude Code + `cost_info` formats, malformed lines, blanks, missing fields, multi-entry files, non-existent file), `aggregateCosts` (empty, multi-file, `byModel`, timestamps), `getCostsForDateRange` (in/out of range, `agentType` filter, session count).
- **`gemini/utils/__tests__/optionsParser.test.ts`** (new, 20 tests) — all three functions across happy path, empty arrays, incomplete blocks, case-insensitive tags, round-trip serialize/parse.
- **`parsers/specialCommands.test.ts`** (extended, 12 → 22) — empty string, whitespace-only, `/compactor` non-match, `/compact /clear` priority ordering, unknown-command null return.

### Mobile (+57 tests — these files were 0%)
- **`lib/__tests__/rate-limit.test.ts`** (new, 26 tests) — `createRateLimiter` sliding window, blocking, `retryAfterMs`, reset, remaining, error propagation, edge cases; `createRateLimitedFetch` convenience wrapper.
- **`lib/__tests__/platform-billing.test.ts`** (new, 17 tests) — `canShowUpgradePrompt`, `getUpgradeMessage`, `getUpgradeButtonLabel`, `getIosManageNote` across iOS + Android + integration gating.
- **`lib/__tests__/supabase.test.ts`** (new, 14 tests) — `getCurrentUser` (success, null, error, no-log on success), `signInWithEmail` (OTP, error, deep link URL, pass-through), `signOut` (success, error, pass-through).

## Test plan
- [x] CLI suite: 1,425 tests pass (58 files, +3 new)
- [x] Mobile suite: 1,055 tests pass (53 suites, +3 new)
- [ ] CI green

## Next in Phase 1.5
Second pass will target `cli/agent/` (biggest target — currently ~19%), `cli/commands/`, `mobile/hooks/`, `mobile/services/` (already has 307 tests — just gap-fill). Separate PR to keep review surface bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)