### PR TITLE
test(coverage): +532 tests — full cross-package sweep (Phase 1.5 wave 3)

### DIFF
--- a/packages/styrby-cli/src/commands/__tests__/daemon.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/daemon.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for the daemon command.
+ *
+ * Covers:
+ * - handleDaemon dispatcher: install, uninstall/remove, status, default (usage)
+ * - Platform guard: unsupported platform logs yellow warning and skips install
+ *
+ * NOTE: The deep macOS/Linux side-effects (launchctl, systemctl, fs writes)
+ * require heavy mocking. We test the public surface (handleDaemon routing)
+ * and the platform-guard branches without re-testing every child_process call.
+ * Filesystem and execSync mocks are set up so install/uninstall can be called
+ * without touching the real filesystem.
+ *
+ * WHY: handleDaemon routing bugs cause the wrong action on a live machine
+ * (e.g. "styrby daemon uninstall" accidentally installing). Platform guards
+ * prevent confusing errors on Windows.
+ *
+ * @module commands/__tests__/daemon.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('node:fs', () => ({
+  default: {},
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/home/testuser'),
+  platform: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('chalk', () => ({
+  default: {
+    blue: (s: string) => s,
+    green: (s: string) => s,
+    red: (s: string) => s,
+    yellow: (s: string) => s,
+    gray: (s: string) => s,
+    bold: (s: string) => s,
+  },
+}));
+
+import { platform } from 'node:os';
+import * as fs from 'node:fs';
+import { execSync } from 'node:child_process';
+import { handleDaemon } from '../daemon';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function mockPlatform(os: string) {
+  vi.mocked(platform).mockReturnValue(os as NodeJS.Platform);
+}
+
+// ============================================================================
+// handleDaemon — dispatcher routing
+// ============================================================================
+
+describe('handleDaemon dispatcher', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('routes "status" to service status handler', async () => {
+    // On darwin, status checks existsSync for plist
+    mockPlatform('darwin');
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await handleDaemon(['status']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /daemon not installed/i.test(m))).toBe(true);
+  });
+
+  it('prints usage when no subcommand is given', async () => {
+    await handleDaemon([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    // Usage output contains "styrby daemon"
+    expect(calls.some((m) => /styrby daemon/i.test(m))).toBe(true);
+  });
+
+  it('prints usage for unknown subcommand', async () => {
+    await handleDaemon(['bogus']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /styrby daemon/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleDaemon — unsupported platform
+// ============================================================================
+
+describe('handleDaemon — unsupported platform', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockPlatform('win32');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints "not supported" message for install on Windows', async () => {
+    await handleDaemon(['install']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /not supported/i.test(m))).toBe(true);
+  });
+
+  it('does not write any files on Windows', async () => {
+    await handleDaemon(['install']);
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('prints "not supported" for uninstall on Windows', async () => {
+    await handleDaemon(['uninstall']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /not supported/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleDaemon install — macOS happy path
+// ============================================================================
+
+describe('handleDaemon install — macOS', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockPlatform('darwin');
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+    vi.mocked(execSync).mockReturnValue('');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('writes the plist file', async () => {
+    await handleDaemon(['install']);
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('calls launchctl load', async () => {
+    await handleDaemon(['install']);
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining('launchctl load'),
+      expect.any(Object)
+    );
+  });
+
+  it('prints success message', async () => {
+    await handleDaemon(['install']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /daemon installed/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleDaemon uninstall — macOS, plist not present
+// ============================================================================
+
+describe('handleDaemon uninstall — macOS, not installed', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockPlatform('darwin');
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints "No daemon installed" when plist does not exist', async () => {
+    await handleDaemon(['uninstall']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /no daemon installed/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleDaemon uninstall — macOS, plist present
+// ============================================================================
+
+describe('handleDaemon uninstall — macOS, installed', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockPlatform('darwin');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.unlinkSync).mockReturnValue(undefined);
+    vi.mocked(execSync).mockReturnValue('');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('removes the plist file', async () => {
+    await handleDaemon(['uninstall']);
+    expect(fs.unlinkSync).toHaveBeenCalled();
+  });
+
+  it('prints "Daemon uninstalled" message', async () => {
+    await handleDaemon(['uninstall']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /daemon uninstalled/i.test(m))).toBe(true);
+  });
+
+  it('"remove" alias also uninstalls', async () => {
+    await handleDaemon(['remove']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /daemon uninstalled/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleDaemon status — macOS, loaded
+// ============================================================================
+
+describe('handleDaemon status — macOS, daemon loaded', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockPlatform('darwin');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    // execSync simulates "launchctl list | grep com.styrby.daemon" output
+    vi.mocked(execSync).mockReturnValue('0 - com.styrby.daemon\n');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints "installed and loaded" status', async () => {
+    await handleDaemon(['status']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /installed and loaded/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleDaemon status — Linux, active service
+// ============================================================================
+
+describe('handleDaemon status — Linux, active', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockPlatform('linux');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(execSync).mockReturnValue('active\n');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints "installed and running" status', async () => {
+    await handleDaemon(['status']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /installed and running/i.test(m))).toBe(true);
+  });
+});

--- a/packages/styrby-cli/src/commands/__tests__/doctor.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/doctor.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the doctor command.
+ *
+ * Covers:
+ * - Node.js version check (pass when >= 18, fail when < 18)
+ * - Config check (pass on valid config, fail on load error)
+ * - Auth check (pass when authenticated, fail when not)
+ * - Agent detection check (pass with agents, fail with none)
+ * - Full runDoctor integration: all-pass and some-fail paths
+ *
+ * WHY: The doctor command is the first stop for support tickets; a broken
+ * check or incorrect pass/fail logic sends users in the wrong direction.
+ *
+ * @module commands/__tests__/doctor.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/configuration', () => ({
+  isAuthenticated: vi.fn(),
+  loadConfig: vi.fn(),
+}));
+
+vi.mock('@/auth/agent-credentials', () => ({
+  getAllAgentStatus: vi.fn(),
+}));
+
+import { isAuthenticated, loadConfig } from '@/configuration';
+import { getAllAgentStatus } from '@/auth/agent-credentials';
+import { logger } from '@/ui/logger';
+import { runDoctor } from '../doctor';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Override process.version with a fabricated version string.
+ *
+ * WHY: process.version is read-only in Node; we need to redefine it on the
+ * property descriptor to simulate old/new Node versions in tests.
+ */
+function setNodeVersion(version: string) {
+  Object.defineProperty(process, 'version', {
+    value: version,
+    configurable: true,
+  });
+}
+
+// ============================================================================
+// runDoctor — all checks pass
+// ============================================================================
+
+describe('runDoctor — all checks pass', () => {
+  const originalVersion = process.version;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setNodeVersion('v20.0.0');
+    vi.mocked(loadConfig).mockReturnValue({ userId: 'user-001' });
+    vi.mocked(isAuthenticated).mockReturnValue(true);
+    vi.mocked(getAllAgentStatus).mockResolvedValue({
+      claude: {
+        agent: 'claude',
+        name: 'Claude Code',
+        installed: true,
+        configured: true,
+        command: 'claude',
+        version: '1.0.0',
+      },
+    });
+  });
+
+  afterEach(() => {
+    setNodeVersion(originalVersion);
+  });
+
+  it('logs PASS for Node.js version', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => m.includes('PASS') && m.includes('Node.js'))).toBe(true);
+  });
+
+  it('logs PASS for Configuration', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => m.includes('PASS') && m.includes('Configuration'))).toBe(true);
+  });
+
+  it('logs PASS for Authentication', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => m.includes('PASS') && m.includes('Authentication'))).toBe(true);
+  });
+
+  it('logs PASS for AI Agents when agents are installed', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => m.includes('PASS') && m.includes('AI Agents'))).toBe(true);
+  });
+
+  it('logs all checks passed at the end', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => /all checks passed/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// runDoctor — Node.js version too old
+// ============================================================================
+
+describe('runDoctor — old Node.js version', () => {
+  const originalVersion = process.version;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setNodeVersion('v16.0.0');
+    vi.mocked(loadConfig).mockReturnValue({ userId: 'user-001' });
+    vi.mocked(isAuthenticated).mockReturnValue(true);
+    vi.mocked(getAllAgentStatus).mockResolvedValue({
+      claude: {
+        agent: 'claude',
+        name: 'Claude Code',
+        installed: true,
+        configured: true,
+        command: 'claude',
+      },
+    });
+  });
+
+  afterEach(() => {
+    setNodeVersion(originalVersion);
+  });
+
+  it('logs FAIL for Node.js version below 18', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => m.includes('FAIL') && m.includes('Node.js'))).toBe(true);
+  });
+
+  it('logs "some checks failed" when node version fails', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => /some checks failed/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// runDoctor — not authenticated
+// ============================================================================
+
+describe('runDoctor — not authenticated', () => {
+  const originalVersion = process.version;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setNodeVersion('v20.0.0');
+    vi.mocked(loadConfig).mockReturnValue({ userId: 'user-001' });
+    vi.mocked(isAuthenticated).mockReturnValue(false);
+    vi.mocked(getAllAgentStatus).mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    setNodeVersion(originalVersion);
+  });
+
+  it('logs FAIL for Authentication', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => m.includes('FAIL') && m.includes('Authentication'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// runDoctor — config load throws
+// ============================================================================
+
+describe('runDoctor — config load error', () => {
+  const originalVersion = process.version;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setNodeVersion('v20.0.0');
+    vi.mocked(loadConfig).mockImplementation(() => {
+      throw new Error('ENOENT: config file not found');
+    });
+    vi.mocked(isAuthenticated).mockReturnValue(false);
+    vi.mocked(getAllAgentStatus).mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    setNodeVersion(originalVersion);
+  });
+
+  it('logs FAIL for Configuration when loadConfig throws', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => m.includes('FAIL') && m.includes('Configuration'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// runDoctor — no agents installed
+// ============================================================================
+
+describe('runDoctor — no agents installed', () => {
+  const originalVersion = process.version;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setNodeVersion('v20.0.0');
+    vi.mocked(loadConfig).mockReturnValue({ userId: 'user-001' });
+    vi.mocked(isAuthenticated).mockReturnValue(true);
+    vi.mocked(getAllAgentStatus).mockResolvedValue({
+      claude: {
+        agent: 'claude',
+        name: 'Claude Code',
+        installed: false,
+        configured: false,
+        command: 'claude',
+      },
+    });
+  });
+
+  afterEach(() => {
+    setNodeVersion(originalVersion);
+  });
+
+  it('logs FAIL for AI Agents when none are installed', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => m.includes('FAIL') && m.includes('AI Agents'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// runDoctor — getAllAgentStatus throws
+// ============================================================================
+
+describe('runDoctor — getAllAgentStatus throws', () => {
+  const originalVersion = process.version;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setNodeVersion('v20.0.0');
+    vi.mocked(loadConfig).mockReturnValue({ userId: 'user-001' });
+    vi.mocked(isAuthenticated).mockReturnValue(true);
+    vi.mocked(getAllAgentStatus).mockRejectedValue(new Error('network error'));
+  });
+
+  afterEach(() => {
+    setNodeVersion(originalVersion);
+  });
+
+  it('logs FAIL for AI Agents check when detection throws', async () => {
+    await runDoctor();
+    const calls = vi.mocked(logger.info).mock.calls.map((c) => c[0] as string);
+    expect(calls.some((m) => m.includes('FAIL') && m.includes('AI Agents'))).toBe(true);
+  });
+});

--- a/packages/styrby-cli/src/commands/__tests__/install-agent.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/install-agent.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Tests for the install-agent command handlers.
+ *
+ * Covers:
+ * - AGENT_PACKAGES data integrity (all four agents have required fields)
+ * - installAgent: already-installed path, npm success path, npm error paths
+ *   (EACCES, 404, ENOTFOUND, generic non-zero exit)
+ * - installAgents: sequential install with per-agent progress callback
+ * - handleInstallCommand: no-args usage, --all with nothing to install,
+ *   unknown agent, already-installed agent, install cancelled
+ *
+ * WHY: installAgent drives the npm child_process spawn path; mishandled exit
+ * codes or stderr patterns produce silent failures on user machines.
+ *
+ * @module commands/__tests__/install-agent.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+// Mock child_process spawn before importing the module under test
+const mockOn = vi.fn();
+const mockStdoutOn = vi.fn();
+const mockStderrOn = vi.fn();
+const mockProc = {
+  stdout: { on: mockStdoutOn },
+  stderr: { on: mockStderrOn },
+  on: mockOn,
+};
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => mockProc),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/auth/agent-credentials', () => ({
+  AGENT_CONFIGS: {
+    claude: { name: 'Claude Code' },
+    codex: { name: 'Codex' },
+    gemini: { name: 'Gemini CLI' },
+    opencode: { name: 'OpenCode' },
+  },
+  getAgentStatus: vi.fn(),
+  getAllAgentStatus: vi.fn(),
+}));
+
+vi.mock('chalk', () => ({
+  default: {
+    bold: (s: string) => s,
+    dim: (s: string) => s,
+    cyan: (s: string) => s,
+    green: (s: string) => s,
+    red: (s: string) => s,
+    yellow: (s: string) => s,
+    gray: (s: string) => s,
+  },
+}));
+
+import { spawn } from 'node:child_process';
+import { getAgentStatus, getAllAgentStatus } from '@/auth/agent-credentials';
+import {
+  AGENT_PACKAGES,
+  installAgent,
+  installAgents,
+  handleInstallCommand,
+} from '../install-agent';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Simulate the child_process spawn lifecycle so the Promise in installWithNpm
+ * resolves deterministically in tests.
+ *
+ * @param stderrContent - Content to emit on stderr (controls error branch logic)
+ * @param exitCode - Exit code emitted by the 'close' event
+ */
+function simulateSpawn(stderrContent: string, exitCode: number) {
+  mockStdoutOn.mockImplementation(() => {});
+  mockStderrOn.mockImplementation((_event: string, cb: (data: Buffer) => void) => {
+    if (stderrContent) cb(Buffer.from(stderrContent));
+  });
+  mockOn.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+    if (event === 'close') setImmediate(() => cb(exitCode));
+    if (event === 'error') {
+      // error listener registered but not called in this path
+    }
+  });
+}
+
+function simulateSpawnError(errorMessage: string) {
+  mockStdoutOn.mockImplementation(() => {});
+  mockStderrOn.mockImplementation(() => {});
+  mockOn.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+    if (event === 'error') setImmediate(() => cb(new Error(errorMessage)));
+  });
+}
+
+// ============================================================================
+// AGENT_PACKAGES data integrity
+// ============================================================================
+
+describe('AGENT_PACKAGES', () => {
+  const agents = ['claude', 'codex', 'gemini', 'opencode'] as const;
+
+  for (const agent of agents) {
+    it(`${agent} has required fields`, () => {
+      const pkg = AGENT_PACKAGES[agent];
+      expect(pkg.packageManager).toBe('npm');
+      expect(typeof pkg.packageName).toBe('string');
+      expect(pkg.packageName.length).toBeGreaterThan(0);
+      expect(typeof pkg.description).toBe('string');
+      expect(typeof pkg.postInstall).toBe('string');
+    });
+  }
+});
+
+// ============================================================================
+// installAgent
+// ============================================================================
+
+describe('installAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns success=true with a message when agent is already installed', async () => {
+    vi.mocked(getAgentStatus).mockResolvedValue({
+      agent: 'claude',
+      name: 'Claude Code',
+      installed: true,
+      configured: true,
+      command: 'claude',
+      version: '1.0.0',
+    });
+
+    const result = await installAgent('claude');
+
+    expect(result.success).toBe(true);
+    expect(result.error).toMatch(/already installed/i);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('returns success=true when npm exits with code 0', async () => {
+    vi.mocked(getAgentStatus).mockResolvedValue({
+      agent: 'claude',
+      name: 'Claude Code',
+      installed: false,
+      configured: false,
+      command: 'claude',
+    });
+
+    simulateSpawn('', 0);
+
+    const result = await installAgent('claude');
+
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+    expect(result.agent).toBe('claude');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns EACCES error message when npm exits with permission denied', async () => {
+    vi.mocked(getAgentStatus).mockResolvedValue({
+      agent: 'codex',
+      name: 'Codex',
+      installed: false,
+      configured: false,
+      command: 'codex',
+    });
+
+    simulateSpawn('npm ERR! code EACCES', 1);
+
+    const result = await installAgent('codex');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/permission denied/i);
+  });
+
+  it('returns 404 error message when package is not found', async () => {
+    vi.mocked(getAgentStatus).mockResolvedValue({
+      agent: 'gemini',
+      name: 'Gemini CLI',
+      installed: false,
+      configured: false,
+      command: 'gemini',
+    });
+
+    simulateSpawn('npm ERR! 404 Not Found', 1);
+
+    const result = await installAgent('gemini');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('returns network error message when npm reports ENOTFOUND', async () => {
+    vi.mocked(getAgentStatus).mockResolvedValue({
+      agent: 'opencode',
+      name: 'OpenCode',
+      installed: false,
+      configured: false,
+      command: 'opencode',
+    });
+
+    simulateSpawn('npm ERR! code ENOTFOUND', 1);
+
+    const result = await installAgent('opencode');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/network error/i);
+  });
+
+  it('returns generic exit code message for unknown npm failure', async () => {
+    vi.mocked(getAgentStatus).mockResolvedValue({
+      agent: 'claude',
+      name: 'Claude Code',
+      installed: false,
+      configured: false,
+      command: 'claude',
+    });
+
+    simulateSpawn('some unknown error', 2);
+
+    const result = await installAgent('claude');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/exit code 2/i);
+  });
+
+  it('returns error when npm binary cannot be spawned', async () => {
+    vi.mocked(getAgentStatus).mockResolvedValue({
+      agent: 'claude',
+      name: 'Claude Code',
+      installed: false,
+      configured: false,
+      command: 'claude',
+    });
+
+    simulateSpawnError('npm not found');
+
+    const result = await installAgent('claude');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/failed to run npm/i);
+  });
+
+  it('calls the onProgress callback during install', async () => {
+    vi.mocked(getAgentStatus).mockResolvedValue({
+      agent: 'claude',
+      name: 'Claude Code',
+      installed: false,
+      configured: false,
+      command: 'claude',
+    });
+
+    simulateSpawn('', 0);
+
+    const messages: string[] = [];
+    await installAgent('claude', (msg) => messages.push(msg));
+
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages.some((m) => /installing/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// installAgents (batch)
+// ============================================================================
+
+describe('installAgents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('installs agents sequentially and returns one result per agent', async () => {
+    vi.mocked(getAgentStatus)
+      .mockResolvedValueOnce({
+        agent: 'claude',
+        name: 'Claude Code',
+        installed: false,
+        configured: false,
+        command: 'claude',
+      })
+      .mockResolvedValueOnce({
+        agent: 'codex',
+        name: 'Codex',
+        installed: false,
+        configured: false,
+        command: 'codex',
+      });
+
+    // Both spawns succeed
+    mockStdoutOn.mockImplementation(() => {});
+    mockStderrOn.mockImplementation(() => {});
+    mockOn.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+      if (event === 'close') setImmediate(() => cb(0));
+    });
+
+    const progressCalls: [string, string][] = [];
+    const results = await installAgents(['claude', 'codex'], (agent, msg) =>
+      progressCalls.push([agent, msg])
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0].agent).toBe('claude');
+    expect(results[1].agent).toBe('codex');
+    expect(results.every((r) => r.success)).toBe(true);
+    expect(progressCalls.length).toBeGreaterThan(0);
+  });
+
+  it('returns mixed results when some agents fail', async () => {
+    vi.mocked(getAgentStatus)
+      .mockResolvedValueOnce({
+        agent: 'claude',
+        name: 'Claude Code',
+        installed: false,
+        configured: false,
+        command: 'claude',
+      })
+      .mockResolvedValueOnce({
+        agent: 'codex',
+        name: 'Codex',
+        installed: false,
+        configured: false,
+        command: 'codex',
+      });
+
+    let callCount = 0;
+    mockStdoutOn.mockImplementation(() => {});
+    mockStderrOn.mockImplementation(() => {});
+    mockOn.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+      if (event === 'close') {
+        callCount++;
+        // First spawn succeeds, second fails
+        setImmediate(() => cb(callCount === 1 ? 0 : 1));
+      }
+    });
+
+    const results = await installAgents(['claude', 'codex']);
+
+    expect(results[0].success).toBe(true);
+    expect(results[1].success).toBe(false);
+  });
+});
+
+// ============================================================================
+// handleInstallCommand
+// ============================================================================
+
+describe('handleInstallCommand', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints usage when no arguments are provided', async () => {
+    await handleInstallCommand([]);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Usage'));
+  });
+
+  it('prints unknown agent message for invalid agent name', async () => {
+    await handleInstallCommand(['bingbong']);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown agent'));
+  });
+
+  it('prints already-installed message when agent is already present', async () => {
+    vi.mocked(getAgentStatus).mockResolvedValue({
+      agent: 'claude',
+      name: 'Claude Code',
+      installed: true,
+      configured: true,
+      command: 'claude',
+      version: '1.0.0',
+    });
+
+    await handleInstallCommand(['claude']);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('already installed'));
+  });
+
+  it('prints all-installed message when --all and no agents need installing', async () => {
+    vi.mocked(getAllAgentStatus).mockResolvedValue({
+      claude: { agent: 'claude', name: 'Claude Code', installed: true, configured: true, command: 'claude' },
+      codex: { agent: 'codex', name: 'Codex', installed: true, configured: true, command: 'codex' },
+      gemini: { agent: 'gemini', name: 'Gemini CLI', installed: true, configured: true, command: 'gemini' },
+      opencode: { agent: 'opencode', name: 'OpenCode', installed: true, configured: true, command: 'opencode' },
+    });
+
+    await handleInstallCommand(['--all']);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('already installed')
+    );
+  });
+});

--- a/packages/styrby-cli/src/commands/__tests__/logs.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/logs.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for the logs command.
+ *
+ * Covers:
+ * - parseLogsArgs: default values, --follow/-f, --lines/-n, invalid value
+ * - handleLogs: no log file exists, empty log file, prints last N lines,
+ *   cannot read file (access denied)
+ *
+ * WHY: parseLogsArgs is pure and easy to exercise exhaustively. handleLogs
+ * branches on file existence / readability; wrong branch logic means users
+ * see no output or the wrong instructions.
+ *
+ * @module commands/__tests__/logs.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  accessSync: vi.fn(),
+  constants: { R_OK: 4 },
+  createReadStream: vi.fn(),
+  statSync: vi.fn(),
+  openSync: vi.fn(),
+  readSync: vi.fn(),
+  closeSync: vi.fn(),
+  watch: vi.fn(),
+}));
+
+vi.mock('node:readline', () => ({
+  createInterface: vi.fn(),
+}));
+
+vi.mock('@/daemon/run', () => ({
+  DAEMON_PATHS: {
+    logFile: '/tmp/.styrby/daemon.log',
+  },
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('chalk', () => ({
+  default: {
+    yellow: (s: string) => s,
+    red: (s: string) => s,
+    gray: (s: string) => s,
+    green: (s: string) => s,
+  },
+}));
+
+import * as fs from 'node:fs';
+import * as readline from 'node:readline';
+import { parseLogsArgs, handleLogs } from '../logs';
+
+// ============================================================================
+// parseLogsArgs
+// ============================================================================
+
+describe('parseLogsArgs', () => {
+  it('returns defaults when no args provided', () => {
+    const opts = parseLogsArgs([]);
+    expect(opts.follow).toBe(false);
+    expect(opts.lines).toBe(50);
+  });
+
+  it('sets follow=true on --follow', () => {
+    expect(parseLogsArgs(['--follow']).follow).toBe(true);
+  });
+
+  it('sets follow=true on -f', () => {
+    expect(parseLogsArgs(['-f']).follow).toBe(true);
+  });
+
+  it('parses --lines N', () => {
+    expect(parseLogsArgs(['--lines', '100']).lines).toBe(100);
+  });
+
+  it('parses -n N', () => {
+    expect(parseLogsArgs(['-n', '200']).lines).toBe(200);
+  });
+
+  it('ignores non-numeric value for --lines and keeps default', () => {
+    // NaN is not finite, so the guard keeps the default
+    expect(parseLogsArgs(['--lines', 'abc']).lines).toBe(50);
+  });
+
+  it('ignores zero for --lines and keeps default', () => {
+    // parsed = 0, which is not > 0
+    expect(parseLogsArgs(['-n', '0']).lines).toBe(50);
+  });
+
+  it('parses both -f and -n together', () => {
+    const opts = parseLogsArgs(['-f', '-n', '75']);
+    expect(opts.follow).toBe(true);
+    expect(opts.lines).toBe(75);
+  });
+});
+
+// ============================================================================
+// handleLogs — log file does not exist
+// ============================================================================
+
+describe('handleLogs — log file not found', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints "No daemon logs found" message', async () => {
+    await handleLogs([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /no daemon logs/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleLogs — log file exists but cannot be read
+// ============================================================================
+
+describe('handleLogs — access denied', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      throw new Error('process.exit called');
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.accessSync).mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('prints cannot-read error and calls process.exit(1)', async () => {
+    await expect(handleLogs([])).rejects.toThrow('process.exit called');
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /cannot read/i.test(m))).toBe(true);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+// ============================================================================
+// handleLogs — log file exists, has content, print mode
+// ============================================================================
+
+describe('handleLogs — prints last N lines', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.accessSync).mockReturnValue(undefined);
+
+    // Simulate readline emitting lines then closing
+    const mockRl = {
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        if (event === 'line') {
+          setImmediate(() => {
+            cb('[2026-04-21] log line 1');
+            cb('[2026-04-21] log line 2');
+          });
+        }
+        if (event === 'close') {
+          setImmediate(() => {
+            // Fire close after line events settle
+            setTimeout(cb, 5);
+          });
+        }
+        if (event === 'error') {
+          // Register but don't call
+        }
+        return mockRl;
+      }),
+    };
+
+    vi.mocked(readline.createInterface).mockReturnValue(mockRl as ReturnType<typeof readline.createInterface>);
+    vi.mocked(fs.createReadStream).mockReturnValue({} as ReturnType<typeof fs.createReadStream>);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints the log lines to stdout', async () => {
+    await handleLogs(['-n', '10']);
+
+    const lines = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes('log line 1'))).toBe(true);
+    expect(lines.some((l) => l.includes('log line 2'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleLogs — log file exists but is empty
+// ============================================================================
+
+describe('handleLogs — empty log file', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.accessSync).mockReturnValue(undefined);
+
+    // Simulate readline emitting no lines then closing immediately
+    const mockRl = {
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        if (event === 'close') {
+          setImmediate(cb);
+        }
+        return mockRl;
+      }),
+    };
+
+    vi.mocked(readline.createInterface).mockReturnValue(mockRl as ReturnType<typeof readline.createInterface>);
+    vi.mocked(fs.createReadStream).mockReturnValue({} as ReturnType<typeof fs.createReadStream>);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints "Log file is empty" message', async () => {
+    await handleLogs([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /log file is empty/i.test(m))).toBe(true);
+  });
+});

--- a/packages/styrby-cli/src/commands/__tests__/stop.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/stop.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the stop command.
+ *
+ * Covers:
+ * - handleStop when daemon is not running (no-op, prints yellow message)
+ * - handleStop when daemon is running and stopDaemon succeeds
+ * - handleStop when stopDaemon rejects (error path + process.exit(1))
+ *
+ * WHY: The stop command is a safe-stop gate; skipping the "not running"
+ * branch or swallowing the stopDaemon error would leave the daemon alive
+ * or show silent failures to users.
+ *
+ * @module commands/__tests__/stop.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('@/daemon/run', () => ({
+  getDaemonStatus: vi.fn(),
+  stopDaemon: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('chalk', () => ({
+  default: {
+    yellow: (s: string) => s,
+    green: (s: string) => s,
+    red: (s: string) => s,
+    gray: (s: string) => s,
+  },
+}));
+
+import { getDaemonStatus, stopDaemon } from '@/daemon/run';
+import { handleStop } from '../stop';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function mockStatus(running: boolean, pid?: number) {
+  vi.mocked(getDaemonStatus).mockReturnValue({ running, pid });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('handleStop — daemon not running', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockStatus(false);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints "No daemon running" message', async () => {
+    await handleStop([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /no daemon running/i.test(m))).toBe(true);
+  });
+
+  it('does not call stopDaemon', async () => {
+    await handleStop([]);
+    expect(stopDaemon).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleStop — daemon running, stop succeeds', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockStatus(true, 12345);
+    vi.mocked(stopDaemon).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('calls stopDaemon', async () => {
+    await handleStop([]);
+    expect(stopDaemon).toHaveBeenCalledOnce();
+  });
+
+  it('prints "Daemon stopped" on success', async () => {
+    await handleStop([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /daemon stopped/i.test(m))).toBe(true);
+  });
+
+  it('includes the PID in the stopping message', async () => {
+    await handleStop([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => m.includes('12345'))).toBe(true);
+  });
+});
+
+describe('handleStop — daemon running, stopDaemon rejects', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      throw new Error('process.exit called');
+    });
+    mockStatus(true, 9999);
+    vi.mocked(stopDaemon).mockRejectedValue(new Error('kill EPERM'));
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('prints failure message containing the error text', async () => {
+    await expect(handleStop([])).rejects.toThrow('process.exit called');
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /failed to stop daemon/i.test(m))).toBe(true);
+  });
+
+  it('calls process.exit(1) on error', async () => {
+    await expect(handleStop([])).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('handleStop — daemon running, stopDaemon throws non-Error', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      throw new Error('process.exit called');
+    });
+    mockStatus(true, 1);
+    // WHY: Testing the non-Error branch in the catch clause (error instanceof Error check)
+    vi.mocked(stopDaemon).mockRejectedValue('string error');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('prints "Unknown error" for non-Error rejection', async () => {
+    await expect(handleStop([])).rejects.toThrow('process.exit called');
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /unknown error/i.test(m))).toBe(true);
+  });
+});

--- a/packages/styrby-cli/src/commands/__tests__/upgrade.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/upgrade.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for the upgrade command.
+ *
+ * Covers:
+ * - compareVersions: equal, older, newer, v-prefix, partial semver
+ * - handleUpgrade: fetch fails, already up-to-date, update available + --check,
+ *   update available + install succeeds, install failure calls process.exit(1)
+ *
+ * WHY: compareVersions drives the "update available" branch; off-by-one in
+ * semver comparison means users either never see update prompts or always see
+ * them. The full handleUpgrade flow mocks fetch so no real network calls occur.
+ *
+ * @module commands/__tests__/upgrade.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/index', () => ({
+  VERSION: '0.1.0',
+}));
+
+vi.mock('chalk', () => ({
+  default: {
+    blue: (s: string) => s,
+    green: (s: string) => s,
+    yellow: (s: string) => s,
+    red: (s: string) => s,
+    gray: (s: string) => s,
+  },
+}));
+
+import { execSync } from 'node:child_process';
+import { handleUpgrade } from '../upgrade';
+
+// ============================================================================
+// compareVersions (tested indirectly via handleUpgrade behaviour)
+// We expose it for direct testing via a thin re-export below.
+// Since compareVersions is not exported, we test its behaviour through
+// handleUpgrade by controlling what VERSION and fetchLatestVersion return.
+// ============================================================================
+
+/**
+ * Build a minimal fetch mock that returns the given version from a JSON body.
+ */
+function mockFetchReturnsVersion(version: string | null) {
+  const globalFetch = vi.fn();
+
+  if (version === null) {
+    // Simulate network error
+    globalFetch.mockRejectedValue(new Error('network error'));
+  } else {
+    globalFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ version }),
+    });
+  }
+
+  vi.stubGlobal('fetch', globalFetch);
+  return globalFetch;
+}
+
+// ============================================================================
+// handleUpgrade — fetch fails
+// ============================================================================
+
+describe('handleUpgrade — fetch fails', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockFetchReturnsVersion(null);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('prints "Could not check for updates" when fetch throws', async () => {
+    await handleUpgrade([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /could not check/i.test(m))).toBe(true);
+  });
+
+  it('does not call execSync when fetch fails', async () => {
+    await handleUpgrade([]);
+    expect(execSync).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// handleUpgrade — already up to date (VERSION = latest)
+// ============================================================================
+
+describe('handleUpgrade — already up to date', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    // VERSION mock is '0.1.0' — return same version from registry
+    mockFetchReturnsVersion('0.1.0');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('prints "latest version" message', async () => {
+    await handleUpgrade([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /latest version/i.test(m))).toBe(true);
+  });
+
+  it('does not call execSync', async () => {
+    await handleUpgrade([]);
+    expect(execSync).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// handleUpgrade — current version is newer than registry
+// ============================================================================
+
+describe('handleUpgrade — current is newer than registry', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    // VERSION is '0.1.0', registry returns older '0.0.9'
+    mockFetchReturnsVersion('0.0.9');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('prints "latest version" when current is ahead of registry', async () => {
+    await handleUpgrade([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /latest version/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleUpgrade — update available, --check only
+// ============================================================================
+
+describe('handleUpgrade — update available, --check flag', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    // VERSION is '0.1.0', registry has '0.2.0' — newer
+    mockFetchReturnsVersion('0.2.0');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('prints update-available message', async () => {
+    await handleUpgrade(['--check']);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /update available/i.test(m))).toBe(true);
+  });
+
+  it('does not call execSync when --check is passed', async () => {
+    await handleUpgrade(['--check']);
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  it('-c short form also skips install', async () => {
+    await handleUpgrade(['-c']);
+    expect(execSync).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// handleUpgrade — update available, installs successfully
+// ============================================================================
+
+describe('handleUpgrade — install succeeds', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockFetchReturnsVersion('0.2.0');
+    vi.mocked(execSync).mockReturnValue('');
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('calls execSync with install command', async () => {
+    await handleUpgrade([]);
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining('styrby-cli@latest'),
+      expect.any(Object)
+    );
+  });
+
+  it('prints success message after install', async () => {
+    await handleUpgrade([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /updated successfully/i.test(m))).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleUpgrade — install fails
+// ============================================================================
+
+describe('handleUpgrade — install fails', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      throw new Error('process.exit called');
+    });
+    mockFetchReturnsVersion('0.2.0');
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error('EACCES permission denied');
+    });
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('prints failure message and calls process.exit(1)', async () => {
+    await expect(handleUpgrade([])).rejects.toThrow('process.exit called');
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /failed to update/i.test(m))).toBe(true);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+// ============================================================================
+// handleUpgrade — fetch returns non-OK response
+// ============================================================================
+
+describe('handleUpgrade — registry non-OK response', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    }));
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('prints "Could not check for updates" when registry returns 404', async () => {
+    await handleUpgrade([]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((m) => /could not check/i.test(m))).toBe(true);
+  });
+});

--- a/packages/styrby-cli/src/costs/__tests__/budget-actions.test.ts
+++ b/packages/styrby-cli/src/costs/__tests__/budget-actions.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for `budget-actions.ts`.
+ *
+ * Covers:
+ *  - BudgetActions.executeAction: skip when not new trigger, notify path,
+ *    warn_and_slowdown path, hard_stop path
+ *  - BudgetActions.executeAllActions: ordering, stops after session stop
+ *  - Slowdown management: triggerSlowdown, clearSlowdown, isSlowdownActive,
+ *    getSlowdownDelay, applySlowdownDelay
+ *  - triggerStop: calls onStopSession
+ *  - createBudgetActions factory
+ *  - checkAndExecuteBudgetActions integration helper
+ *
+ * WHY: Budget actions are the circuit-breaker for over-spend. Wrong behavior
+ * means either users get silently charged past their limit, or sessions get
+ * stopped when they shouldn't be.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('@styrby/shared/pricing', () => ({
+  getModelPriceSync: vi.fn(() => ({
+    inputPer1k: 0.003,
+    outputPer1k: 0.015,
+    cachePer1k: 0.0003,
+    cacheWritePer1k: 0.00375,
+  })),
+}));
+
+// Mock jsonl-parser so BudgetMonitor.checkAllAlerts works without FS
+vi.mock('../jsonl-parser.js', () => ({
+  getCostsForDateRange: vi.fn(async () => ({
+    totalCostUsd: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    entries: [],
+  })),
+}));
+
+import {
+  BudgetActions,
+  createBudgetActions,
+  checkAndExecuteBudgetActions,
+  type BudgetActionsConfig,
+  type ActionResult,
+} from '../budget-actions.js';
+import type { BudgetCheckResult, BudgetMonitor, BudgetAlert } from '../budget-monitor.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const VALID_UUID = '12345678-1234-4234-8234-123456789abc';
+
+function makeAlert(overrides: Partial<BudgetAlert> = {}): BudgetAlert {
+  return {
+    id: VALID_UUID,
+    user_id: VALID_UUID,
+    name: 'Test Alert',
+    threshold_usd: 10,
+    period: 'daily',
+    agent_type: null,
+    action: 'notify',
+    notification_channels: ['in_app'],
+    is_enabled: true,
+    last_triggered_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<BudgetCheckResult> = {}): BudgetCheckResult {
+  return {
+    level: 'warning',
+    alert: makeAlert(),
+    currentSpendUsd: 8,
+    percentUsed: 80,
+    remainingUsd: 2,
+    exceeded: false,
+    isNewTrigger: true,
+    ...overrides,
+  };
+}
+
+/** Build a minimal Supabase mock that tracks calls. */
+function makeSupabase() {
+  const channelMock = {
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn().mockResolvedValue(undefined),
+    unsubscribe: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const selectChain = {
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: { email_budget_alerts: true }, error: null }),
+  };
+
+  const insertChain = {
+    error: null,
+    then: vi.fn(),
+  };
+
+  return {
+    channel: vi.fn(() => channelMock),
+    from: vi.fn((table: string) => {
+      if (table === 'notification_preferences') {
+        return { select: vi.fn(() => selectChain) };
+      }
+      if (table === 'audit_log') {
+        return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      }
+      return {};
+    }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function makeConfig(overrides: Partial<BudgetActionsConfig> = {}): BudgetActionsConfig {
+  return {
+    supabase: makeSupabase(),
+    userId: VALID_UUID,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// BudgetActions: construction
+// ============================================================================
+
+describe('BudgetActions construction', () => {
+  it('creates an instance with factory function', () => {
+    expect(createBudgetActions(makeConfig())).toBeInstanceOf(BudgetActions);
+  });
+
+  it('starts with slowdown inactive', () => {
+    const actions = new BudgetActions(makeConfig());
+    expect(actions.isSlowdownActive()).toBe(false);
+    expect(actions.getSlowdownDelay()).toBe(0);
+  });
+});
+
+// ============================================================================
+// BudgetActions: executeAction — skipping
+// ============================================================================
+
+describe('BudgetActions.executeAction — non-new-trigger skip', () => {
+  it('returns success with empty notifications when isNewTrigger=false and level is not warning/critical', async () => {
+    const actions = new BudgetActions(makeConfig());
+    const result = makeResult({ isNewTrigger: false, level: 'ok' });
+
+    const actionResult = await actions.executeAction(result);
+
+    expect(actionResult.success).toBe(true);
+    expect(actionResult.notificationsSent).toHaveLength(0);
+    expect(actionResult.sessionStopped).toBe(false);
+    expect(actionResult.slowdownApplied).toBe(false);
+  });
+
+  it('still executes when isNewTrigger=false but level=warning (warning/critical override skip)', async () => {
+    const actions = new BudgetActions(makeConfig());
+    const result = makeResult({ isNewTrigger: false, level: 'warning' });
+
+    const actionResult = await actions.executeAction(result);
+
+    // Level is warning — skip guard does NOT apply
+    expect(actionResult.notificationsSent.length).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ============================================================================
+// BudgetActions: executeAction — notify action
+// ============================================================================
+
+describe('BudgetActions.executeAction — notify', () => {
+  it('sends in_app notification for notify action at warning level', async () => {
+    const actions = new BudgetActions(makeConfig());
+    const result = makeResult({
+      level: 'warning',
+      alert: makeAlert({ action: 'notify', notification_channels: ['in_app'] }),
+      isNewTrigger: true,
+    });
+
+    const actionResult = await actions.executeAction(result);
+
+    expect(actionResult.action).toBe('notify');
+    expect(actionResult.sessionStopped).toBe(false);
+    expect(actionResult.slowdownApplied).toBe(false);
+  });
+
+  it('does not stop session on notify action even when exceeded', async () => {
+    const actions = new BudgetActions(makeConfig());
+    const result = makeResult({
+      level: 'exceeded',
+      exceeded: true,
+      alert: makeAlert({ action: 'notify' }),
+      isNewTrigger: true,
+    });
+
+    const actionResult = await actions.executeAction(result);
+
+    expect(actionResult.sessionStopped).toBe(false);
+  });
+});
+
+// ============================================================================
+// BudgetActions: executeAction — warn_and_slowdown action
+// ============================================================================
+
+describe('BudgetActions.executeAction — warn_and_slowdown', () => {
+  it('applies slowdown at warning level', async () => {
+    const onSlowdown = vi.fn();
+    const actions = new BudgetActions(makeConfig({ onSlowdown }));
+    const result = makeResult({
+      level: 'warning',
+      alert: makeAlert({ action: 'warn_and_slowdown' }),
+      isNewTrigger: true,
+    });
+
+    const actionResult = await actions.executeAction(result);
+
+    expect(actionResult.slowdownApplied).toBe(true);
+    expect(actions.isSlowdownActive()).toBe(true);
+    expect(actions.getSlowdownDelay()).toBeGreaterThan(0);
+    expect(onSlowdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies slowdown at critical level with higher delay', async () => {
+    const actions = new BudgetActions(makeConfig());
+    const warningResult = makeResult({
+      level: 'warning',
+      alert: makeAlert({ action: 'warn_and_slowdown' }),
+      isNewTrigger: true,
+    });
+    const criticalResult = makeResult({
+      level: 'critical',
+      alert: makeAlert({ action: 'warn_and_slowdown' }),
+      isNewTrigger: true,
+    });
+
+    const actions2 = new BudgetActions(makeConfig());
+    await actions.executeAction(warningResult);
+    await actions2.executeAction(criticalResult);
+
+    expect(actions2.getSlowdownDelay()).toBeGreaterThan(actions.getSlowdownDelay());
+  });
+
+  it('does not stop session on warn_and_slowdown', async () => {
+    const actions = new BudgetActions(makeConfig());
+    const result = makeResult({
+      level: 'exceeded',
+      exceeded: true,
+      alert: makeAlert({ action: 'warn_and_slowdown' }),
+      isNewTrigger: true,
+    });
+
+    const actionResult = await actions.executeAction(result);
+
+    expect(actionResult.sessionStopped).toBe(false);
+  });
+});
+
+// ============================================================================
+// BudgetActions: executeAction — hard_stop action
+// ============================================================================
+
+describe('BudgetActions.executeAction — hard_stop', () => {
+  it('stops session when level=exceeded', async () => {
+    const onStopSession = vi.fn().mockResolvedValue(undefined);
+    const actions = new BudgetActions(makeConfig({ onStopSession }));
+    const result = makeResult({
+      level: 'exceeded',
+      exceeded: true,
+      alert: makeAlert({ action: 'hard_stop' }),
+      isNewTrigger: true,
+    });
+
+    const actionResult = await actions.executeAction(result);
+
+    expect(actionResult.sessionStopped).toBe(true);
+    expect(onStopSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT stop session when level=warning (only stops on exceeded)', async () => {
+    const onStopSession = vi.fn().mockResolvedValue(undefined);
+    const actions = new BudgetActions(makeConfig({ onStopSession }));
+    const result = makeResult({
+      level: 'warning',
+      exceeded: false,
+      alert: makeAlert({ action: 'hard_stop' }),
+      isNewTrigger: true,
+    });
+
+    const actionResult = await actions.executeAction(result);
+
+    expect(actionResult.sessionStopped).toBe(false);
+    expect(onStopSession).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// BudgetActions: executeAllActions
+// ============================================================================
+
+describe('BudgetActions.executeAllActions', () => {
+  it('skips ok-level results', async () => {
+    const actions = new BudgetActions(makeConfig());
+    const okResult = makeResult({ level: 'ok' });
+
+    const results = await actions.executeAllActions([okResult]);
+    expect(results).toHaveLength(0);
+  });
+
+  it('processes multiple actionable results', async () => {
+    const actions = new BudgetActions(makeConfig());
+    const results = [
+      makeResult({ level: 'warning', alert: makeAlert({ action: 'notify' }) }),
+      makeResult({ level: 'warning', alert: makeAlert({ action: 'notify' }) }),
+    ];
+
+    const actionResults = await actions.executeAllActions(results);
+    expect(actionResults).toHaveLength(2);
+  });
+
+  it('stops processing remaining results after session is stopped', async () => {
+    const onStopSession = vi.fn().mockResolvedValue(undefined);
+    const actions = new BudgetActions(makeConfig({ onStopSession }));
+
+    const stopResult = makeResult({
+      level: 'exceeded',
+      exceeded: true,
+      alert: makeAlert({ action: 'hard_stop' }),
+      isNewTrigger: true,
+    });
+    const notifyResult = makeResult({ level: 'warning', alert: makeAlert({ action: 'notify' }) });
+
+    const actionResults = await actions.executeAllActions([stopResult, notifyResult]);
+
+    // Only 1 result — the second one was skipped after stop
+    expect(actionResults).toHaveLength(1);
+    expect(actionResults[0].sessionStopped).toBe(true);
+  });
+});
+
+// ============================================================================
+// Slowdown management
+// ============================================================================
+
+describe('BudgetActions slowdown management', () => {
+  it('triggerSlowdown activates slowdown', () => {
+    const actions = new BudgetActions(makeConfig());
+    actions.triggerSlowdown(makeResult({ level: 'warning' }));
+    expect(actions.isSlowdownActive()).toBe(true);
+  });
+
+  it('clearSlowdown deactivates slowdown', () => {
+    const actions = new BudgetActions(makeConfig());
+    actions.triggerSlowdown(makeResult({ level: 'warning' }));
+    actions.clearSlowdown();
+    expect(actions.isSlowdownActive()).toBe(false);
+    expect(actions.getSlowdownDelay()).toBe(0);
+  });
+
+  it('applySlowdownDelay resolves immediately when slowdown not active', async () => {
+    const actions = new BudgetActions(makeConfig());
+    // Should not throw or hang
+    await expect(actions.applySlowdownDelay()).resolves.toBeUndefined();
+  });
+
+  it('adds extra delay when percentUsed > 100', () => {
+    const actions = new BudgetActions(makeConfig());
+    const actions2 = new BudgetActions(makeConfig());
+
+    actions.triggerSlowdown(makeResult({ level: 'exceeded', percentUsed: 100 }));
+    actions2.triggerSlowdown(makeResult({ level: 'exceeded', percentUsed: 150 }));
+
+    expect(actions2.getSlowdownDelay()).toBeGreaterThanOrEqual(actions.getSlowdownDelay());
+  });
+});
+
+// ============================================================================
+// checkAndExecuteBudgetActions integration helper
+// ============================================================================
+
+describe('checkAndExecuteBudgetActions', () => {
+  it('calls monitor.checkAllAlerts and actions.executeAllActions', async () => {
+    const mockCheckAllAlerts = vi.fn().mockResolvedValue([]);
+    const mockExecuteAllActions = vi.fn().mockResolvedValue([]);
+
+    const monitor = { checkAllAlerts: mockCheckAllAlerts } as unknown as BudgetMonitor;
+    const actionsInstance = { executeAllActions: mockExecuteAllActions } as unknown as BudgetActions;
+
+    const result = await checkAndExecuteBudgetActions(monitor, actionsInstance);
+
+    expect(mockCheckAllAlerts).toHaveBeenCalledTimes(1);
+    expect(mockExecuteAllActions).toHaveBeenCalledTimes(1);
+    expect(result.checkResults).toEqual([]);
+    expect(result.actionResults).toEqual([]);
+  });
+
+  it('passes check results to executeAllActions', async () => {
+    const checkResult = makeResult({ level: 'warning' });
+    const mockCheckAllAlerts = vi.fn().mockResolvedValue([checkResult]);
+    const mockExecuteAllActions = vi.fn().mockResolvedValue([]);
+
+    const monitor = { checkAllAlerts: mockCheckAllAlerts } as unknown as BudgetMonitor;
+    const actionsInstance = { executeAllActions: mockExecuteAllActions } as unknown as BudgetActions;
+
+    await checkAndExecuteBudgetActions(monitor, actionsInstance);
+
+    expect(mockExecuteAllActions).toHaveBeenCalledWith([checkResult], monitor);
+  });
+});

--- a/packages/styrby-cli/src/costs/__tests__/cost-extractor.test.ts
+++ b/packages/styrby-cli/src/costs/__tests__/cost-extractor.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Unit tests for `cost-extractor.ts`.
+ *
+ * Covers:
+ *  - Per-agent output parsers (parseClaudeOutput, parseCodexOutput,
+ *    parseGeminiOutput, parseOpenCodeOutput)
+ *  - CostExtractor: processOutput, addUsage, createInputOnlyRecord,
+ *    addUsageForMessage, getSummary, reset, deduplication
+ *
+ * WHY: These parsers translate raw agent output into USD costs that show up
+ * in the mobile cost pill. A regression here silently mis-bills users or
+ * drops cost events entirely.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+/**
+ * Mock @styrby/shared/pricing — litellm-pricing requires Node.js builtins
+ * unavailable in the Vitest environment. Return static Sonnet-4 pricing.
+ */
+vi.mock('@styrby/shared/pricing', () => ({
+  getModelPriceSync: vi.fn(() => ({
+    inputPer1k: 0.003,
+    outputPer1k: 0.015,
+    cachePer1k: 0.0003,
+    cacheWritePer1k: 0.00375,
+  })),
+  getModelPrice: vi.fn(async () => ({
+    inputPer1k: 0.003,
+    outputPer1k: 0.015,
+    cachePer1k: 0.0003,
+    cacheWritePer1k: 0.00375,
+  })),
+}));
+
+import {
+  parseClaudeOutput,
+  parseCodexOutput,
+  parseGeminiOutput,
+  parseOpenCodeOutput,
+  CostExtractor,
+  createCostExtractor,
+  type CostRecord,
+} from '../cost-extractor.js';
+import type { TokenUsage } from '../jsonl-parser.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const BASE_USAGE: TokenUsage = {
+  inputTokens: 1000,
+  outputTokens: 500,
+  cacheReadTokens: 200,
+  cacheWriteTokens: 50,
+  model: 'claude-sonnet-4-20250514',
+  timestamp: new Date('2026-04-01T10:00:00Z'),
+};
+
+const SESSION_ID = 'test-session-001';
+
+// ============================================================================
+// Parser: parseClaudeOutput
+// ============================================================================
+
+describe('parseClaudeOutput', () => {
+  it('returns null for empty string', () => {
+    expect(parseClaudeOutput('')).toBeNull();
+  });
+
+  it('returns null when no usage block found', () => {
+    expect(parseClaudeOutput('{"type":"text","text":"hello"}')).toBeNull();
+  });
+
+  it('parses a usage block from a Claude JSONL line', () => {
+    const output = JSON.stringify({
+      model: 'claude-sonnet-4-20250514',
+      usage: {
+        input_tokens: 1234,
+        output_tokens: 567,
+        cache_read_input_tokens: 100,
+        cache_creation_input_tokens: 20,
+      },
+    });
+
+    const result = parseClaudeOutput(output);
+
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(1234);
+    expect(result!.outputTokens).toBe(567);
+    expect(result!.cacheReadTokens).toBe(100);
+    expect(result!.cacheWriteTokens).toBe(20);
+    expect(result!.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('defaults model to claude-sonnet-4-20250514 when model field is absent', () => {
+    const output = '{"usage":{"input_tokens":100,"output_tokens":50}}';
+    const result = parseClaudeOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('picks the last usage block when multiple are present', () => {
+    const first = '{"usage":{"input_tokens":10,"output_tokens":5}}';
+    const second = '{"usage":{"input_tokens":999,"output_tokens":888}}';
+    const result = parseClaudeOutput(`${first}\n${second}`);
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(999);
+    expect(result!.outputTokens).toBe(888);
+  });
+});
+
+// ============================================================================
+// Parser: parseCodexOutput
+// ============================================================================
+
+describe('parseCodexOutput', () => {
+  it('returns null for empty string', () => {
+    expect(parseCodexOutput('')).toBeNull();
+  });
+
+  it('parses "Tokens: X in, Y out" format', () => {
+    const result = parseCodexOutput('Tokens: 1500 in, 400 out, model: gpt-4o');
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(1500);
+    expect(result!.outputTokens).toBe(400);
+    expect(result!.model).toBe('gpt-4o');
+  });
+
+  it('parses "input_tokens=X output_tokens=Y" format', () => {
+    const result = parseCodexOutput('input_tokens=200 output_tokens=100');
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(200);
+    expect(result!.outputTokens).toBe(100);
+  });
+
+  it('returns null when no token patterns match', () => {
+    expect(parseCodexOutput('No tokens here at all')).toBeNull();
+  });
+
+  it('defaults model to gpt-4o when model field absent', () => {
+    const result = parseCodexOutput('Tokens: 100 in, 50 out');
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe('gpt-4o');
+  });
+
+  it('sets cache tokens to 0 (Codex has no cache)', () => {
+    const result = parseCodexOutput('Tokens: 100 in, 50 out');
+    expect(result!.cacheReadTokens).toBe(0);
+    expect(result!.cacheWriteTokens).toBe(0);
+  });
+});
+
+// ============================================================================
+// Parser: parseGeminiOutput
+// ============================================================================
+
+describe('parseGeminiOutput', () => {
+  it('returns null for empty string', () => {
+    expect(parseGeminiOutput('')).toBeNull();
+  });
+
+  it('parses /stats style output', () => {
+    const output = [
+      'Model: gemini-2.0-flash',
+      'Input tokens: 2,500',
+      'Output tokens: 800',
+    ].join('\n');
+
+    const result = parseGeminiOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(2500);
+    expect(result!.outputTokens).toBe(800);
+    expect(result!.model).toBe('gemini-2.0-flash');
+  });
+
+  it('strips commas from token counts', () => {
+    const result = parseGeminiOutput('Input tokens: 1,234,567\nOutput tokens: 98,765');
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(1234567);
+    expect(result!.outputTokens).toBe(98765);
+  });
+
+  it('returns null when neither input nor output token line found', () => {
+    expect(parseGeminiOutput('Model: gemini-2.0-flash\nNo tokens here')).toBeNull();
+  });
+
+  it('defaults model to gemini-2.0-flash when model line absent', () => {
+    const result = parseGeminiOutput('Input tokens: 100\nOutput tokens: 50');
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe('gemini-2.0-flash');
+  });
+
+  it('sets cache tokens to 0 (Gemini has no cache fields)', () => {
+    const result = parseGeminiOutput('Input tokens: 100\nOutput tokens: 50');
+    expect(result!.cacheReadTokens).toBe(0);
+    expect(result!.cacheWriteTokens).toBe(0);
+  });
+});
+
+// ============================================================================
+// Parser: parseOpenCodeOutput
+// ============================================================================
+
+describe('parseOpenCodeOutput', () => {
+  it('returns null for empty string', () => {
+    expect(parseOpenCodeOutput('')).toBeNull();
+  });
+
+  it('parses "tokens: X input, Y output" format', () => {
+    const result = parseOpenCodeOutput('tokens: 300 input, 150 output\nusing: claude-sonnet-4-20250514');
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(300);
+    expect(result!.outputTokens).toBe(150);
+    expect(result!.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('parses "in: X out: Y" format', () => {
+    const result = parseOpenCodeOutput('in: 400 out: 200');
+    expect(result).not.toBeNull();
+    expect(result!.inputTokens).toBe(400);
+    expect(result!.outputTokens).toBe(200);
+  });
+
+  it('returns null when no token pattern matches', () => {
+    expect(parseOpenCodeOutput('no token data here')).toBeNull();
+  });
+
+  it('defaults model to claude-sonnet-4-20250514 when model absent', () => {
+    const result = parseOpenCodeOutput('in: 100 out: 50');
+    expect(result!.model).toBe('claude-sonnet-4-20250514');
+  });
+});
+
+// ============================================================================
+// CostExtractor
+// ============================================================================
+
+describe('CostExtractor', () => {
+  describe('constructor / createCostExtractor', () => {
+    it('creates an instance with factory function', () => {
+      const extractor = createCostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      expect(extractor).toBeInstanceOf(CostExtractor);
+    });
+
+    it('starts with empty records', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      expect(extractor.getRecords()).toHaveLength(0);
+    });
+  });
+
+  describe('addUsage', () => {
+    it('stores a record and emits cost event', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const handler = vi.fn();
+      extractor.on('cost', handler);
+
+      const record = extractor.addUsage(BASE_USAGE);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(record);
+      expect(extractor.getRecords()).toHaveLength(1);
+    });
+
+    it('assigns sessionId and agentType from config', () => {
+      const extractor = new CostExtractor({ agentType: 'gemini', sessionId: 'my-session' });
+      const record = extractor.addUsage(BASE_USAGE);
+      expect(record.sessionId).toBe('my-session');
+      expect(record.agentType).toBe('gemini');
+    });
+
+    it('calculates a positive cost', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const record = extractor.addUsage(BASE_USAGE);
+      expect(record.costUsd).toBeGreaterThan(0);
+    });
+  });
+
+  describe('createInputOnlyRecord', () => {
+    it('sets outputTokens to 0 and uses input-only cost', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const record = extractor.createInputOnlyRecord(BASE_USAGE);
+
+      expect(record.outputTokens).toBe(0);
+      expect(record.inputTokens).toBe(BASE_USAGE.inputTokens);
+      expect(record.costUsd).toBeGreaterThan(0);
+    });
+
+    it('does NOT emit a cost event (just creates the record)', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const handler = vi.fn();
+      extractor.on('cost', handler);
+
+      extractor.createInputOnlyRecord(BASE_USAGE);
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('does NOT push record into internal list (no side-effects)', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      extractor.createInputOnlyRecord(BASE_USAGE);
+      expect(extractor.getRecords()).toHaveLength(0);
+    });
+
+    it('input-only cost is less than full cost for same usage', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const inputOnly = extractor.createInputOnlyRecord(BASE_USAGE);
+      const full = extractor.addUsage(BASE_USAGE);
+      expect(inputOnly.costUsd).toBeLessThan(full.costUsd);
+    });
+  });
+
+  describe('processOutput', () => {
+    it('returns null on empty string', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      expect(extractor.processOutput('')).toBeNull();
+    });
+
+    it('returns null when no usage pattern in output', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      expect(extractor.processOutput('{"type":"text","text":"hello"}')).toBeNull();
+    });
+
+    it('extracts a cost record from new Claude output content', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const chunk = JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+
+      const record = extractor.processOutput(chunk);
+      expect(record).not.toBeNull();
+      expect(record!.inputTokens).toBe(100);
+    });
+
+    it('only processes new content on subsequent calls (incremental)', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const chunk1 = JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+      const chunk2 = JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        usage: { input_tokens: 200, output_tokens: 100 },
+      });
+
+      extractor.processOutput(chunk1);
+      // Second call with cumulative buffer — should only parse the new part
+      const record = extractor.processOutput(chunk1 + '\n' + chunk2);
+
+      // The second call extracts only from the new portion
+      expect(record).not.toBeNull();
+      expect(record!.inputTokens).toBe(200);
+    });
+
+    it('uses Codex parser when agentType is codex', () => {
+      const extractor = new CostExtractor({ agentType: 'codex', sessionId: SESSION_ID });
+      const record = extractor.processOutput('Tokens: 100 in, 50 out');
+      expect(record).not.toBeNull();
+      expect(record!.agentType).toBe('codex');
+    });
+
+    it('uses Gemini parser when agentType is gemini', () => {
+      const extractor = new CostExtractor({ agentType: 'gemini', sessionId: SESSION_ID });
+      const record = extractor.processOutput('Input tokens: 100\nOutput tokens: 50');
+      expect(record).not.toBeNull();
+    });
+  });
+
+  describe('getSummary', () => {
+    it('returns zero totals for empty extractor', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const summary = extractor.getSummary();
+      expect(summary.totalCostUsd).toBe(0);
+      expect(summary.recordCount).toBe(0);
+      expect(summary.totalInputTokens).toBe(0);
+    });
+
+    it('aggregates multiple records correctly', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      extractor.addUsage(BASE_USAGE);
+      extractor.addUsage({ ...BASE_USAGE, inputTokens: 500, outputTokens: 200 });
+
+      const summary = extractor.getSummary();
+      expect(summary.recordCount).toBe(2);
+      expect(summary.totalInputTokens).toBe(BASE_USAGE.inputTokens + 500);
+      expect(summary.totalOutputTokens).toBe(BASE_USAGE.outputTokens + 200);
+      expect(summary.totalCostUsd).toBeGreaterThan(0);
+    });
+
+    it('groups by model in byModel map', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      extractor.addUsage(BASE_USAGE);
+      extractor.addUsage({ ...BASE_USAGE, model: 'claude-haiku-4-20250514' });
+
+      const summary = extractor.getSummary();
+      expect(Object.keys(summary.byModel)).toHaveLength(2);
+      expect(summary.byModel['claude-sonnet-4-20250514']).toBeDefined();
+      expect(summary.byModel['claude-haiku-4-20250514']).toBeDefined();
+    });
+
+    it('preserves sessionId and agentType in summary', () => {
+      const extractor = new CostExtractor({ agentType: 'codex', sessionId: 'xyz' });
+      const summary = extractor.getSummary();
+      expect(summary.sessionId).toBe('xyz');
+      expect(summary.agentType).toBe('codex');
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all records', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      extractor.addUsage(BASE_USAGE);
+      extractor.addUsage(BASE_USAGE);
+      expect(extractor.getRecords()).toHaveLength(2);
+
+      extractor.reset();
+      expect(extractor.getRecords()).toHaveLength(0);
+    });
+
+    it('resets incremental processing pointer so processOutput starts fresh', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const chunk = JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+
+      extractor.processOutput(chunk);
+      extractor.reset();
+
+      // After reset the same chunk should be processed again
+      const record = extractor.processOutput(chunk);
+      expect(record).not.toBeNull();
+    });
+  });
+
+  describe('deduplication in processOutput', () => {
+    it('does not add duplicate records with identical token counts within 1 second', () => {
+      const extractor = new CostExtractor({ agentType: 'claude', sessionId: SESSION_ID });
+      const chunk = JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+
+      // First call processes the chunk
+      extractor.processOutput(chunk);
+      // Reset the length tracker manually to force re-processing the same content
+      // This simulates a repeated chunk in a different call context
+      extractor.reset();
+      extractor.processOutput(chunk);
+
+      // Both calls extract records after reset
+      expect(extractor.getRecords()).toHaveLength(1);
+    });
+  });
+});

--- a/packages/styrby-mobile/src/services/__tests__/encryption.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/encryption.test.ts
@@ -551,4 +551,37 @@ describe('Encryption Service', () => {
       expect(supabase.from).toHaveBeenCalledWith('machine_keys');
     });
   });
+
+  // ==========================================================================
+  // GAP-FILL: additional uncovered branches
+  // ==========================================================================
+
+  describe('getOrCreateKeyPair() — SecureStore write failure', () => {
+    it('throws if SecureStore.setItemAsync fails during keypair generation', async () => {
+      // No stored keypair → will call generateKeyPair then setItemAsync
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(null);
+      (SecureStore.setItemAsync as jest.Mock).mockRejectedValueOnce(
+        new Error('Keychain unavailable')
+      );
+
+      await expect(getOrCreateKeyPair()).rejects.toThrow('Keychain unavailable');
+    });
+  });
+
+  describe('getRecipientPublicKey() — row exists but public_key is null', () => {
+    it('throws "No public key found" when machine_keys row has public_key = null', async () => {
+      (supabase.from as jest.Mock).mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValueOnce({
+          data: { public_key: null }, // row exists, field is null
+          error: null,
+        }),
+      });
+
+      await expect(getRecipientPublicKey('machine-null-key')).rejects.toThrow(
+        'No public key found for machine machine-null-key'
+      );
+    });
+  });
 });

--- a/packages/styrby-mobile/src/services/__tests__/notifications.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/notifications.test.ts
@@ -368,4 +368,69 @@ describe('Notifications Service', () => {
       expect(await getLastNotificationResponse()).toBeNull();
     });
   });
+
+  // ==========================================================================
+  // GAP-FILL: additional uncovered branches
+  // ==========================================================================
+
+  describe('registerForPushNotifications() — Android channels', () => {
+    it('calls setNotificationChannelAsync for default and permissions channels on android', async () => {
+      // WHY: react-native Platform.OS is mocked as 'ios' in jest.setup.js.
+      // We override Platform to android for this single test without re-importing
+      // the module (the notifications module reads Platform.OS at call time,
+      // not at module initialization time).
+      const RN = require('react-native');
+      const originalOS = RN.Platform.OS;
+      RN.Platform.OS = 'android';
+
+      (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValueOnce({
+        status: 'granted',
+      });
+      (Notifications.getExpoPushTokenAsync as jest.Mock).mockResolvedValueOnce({
+        data: 'ExponentPushToken[android-gap]',
+      });
+
+      const result = await registerForPushNotifications();
+
+      // Restore Platform.OS so other tests are unaffected
+      RN.Platform.OS = originalOS;
+
+      expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith(
+        'default',
+        expect.objectContaining({ name: 'Default' })
+      );
+      expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith(
+        'permissions',
+        expect.objectContaining({ name: 'Permission Requests' })
+      );
+      expect(result).toBe('ExponentPushToken[android-gap]');
+    });
+  });
+
+  describe('registerForPushNotifications() — non-physical device', () => {
+    it('returns null when Device.isDevice is false', async () => {
+      // WHY: We mock the expo-device module directly so all importers of
+      // 'expo-device' see isDevice: false for this test. The module-level
+      // mock registered in jest.setup.js is replaced via jest.resetModules
+      // + re-import within this test.
+      //
+      // Because the notifications module is already imported at the top of
+      // this test file (before any per-test mock overrides), we cannot use
+      // isolateModules without --experimental-vm-modules. Instead we rely on
+      // the fact that notifications.ts reads `Device.isDevice` at call time
+      // from its imported reference. We mutate the mock object directly.
+      const DeviceMod = require('expo-device');
+      const original = DeviceMod.isDevice;
+      DeviceMod.isDevice = false;
+
+      const result = await registerForPushNotifications();
+
+      // Restore before assertions to avoid state leak
+      DeviceMod.isDevice = original;
+
+      // WHY: When isDevice is false, the function returns null immediately
+      // before touching Notifications APIs. Result must be null.
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/styrby-mobile/src/services/__tests__/offline-queue.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/offline-queue.test.ts
@@ -1228,4 +1228,79 @@ describe('Offline Queue Service', () => {
       expect(mod.offlineQueue).toBeInstanceOf(SQLiteOfflineQueue);
     });
   });
+
+  // ==========================================================================
+  // GAP-FILL: additional uncovered branches
+  // ==========================================================================
+
+  describe('enqueue() — all EnqueueOptions fields forwarded', () => {
+    it('passes priority, ttl, and maxAttempts to createQueuedCommand', async () => {
+      const message = createTestMessage('opts-test');
+      const opts = { priority: 99, ttl: 10000, maxAttempts: 5 };
+      const futureDate = new Date(Date.now() + 10000).toISOString();
+      const mockCmd = createMockQueuedCommand(message, {
+        priority: 99, maxAttempts: 5, expiresAt: futureDate,
+      });
+      mockCreateQueuedCommand.mockReturnValueOnce(mockCmd);
+
+      const result = await queue.enqueue(message, opts);
+
+      expect(mockCreateQueuedCommand).toHaveBeenCalledWith(message, opts);
+      expect(result.priority).toBe(99);
+      expect(result.maxAttempts).toBe(5);
+    });
+  });
+
+  describe('clearAll() — empty queue', () => {
+    it('resolves without error when queue is already empty', async () => {
+      // mockRows is already empty (cleared in beforeEach)
+      await expect(queue.clearAll()).resolves.toBeUndefined();
+
+      expect(mockRunAsync).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM command_queue')
+      );
+    });
+  });
+
+  describe('processQueue() — sequential drain of all pending items', () => {
+    it('calls sendFn for every item until queue is empty', async () => {
+      const futureDate = new Date(Date.now() + 60000).toISOString();
+      const now = new Date().toISOString();
+
+      // Seed 3 pending rows with distinct IDs
+      const rowIds = ['drain_1', 'drain_2', 'drain_3'];
+      for (const rid of rowIds) {
+        mockRows.set(rid, {
+          id: rid,
+          message: JSON.stringify(createTestMessage(rid)),
+          status: 'pending',
+          attempts: 0,
+          max_attempts: 3,
+          created_at: now,
+          expires_at: futureDate,
+          priority: 0,
+          last_attempt_at: null,
+          last_error: null,
+        });
+      }
+
+      // Simulate dequeue returning each row once then null
+      let dequeueIdx = 0;
+      mockGetFirstAsync.mockImplementation(async (sql: string) => {
+        if (sql.includes("status = 'pending'") && sql.includes('LIMIT 1')) {
+          if (dequeueIdx < rowIds.length) {
+            return { ...mockRows.get(rowIds[dequeueIdx++]) };
+          }
+          return null;
+        }
+        // markFailed lookup by id — not called here since sendFn succeeds
+        return null;
+      });
+
+      const sentMessages: unknown[] = [];
+      await queue.processQueue(async (msg) => { sentMessages.push(msg); });
+
+      expect(sentMessages).toHaveLength(3);
+    });
+  });
 });

--- a/packages/styrby-mobile/src/services/__tests__/offline-storage.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/offline-storage.test.ts
@@ -589,4 +589,26 @@ describe('Offline Storage Service', () => {
       expect(mockStorageRows.size).toBe(10);
     });
   });
+
+  // ==========================================================================
+  // GAP-FILL: additional uncovered branches
+  // ==========================================================================
+
+  describe('saveCommand() — SQLite write failure', () => {
+    it('propagates error when runAsync throws (e.g. SQLITE_FULL)', async () => {
+      mockRunAsync.mockRejectedValueOnce(new Error('SQLITE_FULL'));
+
+      await expect(
+        saveCommand({ command_type: 'chat', payload: { content: 'fail-write' } })
+      ).rejects.toThrow('SQLITE_FULL');
+    });
+  });
+
+  describe('getPendingCommands() — SQLite read failure', () => {
+    it('propagates error when getAllAsync throws (e.g. SQLITE_CORRUPT)', async () => {
+      mockGetAllAsync.mockRejectedValueOnce(new Error('SQLITE_CORRUPT'));
+
+      await expect(getPendingCommands()).rejects.toThrow('SQLITE_CORRUPT');
+    });
+  });
 });

--- a/packages/styrby-mobile/src/services/__tests__/offline-sync.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/offline-sync.test.ts
@@ -624,4 +624,54 @@ describe('Offline Sync Service', () => {
       );
     });
   });
+
+  // ==========================================================================
+  // GAP-FILL: additional uncovered branches
+  // ==========================================================================
+
+  describe('syncPendingCommands() — clearSynced not called when all inserts fail', () => {
+    it('does not call clearSynced when every command fails to insert', async () => {
+      mockGetPendingCommands.mockResolvedValueOnce([
+        createStoredCommand({ id: 'gap_f1' }),
+        createStoredCommand({ id: 'gap_f2' }),
+      ]);
+
+      // All Supabase inserts return an error
+      let callCount = 0;
+      (supabase.from as jest.Mock).mockImplementation(() => {
+        callCount++;
+        const chain: Record<string, unknown> = {
+          insert: jest.fn().mockReturnThis(),
+        };
+        chain.then = (resolve: (v: unknown) => void) =>
+          Promise.resolve({ error: { message: 'Constraint violation' } }).then(resolve);
+        return chain;
+      });
+
+      const result = await syncPendingCommands();
+
+      expect(result).toBe(0);
+      expect(mockClearSynced).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('syncPendingCommands() — null user with null error defers sync', () => {
+    it('returns 0 when auth.getUser returns null user and null error', async () => {
+      // WHY: If the session is missing but no error is returned (e.g. anonymous
+      // or expired session), we should still defer sync rather than crash.
+      mockGetPendingCommands.mockResolvedValueOnce([
+        createStoredCommand({ id: 'gap_nouser' }),
+      ]);
+
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: null,
+      });
+
+      const result = await syncPendingCommands();
+
+      expect(result).toBe(0);
+      expect(supabase.from).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/styrby-mobile/src/services/__tests__/pairing.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/pairing.test.ts
@@ -389,4 +389,64 @@ describe('pairing service', () => {
       expect(result).toBeNull();
     });
   });
+
+  // ==========================================================================
+  // GAP-FILL: additional uncovered branches
+  // ==========================================================================
+
+  describe('getStoredPairingInfo() — SecureStore throws', () => {
+    it('returns null when SecureStore.getItemAsync throws', async () => {
+      const mockGetItemAsync = SecureStore.getItemAsync as jest.MockedFunction<typeof SecureStore.getItemAsync>;
+      mockGetItemAsync.mockRejectedValueOnce(new Error('Keychain locked'));
+
+      const result = await getStoredPairingInfo();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('isPaired() — SecureStore throws', () => {
+    it('returns false when underlying getStoredPairingInfo encounters a SecureStore error', async () => {
+      const mockGetItemAsync = SecureStore.getItemAsync as jest.MockedFunction<typeof SecureStore.getItemAsync>;
+      mockGetItemAsync.mockRejectedValueOnce(new Error('Keychain locked'));
+
+      const result = await isPaired();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('executePairing() — null push token skips savePushToken', () => {
+    it('succeeds and does not call savePushToken when registerForPushNotifications returns null', async () => {
+      // WHY: When the device refuses push permissions or returns null token,
+      // we must skip the savePushToken call. This is the fire-and-forget
+      // path inside registerPushNotificationsAsync.
+      mockRegisterForPushNotifications.mockResolvedValueOnce(null);
+
+      const result = await executePairing('styrby://pair?data=...');
+
+      expect(result.success).toBe(true);
+      expect(result.pairingInfo).toBeDefined();
+
+      // Allow the fire-and-forget async to settle
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockRegisterForPushNotifications).toHaveBeenCalled();
+      expect(mockSavePushToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearPairingInfo() — both SecureStore keys deleted', () => {
+    it('calls deleteItemAsync for PAIRING_INFO_KEY and PAIRING_TOKEN_KEY', async () => {
+      // Pre-populate so the in-memory mock has values to delete
+      await SecureStore.setItemAsync('styrby_pairing_info', JSON.stringify(validPayload));
+      await SecureStore.setItemAsync('styrby_pairing_token', 'tok-gap-fill');
+
+      await clearPairingInfo();
+
+      const mockDeleteItemAsync = SecureStore.deleteItemAsync as jest.MockedFunction<typeof SecureStore.deleteItemAsync>;
+      expect(mockDeleteItemAsync).toHaveBeenCalledWith('styrby_pairing_info');
+      expect(mockDeleteItemAsync).toHaveBeenCalledWith('styrby_pairing_token');
+    });
+  });
 });

--- a/packages/styrby-shared/src/auth/__tests__/passkey.test.ts
+++ b/packages/styrby-shared/src/auth/__tests__/passkey.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for WebAuthn passkey helpers (auth/passkey.ts).
+ *
+ * Covers: extractRpId, buildPublicKeyCredentialCreationOptions,
+ * buildPublicKeyCredentialRequestOptions, isCounterValid, and constants.
+ *
+ * All helpers are pure functions — no mocks needed.
+ *
+ * @module auth/__tests__/passkey
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  extractRpId,
+  buildPublicKeyCredentialCreationOptions,
+  buildPublicKeyCredentialRequestOptions,
+  isCounterValid,
+  DEFAULT_PASSKEY_TIMEOUT_MS,
+  PASSKEY_CHALLENGE_BYTES,
+  PASSKEY_CHALLENGE_TTL_MS,
+} from '../passkey.js';
+
+// ============================================================================
+// extractRpId
+// ============================================================================
+
+describe('extractRpId', () => {
+  it('returns the hostname from an https URL', () => {
+    expect(extractRpId('https://styrby.com/login')).toBe('styrby.com');
+  });
+
+  it('returns localhost for local dev', () => {
+    expect(extractRpId('http://localhost:3000')).toBe('localhost');
+  });
+
+  it('handles Vercel preview deploy hostnames', () => {
+    expect(extractRpId('https://preview-xyz.vercel.app')).toBe('preview-xyz.vercel.app');
+  });
+
+  it('normalizes to lowercase', () => {
+    expect(extractRpId('https://Styrby.COM/path')).toBe('styrby.com');
+  });
+
+  it('strips port numbers', () => {
+    expect(extractRpId('https://styrby.com:443/dashboard')).toBe('styrby.com');
+  });
+
+  it('handles subdomain URLs', () => {
+    expect(extractRpId('https://app.styrby.com')).toBe('app.styrby.com');
+  });
+
+  it('throws TypeError for invalid URLs', () => {
+    expect(() => extractRpId('not-a-url')).toThrow(TypeError);
+    expect(() => extractRpId('')).toThrow(TypeError);
+  });
+});
+
+// ============================================================================
+// buildPublicKeyCredentialCreationOptions
+// ============================================================================
+
+describe('buildPublicKeyCredentialCreationOptions', () => {
+  const baseInput = {
+    rpId: 'styrby.com',
+    rpName: 'Styrby',
+    userId: 'dXNlcklk', // base64url of "userId"
+    userName: 'test@styrby.com',
+    userDisplayName: 'Test User',
+    challenge: 'Y2hhbGxlbmdl', // base64url of "challenge"
+  };
+
+  it('includes correct rp fields', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.rp).toEqual({ id: 'styrby.com', name: 'Styrby' });
+  });
+
+  it('includes correct user fields', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.user).toEqual({
+      id: baseInput.userId,
+      name: baseInput.userName,
+      displayName: baseInput.userDisplayName,
+    });
+  });
+
+  it('echoes the challenge unchanged', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.challenge).toBe(baseInput.challenge);
+  });
+
+  it('includes ES256, EdDSA, and RS256 alg params in preference order', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.pubKeyCredParams).toEqual([
+      { type: 'public-key', alg: -7 },   // ES256
+      { type: 'public-key', alg: -8 },   // EdDSA
+      { type: 'public-key', alg: -257 }, // RS256
+    ]);
+  });
+
+  it('uses DEFAULT_PASSKEY_TIMEOUT_MS when timeoutMs is omitted', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.timeout).toBe(DEFAULT_PASSKEY_TIMEOUT_MS);
+  });
+
+  it('uses the provided timeoutMs when given', () => {
+    const opts = buildPublicKeyCredentialCreationOptions({ ...baseInput, timeoutMs: 30_000 });
+    expect(opts.timeout).toBe(30_000);
+  });
+
+  it('produces an empty excludeCredentials array when none provided', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.excludeCredentials).toEqual([]);
+  });
+
+  it('maps excludeCredentials ids to public-key objects', () => {
+    const opts = buildPublicKeyCredentialCreationOptions({
+      ...baseInput,
+      excludeCredentials: ['cred-1', 'cred-2'],
+    });
+    expect(opts.excludeCredentials).toEqual([
+      { type: 'public-key', id: 'cred-1' },
+      { type: 'public-key', id: 'cred-2' },
+    ]);
+  });
+
+  it('enforces residentKey: required (discoverable credentials)', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.authenticatorSelection.residentKey).toBe('required');
+  });
+
+  it('enforces userVerification: required (NIST AAL3)', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.authenticatorSelection.userVerification).toBe('required');
+  });
+
+  it('uses attestation: none (privacy-preserving)', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.attestation).toBe('none');
+  });
+
+  it('requests credProps extension', () => {
+    const opts = buildPublicKeyCredentialCreationOptions(baseInput);
+    expect(opts.extensions).toEqual({ credProps: true });
+  });
+});
+
+// ============================================================================
+// buildPublicKeyCredentialRequestOptions
+// ============================================================================
+
+describe('buildPublicKeyCredentialRequestOptions', () => {
+  const baseInput = {
+    rpId: 'styrby.com',
+    challenge: 'Y2hhbGxlbmdl',
+  };
+
+  it('echoes rpId and challenge', () => {
+    const opts = buildPublicKeyCredentialRequestOptions(baseInput);
+    expect(opts.rpId).toBe('styrby.com');
+    expect(opts.challenge).toBe('Y2hhbGxlbmdl');
+  });
+
+  it('enforces userVerification: required (NIST AAL3)', () => {
+    const opts = buildPublicKeyCredentialRequestOptions(baseInput);
+    expect(opts.userVerification).toBe('required');
+  });
+
+  it('produces an empty allowCredentials array when none provided', () => {
+    const opts = buildPublicKeyCredentialRequestOptions(baseInput);
+    expect(opts.allowCredentials).toEqual([]);
+  });
+
+  it('maps allowCredentials ids to public-key objects', () => {
+    const opts = buildPublicKeyCredentialRequestOptions({
+      ...baseInput,
+      allowCredentials: ['abc', 'def'],
+    });
+    expect(opts.allowCredentials).toEqual([
+      { type: 'public-key', id: 'abc' },
+      { type: 'public-key', id: 'def' },
+    ]);
+  });
+
+  it('uses DEFAULT_PASSKEY_TIMEOUT_MS when timeoutMs is omitted', () => {
+    const opts = buildPublicKeyCredentialRequestOptions(baseInput);
+    expect(opts.timeout).toBe(DEFAULT_PASSKEY_TIMEOUT_MS);
+  });
+
+  it('respects an explicit timeoutMs', () => {
+    const opts = buildPublicKeyCredentialRequestOptions({ ...baseInput, timeoutMs: 45_000 });
+    expect(opts.timeout).toBe(45_000);
+  });
+});
+
+// ============================================================================
+// isCounterValid
+// ============================================================================
+
+describe('isCounterValid', () => {
+  it('returns true for a normal monotonic increment', () => {
+    expect(isCounterValid(5, 6)).toBe(true);
+    expect(isCounterValid(0, 1)).toBe(true);
+    expect(isCounterValid(100, 200)).toBe(true);
+  });
+
+  it('returns false when incoming equals stored (replay attack)', () => {
+    expect(isCounterValid(5, 5)).toBe(false);
+    expect(isCounterValid(1, 1)).toBe(false);
+  });
+
+  it('returns false when incoming is less than stored (rollback / clone)', () => {
+    expect(isCounterValid(5, 4)).toBe(false);
+    expect(isCounterValid(10, 0)).toBe(false);
+  });
+
+  it('returns true when both counters are zero (Apple/Google fixed-zero behavior)', () => {
+    // WHY: Apple platform keys and certain TPM authenticators deliberately
+    // return signCount=0. Spec permits skipping the check when both are zero.
+    expect(isCounterValid(0, 0)).toBe(true);
+  });
+
+  it('returns false when stored=0 but incoming=0 is already covered, and stored>0 incoming=0 is a rollback', () => {
+    expect(isCounterValid(1, 0)).toBe(false);
+  });
+});
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+describe('Passkey constants', () => {
+  it('DEFAULT_PASSKEY_TIMEOUT_MS is 60 seconds', () => {
+    expect(DEFAULT_PASSKEY_TIMEOUT_MS).toBe(60_000);
+  });
+
+  it('PASSKEY_CHALLENGE_BYTES is 32 (NIST 800-63B >= 64 bits)', () => {
+    expect(PASSKEY_CHALLENGE_BYTES).toBe(32);
+  });
+
+  it('PASSKEY_CHALLENGE_TTL_MS is 5 minutes', () => {
+    expect(PASSKEY_CHALLENGE_TTL_MS).toBe(5 * 60 * 1000);
+  });
+});

--- a/packages/styrby-shared/src/errors/__tests__/classifier.test.ts
+++ b/packages/styrby-shared/src/errors/__tests__/classifier.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for the error classifier (errors/classifier.ts).
+ *
+ * Covers: classifyError, classifyErrors, isErrorFromSource, getPatternById.
+ *
+ * WHY coverage: classifyError is used by the mobile and web UI to surface
+ * human-readable error explanations. Regressions here mean users see "unknown
+ * error" instead of actionable guidance.
+ *
+ * @module errors/__tests__/classifier
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyError,
+  classifyErrors,
+  isErrorFromSource,
+  getPatternById,
+} from '../classifier.js';
+
+// ============================================================================
+// classifyError — known patterns
+// ============================================================================
+
+describe('classifyError — agent patterns', () => {
+  it('classifies rate limit errors as agent/agent_rate_limit', () => {
+    const result = classifyError('Rate limit exceeded: too many requests');
+    expect(result.source).toBe('agent');
+    expect(result.category).toBe('agent_rate_limit');
+    expect(result.confidence).toBeGreaterThanOrEqual(0.7);
+  });
+
+  it('classifies 429 status as agent rate limit', () => {
+    const result = classifyError('HTTP 429: quota exceeded');
+    expect(result.category).toBe('agent_rate_limit');
+  });
+
+  it('classifies context window overflow as agent/agent_context_limit', () => {
+    const result = classifyError('context length exceeded maximum tokens');
+    expect(result.source).toBe('agent');
+    expect(result.category).toBe('agent_context_limit');
+  });
+
+  it('classifies Anthropic API error as agent/agent_api_error', () => {
+    const result = classifyError('Anthropic error: internal server error 500');
+    expect(result.source).toBe('agent');
+    expect(result.category).toBe('agent_api_error');
+  });
+});
+
+describe('classifyError — build patterns', () => {
+  it('classifies TypeScript errors as build/build_type', () => {
+    const result = classifyError('TS2345: Argument of type string is not assignable to type number');
+    expect(result.source).toBe('build');
+    expect(result.category).toBe('build_type');
+  });
+
+  it('extracts TypeScript error code in details', () => {
+    const result = classifyError('TS2345: type mismatch');
+    expect(result.details).toBeDefined();
+    expect((result.details as Record<string, unknown>)?.errorCode).toBe('TS2345');
+  });
+
+  it('classifies npm dependency errors as build/build_dependency', () => {
+    const result = classifyError('npm ERR! ERESOLVE could not resolve peer dep conflict');
+    expect(result.source).toBe('build');
+    expect(result.category).toBe('build_dependency');
+  });
+
+  it('classifies eslint errors as build/build_syntax', () => {
+    const result = classifyError('eslint error: parsing error in src/index.ts');
+    expect(result.source).toBe('build');
+    expect(result.category).toBe('build_syntax');
+  });
+
+  it('classifies test failure as build/test_failure', () => {
+    const result = classifyError('AssertionError: expected 5 to equal 6');
+    expect(result.source).toBe('build');
+    expect(result.category).toBe('test_failure');
+  });
+});
+
+describe('classifyError — network patterns', () => {
+  it('classifies ETIMEDOUT as network/network_timeout', () => {
+    const result = classifyError('ETIMEDOUT: request timed out');
+    expect(result.source).toBe('network');
+    expect(result.category).toBe('network_timeout');
+  });
+
+  it('classifies ENOTFOUND as network/network_dns', () => {
+    const result = classifyError('ENOTFOUND: getaddrinfo ENOTFOUND api.example.com');
+    expect(result.source).toBe('network');
+    expect(result.category).toBe('network_dns');
+  });
+
+  it('classifies offline errors as network/network_offline', () => {
+    const result = classifyError('net::ERR_INTERNET_DISCONNECTED');
+    expect(result.source).toBe('network');
+    expect(result.category).toBe('network_offline');
+  });
+});
+
+describe('classifyError — Styrby relay patterns', () => {
+  it('classifies relay connection failures as styrby/relay_connection', () => {
+    const result = classifyError('Failed to connect to relay: websocket connection failed');
+    expect(result.source).toBe('styrby');
+    expect(result.category).toBe('relay_connection');
+  });
+
+  it('classifies token expiry as styrby/auth_expired', () => {
+    const result = classifyError('Token expired: session expired, please re-authenticate');
+    expect(result.source).toBe('styrby');
+    expect(result.category).toBe('auth_expired');
+  });
+});
+
+// ============================================================================
+// classifyError — unknown / fallback
+// ============================================================================
+
+describe('classifyError — unknown errors', () => {
+  it('returns unknown source and category for unrecognized messages', () => {
+    const result = classifyError('some completely unrecognized gibberish error zzz');
+    expect(result.source).toBe('unknown');
+    expect(result.category).toBe('unknown');
+    expect(result.confidence).toBe(0.1);
+  });
+
+  it('always includes the originalMessage on the result', () => {
+    const msg = 'original error message text';
+    const result = classifyError(msg);
+    expect(result.originalMessage).toBe(msg);
+  });
+
+  it('always includes at least one suggestion', () => {
+    const result = classifyError('totally unknown error');
+    expect(result.suggestions.length).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================================
+// classifyError — location extraction
+// ============================================================================
+
+describe('classifyError — location extraction', () => {
+  it('extracts file, line, and column from TypeScript error', () => {
+    const result = classifyError('TS2345: error at /src/index.ts:10:5');
+    expect(result.location).toBeDefined();
+    expect(result.location?.file).toContain('index.ts');
+    expect(result.location?.line).toBe(10);
+    expect(result.location?.column).toBe(5);
+  });
+
+  it('returns undefined location for messages without file references', () => {
+    const result = classifyError('Rate limit exceeded');
+    // May or may not have location depending on content — only check if present
+    if (result.location !== undefined) {
+      expect(typeof result.location.file).toBe('string');
+    }
+  });
+});
+
+// ============================================================================
+// classifyErrors — deduplication and sorting
+// ============================================================================
+
+describe('classifyErrors', () => {
+  it('deduplicates by category, keeping highest confidence', () => {
+    const results = classifyErrors([
+      'Rate limit exceeded',
+      '429: too many requests',
+    ]);
+    const rateLimitResults = results.filter((r) => r.category === 'agent_rate_limit');
+    expect(rateLimitResults.length).toBe(1);
+  });
+
+  it('sorts results with critical severity first', () => {
+    const results = classifyErrors([
+      'ETIMEDOUT: request timed out',       // warning
+      'TS2345: type error',                  // error
+    ]);
+    // Both should appear; errors should sort before warnings
+    const severities = results.map((r) => r.severity);
+    const errorIdx = severities.indexOf('error');
+    const warningIdx = severities.indexOf('warning');
+    if (errorIdx !== -1 && warningIdx !== -1) {
+      expect(errorIdx).toBeLessThan(warningIdx);
+    }
+  });
+
+  it('handles an empty array gracefully', () => {
+    expect(classifyErrors([])).toEqual([]);
+  });
+
+  it('returns an array of ErrorAttribution objects', () => {
+    const results = classifyErrors(['Rate limit exceeded']);
+    expect(Array.isArray(results)).toBe(true);
+    for (const result of results) {
+      expect(result).toHaveProperty('source');
+      expect(result).toHaveProperty('category');
+      expect(result).toHaveProperty('confidence');
+    }
+  });
+});
+
+// ============================================================================
+// isErrorFromSource
+// ============================================================================
+
+describe('isErrorFromSource', () => {
+  it('returns true when source matches with sufficient confidence', () => {
+    expect(isErrorFromSource('Rate limit exceeded: 429', 'agent')).toBe(true);
+  });
+
+  it('returns false for the wrong source', () => {
+    expect(isErrorFromSource('Rate limit exceeded: 429', 'styrby')).toBe(false);
+  });
+
+  it('returns false for unknown errors (confidence < 0.5)', () => {
+    expect(isErrorFromSource('totally unrecognized error xyz', 'agent')).toBe(false);
+  });
+});
+
+// ============================================================================
+// getPatternById
+// ============================================================================
+
+describe('getPatternById', () => {
+  it('returns the pattern for a known id', () => {
+    const pattern = getPatternById('agent_rate_limit');
+    expect(pattern).toBeDefined();
+    expect(pattern?.source).toBe('agent');
+    expect(pattern?.category).toBe('agent_rate_limit');
+  });
+
+  it('returns the TypeScript error pattern', () => {
+    const pattern = getPatternById('typescript_error');
+    expect(pattern).toBeDefined();
+    expect(pattern?.source).toBe('build');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(getPatternById('nonexistent_pattern_xyz')).toBeUndefined();
+  });
+});

--- a/packages/styrby-shared/src/mcp/__tests__/catalog.test.ts
+++ b/packages/styrby-shared/src/mcp/__tests__/catalog.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the MCP tool catalog (mcp/catalog.ts).
+ *
+ * Validates structural integrity, uniqueness constraints, status lifecycle,
+ * and semver format for all entries in STYRBY_MCP_TOOLS.
+ *
+ * WHY these tests: The catalog is consumed by the CLI (server registration),
+ * web (registry browser), and mobile (settings mirror). Any drift in the
+ * catalog — duplicate names, unknown categories, or malformed versions —
+ * would cause silent mismatches between the UI and the runtime.
+ *
+ * @module mcp/__tests__/catalog
+ */
+
+import { describe, it, expect } from 'vitest';
+import { STYRBY_MCP_TOOLS } from '../catalog.js';
+import type { MCPToolDescriptor, MCPToolCategory, MCPToolStatus } from '../catalog.js';
+
+// ============================================================================
+// Catalog-level structural invariants
+// ============================================================================
+
+describe('STYRBY_MCP_TOOLS catalog', () => {
+  it('is a non-empty readonly array', () => {
+    expect(Array.isArray(STYRBY_MCP_TOOLS)).toBe(true);
+    expect(STYRBY_MCP_TOOLS.length).toBeGreaterThan(0);
+  });
+
+  it('has unique tool names (no duplicates)', () => {
+    const names = STYRBY_MCP_TOOLS.map((t) => t.name);
+    const unique = new Set(names);
+    expect(unique.size).toBe(names.length);
+  });
+
+  it('every tool name is snake_case (MCP spec requirement)', () => {
+    // WHY: MCP clients identify tools by name. Any non-snake_case name
+    // breaks the CLI server registration and the webhook integration.
+    const snakeCasePattern = /^[a-z][a-z0-9_]*$/;
+    for (const tool of STYRBY_MCP_TOOLS) {
+      expect(tool.name, `tool "${tool.name}" should be snake_case`).toMatch(snakeCasePattern);
+    }
+  });
+
+  it('every tool has a non-empty title and description', () => {
+    for (const tool of STYRBY_MCP_TOOLS) {
+      expect(tool.title.length, `"${tool.name}" title should not be empty`).toBeGreaterThan(0);
+      expect(tool.description.length, `"${tool.name}" description should not be empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every tool category is a valid MCPToolCategory', () => {
+    const validCategories: MCPToolCategory[] = ['approval', 'policy', 'audit', 'query', 'mutation'];
+    for (const tool of STYRBY_MCP_TOOLS) {
+      expect(validCategories, `"${tool.name}" has unexpected category "${tool.category}"`).toContain(tool.category);
+    }
+  });
+
+  it('every tool status is a valid MCPToolStatus', () => {
+    const validStatuses: MCPToolStatus[] = ['ga', 'beta', 'planned'];
+    for (const tool of STYRBY_MCP_TOOLS) {
+      expect(validStatuses, `"${tool.name}" has unexpected status "${tool.status}"`).toContain(tool.status);
+    }
+  });
+
+  it('every introducedIn follows loose semver format (major.minor.patch)', () => {
+    // WHY: introducedIn drives the public roadmap display. Malformed versions
+    // cause sort errors in the registry UI's version filter.
+    const semverPattern = /^\d+\.\d+\.\d+$/;
+    for (const tool of STYRBY_MCP_TOOLS) {
+      expect(
+        tool.introducedIn,
+        `"${tool.name}" introducedIn "${tool.introducedIn}" should match major.minor.patch`
+      ).toMatch(semverPattern);
+    }
+  });
+});
+
+// ============================================================================
+// Individual known tools
+// ============================================================================
+
+describe('request_approval tool', () => {
+  const tool = STYRBY_MCP_TOOLS.find((t) => t.name === 'request_approval');
+
+  it('exists in the catalog', () => {
+    expect(tool).toBeDefined();
+  });
+
+  it('is GA status (the only currently released tool)', () => {
+    expect(tool?.status).toBe('ga');
+  });
+
+  it('has category: approval', () => {
+    expect(tool?.category).toBe('approval');
+  });
+
+  it('was introduced in version 0.2.0', () => {
+    expect(tool?.introducedIn).toBe('0.2.0');
+  });
+});
+
+describe('planned tools', () => {
+  const planned = STYRBY_MCP_TOOLS.filter((t) => t.status === 'planned');
+
+  it('there are at least 2 planned tools on the roadmap', () => {
+    expect(planned.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('planned tools are all scheduled for 0.4.0 or later', () => {
+    for (const tool of planned) {
+      const [, minor] = tool.introducedIn.split('.').map(Number);
+      // 0.4.0+ => minor >= 4
+      expect(minor, `planned tool "${tool.name}" should be >= 0.4.0`).toBeGreaterThanOrEqual(4);
+    }
+  });
+});
+
+// ============================================================================
+// Shape conformance (every descriptor satisfies MCPToolDescriptor)
+// ============================================================================
+
+describe('MCPToolDescriptor shape conformance', () => {
+  it('all tools satisfy the MCPToolDescriptor interface keys', () => {
+    const requiredKeys: (keyof MCPToolDescriptor)[] = [
+      'name',
+      'title',
+      'description',
+      'category',
+      'status',
+      'introducedIn',
+    ];
+
+    for (const tool of STYRBY_MCP_TOOLS) {
+      for (const key of requiredKeys) {
+        expect(tool, `tool "${tool.name}" is missing key "${key}"`).toHaveProperty(key);
+      }
+    }
+  });
+});

--- a/packages/styrby-shared/src/relay/__tests__/offline-queue.test.ts
+++ b/packages/styrby-shared/src/relay/__tests__/offline-queue.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for offline queue helpers (relay/offline-queue.ts).
+ *
+ * Tests pure helper functions: getMessagePriority, generateQueueId,
+ * getRetryDelay, shouldRetry, createQueuedCommand.
+ *
+ * WHY: The offline queue is critical for mobile UX when connectivity drops.
+ * Bugs in priority, retry logic, or expiry detection cause lost or
+ * duplicate commands reaching the CLI agent.
+ *
+ * @module relay/__tests__/offline-queue
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getMessagePriority,
+  generateQueueId,
+  getRetryDelay,
+  shouldRetry,
+  createQueuedCommand,
+  QueuePriority,
+  DEFAULT_QUEUE_TTL_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  RETRY_BASE_DELAY_MS,
+} from '../offline-queue.js';
+import type { RelayMessage, CommandMessage } from '../types.js';
+
+// ============================================================================
+// Helpers for building minimal RelayMessages
+// ============================================================================
+
+function makeBase() {
+  return {
+    id: 'msg_test',
+    timestamp: new Date().toISOString(),
+    sender_device_id: 'device-1',
+    sender_type: 'mobile' as const,
+  };
+}
+
+function makeChatMessage(): RelayMessage {
+  return {
+    ...makeBase(),
+    type: 'chat',
+    payload: { content: 'hello', agent: 'claude' },
+  };
+}
+
+function makeCommandMessage(action: CommandMessage['payload']['action']): RelayMessage {
+  return {
+    ...makeBase(),
+    type: 'command',
+    payload: { action },
+  };
+}
+
+function makePermissionResponse(): RelayMessage {
+  return {
+    ...makeBase(),
+    type: 'permission_response',
+    payload: {
+      request_id: 'req-1',
+      approved: true,
+      request_nonce: 'nonce-abc',
+    },
+  };
+}
+
+function makeAckMessage(): RelayMessage {
+  return {
+    ...makeBase(),
+    type: 'ack',
+    payload: { ack_id: 'msg_1', success: true },
+  };
+}
+
+// ============================================================================
+// getMessagePriority
+// ============================================================================
+
+describe('getMessagePriority', () => {
+  it('permission_response → CRITICAL', () => {
+    expect(getMessagePriority(makePermissionResponse())).toBe(QueuePriority.CRITICAL);
+  });
+
+  it('cancel command → CRITICAL', () => {
+    expect(getMessagePriority(makeCommandMessage('cancel'))).toBe(QueuePriority.CRITICAL);
+  });
+
+  it('interrupt command → CRITICAL', () => {
+    expect(getMessagePriority(makeCommandMessage('interrupt'))).toBe(QueuePriority.CRITICAL);
+  });
+
+  it('non-critical command (ping) → NORMAL', () => {
+    expect(getMessagePriority(makeCommandMessage('ping'))).toBe(QueuePriority.NORMAL);
+  });
+
+  it('chat message → HIGH', () => {
+    expect(getMessagePriority(makeChatMessage())).toBe(QueuePriority.HIGH);
+  });
+
+  it('ack message → LOW', () => {
+    expect(getMessagePriority(makeAckMessage())).toBe(QueuePriority.LOW);
+  });
+
+  it('unknown type falls back to NORMAL', () => {
+    // Force-cast to exercise the default branch
+    const unknown = { ...makeBase(), type: 'unknown_future_type', payload: {} } as unknown as RelayMessage;
+    expect(getMessagePriority(unknown)).toBe(QueuePriority.NORMAL);
+  });
+});
+
+// ============================================================================
+// generateQueueId
+// ============================================================================
+
+describe('generateQueueId', () => {
+  it('starts with "queue_"', () => {
+    expect(generateQueueId().startsWith('queue_')).toBe(true);
+  });
+
+  it('produces unique IDs', () => {
+    const ids = new Set(Array.from({ length: 50 }, generateQueueId));
+    expect(ids.size).toBe(50);
+  });
+});
+
+// ============================================================================
+// getRetryDelay — exponential backoff
+// ============================================================================
+
+describe('getRetryDelay', () => {
+  it('returns RETRY_BASE_DELAY_MS on first attempt (0)', () => {
+    expect(getRetryDelay(0)).toBe(RETRY_BASE_DELAY_MS);
+  });
+
+  it('doubles the delay on each additional attempt', () => {
+    expect(getRetryDelay(1)).toBe(RETRY_BASE_DELAY_MS * 2);
+    expect(getRetryDelay(2)).toBe(RETRY_BASE_DELAY_MS * 4);
+    expect(getRetryDelay(3)).toBe(RETRY_BASE_DELAY_MS * 8);
+  });
+
+  it('caps at 30 seconds', () => {
+    expect(getRetryDelay(100)).toBe(30_000);
+  });
+
+  it('does not exceed 30s for any large attempt count', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(getRetryDelay(i)).toBeLessThanOrEqual(30_000);
+    }
+  });
+});
+
+// ============================================================================
+// shouldRetry
+// ============================================================================
+
+describe('shouldRetry', () => {
+  function makeItem(overrides: Partial<Parameters<typeof shouldRetry>[0]> = {}) {
+    return {
+      id: 'q_1',
+      message: makeChatMessage(),
+      status: 'failed' as const,
+      attempts: 1,
+      maxAttempts: DEFAULT_MAX_ATTEMPTS,
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      priority: 0,
+      ...overrides,
+    };
+  }
+
+  it('returns true when status=failed, attempts < maxAttempts, not expired', () => {
+    expect(shouldRetry(makeItem())).toBe(true);
+  });
+
+  it('returns false when status is not "failed"', () => {
+    expect(shouldRetry(makeItem({ status: 'pending' }))).toBe(false);
+    expect(shouldRetry(makeItem({ status: 'sent' }))).toBe(false);
+  });
+
+  it('returns false when attempts >= maxAttempts', () => {
+    expect(shouldRetry(makeItem({ attempts: DEFAULT_MAX_ATTEMPTS }))).toBe(false);
+    expect(shouldRetry(makeItem({ attempts: DEFAULT_MAX_ATTEMPTS + 1 }))).toBe(false);
+  });
+
+  it('returns false when item is expired', () => {
+    expect(shouldRetry(makeItem({ expiresAt: new Date(Date.now() - 1000).toISOString() }))).toBe(false);
+  });
+});
+
+// ============================================================================
+// createQueuedCommand
+// ============================================================================
+
+describe('createQueuedCommand', () => {
+  it('creates a QueuedCommand with status "pending"', () => {
+    const cmd = createQueuedCommand(makeChatMessage());
+    expect(cmd.status).toBe('pending');
+  });
+
+  it('starts with 0 attempts', () => {
+    const cmd = createQueuedCommand(makeChatMessage());
+    expect(cmd.attempts).toBe(0);
+  });
+
+  it('uses DEFAULT_MAX_ATTEMPTS when not specified', () => {
+    const cmd = createQueuedCommand(makeChatMessage());
+    expect(cmd.maxAttempts).toBe(DEFAULT_MAX_ATTEMPTS);
+  });
+
+  it('respects a custom maxAttempts', () => {
+    const cmd = createQueuedCommand(makeChatMessage(), { maxAttempts: 5 });
+    expect(cmd.maxAttempts).toBe(5);
+  });
+
+  it('sets expiresAt to now + DEFAULT_QUEUE_TTL_MS by default', () => {
+    const before = Date.now();
+    const cmd = createQueuedCommand(makeChatMessage());
+    const after = Date.now();
+    const expires = new Date(cmd.expiresAt).getTime();
+    expect(expires).toBeGreaterThanOrEqual(before + DEFAULT_QUEUE_TTL_MS - 50);
+    expect(expires).toBeLessThanOrEqual(after + DEFAULT_QUEUE_TTL_MS + 50);
+  });
+
+  it('respects a custom ttl', () => {
+    const before = Date.now();
+    const cmd = createQueuedCommand(makeChatMessage(), { ttl: 10_000 });
+    const expires = new Date(cmd.expiresAt).getTime();
+    expect(expires).toBeGreaterThanOrEqual(before + 10_000 - 50);
+    expect(expires).toBeLessThanOrEqual(before + 10_000 + 200);
+  });
+
+  it('assigns priority from getMessagePriority when none provided', () => {
+    const chatCmd = createQueuedCommand(makeChatMessage());
+    expect(chatCmd.priority).toBe(QueuePriority.HIGH);
+  });
+
+  it('respects an explicit priority override', () => {
+    const cmd = createQueuedCommand(makeChatMessage(), { priority: QueuePriority.CRITICAL });
+    expect(cmd.priority).toBe(QueuePriority.CRITICAL);
+  });
+
+  it('assigns a unique ID prefixed with "queue_"', () => {
+    const cmd = createQueuedCommand(makeChatMessage());
+    expect(cmd.id.startsWith('queue_')).toBe(true);
+  });
+
+  it('sets createdAt to current ISO timestamp', () => {
+    const before = new Date().toISOString();
+    const cmd = createQueuedCommand(makeChatMessage());
+    expect(cmd.createdAt >= before).toBe(true);
+  });
+});
+
+// ============================================================================
+// QueuePriority constants
+// ============================================================================
+
+describe('QueuePriority constants', () => {
+  it('CRITICAL > HIGH > NORMAL > LOW', () => {
+    expect(QueuePriority.CRITICAL).toBeGreaterThan(QueuePriority.HIGH);
+    expect(QueuePriority.HIGH).toBeGreaterThan(QueuePriority.NORMAL);
+    expect(QueuePriority.NORMAL).toBeGreaterThan(QueuePriority.LOW);
+  });
+
+  it('CRITICAL is 100', () => {
+    expect(QueuePriority.CRITICAL).toBe(100);
+  });
+
+  it('LOW is negative (below normal)', () => {
+    expect(QueuePriority.LOW).toBeLessThan(0);
+  });
+});

--- a/packages/styrby-shared/src/relay/__tests__/pairing.test.ts
+++ b/packages/styrby-shared/src/relay/__tests__/pairing.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for relay pairing helpers (relay/pairing.ts).
+ *
+ * Covers: generatePairingToken, hashPairingToken, createPairingPayload,
+ * encodePairingUrl, decodePairingUrl, isPairingExpired, validatePairingPayload.
+ *
+ * @module relay/__tests__/pairing
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generatePairingToken,
+  hashPairingToken,
+  createPairingPayload,
+  encodePairingUrl,
+  decodePairingUrl,
+  isPairingExpired,
+  validatePairingPayload,
+  PAIRING_SCHEME,
+  PAIRING_TOKEN_EXPIRY_MS,
+  PAIRING_EXPIRY_MINUTES,
+} from '../pairing.js';
+import type { PairingPayload } from '../pairing.js';
+
+// ============================================================================
+// generatePairingToken
+// ============================================================================
+
+describe('generatePairingToken', () => {
+  it('returns a non-empty string', () => {
+    const token = generatePairingToken();
+    expect(typeof token).toBe('string');
+    expect(token.length).toBeGreaterThan(0);
+  });
+
+  it('produces URL-safe base64 (no +, /, or = characters)', () => {
+    const token = generatePairingToken();
+    expect(token).not.toMatch(/[+/=]/);
+  });
+
+  it('produces unique tokens on successive calls', () => {
+    const a = generatePairingToken();
+    const b = generatePairingToken();
+    expect(a).not.toBe(b);
+  });
+
+  it('has sufficient length (>= 40 chars for 32 bytes base64url)', () => {
+    // 32 bytes → ~43 base64url chars (32 * 4/3, rounded, minus padding)
+    expect(generatePairingToken().length).toBeGreaterThanOrEqual(40);
+  });
+});
+
+// ============================================================================
+// hashPairingToken
+// ============================================================================
+
+describe('hashPairingToken', () => {
+  it('returns a 64-character hex string (SHA-256)', async () => {
+    const hash = await hashPairingToken('test-token');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for the same input', async () => {
+    const a = await hashPairingToken('my-token');
+    const b = await hashPairingToken('my-token');
+    expect(a).toBe(b);
+  });
+
+  it('produces different hashes for different inputs', async () => {
+    const a = await hashPairingToken('token-a');
+    const b = await hashPairingToken('token-b');
+    expect(a).not.toBe(b);
+  });
+});
+
+// ============================================================================
+// createPairingPayload
+// ============================================================================
+
+describe('createPairingPayload', () => {
+  const payload = createPairingPayload(
+    'tok123',
+    'user-id-456',
+    'machine-abc',
+    'My MacBook',
+    'https://akmtmxunjhsgldjztdtt.supabase.co',
+    'claude',
+  );
+
+  it('sets version to 1', () => {
+    expect(payload.version).toBe(1);
+  });
+
+  it('echoes all provided fields', () => {
+    expect(payload.token).toBe('tok123');
+    expect(payload.userId).toBe('user-id-456');
+    expect(payload.machineId).toBe('machine-abc');
+    expect(payload.deviceName).toBe('My MacBook');
+    expect(payload.supabaseUrl).toBe('https://akmtmxunjhsgldjztdtt.supabase.co');
+    expect(payload.activeAgent).toBe('claude');
+  });
+
+  it('sets expiresAt to roughly now + PAIRING_TOKEN_EXPIRY_MS', () => {
+    const before = Date.now();
+    const p = createPairingPayload('t', 'u', 'm', 'd', 'https://x.supabase.co');
+    const after = Date.now();
+    const expiresTs = new Date(p.expiresAt).getTime();
+    expect(expiresTs).toBeGreaterThanOrEqual(before + PAIRING_TOKEN_EXPIRY_MS - 50);
+    expect(expiresTs).toBeLessThanOrEqual(after + PAIRING_TOKEN_EXPIRY_MS + 50);
+  });
+
+  it('allows undefined activeAgent', () => {
+    const p = createPairingPayload('t', 'u', 'm', 'd', 'https://x.supabase.co');
+    expect(p.activeAgent).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// encodePairingUrl / decodePairingUrl round-trip
+// ============================================================================
+
+describe('encodePairingUrl + decodePairingUrl', () => {
+  const payload: PairingPayload = {
+    version: 1,
+    token: 'abc123',
+    userId: 'user-1',
+    machineId: 'machine-1',
+    deviceName: 'Dev Machine',
+    supabaseUrl: 'https://test.supabase.co',
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  };
+
+  it('produces a URL starting with the pairing scheme', () => {
+    const url = encodePairingUrl(payload);
+    expect(url.startsWith(PAIRING_SCHEME)).toBe(true);
+  });
+
+  it('round-trips a payload through encode then decode', () => {
+    const url = encodePairingUrl(payload);
+    const decoded = decodePairingUrl(url);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.token).toBe(payload.token);
+    expect(decoded?.userId).toBe(payload.userId);
+    expect(decoded?.machineId).toBe(payload.machineId);
+    expect(decoded?.deviceName).toBe(payload.deviceName);
+    expect(decoded?.supabaseUrl).toBe(payload.supabaseUrl);
+    expect(decoded?.version).toBe(1);
+  });
+
+  it('decodePairingUrl returns null for an invalid URL', () => {
+    expect(decodePairingUrl('not-a-valid-url')).toBeNull();
+  });
+
+  it('decodePairingUrl returns null for a URL with wrong version', () => {
+    const badPayload = { ...payload, version: 2 as unknown as 1 };
+    const url = `${PAIRING_SCHEME}?data=${encodeURIComponent(btoa(JSON.stringify(badPayload)))}`;
+    expect(decodePairingUrl(url)).toBeNull();
+  });
+
+  it('decodePairingUrl returns null for malformed base64', () => {
+    const url = `${PAIRING_SCHEME}?data=!!!notbase64!!!`;
+    expect(decodePairingUrl(url)).toBeNull();
+  });
+});
+
+// ============================================================================
+// isPairingExpired
+// ============================================================================
+
+describe('isPairingExpired', () => {
+  it('returns false for a future expiresAt', () => {
+    const payload: PairingPayload = {
+      version: 1,
+      token: 't',
+      userId: 'u',
+      machineId: 'm',
+      deviceName: 'd',
+      supabaseUrl: 'https://x.supabase.co',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    expect(isPairingExpired(payload)).toBe(false);
+  });
+
+  it('returns true for a past expiresAt', () => {
+    const payload: PairingPayload = {
+      version: 1,
+      token: 't',
+      userId: 'u',
+      machineId: 'm',
+      deviceName: 'd',
+      supabaseUrl: 'https://x.supabase.co',
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    };
+    expect(isPairingExpired(payload)).toBe(true);
+  });
+});
+
+// ============================================================================
+// validatePairingPayload
+// ============================================================================
+
+describe('validatePairingPayload', () => {
+  const validPayload: PairingPayload = {
+    version: 1,
+    token: 'tok',
+    userId: 'user',
+    machineId: 'machine',
+    deviceName: 'name',
+    supabaseUrl: 'https://x.supabase.co',
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  };
+
+  it('accepts a well-formed payload', () => {
+    expect(validatePairingPayload(validPayload)).toBe(true);
+  });
+
+  it('rejects null', () => {
+    expect(validatePairingPayload(null)).toBe(false);
+  });
+
+  it('rejects a string', () => {
+    expect(validatePairingPayload('payload')).toBe(false);
+  });
+
+  it('rejects when version is not 1', () => {
+    expect(validatePairingPayload({ ...validPayload, version: 2 })).toBe(false);
+  });
+
+  it('rejects when a required field is missing', () => {
+    const { token: _omit, ...missing } = validPayload;
+    expect(validatePairingPayload(missing)).toBe(false);
+  });
+
+  it('rejects when a required field is not a string', () => {
+    expect(validatePairingPayload({ ...validPayload, userId: 123 })).toBe(false);
+  });
+});
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+describe('Pairing constants', () => {
+  it('PAIRING_EXPIRY_MINUTES is 5', () => {
+    expect(PAIRING_EXPIRY_MINUTES).toBe(5);
+  });
+
+  it('PAIRING_TOKEN_EXPIRY_MS is 5 minutes in ms', () => {
+    expect(PAIRING_TOKEN_EXPIRY_MS).toBe(5 * 60 * 1000);
+  });
+
+  it('PAIRING_SCHEME is the styrby://pair deep link', () => {
+    expect(PAIRING_SCHEME).toBe('styrby://pair');
+  });
+});

--- a/packages/styrby-shared/src/relay/__tests__/types.test.ts
+++ b/packages/styrby-shared/src/relay/__tests__/types.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for relay type helpers (relay/types.ts).
+ *
+ * Covers: getChannelName, deriveChannelSuffix, generateMessageId,
+ * createBaseMessage, and RelayMessageSchema Zod validation.
+ *
+ * WHY: The relay channel name and Zod schema are security boundaries.
+ * getChannelName guards against channel enumeration; RelayMessageSchema
+ * prevents malformed broadcast payloads from reaching application code
+ * (SEC-RELAY-002).
+ *
+ * @module relay/__tests__/types
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getChannelName,
+  deriveChannelSuffix,
+  generateMessageId,
+  createBaseMessage,
+  RelayMessageSchema,
+} from '../types.js';
+
+// ============================================================================
+// getChannelName
+// ============================================================================
+
+describe('getChannelName', () => {
+  it('returns relay:{userId} without a suffix (legacy format)', () => {
+    expect(getChannelName('abc-123')).toBe('relay:abc-123');
+  });
+
+  it('returns relay:{userId}:{suffix} with a channel suffix', () => {
+    expect(getChannelName('abc-123', 'a3f8c2d1e4b07f91')).toBe('relay:abc-123:a3f8c2d1e4b07f91');
+  });
+
+  it('starts with "relay:" prefix in both forms', () => {
+    expect(getChannelName('user-1').startsWith('relay:')).toBe(true);
+    expect(getChannelName('user-1', 'suffix').startsWith('relay:')).toBe(true);
+  });
+});
+
+// ============================================================================
+// deriveChannelSuffix
+// ============================================================================
+
+describe('deriveChannelSuffix', () => {
+  it('returns a 16-character lowercase hex string', async () => {
+    const suffix = await deriveChannelSuffix('shared-secret');
+    expect(suffix).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('is deterministic for the same input', async () => {
+    const a = await deriveChannelSuffix('my-secret');
+    const b = await deriveChannelSuffix('my-secret');
+    expect(a).toBe(b);
+  });
+
+  it('produces different suffixes for different secrets', async () => {
+    const a = await deriveChannelSuffix('secret-a');
+    const b = await deriveChannelSuffix('secret-b');
+    expect(a).not.toBe(b);
+  });
+
+  it('accepts a Uint8Array input', async () => {
+    const bytes = new TextEncoder().encode('secret-bytes');
+    const suffix = await deriveChannelSuffix(bytes);
+    expect(suffix).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('Uint8Array and string encoding of same content produce the same suffix', async () => {
+    const str = 'same-secret';
+    const bytes = new TextEncoder().encode(str);
+    const fromStr = await deriveChannelSuffix(str);
+    const fromBytes = await deriveChannelSuffix(bytes);
+    expect(fromStr).toBe(fromBytes);
+  });
+});
+
+// ============================================================================
+// generateMessageId
+// ============================================================================
+
+describe('generateMessageId', () => {
+  it('starts with "msg_"', () => {
+    expect(generateMessageId().startsWith('msg_')).toBe(true);
+  });
+
+  it('produces unique IDs', () => {
+    const ids = new Set(Array.from({ length: 50 }, generateMessageId));
+    expect(ids.size).toBe(50);
+  });
+});
+
+// ============================================================================
+// createBaseMessage
+// ============================================================================
+
+describe('createBaseMessage', () => {
+  it('returns an object with id, timestamp, sender_device_id, sender_type', () => {
+    const base = createBaseMessage('device-1', 'cli');
+    expect(base.id.startsWith('msg_')).toBe(true);
+    expect(base.sender_device_id).toBe('device-1');
+    expect(base.sender_type).toBe('cli');
+    expect(typeof base.timestamp).toBe('string');
+  });
+
+  it('timestamp is a valid ISO 8601 string', () => {
+    const base = createBaseMessage('device-1', 'mobile');
+    expect(() => new Date(base.timestamp)).not.toThrow();
+    expect(new Date(base.timestamp).toISOString()).toBe(base.timestamp);
+  });
+});
+
+// ============================================================================
+// RelayMessageSchema — valid messages
+// ============================================================================
+
+describe('RelayMessageSchema — valid messages parse successfully', () => {
+  function baseFields() {
+    return {
+      id: generateMessageId(),
+      timestamp: new Date().toISOString(),
+      sender_device_id: 'device-1',
+      sender_type: 'cli' as const,
+    };
+  }
+
+  it('parses a valid chat message', () => {
+    const msg = {
+      ...baseFields(),
+      type: 'chat',
+      payload: { content: 'hello', agent: 'claude' },
+    };
+    const result = RelayMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a valid permission_request message', () => {
+    const msg = {
+      ...baseFields(),
+      type: 'permission_request',
+      payload: {
+        request_id: 'req-1',
+        session_id: 'sess-1',
+        agent: 'claude',
+        tool_name: 'bash',
+        tool_args: { command: 'ls' },
+        risk_level: 'high',
+        description: 'Run ls command',
+        expires_at: new Date(Date.now() + 30_000).toISOString(),
+        nonce: crypto.randomUUID(),
+      },
+    };
+    const result = RelayMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a valid permission_response message', () => {
+    const msg = {
+      ...baseFields(),
+      type: 'permission_response',
+      payload: {
+        request_id: 'req-1',
+        approved: true,
+        request_nonce: 'nonce-abc',
+      },
+    };
+    const result = RelayMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a valid command message', () => {
+    const msg = {
+      ...baseFields(),
+      type: 'command',
+      payload: { action: 'cancel' },
+    };
+    const result = RelayMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a valid ack message', () => {
+    const msg = {
+      ...baseFields(),
+      type: 'ack',
+      payload: { ack_id: 'msg_1', success: true },
+    };
+    const result = RelayMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// RelayMessageSchema — invalid messages are rejected (SEC-RELAY-002)
+// ============================================================================
+
+describe('RelayMessageSchema — invalid messages fail (SEC-RELAY-002)', () => {
+  it('rejects a message with unknown type', () => {
+    const result = RelayMessageSchema.safeParse({
+      id: 'msg_1',
+      timestamp: new Date().toISOString(),
+      sender_device_id: 'dev',
+      sender_type: 'cli',
+      type: 'malicious_type',
+      payload: {},
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a chat message with invalid agent type', () => {
+    const result = RelayMessageSchema.safeParse({
+      id: 'msg_1',
+      timestamp: new Date().toISOString(),
+      sender_device_id: 'dev',
+      sender_type: 'cli',
+      type: 'chat',
+      payload: { content: 'hello', agent: 'invalid_agent' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects null input', () => {
+    expect(RelayMessageSchema.safeParse(null).success).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    const result = RelayMessageSchema.safeParse({
+      type: 'chat',
+      payload: { content: 'hello', agent: 'claude' },
+      // Missing id, timestamp, sender_device_id, sender_type
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects permission_request missing the nonce field', () => {
+    const result = RelayMessageSchema.safeParse({
+      id: 'msg_1',
+      timestamp: new Date().toISOString(),
+      sender_device_id: 'dev',
+      sender_type: 'cli',
+      type: 'permission_request',
+      payload: {
+        request_id: 'req-1',
+        session_id: 'sess-1',
+        agent: 'claude',
+        tool_name: 'bash',
+        tool_args: {},
+        risk_level: 'high',
+        description: 'test',
+        expires_at: new Date().toISOString(),
+        // nonce is MISSING — should fail
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/styrby-shared/src/utils/__tests__/api-keys.test.ts
+++ b/packages/styrby-shared/src/utils/__tests__/api-keys.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for API key utilities (utils/api-keys.ts).
+ *
+ * Covers: generateRandomString, generateApiKey, extractApiKeyPrefix,
+ * isValidApiKeyFormat, maskApiKey.
+ *
+ * @module utils/__tests__/api-keys
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generateRandomString,
+  generateApiKey,
+  extractApiKeyPrefix,
+  isValidApiKeyFormat,
+  maskApiKey,
+  API_KEY_PREFIX,
+  API_KEY_RANDOM_LENGTH,
+} from '../api-keys.js';
+
+// ============================================================================
+// generateRandomString
+// ============================================================================
+
+describe('generateRandomString', () => {
+  it('returns a string of the exact requested length', () => {
+    expect(generateRandomString(10).length).toBe(10);
+    expect(generateRandomString(32).length).toBe(32);
+    expect(generateRandomString(1).length).toBe(1);
+  });
+
+  it('only contains characters from the allowed alphabet (no ambiguous chars)', () => {
+    // WHY: The alphabet excludes 0, O, l, 1 for readability.
+    const ambiguous = new Set(['0', 'O', 'l', '1']);
+    const result = generateRandomString(200);
+    for (const ch of result) {
+      expect(ambiguous.has(ch), `character "${ch}" should not be in output`).toBe(false);
+    }
+  });
+
+  it('produces alphanumeric output only', () => {
+    const result = generateRandomString(100);
+    expect(result).toMatch(/^[a-zA-Z0-9]+$/);
+  });
+
+  it('produces different values on successive calls (entropy)', () => {
+    const a = generateRandomString(32);
+    const b = generateRandomString(32);
+    // Probability of collision is astronomically low (~2^-186)
+    expect(a).not.toBe(b);
+  });
+});
+
+// ============================================================================
+// generateApiKey
+// ============================================================================
+
+describe('generateApiKey', () => {
+  it('returns an object with key, prefix, and randomPart', () => {
+    const result = generateApiKey();
+    expect(result).toHaveProperty('key');
+    expect(result).toHaveProperty('prefix');
+    expect(result).toHaveProperty('randomPart');
+  });
+
+  it('key starts with the API_KEY_PREFIX', () => {
+    const { key } = generateApiKey();
+    expect(key.startsWith(API_KEY_PREFIX)).toBe(true);
+  });
+
+  it('prefix equals API_KEY_PREFIX constant', () => {
+    const { prefix } = generateApiKey();
+    expect(prefix).toBe(API_KEY_PREFIX);
+  });
+
+  it('randomPart has the correct length', () => {
+    const { randomPart } = generateApiKey();
+    expect(randomPart.length).toBe(API_KEY_RANDOM_LENGTH);
+  });
+
+  it('key is prefix + randomPart concatenated', () => {
+    const { key, prefix, randomPart } = generateApiKey();
+    expect(key).toBe(`${prefix}${randomPart}`);
+  });
+
+  it('key is valid format (passes isValidApiKeyFormat)', () => {
+    const { key } = generateApiKey();
+    expect(isValidApiKeyFormat(key)).toBe(true);
+  });
+
+  it('produces unique keys on each call', () => {
+    const a = generateApiKey().key;
+    const b = generateApiKey().key;
+    expect(a).not.toBe(b);
+  });
+});
+
+// ============================================================================
+// extractApiKeyPrefix
+// ============================================================================
+
+describe('extractApiKeyPrefix', () => {
+  it('returns the prefix for a valid Styrby key', () => {
+    const { key } = generateApiKey();
+    expect(extractApiKeyPrefix(key)).toBe(API_KEY_PREFIX);
+  });
+
+  it('returns null for a key with an unknown prefix', () => {
+    expect(extractApiKeyPrefix('invalid_abc123')).toBeNull();
+    expect(extractApiKeyPrefix('sk_live_somekey')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(extractApiKeyPrefix('')).toBeNull();
+  });
+
+  it('returns null for non-string values', () => {
+    // @ts-expect-error — intentional invalid input test
+    expect(extractApiKeyPrefix(null)).toBeNull();
+    // @ts-expect-error
+    expect(extractApiKeyPrefix(undefined)).toBeNull();
+  });
+});
+
+// ============================================================================
+// isValidApiKeyFormat
+// ============================================================================
+
+describe('isValidApiKeyFormat', () => {
+  it('accepts a freshly generated key', () => {
+    expect(isValidApiKeyFormat(generateApiKey().key)).toBe(true);
+  });
+
+  it('rejects a key with wrong prefix', () => {
+    expect(isValidApiKeyFormat('wrong_' + 'a'.repeat(API_KEY_RANDOM_LENGTH))).toBe(false);
+  });
+
+  it('rejects a key that is too short', () => {
+    expect(isValidApiKeyFormat(`${API_KEY_PREFIX}short`)).toBe(false);
+  });
+
+  it('rejects a key that is too long', () => {
+    expect(isValidApiKeyFormat(`${API_KEY_PREFIX}${'a'.repeat(API_KEY_RANDOM_LENGTH + 1)}`)).toBe(false);
+  });
+
+  it('rejects a key with non-alphanumeric characters in the random part', () => {
+    const badRandomPart = '-'.repeat(API_KEY_RANDOM_LENGTH);
+    expect(isValidApiKeyFormat(`${API_KEY_PREFIX}${badRandomPart}`)).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidApiKeyFormat('')).toBe(false);
+  });
+
+  it('rejects non-string values', () => {
+    // @ts-expect-error — intentional invalid input test
+    expect(isValidApiKeyFormat(null)).toBe(false);
+    // @ts-expect-error
+    expect(isValidApiKeyFormat(42)).toBe(false);
+  });
+});
+
+// ============================================================================
+// maskApiKey
+// ============================================================================
+
+describe('maskApiKey', () => {
+  it('shows prefix + first 4 + ... + last 4 chars of random part', () => {
+    const { key, randomPart } = generateApiKey();
+    const masked = maskApiKey(key);
+    expect(masked).toContain(API_KEY_PREFIX);
+    expect(masked).toContain(randomPart.slice(0, 4));
+    expect(masked).toContain(randomPart.slice(-4));
+    expect(masked).toContain('...');
+  });
+
+  it('does not reveal the full key', () => {
+    const { key } = generateApiKey();
+    const masked = maskApiKey(key);
+    expect(masked).not.toBe(key);
+    // The full 32-char random part should not appear intact
+    const randomPart = key.slice(API_KEY_PREFIX.length);
+    expect(masked).not.toContain(randomPart);
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(maskApiKey('')).toBe('');
+  });
+
+  it('handles non-string gracefully by returning empty string', () => {
+    // @ts-expect-error — intentional invalid input test
+    expect(maskApiKey(null)).toBe('');
+  });
+
+  it('falls back gracefully for unknown prefix: short keys (<=8 chars) return ********', () => {
+    // Source: keys <= 8 chars → '********'
+    expect(maskApiKey('short')).toBe('********');
+    expect(maskApiKey('12345678')).toBe('********');
+  });
+
+  it('falls back gracefully for unknown prefix: longer keys show first+last 4 chars', () => {
+    // Source: keys > 8 chars without a known prefix → first4...last4
+    expect(maskApiKey('123456789abc')).toBe('1234...9abc');
+  });
+});
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+describe('API key constants', () => {
+  it('API_KEY_PREFIX is styrby_', () => {
+    expect(API_KEY_PREFIX).toBe('styrby_');
+  });
+
+  it('API_KEY_RANDOM_LENGTH is 32', () => {
+    expect(API_KEY_RANDOM_LENGTH).toBe(32);
+  });
+});

--- a/packages/styrby-shared/src/utils/__tests__/format-time.test.ts
+++ b/packages/styrby-shared/src/utils/__tests__/format-time.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for time formatting utilities (utils/format-time.ts).
+ *
+ * WHY thorough: formatTime converts Postgres TIME strings to 12-hour display
+ * for both mobile and web quiet-hours UI. Any edge case divergence between
+ * platforms would cause silent display bugs.
+ *
+ * @module utils/__tests__/format-time
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatTime } from '../format-time.js';
+
+describe('formatTime', () => {
+  // ── PM conversions ────────────────────────────────────────────────────────
+  it('converts 22:00:00 to 10:00 PM', () => {
+    expect(formatTime('22:00:00', '--')).toBe('10:00 PM');
+  });
+
+  it('converts 12:00:00 to 12:00 PM (noon)', () => {
+    expect(formatTime('12:00:00', '--')).toBe('12:00 PM');
+  });
+
+  it('converts 13:30:00 to 1:30 PM', () => {
+    expect(formatTime('13:30:00', '--')).toBe('1:30 PM');
+  });
+
+  it('converts 23:59:00 to 11:59 PM', () => {
+    expect(formatTime('23:59:00', '--')).toBe('11:59 PM');
+  });
+
+  // ── AM conversions ────────────────────────────────────────────────────────
+  it('converts 00:00:00 to 12:00 AM (midnight)', () => {
+    expect(formatTime('00:00:00', '--')).toBe('12:00 AM');
+  });
+
+  it('converts 07:30:00 to 7:30 AM', () => {
+    expect(formatTime('07:30:00', '--')).toBe('7:30 AM');
+  });
+
+  it('converts 01:05:00 to 1:05 AM', () => {
+    expect(formatTime('01:05:00', '--')).toBe('1:05 AM');
+  });
+
+  it('converts 11:59:00 to 11:59 AM', () => {
+    expect(formatTime('11:59:00', '--')).toBe('11:59 AM');
+  });
+
+  // ── Fallback values ───────────────────────────────────────────────────────
+  it('returns the fallback when time is null', () => {
+    expect(formatTime(null, 'Not set')).toBe('Not set');
+  });
+
+  it('returns the fallback when time is an empty string', () => {
+    expect(formatTime('', 'N/A')).toBe('N/A');
+  });
+
+  // ── HH:MM format (without seconds) ───────────────────────────────────────
+  it('handles HH:MM format without seconds', () => {
+    expect(formatTime('22:00', '--')).toBe('10:00 PM');
+    expect(formatTime('07:30', '--')).toBe('7:30 AM');
+  });
+
+  // ── Minute padding ────────────────────────────────────────────────────────
+  it('zero-pads single-digit minutes (e.g. 7:05 not 7:5)', () => {
+    expect(formatTime('07:05:00', '--')).toBe('7:05 AM');
+    expect(formatTime('14:02:00', '--')).toBe('2:02 PM');
+  });
+
+  // ── Fallback string varieties ─────────────────────────────────────────────
+  it('returns the exact fallback string provided', () => {
+    expect(formatTime(null, '--')).toBe('--');
+    expect(formatTime(null, 'N/A')).toBe('N/A');
+    expect(formatTime(null, 'Not configured')).toBe('Not configured');
+  });
+});

--- a/packages/styrby-shared/src/utils/__tests__/notification-priority.test.ts
+++ b/packages/styrby-shared/src/utils/__tests__/notification-priority.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for notification priority scoring (utils/notification-priority.ts).
+ *
+ * Covers: calculateNotificationPriority, calculateNotificationPriorityDetailed,
+ * shouldSendNotification, getEstimatedNotificationPercentage,
+ * getThresholdDescription, getThresholdExamples.
+ *
+ * @module utils/__tests__/notification-priority
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  calculateNotificationPriority,
+  calculateNotificationPriorityDetailed,
+  shouldSendNotification,
+  getEstimatedNotificationPercentage,
+  getThresholdDescription,
+  getThresholdExamples,
+} from '../notification-priority.js';
+
+// ============================================================================
+// calculateNotificationPriority — base scores
+// ============================================================================
+
+describe('calculateNotificationPriority — base scores', () => {
+  it('budget_exceeded returns 1 (critical)', () => {
+    expect(calculateNotificationPriority({ type: 'budget_exceeded' })).toBe(1);
+  });
+
+  it('session_started returns 5 (informational)', () => {
+    expect(calculateNotificationPriority({ type: 'session_started' })).toBe(5);
+  });
+
+  it('session_error returns 2 (high)', () => {
+    expect(calculateNotificationPriority({ type: 'session_error' })).toBe(2);
+  });
+
+  it('session_completed returns 4 (normal)', () => {
+    expect(calculateNotificationPriority({ type: 'session_completed' })).toBe(4);
+  });
+
+  it('budget_warning returns 2 (high)', () => {
+    expect(calculateNotificationPriority({ type: 'budget_warning' })).toBe(2);
+  });
+
+  it('permission_request baseline returns 2', () => {
+    expect(calculateNotificationPriority({ type: 'permission_request' })).toBe(2);
+  });
+});
+
+// ============================================================================
+// calculateNotificationPriority — risk adjustments
+// ============================================================================
+
+describe('calculateNotificationPriority — risk level adjustments', () => {
+  it('high-risk permission request bumps priority to 1', () => {
+    expect(calculateNotificationPriority({ type: 'permission_request', riskLevel: 'high' })).toBe(1);
+  });
+
+  it('medium-risk permission request stays at base (2)', () => {
+    expect(calculateNotificationPriority({ type: 'permission_request', riskLevel: 'medium' })).toBe(2);
+  });
+
+  it('low-risk permission request raises priority to 3', () => {
+    expect(calculateNotificationPriority({ type: 'permission_request', riskLevel: 'low' })).toBe(3);
+  });
+});
+
+// ============================================================================
+// calculateNotificationPriority — cost adjustments
+// ============================================================================
+
+describe('calculateNotificationPriority — cost adjustments', () => {
+  it('high cost (>$10) on session_completed makes priority more urgent', () => {
+    const priority = calculateNotificationPriority({
+      type: 'session_completed',
+      costUsd: 15.0,
+    });
+    // base 4 + cost_adjustment -2 = 2
+    expect(priority).toBe(2);
+  });
+
+  it('moderate cost ($5-$10) on session_completed adjusts by -1', () => {
+    const priority = calculateNotificationPriority({
+      type: 'session_completed',
+      costUsd: 7.5,
+    });
+    // base 4 + cost -1 = 3
+    expect(priority).toBe(3);
+  });
+
+  it('low cost (<$1) on session_completed raises priority number by 1', () => {
+    const priority = calculateNotificationPriority({
+      type: 'session_completed',
+      costUsd: 0.05,
+    });
+    // base 4 + cost +1 = 5
+    expect(priority).toBe(5);
+  });
+});
+
+// ============================================================================
+// calculateNotificationPriority — duration adjustments
+// ============================================================================
+
+describe('calculateNotificationPriority — session duration adjustments', () => {
+  it('long session (>1hr) completion bumps urgency by -1', () => {
+    const priority = calculateNotificationPriority({
+      type: 'session_completed',
+      sessionDurationMs: 90 * 60 * 1000, // 90 minutes
+    });
+    // base 4 + duration -1 = 3
+    expect(priority).toBe(3);
+  });
+
+  it('short session (<30min) completion decreases urgency by +1', () => {
+    const priority = calculateNotificationPriority({
+      type: 'session_completed',
+      sessionDurationMs: 5 * 60 * 1000, // 5 minutes
+    });
+    // base 4 + duration +1 = 5
+    expect(priority).toBe(5);
+  });
+});
+
+// ============================================================================
+// calculateNotificationPriority — dangerous tool adjustments
+// ============================================================================
+
+describe('calculateNotificationPriority — dangerous tool adjustments', () => {
+  it('bash tool on permission_request bumps urgency by -1', () => {
+    // base 2 + tool -1 = 1
+    expect(calculateNotificationPriority({ type: 'permission_request', toolName: 'bash' })).toBe(1);
+  });
+
+  it('write_file tool on permission_request is treated as dangerous', () => {
+    const p = calculateNotificationPriority({ type: 'permission_request', toolName: 'write_file' });
+    expect(p).toBeLessThan(2);
+  });
+
+  it('a safe tool (e.g. read_file) does not reduce priority', () => {
+    // base 2, no tool adjustment
+    expect(calculateNotificationPriority({ type: 'permission_request', toolName: 'read_file' })).toBe(2);
+  });
+
+  it('tool name matching is case-insensitive', () => {
+    const pLower = calculateNotificationPriority({ type: 'permission_request', toolName: 'bash' });
+    const pUpper = calculateNotificationPriority({ type: 'permission_request', toolName: 'BASH' });
+    expect(pLower).toBe(pUpper);
+  });
+});
+
+// ============================================================================
+// calculateNotificationPriority — clamping
+// ============================================================================
+
+describe('calculateNotificationPriority — clamping to [1, 5]', () => {
+  it('priority never goes below 1', () => {
+    // budget_exceeded (1) + many downward adjustments should clamp at 1
+    const p = calculateNotificationPriority({
+      type: 'budget_exceeded',
+      costUsd: 100,
+    });
+    expect(p).toBeGreaterThanOrEqual(1);
+  });
+
+  it('priority never goes above 5', () => {
+    // session_started (5) + low cost should clamp at 5
+    const p = calculateNotificationPriority({
+      type: 'session_started',
+      costUsd: 0.01,
+    });
+    expect(p).toBeLessThanOrEqual(5);
+  });
+});
+
+// ============================================================================
+// calculateNotificationPriorityDetailed
+// ============================================================================
+
+describe('calculateNotificationPriorityDetailed', () => {
+  it('returns a PriorityResult with priority, reason, and factors', () => {
+    const result = calculateNotificationPriorityDetailed({ type: 'budget_exceeded' });
+    expect(result).toHaveProperty('priority');
+    expect(result).toHaveProperty('reason');
+    expect(result).toHaveProperty('factors');
+  });
+
+  it('factors.basePriority matches the event type base', () => {
+    const result = calculateNotificationPriorityDetailed({ type: 'session_started' });
+    expect(result.factors.basePriority).toBe(5);
+  });
+
+  it('reason string is non-empty', () => {
+    const result = calculateNotificationPriorityDetailed({ type: 'permission_request', riskLevel: 'high' });
+    expect(result.reason.length).toBeGreaterThan(0);
+  });
+
+  it('high-risk permission reason mentions the risk level', () => {
+    const result = calculateNotificationPriorityDetailed({ type: 'permission_request', riskLevel: 'high' });
+    expect(result.reason.toLowerCase()).toContain('high');
+  });
+
+  it('dangerous tool reason mentions the tool name', () => {
+    const result = calculateNotificationPriorityDetailed({ type: 'permission_request', toolName: 'bash' });
+    expect(result.reason).toContain('bash');
+  });
+
+  it('factors.riskAdjustment is -1 for high risk', () => {
+    const result = calculateNotificationPriorityDetailed({ type: 'permission_request', riskLevel: 'high' });
+    expect(result.factors.riskAdjustment).toBe(-1);
+  });
+
+  it('factors.riskAdjustment is 0 when no risk level provided', () => {
+    const result = calculateNotificationPriorityDetailed({ type: 'permission_request' });
+    expect(result.factors.riskAdjustment).toBe(0);
+  });
+
+  it('all factor fields are numeric', () => {
+    const result = calculateNotificationPriorityDetailed({ type: 'session_completed', costUsd: 5.5 });
+    for (const [key, value] of Object.entries(result.factors)) {
+      expect(typeof value, `factor "${key}" should be a number`).toBe('number');
+    }
+  });
+});
+
+// ============================================================================
+// shouldSendNotification
+// ============================================================================
+
+describe('shouldSendNotification', () => {
+  it('always returns true for free users regardless of priority', () => {
+    expect(shouldSendNotification(5, 1, false)).toBe(true);
+    expect(shouldSendNotification(1, 5, false)).toBe(true);
+  });
+
+  it('returns true for paid users when priority <= threshold', () => {
+    expect(shouldSendNotification(2, 3, true)).toBe(true);
+    expect(shouldSendNotification(3, 3, true)).toBe(true);
+  });
+
+  it('returns false for paid users when priority > threshold', () => {
+    expect(shouldSendNotification(4, 2, true)).toBe(false);
+    expect(shouldSendNotification(5, 4, true)).toBe(false);
+  });
+});
+
+// ============================================================================
+// getEstimatedNotificationPercentage
+// ============================================================================
+
+describe('getEstimatedNotificationPercentage', () => {
+  it('returns 5 for threshold 1 (urgent only)', () => {
+    expect(getEstimatedNotificationPercentage(1)).toBe(5);
+  });
+
+  it('returns 100 for threshold 5 (all notifications)', () => {
+    expect(getEstimatedNotificationPercentage(5)).toBe(100);
+  });
+
+  it('percentages increase monotonically with threshold', () => {
+    const values = [1, 2, 3, 4, 5].map(getEstimatedNotificationPercentage);
+    for (let i = 1; i < values.length; i++) {
+      expect(values[i]).toBeGreaterThan(values[i - 1]);
+    }
+  });
+
+  it('returns 50 for unknown threshold (safe default)', () => {
+    expect(getEstimatedNotificationPercentage(99)).toBe(50);
+    expect(getEstimatedNotificationPercentage(0)).toBe(50);
+  });
+});
+
+// ============================================================================
+// getThresholdDescription
+// ============================================================================
+
+describe('getThresholdDescription', () => {
+  it('returns a non-empty string for thresholds 1-5', () => {
+    for (let i = 1; i <= 5; i++) {
+      expect(getThresholdDescription(i).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns "Urgent only" for threshold 1', () => {
+    expect(getThresholdDescription(1)).toBe('Urgent only');
+  });
+
+  it('returns "All notifications" for threshold 5', () => {
+    expect(getThresholdDescription(5)).toBe('All notifications');
+  });
+
+  it('returns "Unknown" for out-of-range thresholds', () => {
+    expect(getThresholdDescription(0)).toBe('Unknown');
+    expect(getThresholdDescription(99)).toBe('Unknown');
+  });
+});
+
+// ============================================================================
+// getThresholdExamples
+// ============================================================================
+
+describe('getThresholdExamples', () => {
+  it('returns an array of strings for each valid threshold', () => {
+    for (let i = 1; i <= 5; i++) {
+      const examples = getThresholdExamples(i);
+      expect(Array.isArray(examples)).toBe(true);
+      expect(examples.every((e) => typeof e === 'string')).toBe(true);
+    }
+  });
+
+  it('accumulates examples: threshold 5 includes threshold 1 examples', () => {
+    const t1Examples = getThresholdExamples(1);
+    const t5Examples = getThresholdExamples(5);
+    // All t1 examples should appear in t5 examples
+    for (const ex of t1Examples) {
+      expect(t5Examples).toContain(ex);
+    }
+  });
+
+  it('threshold 5 returns more examples than threshold 1', () => {
+    expect(getThresholdExamples(5).length).toBeGreaterThan(getThresholdExamples(1).length);
+  });
+});

--- a/packages/styrby-web/src/app/api/agent-configs/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/agent-configs/__tests__/route.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Agent Configs API Route Tests
+ *
+ * Tests GET and POST /api/agent-configs.
+ *
+ * WHY: The POST handler enforces the user's tier agent limit (SEC-LOGIC-002).
+ * A regression here could let free users create unlimited agent configs by
+ * calling Supabase directly, bypassing the quota enforcement.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetUser = vi.fn();
+
+const fromCallQueue: Array<{ data?: unknown; error?: unknown; count?: number }> = [];
+
+function createChainMock() {
+  const result = fromCallQueue.shift() ?? { data: null, error: null };
+  const chain: Record<string, unknown> = {};
+
+  for (const method of [
+    'select', 'eq', 'order', 'limit', 'insert', 'update', 'delete', 'is', 'single',
+  ]) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  chain['single'] = vi.fn().mockResolvedValue(result);
+  chain['then'] = (resolve: (v: unknown) => void) => resolve(result);
+
+  return chain;
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: vi.fn(() => createChainMock()),
+  })),
+}));
+
+vi.mock('@/lib/tier-enforcement', () => ({
+  checkTierLimit: vi.fn(() => ({
+    allowed: true,
+    limit: 3,
+    current: 0,
+    tier: 'pro',
+    upgradeUrl: '/pricing',
+  })),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn(() => ({ allowed: true, remaining: 29 })),
+  RATE_LIMITS: {
+    budgetAlerts: { windowMs: 60000, maxRequests: 30 },
+  },
+  rateLimitResponse: vi.fn((retryAfter: number) =>
+    new Response(JSON.stringify({ error: 'RATE_LIMITED' }), {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfter) },
+    })
+  ),
+}));
+
+// @styrby/shared TIER_LIMITS
+vi.mock('@styrby/shared', () => ({
+  TIER_LIMITS: {
+    free: { maxAgents: 1 },
+    pro: { maxAgents: 3 },
+    power: { maxAgents: 9 },
+  },
+}));
+
+import { GET, POST } from '../route';
+import { checkTierLimit } from '@/lib/tier-enforcement';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const AUTH_USER = { id: 'user-uuid-abc', email: 'dev@example.com' };
+
+function mockAuthenticated() {
+  mockGetUser.mockResolvedValue({ data: { user: AUTH_USER }, error: null });
+}
+
+function mockUnauthenticated() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'Not authenticated' } });
+}
+
+function makePostRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/agent-configs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-forwarded-for': '127.0.0.1' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Agent Configs API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromCallQueue.length = 0;
+  });
+
+  // --------------------------------------------------------------------------
+  // Authentication
+  // --------------------------------------------------------------------------
+
+  describe('authentication', () => {
+    it('GET returns 401 when unauthenticated', async () => {
+      mockUnauthenticated();
+      const res = await GET();
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('UNAUTHORIZED');
+    });
+
+    it('POST returns 401 when unauthenticated', async () => {
+      mockUnauthenticated();
+      const res = await POST(makePostRequest({ agentType: 'claude' }));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // GET /api/agent-configs
+  // --------------------------------------------------------------------------
+
+  describe('GET /api/agent-configs', () => {
+    it('returns configs with tier and maxAgents for authenticated user', async () => {
+      mockAuthenticated();
+      // 1. agent_configs select
+      fromCallQueue.push({ data: [{ id: 'cfg-1', agent_type: 'claude', is_enabled: true }], error: null });
+      // 2. subscriptions select (tier lookup)
+      fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.configs).toHaveLength(1);
+      expect(body.tier).toBe('pro');
+      expect(body.maxAgents).toBe(3);
+      expect(body.configCount).toBe(1);
+    });
+
+    it('returns empty configs array and defaults to free tier', async () => {
+      mockAuthenticated();
+      fromCallQueue.push({ data: [], error: null });
+      fromCallQueue.push({ data: null, error: null }); // no subscription → free
+
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.configs).toHaveLength(0);
+      expect(body.tier).toBe('free');
+      expect(body.maxAgents).toBe(1);
+    });
+
+    it('returns 500 on DB fetch error', async () => {
+      mockAuthenticated();
+      fromCallQueue.push({ data: null, error: { message: 'DB down' } });
+
+      const res = await GET();
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('INTERNAL_ERROR');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // POST /api/agent-configs
+  // --------------------------------------------------------------------------
+
+  describe('POST /api/agent-configs — input validation', () => {
+    it('rejects invalid agentType', async () => {
+      mockAuthenticated();
+      const res = await POST(makePostRequest({ agentType: 'gpt-5' }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects temperature out of range', async () => {
+      mockAuthenticated();
+      const res = await POST(makePostRequest({ agentType: 'claude', temperature: 3.5 }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects customSystemPrompt exceeding 50,000 chars', async () => {
+      mockAuthenticated();
+      const res = await POST(makePostRequest({ agentType: 'claude', customSystemPrompt: 'x'.repeat(50_001) }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects autoApprovePatterns exceeding 50 entries', async () => {
+      mockAuthenticated();
+      const patterns = Array.from({ length: 51 }, (_, i) => `pattern-${i}`);
+      const res = await POST(makePostRequest({ agentType: 'claude', autoApprovePatterns: patterns }));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/agent-configs — tier enforcement', () => {
+    it('returns 403 when tier limit exceeded', async () => {
+      mockAuthenticated();
+      vi.mocked(checkTierLimit).mockResolvedValueOnce({
+        allowed: false as const,
+        limit: 1,
+        current: 1,
+        tier: 'free' as const,
+        upgradeUrl: '/pricing' as const,
+      });
+
+      const res = await POST(makePostRequest({ agentType: 'claude' }));
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('TIER_LIMIT_EXCEEDED');
+    });
+  });
+
+  describe('POST /api/agent-configs — happy path', () => {
+    it('creates config and returns 201 with the new config', async () => {
+      mockAuthenticated();
+      vi.mocked(checkTierLimit).mockResolvedValueOnce({
+        allowed: true as const,
+      });
+      const newConfig = { id: 'cfg-new', agent_type: 'claude', is_enabled: true };
+      fromCallQueue.push({ data: newConfig, error: null });
+
+      const res = await POST(makePostRequest({ agentType: 'claude' }));
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.config.agent_type).toBe('claude');
+    });
+
+    it('returns 409 when config already exists for agent type', async () => {
+      mockAuthenticated();
+      vi.mocked(checkTierLimit).mockResolvedValueOnce({
+        allowed: true as const,
+      });
+      fromCallQueue.push({ data: null, error: { code: '23505', message: 'unique violation' } });
+
+      const res = await POST(makePostRequest({ agentType: 'codex' }));
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe('CONFLICT');
+    });
+  });
+
+  describe('POST /api/agent-configs — rate limit', () => {
+    it('returns 429 when rate limited', async () => {
+      const { rateLimit } = await import('@/lib/rateLimit');
+      vi.mocked(rateLimit).mockResolvedValueOnce({ allowed: false, retryAfter: 30, remaining: 0, resetAt: Date.now() + 30000 });
+
+      mockAuthenticated();
+      const res = await POST(makePostRequest({ agentType: 'claude' }));
+      expect(res.status).toBe(429);
+    });
+  });
+});

--- a/packages/styrby-web/src/app/api/bookmarks/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/bookmarks/__tests__/route.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Bookmarks API Route Tests
+ *
+ * Tests GET, POST, DELETE /api/bookmarks.
+ *
+ * WHY: Bookmark creation is tier-gated (Free: 5, Pro: 50, Power: -1 unlimited).
+ * Regressions here could allow free users to exceed their limit or let the
+ * duplicate-bookmark 409 path silently degrade to 500.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetUser = vi.fn();
+
+const fromCallQueue: Array<{ data?: unknown; error?: unknown; count?: number }> = [];
+
+function createChainMock() {
+  const result = fromCallQueue.shift() ?? { data: null, error: null };
+  const chain: Record<string, unknown> = {};
+
+  for (const method of [
+    'select', 'eq', 'order', 'limit', 'insert', 'delete', 'single',
+  ]) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  chain['single'] = vi.fn().mockResolvedValue(result);
+  chain['then'] = (resolve: (v: unknown) => void) => resolve(result);
+
+  return chain;
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: vi.fn(() => createChainMock()),
+  })),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn(() => ({ allowed: true, remaining: 29 })),
+  RATE_LIMITS: {
+    budgetAlerts: { windowMs: 60000, maxRequests: 30 },
+  },
+  rateLimitResponse: vi.fn((retryAfter: number) =>
+    new Response(JSON.stringify({ error: 'RATE_LIMITED' }), {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfter) },
+    })
+  ),
+}));
+
+// Mock TIERS from polar.ts to provide bookmark limits
+vi.mock('@/lib/polar', () => ({
+  TIERS: {
+    free: { limits: { bookmarks: 5 } },
+    pro: { limits: { bookmarks: 50 } },
+    power: { limits: { bookmarks: -1 } },
+  },
+}));
+
+import { GET, POST, DELETE } from '../route';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const AUTH_USER = { id: 'user-bookmark-123', email: 'test@example.com' };
+const VALID_SESSION_ID = '00000000-0000-0000-0000-000000000001';
+
+function mockAuthenticated() {
+  mockGetUser.mockResolvedValue({ data: { user: AUTH_USER }, error: null });
+}
+
+function mockUnauthenticated() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'Unauthorized' } });
+}
+
+function makeRequest(method: string, body?: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/bookmarks', {
+    method,
+    headers: { 'Content-Type': 'application/json', 'x-forwarded-for': '127.0.0.1' },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Bookmarks API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromCallQueue.length = 0;
+  });
+
+  // --------------------------------------------------------------------------
+  // Authentication
+  // --------------------------------------------------------------------------
+
+  describe('authentication', () => {
+    it('GET returns 401 when unauthenticated', async () => {
+      mockUnauthenticated();
+      const res = await GET();
+      expect(res.status).toBe(401);
+    });
+
+    it('POST returns 401 when unauthenticated', async () => {
+      mockUnauthenticated();
+      const res = await POST(makeRequest('POST', { session_id: VALID_SESSION_ID }));
+      expect(res.status).toBe(401);
+    });
+
+    it('DELETE returns 401 when unauthenticated', async () => {
+      mockUnauthenticated();
+      const res = await DELETE(makeRequest('DELETE', { session_id: VALID_SESSION_ID }));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // GET /api/bookmarks
+  // --------------------------------------------------------------------------
+
+  describe('GET /api/bookmarks', () => {
+    it('returns bookmarks with tier and limit info', async () => {
+      mockAuthenticated();
+      // 1. session_bookmarks select
+      fromCallQueue.push({ data: [{ id: 'bm-1', session_id: VALID_SESSION_ID, note: null, created_at: '2026-01-01T00:00:00Z' }], error: null });
+      // 2. subscriptions lookup (getUserTier)
+      fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.bookmarks).toHaveLength(1);
+      expect(body.tier).toBe('pro');
+      expect(body.bookmarkLimit).toBe(50);
+      expect(body.bookmarkCount).toBe(1);
+    });
+
+    it('returns empty bookmarks for new user on free tier', async () => {
+      mockAuthenticated();
+      fromCallQueue.push({ data: [], error: null });
+      fromCallQueue.push({ data: null, error: null }); // no subscription → free
+
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.bookmarks).toHaveLength(0);
+      expect(body.tier).toBe('free');
+      expect(body.bookmarkLimit).toBe(5);
+    });
+
+    it('returns 500 on DB error', async () => {
+      mockAuthenticated();
+      fromCallQueue.push({ data: null, error: { message: 'connection refused' } });
+
+      const res = await GET();
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // POST /api/bookmarks
+  // --------------------------------------------------------------------------
+
+  describe('POST /api/bookmarks — input validation', () => {
+    it('rejects missing session_id', async () => {
+      mockAuthenticated();
+      const res = await POST(makeRequest('POST', { note: 'some note' }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects non-UUID session_id', async () => {
+      mockAuthenticated();
+      const res = await POST(makeRequest('POST', { session_id: 'not-a-uuid' }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects note longer than 500 chars', async () => {
+      mockAuthenticated();
+      const res = await POST(makeRequest('POST', { session_id: VALID_SESSION_ID, note: 'x'.repeat(501) }));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/bookmarks — tier enforcement', () => {
+    it('returns 403 when free user is at bookmark limit (5/5)', async () => {
+      mockAuthenticated();
+      // getUserTier → free
+      fromCallQueue.push({ data: null, error: null });
+      // count → 5 (at limit)
+      fromCallQueue.push({ count: 5, error: null });
+
+      const res = await POST(makeRequest('POST', { session_id: VALID_SESSION_ID }));
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toContain('Free plan');
+    });
+
+    it('returns 403 when pro user is at bookmark limit (50/50)', async () => {
+      mockAuthenticated();
+      fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ count: 50, error: null });
+
+      const res = await POST(makeRequest('POST', { session_id: VALID_SESSION_ID }));
+      expect(res.status).toBe(403);
+    });
+
+    it('allows power user to exceed 50 bookmarks (unlimited)', async () => {
+      mockAuthenticated();
+      fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ count: 999, error: null }); // -1 = unlimited
+      fromCallQueue.push({ data: { id: 'bm-new', session_id: VALID_SESSION_ID }, error: null });
+
+      const res = await POST(makeRequest('POST', { session_id: VALID_SESSION_ID }));
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('POST /api/bookmarks — success and conflicts', () => {
+    it('creates bookmark and returns 201', async () => {
+      mockAuthenticated();
+      fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ count: 1, error: null });
+      fromCallQueue.push({ data: { id: 'bm-created', session_id: VALID_SESSION_ID, note: 'key session' }, error: null });
+
+      const res = await POST(makeRequest('POST', { session_id: VALID_SESSION_ID, note: 'key session' }));
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.bookmark).toBeDefined();
+    });
+
+    it('returns 409 when session is already bookmarked', async () => {
+      mockAuthenticated();
+      fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ count: 1, error: null });
+      fromCallQueue.push({ data: null, error: { code: '23505', message: 'unique violation' } });
+
+      const res = await POST(makeRequest('POST', { session_id: VALID_SESSION_ID }));
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe('Session is already bookmarked');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // DELETE /api/bookmarks
+  // --------------------------------------------------------------------------
+
+  describe('DELETE /api/bookmarks', () => {
+    it('rejects missing session_id', async () => {
+      mockAuthenticated();
+      const res = await DELETE(makeRequest('DELETE', {}));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects non-UUID session_id', async () => {
+      mockAuthenticated();
+      const res = await DELETE(makeRequest('DELETE', { session_id: 'bad-id' }));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 when bookmark does not exist', async () => {
+      mockAuthenticated();
+      // existence check → not found
+      fromCallQueue.push({ data: null, error: null });
+
+      const res = await DELETE(makeRequest('DELETE', { session_id: VALID_SESSION_ID }));
+      expect(res.status).toBe(404);
+    });
+
+    it('deletes bookmark and returns success', async () => {
+      mockAuthenticated();
+      // existence check → found
+      fromCallQueue.push({ data: { id: 'bm-1' }, error: null });
+      // delete → success
+      fromCallQueue.push({ data: null, error: null });
+
+      const res = await DELETE(makeRequest('DELETE', { session_id: VALID_SESSION_ID }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Rate limiting
+  // --------------------------------------------------------------------------
+
+  describe('rate limiting', () => {
+    it('POST returns 429 when rate limited', async () => {
+      const { rateLimit } = await import('@/lib/rateLimit');
+      vi.mocked(rateLimit).mockResolvedValueOnce({ allowed: false, retryAfter: 30, remaining: 0, resetAt: Date.now() + 30000 });
+      mockAuthenticated();
+
+      const res = await POST(makeRequest('POST', { session_id: VALID_SESSION_ID }));
+      expect(res.status).toBe(429);
+    });
+  });
+});

--- a/packages/styrby-web/src/app/api/onboarding/complete/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/onboarding/complete/__tests__/route.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Onboarding Complete Route Tests
+ *
+ * Tests POST /api/onboarding/complete.
+ *
+ * WHY: This endpoint marks onboarding complete by updating profiles. Regressions
+ * could leave users stuck in onboarding forever (DB error path) or allow
+ * unauthenticated calls to reset other users' onboarding state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetUser = vi.fn();
+
+const fromCallQueue: Array<{ data?: unknown; error?: unknown }> = [];
+
+function createChainMock() {
+  const result = fromCallQueue.shift() ?? { data: null, error: null };
+  const chain: Record<string, unknown> = {};
+
+  for (const method of ['update', 'eq', 'select', 'single']) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  chain['then'] = (resolve: (v: unknown) => void) => resolve(result);
+
+  return chain;
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: vi.fn(() => createChainMock()),
+  })),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn(() => ({ allowed: true, remaining: 4 })),
+  rateLimitResponse: vi.fn((retryAfter: number) =>
+    new Response(JSON.stringify({ error: 'RATE_LIMITED' }), {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfter) },
+    })
+  ),
+}));
+
+import { POST } from '../route';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const AUTH_USER = { id: 'user-onboard-42', email: 'dev@example.com' };
+
+function mockAuthenticated() {
+  mockGetUser.mockResolvedValue({ data: { user: AUTH_USER }, error: null });
+}
+
+function mockUnauthenticated() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'Not authenticated' } });
+}
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost:3000/api/onboarding/complete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-forwarded-for': '10.0.0.1' },
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('POST /api/onboarding/complete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromCallQueue.length = 0;
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockUnauthenticated();
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 200 with success: true when authenticated and DB update succeeds', async () => {
+    mockAuthenticated();
+    // profiles.update().eq() → no error
+    fromCallQueue.push({ data: null, error: null });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it('returns 500 when DB update fails', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: null, error: { message: 'column not found' } });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to complete onboarding');
+  });
+
+  it('returns 429 when rate limited', async () => {
+    const { rateLimit } = await import('@/lib/rateLimit');
+    vi.mocked(rateLimit).mockResolvedValueOnce({ allowed: false, retryAfter: 60, remaining: 0, resetAt: Date.now() + 60000 });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(429);
+  });
+});

--- a/packages/styrby-web/src/app/api/push/unsubscribe/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/push/unsubscribe/__tests__/route.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Push Unsubscribe Route Tests
+ *
+ * Tests DELETE /api/push/unsubscribe.
+ *
+ * WHY: The endpoint includes SSRF protection via an allowlist of known push
+ * service hostnames. Regressions could open an SSRF vector or silently fail
+ * to remove subscriptions, leading to ghost push tokens in the DB.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetUser = vi.fn();
+
+const fromCallQueue: Array<{ data?: unknown; error?: unknown }> = [];
+
+function createChainMock() {
+  const result = fromCallQueue.shift() ?? { data: null, error: null };
+  const chain: Record<string, unknown> = {};
+
+  for (const method of ['delete', 'eq', 'single', 'select']) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  chain['then'] = (resolve: (v: unknown) => void) => resolve(result);
+
+  return chain;
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: vi.fn(() => createChainMock()),
+  })),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn(() => ({ allowed: true, remaining: 4 })),
+  rateLimitResponse: vi.fn((retryAfter: number) =>
+    new Response(JSON.stringify({ error: 'RATE_LIMITED' }), {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfter) },
+    })
+  ),
+}));
+
+import { DELETE } from '../route';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const AUTH_USER = { id: 'user-push-999', email: 'user@example.com' };
+
+function mockAuthenticated() {
+  mockGetUser.mockResolvedValue({ data: { user: AUTH_USER }, error: null });
+}
+
+function mockUnauthenticated() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'Not authenticated' } });
+}
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/push/unsubscribe', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', 'x-forwarded-for': '10.0.0.1' },
+    body: JSON.stringify(body),
+  });
+}
+
+// Known-good push endpoints from the allowlist
+const FCM_ENDPOINT = 'https://fcm.googleapis.com/v1/projects/styrby/messages:send?token=abc123';
+const MOZILLA_ENDPOINT = 'https://updates.push.services.mozilla.com/push/v1/abcdef1234567890';
+const APPLE_ENDPOINT = 'https://web.push.apple.com/push/v1/somepushtoken';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('DELETE /api/push/unsubscribe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromCallQueue.length = 0;
+  });
+
+  // --------------------------------------------------------------------------
+  // Authentication
+  // --------------------------------------------------------------------------
+
+  it('returns 401 when unauthenticated', async () => {
+    mockUnauthenticated();
+    const res = await DELETE(makeRequest({ endpoint: FCM_ENDPOINT }));
+    expect(res.status).toBe(401);
+  });
+
+  // --------------------------------------------------------------------------
+  // Input validation
+  // --------------------------------------------------------------------------
+
+  it('rejects missing endpoint', async () => {
+    mockAuthenticated();
+    const res = await DELETE(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-URL endpoint', async () => {
+    mockAuthenticated();
+    const res = await DELETE(makeRequest({ endpoint: 'not-a-url' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects endpoint from disallowed host (SSRF guard)', async () => {
+    mockAuthenticated();
+    const res = await DELETE(makeRequest({ endpoint: 'https://internal.corp.local/push/token' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('push service');
+  });
+
+  it('rejects endpoint that is too long (>2048 chars)', async () => {
+    mockAuthenticated();
+    const res = await DELETE(makeRequest({ endpoint: 'https://fcm.googleapis.com/' + 'x'.repeat(2040) }));
+    expect(res.status).toBe(400);
+  });
+
+  // --------------------------------------------------------------------------
+  // SSRF allowlist — accepted hosts
+  // --------------------------------------------------------------------------
+
+  it('accepts FCM endpoint and deletes subscription', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: null, error: null }); // delete success
+
+    const res = await DELETE(makeRequest({ endpoint: FCM_ENDPOINT }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it('accepts Mozilla push endpoint', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: null, error: null });
+
+    const res = await DELETE(makeRequest({ endpoint: MOZILLA_ENDPOINT }));
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts Apple Web Push endpoint', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: null, error: null });
+
+    const res = await DELETE(makeRequest({ endpoint: APPLE_ENDPOINT }));
+    expect(res.status).toBe(200);
+  });
+
+  // --------------------------------------------------------------------------
+  // DB error handling
+  // --------------------------------------------------------------------------
+
+  it('returns 500 on delete DB error', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: null, error: { message: 'constraint violation' } });
+
+    const res = await DELETE(makeRequest({ endpoint: FCM_ENDPOINT }));
+    expect(res.status).toBe(500);
+  });
+
+  // --------------------------------------------------------------------------
+  // Rate limiting
+  // --------------------------------------------------------------------------
+
+  it('returns 429 when rate limited', async () => {
+    const { rateLimit } = await import('@/lib/rateLimit');
+    vi.mocked(rateLimit).mockResolvedValueOnce({ allowed: false, retryAfter: 60, remaining: 0, resetAt: Date.now() + 60000 });
+
+    const res = await DELETE(makeRequest({ endpoint: FCM_ENDPOINT }));
+    expect(res.status).toBe(429);
+  });
+});

--- a/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
@@ -1,0 +1,241 @@
+/**
+ * GET /api/v1/costs/export — Integration Tests
+ *
+ * Tests CSV export of cost records (Power-tier only).
+ *
+ * WHY: CSV export reads up to 50,000 rows of private financial data. Bugs
+ * could let non-Power users export data, expose wrong user's records, or
+ * produce malformed CSV that breaks Excel/Sheets imports.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockAuthContext = {
+  userId: 'export-user-123',
+  keyId: 'key-export-456',
+  scopes: ['read'],
+};
+
+vi.mock('@/middleware/api-auth', () => ({
+  withApiAuth: vi.fn((handler: Function) => {
+    return async (request: NextRequest) => handler(request, mockAuthContext);
+  }),
+  addRateLimitHeaders: vi.fn((response: NextResponse) => response),
+}));
+
+const fromCallQueue: Array<{ data?: unknown; error?: unknown }> = [];
+
+function createChainMock() {
+  const result = fromCallQueue.shift() ?? { data: null, error: null };
+  const chain: Record<string, unknown> = {};
+
+  for (const method of [
+    'select', 'eq', 'gte', 'order', 'limit', 'single', 'maybeSingle',
+  ]) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  chain['single'] = vi.fn().mockResolvedValue(result);
+  chain['maybeSingle'] = vi.fn().mockResolvedValue(result);
+  chain['then'] = (resolve: (v: unknown) => void) => resolve(result);
+
+  return chain;
+}
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn(() => ({
+    from: vi.fn(() => createChainMock()),
+  })),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn(() => ({ allowed: true, remaining: 0 })),
+  RATE_LIMITS: {
+    export: { windowMs: 3600000, maxRequests: 1 },
+  },
+  rateLimitResponse: vi.fn((retryAfter: number) =>
+    new Response(JSON.stringify({ error: 'RATE_LIMITED' }), {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfter) },
+    })
+  ),
+}));
+
+import { GET } from '../route';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeRequest(queryString = ''): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/v1/costs/export${queryString}`, {
+    method: 'GET',
+    headers: {
+      Authorization: 'Bearer sk_live_test',
+      'x-forwarded-for': '10.0.0.1',
+    },
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('GET /api/v1/costs/export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromCallQueue.length = 0;
+  });
+
+  // --------------------------------------------------------------------------
+  // Tier enforcement
+  // --------------------------------------------------------------------------
+
+  it('returns 403 for free tier users', async () => {
+    // subscriptions → free tier
+    fromCallQueue.push({ data: { tier: 'free' }, error: null });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain('Power tier');
+  });
+
+  it('returns 403 for pro tier users', async () => {
+    fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when no subscription found (defaults to free)', async () => {
+    fromCallQueue.push({ data: null, error: { code: 'PGRST116', message: 'no rows' } });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+  });
+
+  // --------------------------------------------------------------------------
+  // Query validation
+  // --------------------------------------------------------------------------
+
+  it('returns 400 for days=0 (below minimum)', async () => {
+    fromCallQueue.push({ data: { tier: 'power' }, error: null });
+
+    const res = await GET(makeRequest('?days=0'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for days=366 (exceeds max 365)', async () => {
+    fromCallQueue.push({ data: { tier: 'power' }, error: null });
+
+    const res = await GET(makeRequest('?days=366'));
+    expect(res.status).toBe(400);
+  });
+
+  // --------------------------------------------------------------------------
+  // Happy path — CSV response
+  // --------------------------------------------------------------------------
+
+  it('returns CSV with correct headers for power user with data', async () => {
+    // subscriptions → power
+    fromCallQueue.push({ data: { tier: 'power' }, error: null });
+    // cost_records → sample rows
+    fromCallQueue.push({
+      data: [
+        {
+          recorded_at: '2026-01-15T10:00:00Z',
+          session_id: '00000000-0000-0000-0000-000000000001',
+          agent_type: 'claude',
+          model: 'claude-sonnet-4',
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_read_tokens: 200,
+          cost_usd: 0.0025,
+        },
+      ],
+      error: null,
+    });
+
+    const res = await GET(makeRequest('?days=7'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/csv');
+    expect(res.headers.get('Content-Disposition')).toMatch(/attachment; filename="styrby-costs-\d{4}-\d{2}-\d{2}\.csv"/);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+
+    const text = await res.text();
+    // Verify CSV header row
+    expect(text).toContain('date,session_id,agent_type,model,input_tokens,output_tokens,cache_tokens,cost_usd');
+    // Verify data row
+    expect(text).toContain('claude');
+    expect(text).toContain('claude-sonnet-4');
+  });
+
+  it('returns CSV with only header row when no records exist', async () => {
+    fromCallQueue.push({ data: { tier: 'power' }, error: null });
+    fromCallQueue.push({ data: [], error: null });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // Only the header line, no extra rows
+    const lines = text.trim().split('\r\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe('date,session_id,agent_type,model,input_tokens,output_tokens,cache_tokens,cost_usd');
+  });
+
+  it('uses RFC 4180 CRLF line endings', async () => {
+    fromCallQueue.push({ data: { tier: 'power' }, error: null });
+    fromCallQueue.push({
+      data: [
+        {
+          recorded_at: '2026-01-20T00:00:00Z',
+          session_id: '00000000-0000-0000-0000-000000000002',
+          agent_type: 'codex',
+          model: 'gpt-4o',
+          input_tokens: 500,
+          output_tokens: 250,
+          cache_read_tokens: 0,
+          cost_usd: 0.001,
+        },
+      ],
+      error: null,
+    });
+
+    const res = await GET(makeRequest());
+    const text = await res.text();
+    // CRLF line endings per RFC 4180
+    expect(text).toContain('\r\n');
+  });
+
+  // --------------------------------------------------------------------------
+  // DB error
+  // --------------------------------------------------------------------------
+
+  it('returns 500 when cost_records query fails', async () => {
+    fromCallQueue.push({ data: { tier: 'power' }, error: null });
+    fromCallQueue.push({ data: null, error: { message: 'timeout' } });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+  });
+
+  // --------------------------------------------------------------------------
+  // Rate limiting
+  // --------------------------------------------------------------------------
+
+  it('returns 429 when rate limited', async () => {
+    const { rateLimit } = await import('@/lib/rateLimit');
+    vi.mocked(rateLimit).mockResolvedValueOnce({ allowed: false, retryAfter: 3600, remaining: 0, resetAt: Date.now() + 3600000 });
+    // Tier check happens after rate limit in handler
+    fromCallQueue.push({ data: { tier: 'power' }, error: null });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(429);
+  });
+});

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Session Checkpoints API Tests
+ *
+ * Tests GET, POST, DELETE /api/v1/sessions/[id]/checkpoints.
+ *
+ * WHY: Checkpoints are a Power-tier feature. Regressions could let free users
+ * create checkpoints, let the name uniqueness 409 path degrade to 500, or
+ * accept invalid session IDs without proper 400 responses.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockAuthContext = {
+  userId: 'checkpoint-user-99',
+  keyId: 'key-chk-123',
+  scopes: ['read', 'write'],
+};
+
+vi.mock('@/middleware/api-auth', () => ({
+  withApiAuth: vi.fn((handler: Function) => {
+    return async (request: NextRequest) => handler(request, mockAuthContext);
+  }),
+  addRateLimitHeaders: vi.fn((response: NextResponse) => response),
+}));
+
+const fromCallQueue: Array<{ data?: unknown; error?: unknown; count?: number }> = [];
+
+function createChainMock() {
+  const result = fromCallQueue.shift() ?? { data: null, error: null };
+  const chain: Record<string, unknown> = {};
+
+  for (const method of [
+    'select', 'eq', 'is', 'order', 'limit', 'insert', 'delete',
+    'single', 'maybeSingle',
+  ]) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  chain['single'] = vi.fn().mockResolvedValue(result);
+  chain['maybeSingle'] = vi.fn().mockResolvedValue(result);
+  chain['then'] = (resolve: (v: unknown) => void) => resolve(result);
+
+  return chain;
+}
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn(() => ({
+    from: vi.fn(() => createChainMock()),
+  })),
+}));
+
+import { GET, POST, DELETE } from '../route';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const VALID_SESSION_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const INVALID_SESSION_ID = 'not-a-uuid';
+
+function makeRequest(method: string, sessionId: string, body?: Record<string, unknown>, query = ''): NextRequest {
+  return new NextRequest(
+    `http://localhost:3000/api/v1/sessions/${sessionId}/checkpoints${query}`,
+    {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer sk_live_test',
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    }
+  );
+}
+
+const VALID_CHECKPOINT_BODY = {
+  name: 'before-refactor',
+  description: 'Checkpoint before the big refactor',
+  messageSequenceNumber: 42,
+  contextSnapshot: { totalTokens: 12000, fileCount: 5 },
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Session Checkpoints API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromCallQueue.length = 0;
+  });
+
+  // --------------------------------------------------------------------------
+  // GET /api/v1/sessions/[id]/checkpoints
+  // --------------------------------------------------------------------------
+
+  describe('GET', () => {
+    it('returns 400 for invalid session ID', async () => {
+      const res = await GET(makeRequest('GET', INVALID_SESSION_ID));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Invalid session ID');
+    });
+
+    it('returns 404 when session not found or not owned by user', async () => {
+      // session lookup → not found
+      fromCallQueue.push({ data: null, error: { code: 'PGRST116', message: 'not found' } });
+
+      const res = await GET(makeRequest('GET', VALID_SESSION_ID));
+      expect(res.status).toBe(404);
+    });
+
+    it('returns checkpoints array for owned session', async () => {
+      // session ownership check → found
+      fromCallQueue.push({ data: { id: VALID_SESSION_ID }, error: null });
+      // checkpoints select → array
+      fromCallQueue.push({
+        data: [
+          {
+            id: 'chk-1',
+            session_id: VALID_SESSION_ID,
+            name: 'step-1',
+            description: null,
+            message_sequence_number: 10,
+            context_snapshot: { totalTokens: 5000, fileCount: 3 },
+            created_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+        error: null,
+      });
+
+      const res = await GET(makeRequest('GET', VALID_SESSION_ID));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.checkpoints).toHaveLength(1);
+      expect(body.checkpoints[0].name).toBe('step-1');
+    });
+
+    it('returns empty array when session has no checkpoints', async () => {
+      fromCallQueue.push({ data: { id: VALID_SESSION_ID }, error: null });
+      fromCallQueue.push({ data: [], error: null });
+
+      const res = await GET(makeRequest('GET', VALID_SESSION_ID));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.checkpoints).toHaveLength(0);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // POST /api/v1/sessions/[id]/checkpoints
+  // --------------------------------------------------------------------------
+
+  describe('POST', () => {
+    it('returns 400 for invalid session ID', async () => {
+      const res = await POST(makeRequest('POST', INVALID_SESSION_ID, VALID_CHECKPOINT_BODY));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 403 for free tier users', async () => {
+      // subscriptions → free (not power)
+      fromCallQueue.push({ data: null, error: null }); // maybeSingle → null → defaults to free
+
+      const res = await POST(makeRequest('POST', VALID_SESSION_ID, VALID_CHECKPOINT_BODY));
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toContain('Power plan');
+    });
+
+    it('returns 403 for pro tier users', async () => {
+      fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+
+      const res = await POST(makeRequest('POST', VALID_SESSION_ID, VALID_CHECKPOINT_BODY));
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 400 for missing name', async () => {
+      fromCallQueue.push({ data: { tier: 'power' }, error: null });
+
+      const res = await POST(makeRequest('POST', VALID_SESSION_ID, { messageSequenceNumber: 5 }));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for name with invalid characters', async () => {
+      fromCallQueue.push({ data: { tier: 'power' }, error: null });
+
+      const res = await POST(makeRequest('POST', VALID_SESSION_ID, {
+        ...VALID_CHECKPOINT_BODY,
+        name: 'invalid name!@#',
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for name exceeding 80 chars', async () => {
+      fromCallQueue.push({ data: { tier: 'power' }, error: null });
+
+      const res = await POST(makeRequest('POST', VALID_SESSION_ID, {
+        ...VALID_CHECKPOINT_BODY,
+        name: 'x'.repeat(81),
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for negative messageSequenceNumber', async () => {
+      fromCallQueue.push({ data: { tier: 'power' }, error: null });
+
+      const res = await POST(makeRequest('POST', VALID_SESSION_ID, {
+        ...VALID_CHECKPOINT_BODY,
+        messageSequenceNumber: -1,
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 when session not found for power user', async () => {
+      // tier check → power
+      fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      // session ownership → not found
+      fromCallQueue.push({ data: null, error: { code: 'PGRST116', message: 'not found' } });
+
+      const res = await POST(makeRequest('POST', VALID_SESSION_ID, VALID_CHECKPOINT_BODY));
+      expect(res.status).toBe(404);
+    });
+
+    it('creates checkpoint and returns 201 for power user', async () => {
+      fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: { id: VALID_SESSION_ID }, error: null }); // session
+      const inserted = {
+        id: 'chk-new',
+        session_id: VALID_SESSION_ID,
+        name: 'before-refactor',
+        description: 'Checkpoint before the big refactor',
+        message_sequence_number: 42,
+        context_snapshot: { totalTokens: 12000, fileCount: 5 },
+        created_at: '2026-04-21T00:00:00Z',
+      };
+      fromCallQueue.push({ data: inserted, error: null });
+
+      const res = await POST(makeRequest('POST', VALID_SESSION_ID, VALID_CHECKPOINT_BODY));
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.checkpoint.name).toBe('before-refactor');
+      expect(body.checkpoint.messageSequenceNumber).toBe(42);
+    });
+
+    it('returns 409 when checkpoint name already exists in session', async () => {
+      fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: { id: VALID_SESSION_ID }, error: null });
+      fromCallQueue.push({ data: null, error: { code: '23505', message: 'unique violation' } });
+
+      const res = await POST(makeRequest('POST', VALID_SESSION_ID, VALID_CHECKPOINT_BODY));
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toContain('already exists');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // DELETE /api/v1/sessions/[id]/checkpoints
+  // --------------------------------------------------------------------------
+
+  describe('DELETE', () => {
+    it('returns 400 for invalid session ID', async () => {
+      const res = await DELETE(makeRequest('DELETE', INVALID_SESSION_ID));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when neither checkpointId nor name provided', async () => {
+      const res = await DELETE(makeRequest('DELETE', VALID_SESSION_ID));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('checkpointId or name');
+    });
+
+    it('returns 400 for invalid checkpointId UUID', async () => {
+      const res = await DELETE(makeRequest('DELETE', VALID_SESSION_ID, undefined, '?checkpointId=not-a-uuid'));
+      expect(res.status).toBe(400);
+    });
+
+    it('deletes by name and returns deleted: true', async () => {
+      fromCallQueue.push({ data: null, error: null, count: 1 });
+
+      const res = await DELETE(makeRequest('DELETE', VALID_SESSION_ID, undefined, '?name=before-refactor'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.deleted).toBe(true);
+    });
+
+    it('deletes by checkpointId and returns deleted: true', async () => {
+      const checkpointId = 'ffffffff-aaaa-bbbb-cccc-dddddddddddd';
+      fromCallQueue.push({ data: null, error: null, count: 1 });
+
+      const res = await DELETE(makeRequest('DELETE', VALID_SESSION_ID, undefined, `?checkpointId=${checkpointId}`));
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/packages/styrby-web/src/lib/__tests__/blog-data.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/blog-data.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for lib/blog-data.ts
+ *
+ * WHY: blog-data.ts is the authoritative registry for article metadata. Bugs
+ * here (duplicate slugs, missing required fields, wrong category assignments)
+ * cause broken links and empty blog pages that aren't caught until users see 404s.
+ * These tests act as a schema regression check for the article list.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  blogArticles,
+  getArticleBySlug,
+  getCategories,
+  categoryLabels,
+  categoryColors,
+  type BlogCategory,
+} from '../blog-data';
+
+// ============================================================================
+// blogArticles registry
+// ============================================================================
+
+describe('blogArticles', () => {
+  it('contains at least one article', () => {
+    expect(blogArticles.length).toBeGreaterThan(0);
+  });
+
+  it('every article has the required fields', () => {
+    for (const article of blogArticles) {
+      expect(article.slug, `slug missing on: ${JSON.stringify(article)}`).toBeTruthy();
+      expect(article.title).toBeTruthy();
+      expect(article.date).toBeTruthy();
+      expect(article.category).toBeTruthy();
+      expect(article.description).toBeTruthy();
+      expect(article.readTime).toBeGreaterThan(0);
+    }
+  });
+
+  it('slug values contain only URL-safe characters', () => {
+    for (const article of blogArticles) {
+      expect(article.slug).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it('has no duplicate slugs', () => {
+    const slugs = blogArticles.map((a) => a.slug);
+    const unique = new Set(slugs);
+    expect(unique.size).toBe(slugs.length);
+  });
+
+  it('date values are in YYYY-MM-DD format', () => {
+    const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+    for (const article of blogArticles) {
+      expect(article.date, `Invalid date on "${article.slug}"`).toMatch(ISO_DATE);
+    }
+  });
+
+  it('every category is a valid BlogCategory', () => {
+    const valid: BlogCategory[] = ['comparison', 'deep-dive', 'use-case', 'technical', 'company'];
+    for (const article of blogArticles) {
+      expect(valid).toContain(article.category);
+    }
+  });
+
+  it('readTime is a positive integer', () => {
+    for (const article of blogArticles) {
+      expect(Number.isInteger(article.readTime)).toBe(true);
+      expect(article.readTime).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ============================================================================
+// getArticleBySlug
+// ============================================================================
+
+describe('getArticleBySlug', () => {
+  it('returns the correct article for a known slug', () => {
+    const firstSlug = blogArticles[0].slug;
+    const found = getArticleBySlug(firstSlug);
+    expect(found).toBeDefined();
+    expect(found!.slug).toBe(firstSlug);
+  });
+
+  it('returns undefined for an unknown slug', () => {
+    expect(getArticleBySlug('does-not-exist-xyz')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(getArticleBySlug('')).toBeUndefined();
+  });
+
+  it('is case-sensitive (slug must be exact match)', () => {
+    const slug = blogArticles[0].slug;
+    expect(getArticleBySlug(slug.toUpperCase())).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// getCategories
+// ============================================================================
+
+describe('getCategories', () => {
+  it('returns only categories that have at least one article', () => {
+    const usedCategories = new Set(blogArticles.map((a) => a.category));
+    const returned = getCategories();
+    for (const cat of returned) {
+      expect(usedCategories.has(cat)).toBe(true);
+    }
+  });
+
+  it('returns each used category exactly once', () => {
+    const categories = getCategories();
+    const unique = new Set(categories);
+    expect(unique.size).toBe(categories.length);
+  });
+
+  it('returns categories in the defined display order', () => {
+    const order: BlogCategory[] = ['comparison', 'deep-dive', 'use-case', 'technical', 'company'];
+    const returned = getCategories();
+
+    // The returned list must be a subsequence of the display order
+    let orderIdx = 0;
+    for (const cat of returned) {
+      const found = order.indexOf(cat, orderIdx);
+      expect(found).toBeGreaterThanOrEqual(orderIdx);
+      orderIdx = found + 1;
+    }
+  });
+});
+
+// ============================================================================
+// categoryLabels and categoryColors
+// ============================================================================
+
+describe('categoryLabels', () => {
+  it('has a label for every valid category', () => {
+    const categories: BlogCategory[] = ['comparison', 'deep-dive', 'use-case', 'technical', 'company'];
+    for (const cat of categories) {
+      expect(categoryLabels[cat]).toBeTruthy();
+    }
+  });
+});
+
+describe('categoryColors', () => {
+  it('has a color class for every valid category', () => {
+    const categories: BlogCategory[] = ['comparison', 'deep-dive', 'use-case', 'technical', 'company'];
+    for (const cat of categories) {
+      expect(categoryColors[cat]).toBeTruthy();
+    }
+  });
+});

--- a/packages/styrby-web/src/lib/__tests__/config.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/config.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for lib/config.ts — getAppUrl helper.
+ *
+ * WHY: Two route files previously used different hardcoded domain fallbacks.
+ * getAppUrl() centralises the canonical URL. These tests lock in the fallback
+ * behaviour and warn-not-throw contract so a future refactor cannot silently
+ * change the canonical domain or start throwing on a missing env var.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const originalEnv = { ...process.env };
+const originalNodeEnv = process.env.NODE_ENV;
+
+/**
+ * WHY Object.defineProperty: NODE_ENV is typed as read-only in TypeScript's
+ * NodeJS.ProcessEnv. We need to override it per-test to exercise the production
+ * vs. development code path in getAppUrl(). defineProperty bypasses the
+ * TS readonly constraint without casting and is the standard testing pattern.
+ */
+function setNodeEnv(value: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', { value, writable: true, configurable: true });
+}
+
+describe('getAppUrl', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    setNodeEnv(originalNodeEnv);
+  });
+
+  it('returns the env var value when NEXT_PUBLIC_APP_URL is set', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://custom.styrby.dev';
+    const { getAppUrl } = await import('../config');
+    expect(getAppUrl()).toBe('https://custom.styrby.dev');
+  });
+
+  it('falls back to https://styrbyapp.com in production when env var is missing', async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    setNodeEnv('production');
+    const { getAppUrl } = await import('../config');
+    expect(getAppUrl()).toBe('https://styrbyapp.com');
+  });
+
+  it('falls back to https://styrbyapp.com in development and emits a console.warn', async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    setNodeEnv('development');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { getAppUrl } = await import('../config');
+    const result = getAppUrl();
+
+    expect(result).toBe('https://styrbyapp.com');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('NEXT_PUBLIC_APP_URL'));
+    warnSpy.mockRestore();
+  });
+
+  it('does NOT emit console.warn in production when env var is missing', async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    setNodeEnv('production');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { getAppUrl } = await import('../config');
+    getAppUrl();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('returns value without trailing slash when env var has no slash', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.styrby.com';
+    const { getAppUrl } = await import('../config');
+    expect(getAppUrl()).not.toMatch(/\/$/);
+  });
+});

--- a/packages/styrby-web/src/lib/__tests__/onboarding.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/onboarding.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for lib/onboarding.ts — getOnboardingState
+ *
+ * WHY: Onboarding state drives the welcome modal and sidebar banner shown to
+ * new users. Regressions could leave users stuck in onboarding (isComplete
+ * never true), show wrong steps for a tier, or fail to take the fast path
+ * when onboarding_completed_at is already set.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getOnboardingState } from '../onboarding';
+
+// ============================================================================
+// Mock Supabase client builder
+// ============================================================================
+
+type QueryResult = { data?: unknown; error?: unknown; count?: number };
+
+/**
+ * Builds a minimal Supabase mock that returns results from a queue.
+ * Each .from() call consumes one item from the queue.
+ */
+function buildMockSupabase(queue: QueryResult[]): SupabaseClient {
+  const idx = { current: 0 };
+
+  function makeChain(): Record<string, unknown> {
+    const result = queue[idx.current++] ?? { data: null, error: null };
+    const chain: Record<string, unknown> = {};
+
+    const chainable = [
+      'from', 'select', 'eq', 'is', 'order', 'limit',
+      'insert', 'update', 'delete', 'single', 'maybeSingle',
+    ];
+    for (const method of chainable) {
+      chain[method] = vi.fn().mockReturnValue(chain);
+    }
+
+    chain['single'] = vi.fn().mockResolvedValue(result);
+    chain['maybeSingle'] = vi.fn().mockResolvedValue(result);
+    chain['then'] = (resolve: (v: unknown) => void) => resolve(result);
+
+    return chain;
+  }
+
+  return {
+    from: vi.fn(() => makeChain()),
+  } as unknown as SupabaseClient;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('getOnboardingState', () => {
+  const USER_ID = 'onboard-user-xyz';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // Fast path: already completed
+  // --------------------------------------------------------------------------
+
+  it('returns isComplete: true when onboarding_completed_at is set', async () => {
+    const supabase = buildMockSupabase([
+      { data: { onboarding_completed_at: '2026-01-01T00:00:00Z' }, error: null },
+    ]);
+
+    const state = await getOnboardingState(supabase, USER_ID);
+
+    expect(state.isComplete).toBe(true);
+    expect(state.onboardingCompletedAt).toBe('2026-01-01T00:00:00Z');
+    // Fast path returns minimal state (no steps)
+    expect(state.steps).toHaveLength(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // Free tier — 1 step
+  // --------------------------------------------------------------------------
+
+  it('shows 1 step for free tier user with no machine', async () => {
+    const supabase = buildMockSupabase([
+      // profiles → no completed_at
+      { data: { onboarding_completed_at: null }, error: null },
+      // subscriptions → free (null = free default)
+      { data: null, error: null },
+      // machines count → 0
+      { count: 0, data: null, error: null },
+      // budget_alerts count → 0
+      { count: 0, data: null, error: null },
+      // device_tokens count → 0
+      { count: 0, data: null, error: null },
+      // team_members count → 0
+      { count: 0, data: null, error: null },
+      // api_keys count → 0
+      { count: 0, data: null, error: null },
+    ]);
+
+    const state = await getOnboardingState(supabase, USER_ID);
+
+    expect(state.tier).toBe('free');
+    expect(state.totalSteps).toBe(1);
+    expect(state.completedCount).toBe(0);
+    expect(state.isComplete).toBe(false);
+    expect(state.steps[0].id).toBe('connect-machine');
+    expect(state.steps[0].completed).toBe(false);
+  });
+
+  it('returns isComplete: true for free tier user who has connected a machine', async () => {
+    const supabase = buildMockSupabase([
+      { data: { onboarding_completed_at: null }, error: null },
+      { data: null, error: null }, // free tier
+      { count: 1, data: null, error: null }, // has machine
+      { count: 0, data: null, error: null },
+      { count: 0, data: null, error: null },
+      { count: 0, data: null, error: null },
+      { count: 0, data: null, error: null },
+    ]);
+
+    const state = await getOnboardingState(supabase, USER_ID);
+
+    expect(state.isComplete).toBe(true);
+    expect(state.completedCount).toBe(1);
+    expect(state.steps[0].completed).toBe(true);
+  });
+
+  // --------------------------------------------------------------------------
+  // Pro tier — 3 steps
+  // --------------------------------------------------------------------------
+
+  it('shows 3 steps for pro tier user', async () => {
+    const supabase = buildMockSupabase([
+      { data: { onboarding_completed_at: null }, error: null },
+      { data: { tier: 'pro' }, error: null },
+      { count: 0, data: null, error: null }, // machines
+      { count: 0, data: null, error: null }, // budget_alerts
+      { count: 0, data: null, error: null }, // device_tokens
+      { count: 0, data: null, error: null }, // team_members
+      { count: 0, data: null, error: null }, // api_keys
+    ]);
+
+    const state = await getOnboardingState(supabase, USER_ID);
+
+    expect(state.tier).toBe('pro');
+    expect(state.totalSteps).toBe(3);
+    const stepIds = state.steps.map((s) => s.id);
+    expect(stepIds).toContain('connect-machine');
+    expect(stepIds).toContain('set-budget-alert');
+    expect(stepIds).toContain('install-mobile-app');
+  });
+
+  it('reflects partial completion for pro user', async () => {
+    const supabase = buildMockSupabase([
+      { data: { onboarding_completed_at: null }, error: null },
+      { data: { tier: 'pro' }, error: null },
+      { count: 1, data: null, error: null }, // has machine ✓
+      { count: 0, data: null, error: null }, // no budget alert
+      { count: 1, data: null, error: null }, // has device token ✓
+      { count: 0, data: null, error: null },
+      { count: 0, data: null, error: null },
+    ]);
+
+    const state = await getOnboardingState(supabase, USER_ID);
+
+    expect(state.completedCount).toBe(2);
+    expect(state.totalSteps).toBe(3);
+    expect(state.isComplete).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
+  // Power tier — 5 steps
+  // --------------------------------------------------------------------------
+
+  it('shows 5 steps for power tier user', async () => {
+    const supabase = buildMockSupabase([
+      { data: { onboarding_completed_at: null }, error: null },
+      { data: { tier: 'power' }, error: null },
+      { count: 0, data: null, error: null }, // machines
+      { count: 0, data: null, error: null }, // budget_alerts
+      { count: 0, data: null, error: null }, // device_tokens
+      { count: 0, data: null, error: null }, // team_members
+      { count: 0, data: null, error: null }, // api_keys
+      // team_invitations (power-only check)
+      { count: 0, data: null, error: null },
+    ]);
+
+    const state = await getOnboardingState(supabase, USER_ID);
+
+    expect(state.tier).toBe('power');
+    expect(state.totalSteps).toBe(5);
+    const stepIds = state.steps.map((s) => s.id);
+    expect(stepIds).toContain('invite-team-member');
+    expect(stepIds).toContain('create-api-key');
+  });
+
+  it('marks invite-team-member complete when there are sent invitations', async () => {
+    const supabase = buildMockSupabase([
+      { data: { onboarding_completed_at: null }, error: null },
+      { data: { tier: 'power' }, error: null },
+      { count: 1, data: null, error: null }, // machine
+      { count: 1, data: null, error: null }, // budget alert
+      { count: 1, data: null, error: null }, // device token
+      { count: 0, data: null, error: null }, // team_members (unused)
+      { count: 1, data: null, error: null }, // api_keys
+      { count: 2, data: null, error: null }, // team_invitations → invited someone
+    ]);
+
+    const state = await getOnboardingState(supabase, USER_ID);
+
+    const teamStep = state.steps.find((s) => s.id === 'invite-team-member');
+    expect(teamStep!.completed).toBe(true);
+    expect(state.completedCount).toBe(5);
+    expect(state.isComplete).toBe(true);
+  });
+
+  // --------------------------------------------------------------------------
+  // Step metadata
+  // --------------------------------------------------------------------------
+
+  it('each step has required fields (id, label, description, href)', async () => {
+    const supabase = buildMockSupabase([
+      { data: { onboarding_completed_at: null }, error: null },
+      { data: { tier: 'power' }, error: null },
+      { count: 0, data: null, error: null },
+      { count: 0, data: null, error: null },
+      { count: 0, data: null, error: null },
+      { count: 0, data: null, error: null },
+      { count: 0, data: null, error: null },
+      { count: 0, data: null, error: null },
+    ]);
+
+    const state = await getOnboardingState(supabase, USER_ID);
+
+    for (const step of state.steps) {
+      expect(step.id).toBeTruthy();
+      expect(step.label).toBeTruthy();
+      expect(step.description).toBeTruthy();
+      expect(step.href).toMatch(/^\//);
+    }
+  });
+});

--- a/packages/styrby-web/src/lib/__tests__/otel-config.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/otel-config.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for lib/otel-config.ts
+ *
+ * WHY: OTEL config is user-managed and involves URL/header validation.
+ * Regressions in validateOtelConfig() could accept malformed endpoints,
+ * allow empty service names, or accept unreasonably large timeouts — all
+ * of which would produce useless env vars copied to the user's shell profile.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  defaultOtelConfig,
+  validateOtelConfig,
+  generateEnvVars,
+  OTEL_PRESETS,
+  type OtelUserConfig,
+} from '../otel-config';
+
+// ============================================================================
+// defaultOtelConfig
+// ============================================================================
+
+describe('defaultOtelConfig', () => {
+  it('returns a disabled config with safe defaults', () => {
+    const cfg = defaultOtelConfig();
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.endpoint).toBe('');
+    expect(cfg.headers).toEqual({});
+    expect(cfg.serviceName).toBe('styrby-cli');
+    expect(cfg.timeoutMs).toBe(5000);
+  });
+
+  it('returns a new object on each call (no shared reference)', () => {
+    const a = defaultOtelConfig();
+    const b = defaultOtelConfig();
+    expect(a).not.toBe(b);
+  });
+});
+
+// ============================================================================
+// validateOtelConfig
+// ============================================================================
+
+describe('validateOtelConfig', () => {
+  const validConfig: OtelUserConfig = {
+    enabled: true,
+    endpoint: 'https://otlp-gateway-prod-us-east-0.grafana.net/otlp/v1/metrics',
+    headers: { Authorization: 'Basic abc123' },
+    serviceName: 'styrby-cli',
+    timeoutMs: 5000,
+  };
+
+  it('returns isValid: true for a well-formed config', () => {
+    const result = validateOtelConfig(validConfig);
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual({});
+  });
+
+  it('returns isValid: true when disabled (endpoint not required)', () => {
+    const result = validateOtelConfig({ ...validConfig, enabled: false, endpoint: '' });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('requires endpoint when enabled', () => {
+    const result = validateOtelConfig({ ...validConfig, endpoint: '' });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.endpoint).toBeTruthy();
+  });
+
+  it('rejects endpoint not starting with http:// or https://', () => {
+    const result = validateOtelConfig({ ...validConfig, endpoint: 'ftp://bad.endpoint/v1/metrics' });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.endpoint).toContain('http');
+  });
+
+  it('rejects malformed URL as endpoint', () => {
+    const result = validateOtelConfig({ ...validConfig, endpoint: 'https://' });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.endpoint).toBeTruthy();
+  });
+
+  it('rejects empty serviceName', () => {
+    const result = validateOtelConfig({ ...validConfig, serviceName: '   ' });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.serviceName).toBeTruthy();
+  });
+
+  it('rejects serviceName exceeding 128 chars', () => {
+    const result = validateOtelConfig({ ...validConfig, serviceName: 'x'.repeat(129) });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.serviceName).toContain('128');
+  });
+
+  it('rejects timeoutMs below 1000', () => {
+    const result = validateOtelConfig({ ...validConfig, timeoutMs: 500 });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.timeoutMs).toContain('1000');
+  });
+
+  it('rejects timeoutMs above 30000', () => {
+    const result = validateOtelConfig({ ...validConfig, timeoutMs: 30_001 });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.timeoutMs).toContain('30,000');
+  });
+
+  it('accepts timeoutMs at the boundaries (1000 and 30000)', () => {
+    expect(validateOtelConfig({ ...validConfig, timeoutMs: 1000 }).isValid).toBe(true);
+    expect(validateOtelConfig({ ...validConfig, timeoutMs: 30000 }).isValid).toBe(true);
+  });
+
+  it('rejects non-integer timeoutMs', () => {
+    const result = validateOtelConfig({ ...validConfig, timeoutMs: 2500.5 });
+    expect(result.isValid).toBe(false);
+  });
+
+  it('does not validate optional fields when they are undefined', () => {
+    // If serviceName / timeoutMs are not provided, no errors should fire for those fields
+    const result = validateOtelConfig({ enabled: false });
+    expect(result.errors.serviceName).toBeUndefined();
+    expect(result.errors.timeoutMs).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// generateEnvVars
+// ============================================================================
+
+describe('generateEnvVars', () => {
+  it('generates the correct shell exports', () => {
+    const cfg: OtelUserConfig = {
+      enabled: true,
+      endpoint: 'https://api.honeycomb.io/v1/metrics',
+      headers: {},
+      serviceName: 'my-service',
+      timeoutMs: 8000,
+    };
+
+    const output = generateEnvVars(cfg);
+    expect(output).toContain('export STYRBY_OTEL_ENABLED=true');
+    expect(output).toContain('export STYRBY_OTEL_ENDPOINT="https://api.honeycomb.io/v1/metrics"');
+    expect(output).toContain('export STYRBY_OTEL_SERVICE="my-service"');
+    expect(output).toContain('export STYRBY_OTEL_TIMEOUT_MS="8000"');
+  });
+
+  it('includes STYRBY_OTEL_HEADERS when headers are present', () => {
+    const cfg: OtelUserConfig = {
+      enabled: true,
+      endpoint: 'https://api.honeycomb.io/v1/metrics',
+      headers: { 'X-Honeycomb-Team': 'my-key' },
+      serviceName: 'styrby-cli',
+      timeoutMs: 5000,
+    };
+
+    const output = generateEnvVars(cfg);
+    expect(output).toContain('STYRBY_OTEL_HEADERS');
+    expect(output).toContain('X-Honeycomb-Team');
+  });
+
+  it('omits STYRBY_OTEL_HEADERS line when headers are empty', () => {
+    const cfg: OtelUserConfig = {
+      enabled: false,
+      endpoint: '',
+      headers: {},
+      serviceName: 'styrby-cli',
+      timeoutMs: 5000,
+    };
+
+    const output = generateEnvVars(cfg);
+    expect(output).not.toContain('STYRBY_OTEL_HEADERS');
+  });
+
+  it('outputs false for disabled config', () => {
+    const cfg: OtelUserConfig = { ...defaultOtelConfig(), enabled: false };
+    const output = generateEnvVars(cfg);
+    expect(output).toContain('STYRBY_OTEL_ENABLED=false');
+  });
+});
+
+// ============================================================================
+// OTEL_PRESETS
+// ============================================================================
+
+describe('OTEL_PRESETS', () => {
+  it('contains at least 4 presets', () => {
+    expect(OTEL_PRESETS.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('each preset has required fields', () => {
+    for (const preset of OTEL_PRESETS) {
+      expect(preset.id).toBeTruthy();
+      expect(preset.name).toBeTruthy();
+      expect(typeof preset.endpoint).toBe('string');
+      expect(preset.headersTemplate).toBeDefined();
+      expect(preset.helpText).toBeTruthy();
+      expect(preset.docsUrl).toMatch(/^https?:\/\//);
+    }
+  });
+
+  it('includes Grafana Cloud, Datadog, and Honeycomb presets', () => {
+    const ids = OTEL_PRESETS.map((p) => p.id);
+    expect(ids).toContain('grafana-cloud');
+    expect(ids).toContain('datadog');
+    expect(ids).toContain('honeycomb');
+  });
+
+  it('includes a custom preset with empty endpoint', () => {
+    const custom = OTEL_PRESETS.find((p) => p.id === 'custom');
+    expect(custom).toBeDefined();
+    expect(custom!.endpoint).toBe('');
+  });
+});

--- a/packages/styrby-web/src/lib/__tests__/utils.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for lib/utils.ts — cn() class-name utility
+ *
+ * WHY: cn() is the foundation of every component's conditional styling. A bug
+ * here (wrong Tailwind conflict resolution or clsx behavior) causes broken
+ * layouts across the entire dashboard without a clear failure signal.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { cn } from '../utils';
+
+describe('cn', () => {
+  it('returns a single class unchanged', () => {
+    expect(cn('text-white')).toBe('text-white');
+  });
+
+  it('combines multiple classes', () => {
+    const result = cn('flex', 'items-center', 'gap-4');
+    expect(result).toBe('flex items-center gap-4');
+  });
+
+  it('handles conditional classes with truthy boolean', () => {
+    const isActive = true;
+    const result = cn('btn', isActive && 'btn-active');
+    expect(result).toContain('btn-active');
+    expect(result).toContain('btn');
+  });
+
+  it('omits conditional classes with falsy boolean', () => {
+    const isActive = false;
+    const result = cn('btn', isActive && 'btn-active');
+    expect(result).not.toContain('btn-active');
+  });
+
+  it('resolves Tailwind class conflicts (last wins)', () => {
+    // twMerge should resolve 'p-2 p-4' → 'p-4'
+    const result = cn('p-2', 'p-4');
+    expect(result).toBe('p-4');
+    expect(result).not.toContain('p-2');
+  });
+
+  it('handles object syntax from clsx', () => {
+    const result = cn({ 'text-red-500': true, 'text-blue-500': false });
+    expect(result).toContain('text-red-500');
+    expect(result).not.toContain('text-blue-500');
+  });
+
+  it('handles array inputs', () => {
+    const result = cn(['flex', 'gap-2'], 'text-sm');
+    expect(result).toContain('flex');
+    expect(result).toContain('gap-2');
+    expect(result).toContain('text-sm');
+  });
+
+  it('ignores null and undefined values', () => {
+    const result = cn('base', null, undefined, 'extra');
+    expect(result).toContain('base');
+    expect(result).toContain('extra');
+    expect(result).not.toContain('null');
+    expect(result).not.toContain('undefined');
+  });
+
+  it('returns empty string for no inputs', () => {
+    expect(cn()).toBe('');
+  });
+
+  it('resolves padding conflict: p-4 overrides px-2', () => {
+    // twMerge should keep p-4 and remove conflicting px-2
+    const result = cn('px-2', 'p-4');
+    expect(result).toBe('p-4');
+  });
+
+  it('handles mixed conditional and static classes', () => {
+    // WHY string cast: TS narrows a string literal to its exact type and
+    // flags === comparisons against other literals as unreachable.
+    // Casting to string keeps the runtime behaviour identical while satisfying tsc.
+    const variant = 'destructive' as string;
+    const result = cn(
+      'inline-flex items-center rounded-md',
+      variant === 'destructive' && 'bg-red-500 text-white',
+      variant === 'default' && 'bg-blue-500'
+    );
+    expect(result).toContain('bg-red-500');
+    expect(result).toContain('text-white');
+    expect(result).not.toContain('bg-blue-500');
+  });
+});


### PR DESCRIPTION
## Summary
Five parallel agents covering CLI, shared, mobile services, and web. Test-only — no source modifications. Typecheck clean across all packages.

### CLI (+140 tests)
- `commands/__tests__/`: install-agent (18), daemon (15), doctor (11), upgrade (12), logs (12), stop (8) = 76.
- `costs/__tests__/`: cost-extractor (44), budget-actions (20) = 64.

### Shared (+240 tests, 9 new files)
- `auth/passkey` (33): WebAuthn L3 option builders, counter validation, RP ID extraction
- `mcp/catalog` (14), `utils/api-keys` (30), `utils/format-time` (13)
- `utils/notification-priority` (42), `errors/classifier` (29)
- `relay/pairing` (27), `relay/offline-queue` (30), `relay/types` (22)

### Mobile services gap-fill (+15 tests — error branches + edge cases)
- `encryption`, `notifications`, `offline-queue`, `offline-storage`, `offline-sync`, `pairing`

### Web (+137 tests, 11 new files)
- 6 API route tests: `agent-configs`, `bookmarks`, `onboarding/complete`, `push/unsubscribe`, `v1/costs/export`, `v1/sessions/[id]/checkpoints`
- 5 lib tests: `config`, `otel-config`, `blog-data`, `utils`, `onboarding`

### Held for wave 4 (test quality — covered as follow-up)
- `AcpBackend` orchestrator (vi.mock factory hoisting with class needs `vi.hoisted()`)
- `budget-monitor` + `cost-reporter` (Supabase chain mock needs `.from().insert().select()` stub)

## Test plan
- [x] CLI: 1,717 tests pass (was 1,510)
- [x] Shared: 823 tests pass (was 583)
- [x] Mobile: 1,194 tests pass (was 1,179)
- [x] Web: 1,608 tests pass (was 1,471)
- [x] All packages typecheck clean
- [ ] CI green (Lint & Type Check, Web Unit Tests, Build Web, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)