### PR TITLE
feat(shared): unified CostReport type + Zod schema (Phase 1.6.1 PR-B)

### DIFF
--- a/packages/styrby-shared/src/cost/__tests__/types.test.ts
+++ b/packages/styrby-shared/src/cost/__tests__/types.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Tests for the CostReport Zod schema (cost/types.ts).
+ *
+ * Covers:
+ *   - Happy paths for each billing model ('api-key', 'subscription', 'credit', 'free')
+ *   - All 5 cross-field refinements fire with the correct error message on violation
+ *   - Optional fields (subscriptionUsage, credits) parse correctly when absent
+ *   - Token counts reject negative integers
+ *   - rawAgentPayload accepts arbitrary JSON shapes
+ *   - Union branches for CostSource ('agent-reported', 'styrby-estimate')
+ *
+ * WHY: CostReportSchema is a security and data-quality boundary. Every agent
+ * factory feeds data through this schema before it reaches cost_records and
+ * the dashboard. A missed validation here corrupts spend totals and budget
+ * alerts for the user.
+ *
+ * @module cost/__tests__/types
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CostReportSchema,
+  BILLING_MODELS,
+  COST_SOURCES,
+} from '../types.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+/** Minimal valid 'api-key' report — all required fields, no optionals. */
+const BASE_API_KEY = {
+  sessionId: 'sess-001',
+  messageId: 'msg-001',
+  agentType: 'claude',
+  model: 'claude-sonnet-4-5',
+  timestamp: '2026-04-21T14:30:00.000Z',
+  source: 'agent-reported' as const,
+  billingModel: 'api-key' as const,
+  costUsd: 0.0042,
+  inputTokens: 1200,
+  outputTokens: 800,
+  cacheReadTokens: 400,
+  cacheWriteTokens: 100,
+  rawAgentPayload: { usage: { input_tokens: 1200, output_tokens: 800 } },
+};
+
+/** Minimal valid 'subscription' report. */
+const BASE_SUBSCRIPTION = {
+  ...BASE_API_KEY,
+  billingModel: 'subscription' as const,
+  costUsd: 0,
+  rawAgentPayload: null,
+  subscriptionUsage: {
+    fractionUsed: 0.47,
+    rawSignal: '47% of daily limit used',
+  },
+};
+
+/** Minimal valid 'credit' report (Kiro-style). */
+const BASE_CREDIT = {
+  ...BASE_API_KEY,
+  agentType: 'kiro',
+  billingModel: 'credit' as const,
+  costUsd: 0.05,
+  credits: {
+    consumed: 5,
+    rateUsdPerCredit: 0.01,
+  },
+};
+
+/** Minimal valid 'free' report (Kilo+Ollama). */
+const BASE_FREE = {
+  ...BASE_API_KEY,
+  agentType: 'kilo',
+  model: 'llama3.3',
+  billingModel: 'free' as const,
+  costUsd: 0,
+  rawAgentPayload: null,
+  source: 'styrby-estimate' as const,
+};
+
+// ============================================================================
+// Happy paths — one per billing model
+// ============================================================================
+
+describe('CostReportSchema — happy paths', () => {
+  it('parses a valid api-key report', () => {
+    const result = CostReportSchema.safeParse(BASE_API_KEY);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a valid subscription report', () => {
+    const result = CostReportSchema.safeParse(BASE_SUBSCRIPTION);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a valid credit report', () => {
+    const result = CostReportSchema.safeParse(BASE_CREDIT);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses a valid free report', () => {
+    const result = CostReportSchema.safeParse(BASE_FREE);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts messageId as null (session-level aggregation)', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, messageId: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts rawAgentPayload with arbitrary nested JSON', () => {
+    const payload = {
+      deeply: { nested: { array: [1, 'two', true, null], obj: { x: 99 } } },
+    };
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, rawAgentPayload: payload });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts rawAgentPayload as null for api-key source agent-reported (explicit null)', () => {
+    // rawAgentPayload null is valid for any source/billingModel combination
+    // EXCEPT styrby-estimate (which requires null) — so null on api-key is fine.
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, rawAgentPayload: null });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// BILLING_MODELS and COST_SOURCES const arrays
+// ============================================================================
+
+describe('exported const arrays', () => {
+  it('BILLING_MODELS contains all four expected values', () => {
+    expect(BILLING_MODELS).toEqual(['api-key', 'subscription', 'credit', 'free']);
+  });
+
+  it('COST_SOURCES contains both expected values', () => {
+    expect(COST_SOURCES).toEqual(['agent-reported', 'styrby-estimate']);
+  });
+});
+
+// ============================================================================
+// Refinement 1 — subscription costUsd must be 0
+// ============================================================================
+
+describe('Refinement 1: subscription → costUsd must be 0', () => {
+  it('rejects subscription report with non-zero costUsd', () => {
+    const bad = { ...BASE_SUBSCRIPTION, costUsd: 1.5 };
+    const result = CostReportSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("costUsd must be 0 when billingModel is 'subscription'");
+    }
+  });
+
+  it('accepts subscription report with costUsd exactly 0', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_SUBSCRIPTION, costUsd: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it('does NOT fire for api-key with non-zero costUsd', () => {
+    // api-key can have any non-negative costUsd
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, costUsd: 9.99 });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Refinement 2 — credit billingModel requires credits field
+// ============================================================================
+
+describe('Refinement 2: credit → credits must be present', () => {
+  it('rejects credit report missing credits field', () => {
+    const { credits: _credits, ...bad } = BASE_CREDIT as typeof BASE_CREDIT & { credits?: unknown };
+    const result = CostReportSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain("credits must be present when billingModel is 'credit'");
+    }
+  });
+
+  it('accepts credit report with credits present', () => {
+    const result = CostReportSchema.safeParse(BASE_CREDIT);
+    expect(result.success).toBe(true);
+  });
+
+  it('does NOT fire for api-key without credits', () => {
+    // api-key never needs credits
+    const result = CostReportSchema.safeParse(BASE_API_KEY);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Refinement 3 — styrby-estimate requires rawAgentPayload null
+// ============================================================================
+
+describe('Refinement 3: styrby-estimate → rawAgentPayload must be null', () => {
+  it('rejects styrby-estimate report with non-null rawAgentPayload', () => {
+    const bad = {
+      ...BASE_FREE,
+      source: 'styrby-estimate' as const,
+      rawAgentPayload: { some: 'payload' },
+    };
+    const result = CostReportSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain(
+        "rawAgentPayload must be null when source is 'styrby-estimate'"
+      );
+    }
+  });
+
+  it('accepts styrby-estimate report with null rawAgentPayload', () => {
+    const result = CostReportSchema.safeParse(BASE_FREE);
+    expect(result.success).toBe(true);
+  });
+
+  it('does NOT fire for agent-reported with non-null rawAgentPayload', () => {
+    // agent-reported can carry a payload
+    const result = CostReportSchema.safeParse(BASE_API_KEY);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Refinement 4 — fractionUsed must be in [0, 1] when not null
+// ============================================================================
+
+describe('Refinement 4: fractionUsed must be in [0, 1]', () => {
+  it('rejects fractionUsed > 1', () => {
+    const bad = {
+      ...BASE_SUBSCRIPTION,
+      subscriptionUsage: { fractionUsed: 1.01, rawSignal: 'overflow' },
+    };
+    const result = CostReportSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain(
+        'subscriptionUsage.fractionUsed must be in [0, 1] when not null'
+      );
+    }
+  });
+
+  it('rejects fractionUsed < 0', () => {
+    const bad = {
+      ...BASE_SUBSCRIPTION,
+      subscriptionUsage: { fractionUsed: -0.01, rawSignal: 'underflow' },
+    };
+    const result = CostReportSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain(
+        'subscriptionUsage.fractionUsed must be in [0, 1] when not null'
+      );
+    }
+  });
+
+  it('accepts fractionUsed exactly 0', () => {
+    const ok = {
+      ...BASE_SUBSCRIPTION,
+      subscriptionUsage: { fractionUsed: 0, rawSignal: 'fresh quota' },
+    };
+    expect(CostReportSchema.safeParse(ok).success).toBe(true);
+  });
+
+  it('accepts fractionUsed exactly 1', () => {
+    const ok = {
+      ...BASE_SUBSCRIPTION,
+      subscriptionUsage: { fractionUsed: 1, rawSignal: 'quota exhausted' },
+    };
+    expect(CostReportSchema.safeParse(ok).success).toBe(true);
+  });
+
+  it('accepts fractionUsed: null (agent hides quota)', () => {
+    const ok = {
+      ...BASE_SUBSCRIPTION,
+      subscriptionUsage: { fractionUsed: null, rawSignal: null },
+    };
+    expect(CostReportSchema.safeParse(ok).success).toBe(true);
+  });
+
+  it('does NOT fire when subscriptionUsage is absent', () => {
+    // api-key with no subscriptionUsage — refinement must not trigger
+    expect(CostReportSchema.safeParse(BASE_API_KEY).success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Refinement 5 — timestamp must be a valid ISO 8601 datetime
+// ============================================================================
+
+describe('Refinement 5: timestamp must be valid ISO 8601', () => {
+  it('rejects a non-parseable timestamp', () => {
+    const bad = { ...BASE_API_KEY, timestamp: 'not-a-date' };
+    const result = CostReportSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain('timestamp must be a valid ISO 8601 datetime string');
+    }
+  });
+
+  it('rejects an empty timestamp string', () => {
+    const bad = { ...BASE_API_KEY, timestamp: '' };
+    const result = CostReportSchema.safeParse(bad);
+    // Empty string fails the min(1) check before reaching the refine
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a UTC ISO 8601 string', () => {
+    const ok = { ...BASE_API_KEY, timestamp: '2026-04-21T14:30:00.000Z' };
+    expect(CostReportSchema.safeParse(ok).success).toBe(true);
+  });
+
+  it('accepts an ISO 8601 string with timezone offset', () => {
+    const ok = { ...BASE_API_KEY, timestamp: '2026-04-21T09:30:00.000-05:00' };
+    expect(CostReportSchema.safeParse(ok).success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Token count validation
+// ============================================================================
+
+describe('Token count validation', () => {
+  it('rejects negative inputTokens', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, inputTokens: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative outputTokens', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, outputTokens: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative cacheReadTokens', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, cacheReadTokens: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative cacheWriteTokens', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, cacheWriteTokens: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts all token counts at 0', () => {
+    const result = CostReportSchema.safeParse({
+      ...BASE_API_KEY,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects non-integer inputTokens', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, inputTokens: 1.5 });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// Optional fields absent
+// ============================================================================
+
+describe('Optional fields absent', () => {
+  it('parses correctly when subscriptionUsage is absent (api-key)', () => {
+    const { subscriptionUsage: _su, ...noSu } = BASE_SUBSCRIPTION as typeof BASE_SUBSCRIPTION & { subscriptionUsage?: unknown };
+    const result = CostReportSchema.safeParse({ ...noSu, billingModel: 'api-key', costUsd: 0.01 });
+    expect(result.success).toBe(true);
+  });
+
+  it('parses correctly when credits is absent (api-key)', () => {
+    // credits is optional for non-credit billing models
+    const result = CostReportSchema.safeParse(BASE_API_KEY);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.credits).toBeUndefined();
+    }
+  });
+
+  it('subscriptionUsage is undefined in parsed output when not provided', () => {
+    const result = CostReportSchema.safeParse(BASE_API_KEY);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.subscriptionUsage).toBeUndefined();
+    }
+  });
+});
+
+// ============================================================================
+// CostSource union branches
+// ============================================================================
+
+describe('CostSource union branches', () => {
+  it('accepts source: agent-reported', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, source: 'agent-reported' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts source: styrby-estimate with null rawAgentPayload', () => {
+    const result = CostReportSchema.safeParse({
+      ...BASE_API_KEY,
+      source: 'styrby-estimate',
+      rawAgentPayload: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown source value', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, source: 'made-up' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// BillingModel enum exhaustiveness
+// ============================================================================
+
+describe('BillingModel enum', () => {
+  it('rejects unknown billingModel value', () => {
+    const result = CostReportSchema.safeParse({ ...BASE_API_KEY, billingModel: 'magic' });
+    expect(result.success).toBe(false);
+  });
+
+  it.each(BILLING_MODELS)('accepts billingModel: %s in appropriate context', (model) => {
+    // Build a valid fixture for each billing model
+    const fixtures: Record<string, object> = {
+      'api-key': BASE_API_KEY,
+      subscription: BASE_SUBSCRIPTION,
+      credit: BASE_CREDIT,
+      free: BASE_FREE,
+    };
+    const result = CostReportSchema.safeParse(fixtures[model]);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/styrby-shared/src/cost/index.ts
+++ b/packages/styrby-shared/src/cost/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Styrby Cost Module
+ *
+ * Exports the unified {@link CostReport} interface, supporting enums, and
+ * the {@link CostReportSchema} Zod validator for Phase 1.6.1 "Real LLM Cost
+ * Surfacing."
+ *
+ * Usage:
+ * ```ts
+ * import { CostReportSchema, type CostReport } from '@styrby/shared';
+ * ```
+ */
+
+export * from './types.js';

--- a/packages/styrby-shared/src/cost/types.ts
+++ b/packages/styrby-shared/src/cost/types.ts
@@ -1,0 +1,325 @@
+/**
+ * Styrby Cost Types — Phase 1.6.1 "Real LLM Cost Surfacing"
+ *
+ * Unified cost report type consumed by:
+ *   - The CLI reporter (`packages/styrby-cli/src/costs/cost-reporter.ts`)
+ *   - The web dashboard (`packages/styrby-web`)
+ *   - The mobile dashboard (`packages/styrby-mobile`)
+ *
+ * Every field mirrors a column in `cost_records` (migration 022). All 11
+ * agent factories (Claude Code, Codex, Gemini CLI, OpenCode, Aider, Goose,
+ * Amp, Crush, Kilo, Kiro, Droid) emit their native cost/usage data through
+ * this single shape so downstream consumers never branch on agent type.
+ *
+ * Billing model taxonomy:
+ *   - 'api-key'      — user pays per-token at market rate (variable USD cost).
+ *   - 'subscription' — flat-rate plan (Claude Max, Gemini Workspace).
+ *                      `costUsd` is always 0; quota fraction is the signal.
+ *   - 'credit'       — per-prompt credits (Kiro).
+ *                      `costUsd` is derived from `credits.consumed * credits.rateUsdPerCredit`.
+ *   - 'free'         — local or free-tier model (Kilo+Ollama, Gemini free tier).
+ *                      `costUsd` = 0; no quota; informational only.
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Enums / Const Arrays
+// ============================================================================
+
+/**
+ * All billing models supported by Styrby agents.
+ *
+ * Used as a const-array so TypeScript infers the narrowest union type from
+ * the `as const` annotation, matching the pattern in relay/types.ts.
+ */
+export const BILLING_MODELS = ['api-key', 'subscription', 'credit', 'free'] as const;
+
+/**
+ * Union type derived from {@link BILLING_MODELS}.
+ *
+ * @example
+ * const model: BillingModel = 'api-key';
+ */
+export type BillingModel = (typeof BILLING_MODELS)[number];
+
+/**
+ * Identifies whether cost data came directly from the agent's own output
+ * or was estimated by Styrby's cost calculator.
+ *
+ * WHY: When an agent does not report token counts natively (e.g. Aider in
+ * some modes), Styrby derives a best-effort estimate. Consumers that need
+ * high-precision accounting (budget alerts, SOC2 audit export) must be able
+ * to distinguish agent-reported from estimated values.
+ */
+export const COST_SOURCES = ['agent-reported', 'styrby-estimate'] as const;
+
+/**
+ * Union type derived from {@link COST_SOURCES}.
+ */
+export type CostSource = (typeof COST_SOURCES)[number];
+
+// ============================================================================
+// Interface
+// ============================================================================
+
+/**
+ * Unified cost report for a single agent usage event or session-level aggregation.
+ *
+ * Covers four billing models:
+ *   - 'api-key'      — user pays per-token at market rate (variable USD cost).
+ *   - 'subscription' — user on a flat-rate plan (Claude Max, Gemini Workspace).
+ *                      costUsd is always 0; quota fraction is what matters.
+ *   - 'credit'       — agent charges per-prompt credits (Kiro).
+ *                      costUsd is derived from credits * creditRateUsd.
+ *   - 'free'         — local or free-tier model (Kilo+Ollama, Gemini free tier).
+ *                      costUsd = 0; no quota; informational only.
+ *
+ * Every field mirrors a column in cost_records (migration 022). The CLI
+ * reporter and web/mobile dashboards consume the same shape.
+ */
+export interface CostReport {
+  /** Supabase UUID of the session this cost event belongs to. */
+  sessionId: string;
+
+  /**
+   * Supabase UUID of the individual message within the session, or null when
+   * the report represents a session-level aggregation rather than a single turn.
+   */
+  messageId: string | null;
+
+  /** Agent that generated the cost (e.g. 'claude', 'codex', 'kiro'). */
+  agentType: string;
+
+  /** Specific model name as reported by the agent (e.g. 'claude-sonnet-4-5'). */
+  model: string;
+
+  /**
+   * ISO 8601 datetime string of when the event occurred.
+   *
+   * @example "2026-04-21T14:30:00.000Z"
+   */
+  timestamp: string;
+
+  /** Whether cost data came from the agent directly or was estimated by Styrby. */
+  source: CostSource;
+
+  /** Billing model that applies to this agent/plan combination. */
+  billingModel: BillingModel;
+
+  /**
+   * Total USD cost for this event. Always >= 0.
+   *
+   * For 'subscription' and 'free' billing models this is always 0.
+   * For 'credit' this equals `credits.consumed * credits.rateUsdPerCredit`.
+   */
+  costUsd: number;
+
+  /** Tokens sent to the model (user prompts + injected context). */
+  inputTokens: number;
+
+  /** Tokens received from the model (response text). */
+  outputTokens: number;
+
+  /**
+   * Cache-read tokens that avoided re-processing.
+   *
+   * WHY: Claude's prompt-caching feature lets repeated context be reused at
+   * ~10% of the normal input token price. Tracking cache reads separately
+   * lets the cost dashboard show users how much they saved via caching.
+   */
+  cacheReadTokens: number;
+
+  /**
+   * Cache-write tokens that were stored for future reads.
+   *
+   * WHY: Cache writes are charged at ~25% above normal input token price.
+   * Surfacing this separately gives users full cost transparency.
+   */
+  cacheWriteTokens: number;
+
+  /**
+   * Subscription quota metadata.
+   *
+   * Populated ONLY when `billingModel === 'subscription'`. Undefined for all
+   * other billing models to keep the shape lean.
+   */
+  subscriptionUsage?: {
+    /**
+     * Fraction of the plan's usage quota consumed, in the range [0, 1].
+     *
+     * Null when the agent does not surface quota information (e.g. Gemini
+     * Workspace hides quota from the API response in some configurations).
+     */
+    fractionUsed: number | null;
+
+    /**
+     * Raw quota signal string as emitted by the agent, preserved for
+     * debugging and future parser improvements.
+     *
+     * @example "47% of daily limit used"
+     */
+    rawSignal: string | null;
+  };
+
+  /**
+   * Credit consumption details.
+   *
+   * Populated ONLY when `billingModel === 'credit'`. Undefined for all other
+   * billing models.
+   */
+  credits?: {
+    /** Number of credits consumed by this event. */
+    consumed: number;
+
+    /**
+     * Exchange rate: how many USD one credit is worth at the time of the event.
+     *
+     * WHY: Credit rates can change over time. Snapshotting the rate at event
+     * time lets historical cost calculations remain accurate even after a
+     * provider reprices their credit packs.
+     */
+    rateUsdPerCredit: number;
+  };
+
+  /**
+   * Raw agent payload for audit trail and future parser improvements.
+   *
+   * Only meaningful when `source === 'agent-reported'`. Must be null when
+   * `source === 'styrby-estimate'` because there is no agent payload to store.
+   *
+   * WHY: Preserving the raw payload lets us recompute cost with improved
+   * parsers without having to re-run the original agent session. It also
+   * satisfies SOC2 CC7.2 (evidence of monitored activity).
+   */
+  rawAgentPayload: Record<string, unknown> | null;
+}
+
+// ============================================================================
+// Zod Schema
+// ============================================================================
+
+/**
+ * Zod schema for {@link CostReport}.
+ *
+ * Applies five cross-field refinements on top of the structural validation:
+ *   1. `billingModel === 'subscription'` → `costUsd` must equal 0.
+ *   2. `billingModel === 'credit'` → `credits` must be present.
+ *   3. `source === 'styrby-estimate'` → `rawAgentPayload` must be null.
+ *   4. `subscriptionUsage.fractionUsed`, when not null, must be in [0, 1].
+ *   5. `timestamp` must be a valid ISO 8601 datetime string.
+ *
+ * @example
+ * const result = CostReportSchema.safeParse(agentPayload);
+ * if (!result.success) {
+ *   console.warn('[CostReporter] Dropped malformed cost report:', result.error.issues);
+ *   return;
+ * }
+ * const report = result.data; // fully typed CostReport
+ */
+export const CostReportSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    messageId: z.string().min(1).nullable(),
+    agentType: z.string().min(1),
+    model: z.string().min(1),
+
+    // WHY: We validate timestamp structurally (ISO 8601) rather than storing a
+    // Date object because CostReport is serialised to JSON for the relay channel
+    // and Supabase REST API. Keeping it a string avoids lossy timezone
+    // conversions at serialisation boundaries.
+    timestamp: z.string().min(1),
+
+    source: z.enum(COST_SOURCES),
+    billingModel: z.enum(BILLING_MODELS),
+
+    costUsd: z.number().min(0),
+
+    inputTokens: z.number().int().min(0),
+    outputTokens: z.number().int().min(0),
+    cacheReadTokens: z.number().int().min(0),
+    cacheWriteTokens: z.number().int().min(0),
+
+    subscriptionUsage: z
+      .object({
+        fractionUsed: z.number().nullable(),
+        rawSignal: z.string().nullable(),
+      })
+      .optional(),
+
+    credits: z
+      .object({
+        consumed: z.number().min(0),
+        rateUsdPerCredit: z.number().min(0),
+      })
+      .optional(),
+
+    rawAgentPayload: z.record(z.unknown()).nullable(),
+  })
+  // Refinement 1: subscription billing must never carry a USD cost.
+  // WHY: Flat-rate plans have zero marginal cost per request from the user's
+  // perspective. Storing a non-zero costUsd would distort budget-alert
+  // thresholds and monthly spend totals in the dashboard.
+  .refine(
+    (r) => !(r.billingModel === 'subscription' && r.costUsd !== 0),
+    {
+      message: "costUsd must be 0 when billingModel is 'subscription'",
+      path: ['costUsd'],
+    }
+  )
+  // Refinement 2: credit billing must include the credits breakdown.
+  // WHY: Without credits.consumed and credits.rateUsdPerCredit the dashboard
+  // cannot verify that costUsd was derived correctly, breaking the audit trail.
+  .refine(
+    (r) => !(r.billingModel === 'credit' && r.credits === undefined),
+    {
+      message: "credits must be present when billingModel is 'credit'",
+      path: ['credits'],
+    }
+  )
+  // Refinement 3: Styrby estimates have no source agent payload.
+  // WHY: An estimate is synthesised by Styrby's cost calculator from token
+  // counts alone — there is no raw agent response to preserve. Storing a
+  // non-null payload here would imply false provenance in the audit log.
+  .refine(
+    (r) => !(r.source === 'styrby-estimate' && r.rawAgentPayload !== null),
+    {
+      message: "rawAgentPayload must be null when source is 'styrby-estimate'",
+      path: ['rawAgentPayload'],
+    }
+  )
+  // Refinement 4: fractionUsed, when not null, must be a valid [0, 1] fraction.
+  // WHY: Values outside [0, 1] indicate a parser bug or a provider that changed
+  // their quota response format. Clamping silently would hide these regressions;
+  // rejecting them forces the parser to be fixed.
+  .refine(
+    (r) => {
+      if (r.subscriptionUsage?.fractionUsed == null) return true;
+      return r.subscriptionUsage.fractionUsed >= 0 && r.subscriptionUsage.fractionUsed <= 1;
+    },
+    {
+      message: 'subscriptionUsage.fractionUsed must be in [0, 1] when not null',
+      path: ['subscriptionUsage', 'fractionUsed'],
+    }
+  )
+  // Refinement 5: timestamp must be a parseable ISO 8601 datetime.
+  // WHY: An unparseable timestamp breaks time-series queries on cost_records
+  // and makes the cost chart render nothing. Fail fast at ingestion rather
+  // than silently storing garbage in the DB.
+  .refine(
+    (r) => !isNaN(Date.parse(r.timestamp)),
+    {
+      message: 'timestamp must be a valid ISO 8601 datetime string',
+      path: ['timestamp'],
+    }
+  );
+
+/**
+ * TypeScript type inferred from {@link CostReportSchema}.
+ *
+ * Structurally equivalent to {@link CostReport}; use whichever is more
+ * convenient. The Zod-inferred variant (`ZodCostReport`) is preferred at
+ * runtime parse boundaries; the hand-written interface is preferred in
+ * function signatures for readability.
+ */
+export type ZodCostReport = z.infer<typeof CostReportSchema>;

--- a/packages/styrby-shared/src/index.ts
+++ b/packages/styrby-shared/src/index.ts
@@ -52,6 +52,11 @@ export * from './hooks/index.js';
 // when present, falls back to the words*1.3 heuristic everywhere else).
 export * from './tokenizers/index.js';
 
+// Phase 1.6.1 — unified cost report type for real LLM cost surfacing.
+// CostReport, CostReportSchema, BillingModel, CostSource, and supporting
+// constants are consumed by the CLI reporter and the web/mobile dashboards.
+export * from './cost/index.js';
+
 // Phase 2 — Team Tier (0.8.7 + 0.9.2).
 // DB-mirror types (interfaces + Zod schemas + runtime constants). These
 // are the thin shape-of-table types used by CRUD API code. The policy


### PR DESCRIPTION
## Summary
Ships the `@styrby/shared/cost` module — one TypeScript shape every agent factory, the CLI reporter, and the web + mobile dashboards consume.

**New exports** (`packages/styrby-shared/src/cost/types.ts`):
- `BILLING_MODELS` = `['api-key', 'subscription', 'credit', 'free']`
- `COST_SOURCES` = `['agent-reported', 'styrby-estimate']`
- `type BillingModel`, `CostSource`
- `interface CostReport` — identity + source + billingModel + costUsd + token counts + optional `subscriptionUsage` + `credits` + `rawAgentPayload` audit trail
- `CostReportSchema` (Zod) + `ZodCostReport` convenience type

**5 Zod refinements** enforcing migration 022's business rules:
1. subscription → `costUsd = 0`
2. credit → `{ consumed, rateUsdPerCredit }` required
3. styrby-estimate → `rawAgentPayload = null`
4. `subscriptionUsage.fractionUsed` ∈ [0, 1] when non-null
5. `timestamp` is ISO 8601

Shape matches migration 022's `cost_records` 1:1 so the reporter can map without field-renaming.

## Test plan
- [x] `@styrby/shared` typecheck clean
- [x] 1,051 tests pass (+45 new across 12 describe blocks)
- [x] `it.each(BILLING_MODELS)` forces exhaustive fixtures — adding a 5th model surfaces missing coverage immediately
- [ ] CI green

## Blocks / unblocks
- Unblocks Phase 1.6.1 **PR-C** (8 factories adopt CostReport shape) and **PR-D** (Aider/Codex/Gemini gap parsers) and **PR-F** (UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)