### PR TITLE
feat(cli): 8 agent factories emit unified CostReport (Phase 1.6.1 PR-C)

### DIFF
--- a/packages/styrby-cli/src/agent/factories/__tests__/amp.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/amp.test.ts
@@ -1093,3 +1093,67 @@ describe('AmpBackend — waitForResponseComplete', () => {
     await expect(backend.waitForResponseComplete?.(1000)).resolves.toBeUndefined();
   });
 });
+
+// ===========================================================================
+// AmpBackend — cost-report emission
+// ===========================================================================
+
+/**
+ * Tests for the unified CostReport event added to Amp usage events.
+ *
+ * WHY: migration 022 persists billing_model / source / raw_agent_payload.
+ * Amp always emits agent-reported with billingModel=api-key. When sub_agent_id
+ * is present it must appear in rawAgentPayload for sub-agent cost attribution.
+ */
+describe('AmpBackend — cost-report emission', () => {
+  it('emits cost-report with billingModel=api-key and source=agent-reported on usage event', async () => {
+    const { backend } = createAmpBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      ampUsage({ input_tokens: 800, output_tokens: 300, cache_read_tokens: 50, cost_usd: 0.012 }),
+    ]);
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    const r = reports[0] as any;
+    expect(r.report.billingModel).toBe('api-key');
+    expect(r.report.source).toBe('agent-reported');
+    expect(r.report.agentType).toBe('amp');
+    expect(r.report.inputTokens).toBe(800);
+    expect(r.report.outputTokens).toBe(300);
+    expect(r.report.cacheReadTokens).toBe(50);
+    expect(r.report.rawAgentPayload).not.toBeNull();
+  });
+
+  it('includes sub_agent_id in rawAgentPayload when usage event has sub_agent_id', async () => {
+    const { backend } = createAmpBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'deep task');
+    simulateProcess(currentMockProcess, [
+      ampUsage({ input_tokens: 300, output_tokens: 100, cost_usd: 0.005, sub_agent_id: 'sub-xyz' }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.rawAgentPayload?.sub_agent_id).toBe('sub-xyz');
+  });
+
+  it('cost-report has messageId=null (Amp does not expose per-message IDs)', async () => {
+    const { backend } = createAmpBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [ampUsage({ cost_usd: 0.003 })]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.messageId).toBeNull();
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/claude.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/claude.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for the Claude factory helpers.
+ *
+ * Covers:
+ * - `detectClaudeBillingModel` — reads ~/.claude/auth.json to determine billing
+ * - `parseClaudeJsonlLine` — structured JSONL parser that emits CostReport
+ *
+ * The fs module is mocked so no real ~/.claude/auth.json is required.
+ * Tests verify the full CostReport shape including billingModel, source,
+ * subscriptionUsage (subscription path), and rawAgentPayload.
+ *
+ * @module factories/__tests__/claude.test.ts
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before module imports so Vitest's hoisting replaces them
+// ---------------------------------------------------------------------------
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — after vi.mock declarations
+// ---------------------------------------------------------------------------
+
+import * as fs from 'node:fs';
+import { detectClaudeBillingModel, parseClaudeJsonlLine } from '../claude';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockExistsSync = fs.existsSync as unknown as ReturnType<typeof vi.fn>;
+const mockReadFileSync = fs.readFileSync as unknown as ReturnType<typeof vi.fn>;
+
+/**
+ * Configure the fs mock to return a specific auth.json content.
+ *
+ * @param content - Parsed object to serialize as auth.json
+ */
+function setAuthJson(content: Record<string, unknown>): void {
+  mockExistsSync.mockReturnValue(true);
+  mockReadFileSync.mockReturnValue(JSON.stringify(content));
+}
+
+/**
+ * Configure the fs mock to simulate a missing auth.json.
+ */
+function setAuthJsonMissing(): void {
+  mockExistsSync.mockReturnValue(false);
+}
+
+/**
+ * Configure the fs mock to simulate a malformed auth.json.
+ */
+function setAuthJsonMalformed(): void {
+  mockExistsSync.mockReturnValue(true);
+  mockReadFileSync.mockReturnValue('{invalid json here');
+}
+
+/** Build a valid Claude JSONL assistant message with usage */
+function claudeAssistantLine(opts: {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  model?: string;
+  timestamp?: string;
+}): string {
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: opts.timestamp ?? new Date().toISOString(),
+    message: {
+      model: opts.model ?? 'claude-sonnet-4-20250514',
+      usage: {
+        input_tokens: opts.inputTokens ?? 0,
+        output_tokens: opts.outputTokens ?? 0,
+        cache_read_input_tokens: opts.cacheReadTokens,
+        cache_creation_input_tokens: opts.cacheWriteTokens,
+      },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Teardown
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ===========================================================================
+// detectClaudeBillingModel
+// ===========================================================================
+
+/**
+ * Tests for `detectClaudeBillingModel` — auth.json detection logic.
+ */
+describe('detectClaudeBillingModel', () => {
+  it('returns "api-key" when ~/.claude/auth.json does not exist', () => {
+    setAuthJsonMissing();
+
+    const result = detectClaudeBillingModel();
+
+    expect(result).toBe('api-key');
+  });
+
+  it('returns "subscription" for subscriptionType="max"', () => {
+    setAuthJson({ subscriptionType: 'max' });
+
+    expect(detectClaudeBillingModel()).toBe('subscription');
+  });
+
+  it('returns "subscription" for subscriptionType="pro"', () => {
+    setAuthJson({ subscriptionType: 'pro' });
+
+    expect(detectClaudeBillingModel()).toBe('subscription');
+  });
+
+  it('returns "subscription" for subscriptionType="claude_max"', () => {
+    setAuthJson({ subscriptionType: 'claude_max' });
+
+    expect(detectClaudeBillingModel()).toBe('subscription');
+  });
+
+  it('returns "subscription" for subscriptionType="claude_pro"', () => {
+    setAuthJson({ subscriptionType: 'claude_pro' });
+
+    expect(detectClaudeBillingModel()).toBe('subscription');
+  });
+
+  it('returns "subscription" when subscriptionType is uppercase (MAX)', () => {
+    setAuthJson({ subscriptionType: 'MAX' });
+
+    expect(detectClaudeBillingModel()).toBe('subscription');
+  });
+
+  it('returns "api-key" for unknown subscriptionType', () => {
+    setAuthJson({ subscriptionType: 'enterprise_unknown' });
+
+    expect(detectClaudeBillingModel()).toBe('api-key');
+  });
+
+  it('returns "api-key" when subscriptionType field is absent', () => {
+    setAuthJson({ userId: 'user-123', apiKey: 'sk-...' });
+
+    expect(detectClaudeBillingModel()).toBe('api-key');
+  });
+
+  it('returns "api-key" when auth.json is malformed JSON', () => {
+    setAuthJsonMalformed();
+
+    expect(detectClaudeBillingModel()).toBe('api-key');
+  });
+
+  it('returns "api-key" when readFileSync throws', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => { throw new Error('EACCES: permission denied'); });
+
+    expect(detectClaudeBillingModel()).toBe('api-key');
+  });
+});
+
+// ===========================================================================
+// parseClaudeJsonlLine — api-key path
+// ===========================================================================
+
+/**
+ * Tests for the structured JSONL parser in api-key billing mode.
+ */
+describe('parseClaudeJsonlLine — api-key billing model', () => {
+  const SESSION_ID = 'sess-api-key-001';
+
+  it('returns a CostReport with billingModel=api-key for a valid assistant line', () => {
+    const line = claudeAssistantLine({ inputTokens: 1000, outputTokens: 400 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'api-key');
+
+    expect(report).not.toBeNull();
+    expect(report!.billingModel).toBe('api-key');
+    expect(report!.source).toBe('agent-reported');
+    expect(report!.agentType).toBe('claude');
+    expect(report!.sessionId).toBe(SESSION_ID);
+  });
+
+  it('maps input_tokens and output_tokens correctly', () => {
+    const line = claudeAssistantLine({ inputTokens: 1500, outputTokens: 600 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'api-key');
+
+    expect(report!.inputTokens).toBe(1500);
+    expect(report!.outputTokens).toBe(600);
+  });
+
+  it('maps cache_read_input_tokens to cacheReadTokens', () => {
+    const line = claudeAssistantLine({ cacheReadTokens: 200 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'api-key');
+
+    expect(report!.cacheReadTokens).toBe(200);
+  });
+
+  it('maps cache_creation_input_tokens to cacheWriteTokens', () => {
+    const line = claudeAssistantLine({ cacheWriteTokens: 80 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'api-key');
+
+    expect(report!.cacheWriteTokens).toBe(80);
+  });
+
+  it('uses model from message.model when present', () => {
+    const line = claudeAssistantLine({ model: 'claude-opus-4-20260101' });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'api-key');
+
+    expect(report!.model).toBe('claude-opus-4-20260101');
+  });
+
+  it('defaults model to "unknown" when message.model is absent', () => {
+    const raw = JSON.stringify({
+      type: 'assistant',
+      message: { usage: { input_tokens: 10, output_tokens: 5 } },
+    });
+
+    const report = parseClaudeJsonlLine(raw, SESSION_ID, 'api-key');
+
+    expect(report!.model).toBe('unknown');
+  });
+
+  it('sets rawAgentPayload to a non-null object', () => {
+    const line = claudeAssistantLine({ inputTokens: 500 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'api-key');
+
+    expect(report!.rawAgentPayload).not.toBeNull();
+    expect(typeof report!.rawAgentPayload).toBe('object');
+  });
+
+  it('uses line timestamp when present', () => {
+    const ts = '2026-04-21T12:00:00.000Z';
+    const line = claudeAssistantLine({ timestamp: ts });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'api-key');
+
+    expect(report!.timestamp).toBe(ts);
+  });
+
+  it('falls back to current ISO timestamp when line has no timestamp', () => {
+    const raw = JSON.stringify({
+      type: 'assistant',
+      message: { usage: { input_tokens: 10 } },
+    });
+    const before = Date.now();
+    const report = parseClaudeJsonlLine(raw, SESSION_ID, 'api-key');
+    const after = Date.now();
+
+    expect(report).not.toBeNull();
+    const t = new Date(report!.timestamp).getTime();
+    expect(t).toBeGreaterThanOrEqual(before);
+    expect(t).toBeLessThanOrEqual(after);
+  });
+
+  it('returns null for non-assistant message types', () => {
+    const line = JSON.stringify({ type: 'user', message: { content: 'hello' } });
+
+    expect(parseClaudeJsonlLine(line, SESSION_ID, 'api-key')).toBeNull();
+  });
+
+  it('returns null when message.usage is absent', () => {
+    const line = JSON.stringify({ type: 'assistant', message: { model: 'claude-sonnet-4' } });
+
+    expect(parseClaudeJsonlLine(line, SESSION_ID, 'api-key')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseClaudeJsonlLine('', SESSION_ID, 'api-key')).toBeNull();
+  });
+
+  it('returns null for whitespace-only string', () => {
+    expect(parseClaudeJsonlLine('   ', SESSION_ID, 'api-key')).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseClaudeJsonlLine('{broken', SESSION_ID, 'api-key')).toBeNull();
+  });
+
+  it('returns null for non-JSON text line', () => {
+    expect(parseClaudeJsonlLine('Loading claude...', SESSION_ID, 'api-key')).toBeNull();
+  });
+
+  it('messageId is null (not exposed in JSONL)', () => {
+    const line = claudeAssistantLine({ inputTokens: 100 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'api-key');
+
+    expect(report!.messageId).toBeNull();
+  });
+
+  it('does NOT include subscriptionUsage for api-key billing', () => {
+    const line = claudeAssistantLine({ inputTokens: 100 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'api-key');
+
+    expect((report as any).subscriptionUsage).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// parseClaudeJsonlLine — subscription path
+// ===========================================================================
+
+/**
+ * Tests for the parser in subscription billing mode (Claude Max/Pro).
+ *
+ * WHY: Subscription users must see costUsd=0 and subscriptionUsage populated.
+ * The CostReport must still carry token counts for usage monitoring even though
+ * the cost is $0.
+ */
+describe('parseClaudeJsonlLine — subscription billing model', () => {
+  const SESSION_ID = 'sess-sub-001';
+
+  it('returns costUsd=0 for subscription billing', () => {
+    const line = claudeAssistantLine({ inputTokens: 2000, outputTokens: 800 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'subscription');
+
+    expect(report!.costUsd).toBe(0);
+  });
+
+  it('returns billingModel=subscription', () => {
+    const line = claudeAssistantLine({ inputTokens: 500 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'subscription');
+
+    expect(report!.billingModel).toBe('subscription');
+  });
+
+  it('includes subscriptionUsage block with fractionUsed=null', () => {
+    const line = claudeAssistantLine({ inputTokens: 300, outputTokens: 100 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'subscription');
+
+    expect(report!.subscriptionUsage).toBeDefined();
+    expect(report!.subscriptionUsage!.fractionUsed).toBeNull();
+  });
+
+  it('still records token counts for usage monitoring', () => {
+    const line = claudeAssistantLine({ inputTokens: 1200, outputTokens: 500, cacheReadTokens: 100 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'subscription');
+
+    expect(report!.inputTokens).toBe(1200);
+    expect(report!.outputTokens).toBe(500);
+    expect(report!.cacheReadTokens).toBe(100);
+  });
+
+  it('source is agent-reported even for subscription billing', () => {
+    const line = claudeAssistantLine({ inputTokens: 400 });
+
+    const report = parseClaudeJsonlLine(line, SESSION_ID, 'subscription');
+
+    expect(report!.source).toBe('agent-reported');
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/crush.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/crush.test.ts
@@ -1037,3 +1037,70 @@ describe('CrushBackend — line buffer handling', () => {
     expect(textMessages).toHaveLength(1);
   });
 });
+
+// ===========================================================================
+// CrushBackend — cost-report emission
+// ===========================================================================
+
+/**
+ * Tests for the unified CostReport event added to Crush usage events.
+ *
+ * WHY: migration 022 requires billing_model / source / raw_agent_payload.
+ * Crush always emits agent-reported because its usage event always carries the
+ * full cost breakdown from the Sourcegraph backend.
+ */
+describe('CrushBackend — cost-report emission', () => {
+  it('emits cost-report with billingModel=api-key and source=agent-reported on usage event', async () => {
+    const { backend } = createCrushBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      crushUsage({
+        input_tokens: 1000,
+        output_tokens: 400,
+        cache_read_input_tokens: 60,
+        cache_creation_input_tokens: 20,
+        cost_usd: 0.018,
+      }),
+    ]);
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    const r = reports[0] as any;
+    expect(r.report.billingModel).toBe('api-key');
+    expect(r.report.source).toBe('agent-reported');
+    expect(r.report.agentType).toBe('crush');
+    expect(r.report.inputTokens).toBe(1000);
+    expect(r.report.outputTokens).toBe(400);
+    expect(r.report.cacheReadTokens).toBe(60);
+    expect(r.report.cacheWriteTokens).toBe(20);
+    expect(r.report.rawAgentPayload).not.toBeNull();
+  });
+
+  it('emits one cost-report per usage event with per-event incremental token counts', async () => {
+    const { backend } = createCrushBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      crushUsage({ input_tokens: 200, output_tokens: 80, cost_usd: 0.002 }),
+      crushUsage({ input_tokens: 300, output_tokens: 120, cost_usd: 0.003 }),
+    ]);
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    // WHY: Each cost-report carries the incremental tokens from a single usage
+    // event, not session-accumulated totals. The cost-reporter sums them server-side.
+    expect(reports.length).toBe(2);
+    const r1 = reports[0] as any;
+    expect(r1.report.inputTokens).toBe(200);
+    expect(r1.report.outputTokens).toBe(80);
+    const r2 = reports[1] as any;
+    expect(r2.report.inputTokens).toBe(300);
+    expect(r2.report.outputTokens).toBe(120);
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/droid.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/droid.test.ts
@@ -1093,3 +1093,67 @@ describe('DroidBackend — session_id tracking', () => {
     expect(args).toContain('droid-sess-abc');
   });
 });
+
+// ===========================================================================
+// DroidBackend — cost-report emission
+// ===========================================================================
+
+/**
+ * Tests for the unified CostReport event emitted by Droid usage events.
+ *
+ * WHY: Droid mirrors Goose's pattern — source='agent-reported' with rawAgentPayload
+ * when cost_usd is present; source='styrby-estimate' with rawAgentPayload=null
+ * when cost_usd is absent.
+ */
+describe('DroidBackend — cost-report emission', () => {
+  it('emits cost-report with source=agent-reported when usage event has cost_usd', async () => {
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'droid-v2' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      droidUsage({ prompt_tokens: 1200, completion_tokens: 600, cost_usd: 0.045 }),
+    ]);
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    const r = reports[0] as any;
+    expect(r.report.billingModel).toBe('api-key');
+    expect(r.report.source).toBe('agent-reported');
+    expect(r.report.agentType).toBe('droid');
+    expect(r.report.rawAgentPayload).not.toBeNull();
+  });
+
+  it('emits cost-report with source=styrby-estimate and rawAgentPayload=null when cost_usd is absent', async () => {
+    const { backend } = createDroidBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      droidUsage({ prompt_tokens: 800, completion_tokens: 300 }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.source).toBe('styrby-estimate');
+    expect(r.report.rawAgentPayload).toBeNull();
+  });
+
+  it('cost-report costUsd reflects the agent-provided value', async () => {
+    const { backend } = createDroidBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      droidUsage({ prompt_tokens: 500, completion_tokens: 200, cost_usd: 0.022 }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.costUsd).toBeCloseTo(0.022);
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/goose.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/goose.test.ts
@@ -1036,3 +1036,77 @@ describe('GooseBackend — waitForResponseComplete', () => {
     await expect(backend.waitForResponseComplete?.(1000)).resolves.toBeUndefined();
   });
 });
+
+// ===========================================================================
+// GooseBackend — cost-report emission
+// ===========================================================================
+
+/**
+ * Tests for the unified CostReport event added to Goose cost events.
+ *
+ * WHY: migration 022 columns require billing_model / source / raw_agent_payload.
+ * When Goose provides cost_usd the source is 'agent-reported' with rawAgentPayload.
+ * When cost_usd is absent, source falls back to 'styrby-estimate' and rawAgentPayload is null.
+ */
+describe('GooseBackend — cost-report emission', () => {
+  it('emits cost-report with source=agent-reported when cost event has cost_usd', async () => {
+    const { backend } = createGooseBackend({ ...BASE_OPTIONS, model: 'claude-opus-4' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      gooseCost({
+        input_tokens: 500,
+        output_tokens: 200,
+        cache_read_input_tokens: 30,
+        cache_creation_input_tokens: 10,
+        cost_usd: 0.0088,
+      }),
+    ]);
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    const r = reports[0] as any;
+    expect(r.report.billingModel).toBe('api-key');
+    expect(r.report.source).toBe('agent-reported');
+    expect(r.report.agentType).toBe('goose');
+    expect(r.report.inputTokens).toBe(500);
+    expect(r.report.outputTokens).toBe(200);
+    expect(r.report.cacheReadTokens).toBe(30);
+    expect(r.report.cacheWriteTokens).toBe(10);
+    expect(r.report.rawAgentPayload).not.toBeNull();
+  });
+
+  it('emits cost-report with source=styrby-estimate and rawAgentPayload=null when cost_usd is absent', async () => {
+    const { backend } = createGooseBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      gooseCost({ input_tokens: 100, output_tokens: 40 }),
+    ]);
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    const r = reports[0] as any;
+    expect(r.report.source).toBe('styrby-estimate');
+    expect(r.report.rawAgentPayload).toBeNull();
+  });
+
+  it('cost-report billingModel is always api-key for Goose', async () => {
+    const { backend } = createGooseBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [gooseCost({ cost_usd: 0.005 })]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.billingModel).toBe('api-key');
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/kilo.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/kilo.test.ts
@@ -1195,3 +1195,108 @@ describe('KiloBackend — line buffer handling', () => {
     expect((textMessages[0] as any).textDelta).toBe('Split JSON content');
   });
 });
+
+// ===========================================================================
+// KiloBackend — cost-report emission
+// ===========================================================================
+
+/**
+ * Tests for the unified CostReport event emitted by Kilo token events.
+ *
+ * WHY: Kilo supports local (Ollama / local-* models) and cloud models.
+ * Local models → billingModel='free', costUsd=0.
+ * Cloud models → billingModel='api-key', source determined by presence of cost_usd.
+ */
+describe('KiloBackend — cost-report emission (cloud model)', () => {
+  it('emits billingModel=api-key and source=agent-reported when cost_usd is present', async () => {
+    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      kiloTokens({ input_tokens: 600, output_tokens: 250, cache_read_tokens: 40, cost_usd: 0.009 }),
+    ]);
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    const r = reports[0] as any;
+    expect(r.report.billingModel).toBe('api-key');
+    expect(r.report.source).toBe('agent-reported');
+    expect(r.report.agentType).toBe('kilo');
+    expect(r.report.costUsd).toBe(0.009);
+    expect(r.report.inputTokens).toBe(600);
+    expect(r.report.cacheReadTokens).toBe(40);
+  });
+
+  it('emits billingModel=api-key and source=styrby-estimate when cost_usd is absent', async () => {
+    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      kiloTokens({ input_tokens: 400, output_tokens: 100 }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.billingModel).toBe('api-key');
+    expect(r.report.source).toBe('styrby-estimate');
+  });
+});
+
+describe('KiloBackend — cost-report emission (local / Ollama model)', () => {
+  it('emits billingModel=free and costUsd=0 for ollama model names', async () => {
+    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'ollama/llama3' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      kiloTokens({ input_tokens: 300, output_tokens: 120, cost_usd: 0 }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.billingModel).toBe('free');
+    expect(r.report.costUsd).toBe(0);
+  });
+
+  it('emits billingModel=free for local- prefixed model names', async () => {
+    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'local-mistral-7b' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      kiloTokens({ input_tokens: 200, output_tokens: 80 }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.billingModel).toBe('free');
+    expect(r.report.costUsd).toBe(0);
+  });
+
+  it('emits billingModel=free when apiBaseUrl points to localhost', async () => {
+    const { backend } = createKiloBackend({
+      ...BASE_OPTIONS,
+      model: 'llama3',
+      apiBaseUrl: 'http://localhost:11434',
+    });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      kiloTokens({ input_tokens: 100, output_tokens: 50 }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.billingModel).toBe('free');
+    expect(r.report.costUsd).toBe(0);
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/kiro.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/kiro.test.ts
@@ -987,3 +987,86 @@ describe('KiroBackend — extra args validation', () => {
     await expect(backend.sendPrompt(sessionId, 'test')).rejects.toThrow('Unsafe character');
   });
 });
+
+// ===========================================================================
+// KiroBackend — cost-report emission
+// ===========================================================================
+
+/**
+ * Tests for the unified CostReport event emitted by Kiro usage events.
+ *
+ * WHY: Kiro uses credit-based billing (AWS credits). The CostReport must carry
+ * billingModel='credit' and a credits object with consumed + rateUsdPerCredit.
+ * KIRO_CREDIT_TO_USD is exported for downstream config; we snapshot it here
+ * so any rate change causes a visible test failure.
+ */
+describe('KiroBackend — cost-report emission', () => {
+  it('emits cost-report with billingModel=credit and credits object on usage event', async () => {
+    const { backend } = createKiroBackend({ ...BASE_OPTIONS, model: 'kiro-default' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      kiroUsage({ credits_consumed: 5, input_tokens: 400, output_tokens: 150 }),
+    ]);
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    const r = reports[0] as any;
+    expect(r.report.billingModel).toBe('credit');
+    expect(r.report.source).toBe('agent-reported');
+    expect(r.report.agentType).toBe('kiro');
+    expect(r.report.credits).toBeDefined();
+    expect(r.report.credits.consumed).toBe(5);
+    expect(typeof r.report.credits.rateUsdPerCredit).toBe('number');
+    expect(r.report.credits.rateUsdPerCredit).toBeGreaterThan(0);
+  });
+
+  it('costUsd equals credits * rateUsdPerCredit when cost_usd is not provided', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      kiroUsage({ credits_consumed: 10, input_tokens: 200, output_tokens: 80 }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    const { credits } = r.report;
+    expect(r.report.costUsd).toBeCloseTo(credits.consumed * credits.rateUsdPerCredit);
+  });
+
+  it('cost-report has rawAgentPayload set on agent-reported event', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      kiroUsage({ credits_consumed: 3, input_tokens: 150, output_tokens: 60 }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.rawAgentPayload).not.toBeNull();
+  });
+
+  it('uses cost_usd directly when Kiro provides it', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      kiroUsage({ credits_consumed: 2, cost_usd: 0.025, input_tokens: 100, output_tokens: 50 }),
+    ]);
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r.report.costUsd).toBeCloseTo(0.025);
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
@@ -926,3 +926,89 @@ describe('OpenCodeBackend — stderr handling', () => {
     await backend.dispose();
   });
 });
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Tests for the new cost-report event shape emitted by OpenCodeBackend.
+ *
+ * WHY: migration 022 adds billing_model / source / raw_agent_payload columns.
+ * These tests assert that cost-report events carry the correct shape so
+ * cost-reporter can persist them without data loss.
+ */
+describe('OpenCodeBackend — cost-report emission', () => {
+  it('emits cost-report with billingModel=api-key and source=agent-reported when session has Cost', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project', model: 'claude-sonnet-4' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+
+    emitStdout(
+      JSON.stringify({
+        type: 'session',
+        session: {
+          id: 'oc-sess-abc',
+          Cost: 0.0055,
+          PromptTokens: 2000,
+          CompletionTokens: 400,
+          TotalTokens: 2400,
+        },
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports).toHaveLength(1);
+    const r = reports[0] as any;
+    expect(r.report.billingModel).toBe('api-key');
+    expect(r.report.source).toBe('agent-reported');
+    expect(r.report.agentType).toBe('opencode');
+    expect(r.report.inputTokens).toBe(2000);
+    expect(r.report.outputTokens).toBe(400);
+    expect(r.report.rawAgentPayload).toMatchObject({ id: 'oc-sess-abc', Cost: 0.0055 });
+    await backend.dispose();
+  });
+
+  it('does NOT emit cost-report when session event has no Cost field', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+
+    emitStdout(
+      JSON.stringify({
+        type: 'session',
+        session: { PromptTokens: 100, CompletionTokens: 50 },
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports).toHaveLength(0);
+    await backend.dispose();
+  });
+
+  it('cost-report timestamp is a valid ISO 8601 string', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { messages } = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+    const promptPromise = backend.sendPrompt(sessionId, 'go');
+
+    emitStdout(
+      JSON.stringify({
+        type: 'session',
+        session: { Cost: 0.001, PromptTokens: 10, CompletionTokens: 5 },
+      }),
+    );
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r).toBeDefined();
+    expect(() => new Date(r.report.timestamp)).not.toThrow();
+    expect(new Date(r.report.timestamp).toISOString()).toBe(r.report.timestamp);
+    await backend.dispose();
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/amp.ts
+++ b/packages/styrby-cli/src/agent/factories/amp.ts
@@ -35,6 +35,7 @@ import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
+import type { CostReport } from '@styrby/shared/cost';
 
 // ============================================================================
 // Types
@@ -349,12 +350,19 @@ class AmpBackend extends StreamingAgentBackendBase {
         // per-sub-agent usage in deep mode). We accumulate all usage so
         // the total token count reflects the full cost of the deep analysis.
         if (msg.usage) {
-          this.inputTokens += msg.usage.input_tokens ?? 0;
-          this.outputTokens += msg.usage.output_tokens ?? 0;
-          this.cacheReadTokens += msg.usage.cache_read_tokens ?? 0;
-          this.cacheWriteTokens += msg.usage.cache_write_tokens ?? 0;
-          this.totalCostUsd += msg.usage.cost_usd ?? 0;
+          const incrInput = msg.usage.input_tokens ?? 0;
+          const incrOutput = msg.usage.output_tokens ?? 0;
+          const incrCacheRead = msg.usage.cache_read_tokens ?? 0;
+          const incrCacheWrite = msg.usage.cache_write_tokens ?? 0;
+          const incrCost = msg.usage.cost_usd ?? 0;
 
+          this.inputTokens += incrInput;
+          this.outputTokens += incrOutput;
+          this.cacheReadTokens += incrCacheRead;
+          this.cacheWriteTokens += incrCacheWrite;
+          this.totalCostUsd += incrCost;
+
+          // Emit legacy token-count (keep for existing consumers)
           this.emit({
             type: 'token-count',
             inputTokens: this.inputTokens,
@@ -365,6 +373,30 @@ class AmpBackend extends StreamingAgentBackendBase {
             // Include sub-agent attribution for deep mode cost visibility
             subAgentId: msg.usage.sub_agent_id,
           });
+
+          // WHY: Emit unified CostReport for cost-reporter. Amp always reports
+          // agent-provided cost_usd. Include sub_agent_id in rawAgentPayload so
+          // deep-mode attribution is preserved in the audit trail.
+          const rawPayload: Record<string, unknown> = { ...(msg.usage as unknown as Record<string, unknown>) };
+          if (msg.usage.sub_agent_id) {
+            rawPayload.sub_agent_id = msg.usage.sub_agent_id;
+          }
+          const costReport: CostReport = {
+            sessionId: this.sessionId ?? '',
+            messageId: null,
+            agentType: 'amp',
+            model: this.options.model ?? 'unknown',
+            timestamp: new Date().toISOString(),
+            source: 'agent-reported',
+            billingModel: 'api-key',
+            costUsd: incrCost,
+            inputTokens: incrInput,
+            outputTokens: incrOutput,
+            cacheReadTokens: incrCacheRead,
+            cacheWriteTokens: incrCacheWrite,
+            rawAgentPayload: rawPayload,
+          };
+          this.emit({ type: 'cost-report', report: costReport } as any);
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/claude.ts
+++ b/packages/styrby-cli/src/agent/factories/claude.ts
@@ -1,0 +1,190 @@
+/**
+ * Claude Cost Factory — JSONL-path CostReport emitter
+ *
+ * This module provides helpers to parse Claude Code JSONL output lines and
+ * emit unified {@link CostReport} events. It covers the structured JSONL path
+ * only — the brittle regex in `cost-extractor.ts#parseClaudeOutput` is NOT
+ * touched here (that is PR-D gap-fix work).
+ *
+ * Auth-mode detection:
+ *   - Reads `~/.claude/auth.json` for a `subscriptionType` field.
+ *   - If found and matches Max/Pro → `billingModel: 'subscription'`, `costUsd: 0`.
+ *   - If the file is missing or the field is absent → default to `'api-key'`.
+ *   - Detection failure is logged at DEBUG level, never a hard error.
+ *
+ * Usage:
+ * ```ts
+ * // Detect billing model once at session start
+ * const billingModel = detectClaudeBillingModel();
+ *
+ * // For each JSONL line from Claude Code stdout:
+ * const report = parseClaudeJsonlLine(line, sessionId, billingModel);
+ * if (report) backend.emit({ type: 'cost-report', report });
+ * ```
+ *
+ * @module factories/claude
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { logger } from '@/ui/logger';
+import type { CostReport, BillingModel } from '@styrby/shared/cost';
+
+// ============================================================================
+// Auth Mode Detection
+// ============================================================================
+
+/**
+ * Subscription type strings written by Claude Code to `~/.claude/auth.json`.
+ *
+ * WHY: Claude Max and Claude Pro are flat-rate plans — costUsd must be 0
+ * for subscription sessions. We detect the plan from the auth file so the
+ * cost dashboard shows subscription users $0 instead of a phantom API cost.
+ */
+const CLAUDE_SUBSCRIPTION_TYPES = new Set(['max', 'pro', 'claude_max', 'claude_pro']);
+
+/**
+ * Detect the Claude Code billing model by inspecting `~/.claude/auth.json`.
+ *
+ * WHY: Claude Code writes auth state (including subscription tier) to a
+ * local JSON file. Checking it at session start lets us classify cost events
+ * without requiring an extra API call.
+ *
+ * Falls back to `'api-key'` if the file is missing, unreadable, or does not
+ * contain a recognisable `subscriptionType` field. This is intentional:
+ * missing detection is Phase 1.6.1 PR-D's problem, not PR-C's.
+ *
+ * @returns `'subscription'` for Claude Max/Pro users; `'api-key'` otherwise.
+ */
+export function detectClaudeBillingModel(): BillingModel {
+  const authJsonPath = path.join(os.homedir(), '.claude', 'auth.json');
+  try {
+    if (!fs.existsSync(authJsonPath)) {
+      logger.debug('[ClaudeFactory] ~/.claude/auth.json not found — defaulting to api-key billing');
+      return 'api-key';
+    }
+
+    const raw = fs.readFileSync(authJsonPath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const subType = (parsed.subscriptionType as string | undefined)?.toLowerCase() ?? '';
+
+    if (CLAUDE_SUBSCRIPTION_TYPES.has(subType)) {
+      logger.debug(`[ClaudeFactory] Detected subscription billing model: ${subType}`);
+      return 'subscription';
+    }
+
+    logger.debug(`[ClaudeFactory] subscriptionType="${subType}" not recognised — defaulting to api-key`);
+    return 'api-key';
+  } catch (err) {
+    logger.debug('[ClaudeFactory] Could not read ~/.claude/auth.json — defaulting to api-key billing', err);
+    return 'api-key';
+  }
+}
+
+// ============================================================================
+// JSONL Parser
+// ============================================================================
+
+/**
+ * Parsed shape of a Claude Code JSONL assistant message.
+ *
+ * WHY: Claude Code emits JSONL lines where assistant messages include a
+ * `message.usage` block with token counts. Typing this explicitly lets TypeScript
+ * catch format regressions at compile time.
+ */
+interface ClaudeJsonlAssistantMessage {
+  type: 'assistant';
+  timestamp?: string;
+  message?: {
+    model?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_read_input_tokens?: number;
+      cache_creation_input_tokens?: number;
+    };
+  };
+}
+
+/**
+ * Parse a single Claude Code JSONL output line and return a {@link CostReport}.
+ *
+ * This is the structured JSONL path — it handles `{ type: "assistant", message.usage }`.
+ * The brittle regex (`parseClaudeOutput` in `cost-extractor.ts`) is left untouched.
+ *
+ * WHY: The structured JSONL path is the preferred extraction method because it
+ * directly reads the typed `usage` block rather than regex-scanning raw text.
+ * This parser is called per line by the JSONL file-watcher in cost-extractor.ts.
+ *
+ * @param line - A single JSONL line from Claude Code's streaming output
+ * @param sessionId - The Supabase session UUID to attach to the report
+ * @param billingModel - Pre-detected billing model for this Claude session
+ * @returns A {@link CostReport} if the line contains token usage, or `null` otherwise
+ *
+ * @example
+ * const billing = detectClaudeBillingModel();
+ * const report = parseClaudeJsonlLine(line, 'uuid-...', billing);
+ * if (report) emitter.emit({ type: 'cost-report', report });
+ */
+export function parseClaudeJsonlLine(
+  line: string,
+  sessionId: string,
+  billingModel: BillingModel
+): CostReport | null {
+  const trimmed = line.trim();
+  if (!trimmed || !trimmed.startsWith('{')) return null;
+
+  let data: ClaudeJsonlAssistantMessage;
+  try {
+    data = JSON.parse(trimmed) as ClaudeJsonlAssistantMessage;
+  } catch {
+    return null;
+  }
+
+  // Only assistant messages carry usage data
+  if (data.type !== 'assistant' || !data.message?.usage) return null;
+
+  const usage = data.message.usage;
+  const inputTokens = usage.input_tokens ?? 0;
+  const outputTokens = usage.output_tokens ?? 0;
+  const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
+  const cacheWriteTokens = usage.cache_creation_input_tokens ?? 0;
+  const model = data.message.model ?? 'unknown';
+
+  // WHY: Subscription billing (Claude Max/Pro) has zero marginal cost per request.
+  // We still store the token counts for usage monitoring but must not report a USD cost.
+  const costUsd = billingModel === 'subscription' ? 0 : 0; // USD cost unknown from JSONL alone — set to 0; cost-reporter may enrich via pricing table
+
+  const rawPayload: Record<string, unknown> = {
+    type: data.type,
+    model,
+    usage: usage as unknown as Record<string, unknown>,
+  };
+
+  const report: CostReport = {
+    sessionId,
+    messageId: null,
+    agentType: 'claude',
+    model,
+    timestamp: data.timestamp ?? new Date().toISOString(),
+    source: 'agent-reported',
+    billingModel,
+    costUsd,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    ...(billingModel === 'subscription'
+      ? {
+          subscriptionUsage: {
+            fractionUsed: null, // Claude Code does not expose quota fraction
+            rawSignal: null,
+          },
+        }
+      : {}),
+    rawAgentPayload: rawPayload,
+  };
+
+  return report;
+}

--- a/packages/styrby-cli/src/agent/factories/crush.ts
+++ b/packages/styrby-cli/src/agent/factories/crush.ts
@@ -34,6 +34,7 @@ import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
+import type { CostReport } from '@styrby/shared/cost';
 
 // ============================================================================
 // Types
@@ -299,12 +300,19 @@ class CrushBackend extends StreamingAgentBackendBase {
         // WHY: Crush emits a usage event after each model turn with ACP usage data.
         // We accumulate across the session so the mobile app shows a running total.
         if (event.usage) {
-          this.inputTokens += event.usage.input_tokens ?? 0;
-          this.outputTokens += event.usage.output_tokens ?? 0;
-          this.cacheReadTokens += event.usage.cache_read_input_tokens ?? 0;
-          this.cacheWriteTokens += event.usage.cache_creation_input_tokens ?? 0;
-          this.totalCostUsd += event.usage.cost_usd ?? 0;
+          const incrInput = event.usage.input_tokens ?? 0;
+          const incrOutput = event.usage.output_tokens ?? 0;
+          const incrCacheRead = event.usage.cache_read_input_tokens ?? 0;
+          const incrCacheWrite = event.usage.cache_creation_input_tokens ?? 0;
+          const incrCost = event.usage.cost_usd ?? 0;
 
+          this.inputTokens += incrInput;
+          this.outputTokens += incrOutput;
+          this.cacheReadTokens += incrCacheRead;
+          this.cacheWriteTokens += incrCacheWrite;
+          this.totalCostUsd += incrCost;
+
+          // Emit legacy token-count (keep for existing consumers)
           this.emit({
             type: 'token-count',
             inputTokens: this.inputTokens,
@@ -313,6 +321,25 @@ class CrushBackend extends StreamingAgentBackendBase {
             cacheWriteTokens: this.cacheWriteTokens,
             costUsd: this.totalCostUsd,
           });
+
+          // WHY: Emit unified CostReport. Crush always reports agent-provided
+          // cost_usd via ACP, so source is always 'agent-reported'.
+          const costReport: CostReport = {
+            sessionId: this.sessionId ?? '',
+            messageId: null,
+            agentType: 'crush',
+            model: this.options.model ?? 'unknown',
+            timestamp: new Date().toISOString(),
+            source: 'agent-reported',
+            billingModel: 'api-key',
+            costUsd: incrCost,
+            inputTokens: incrInput,
+            outputTokens: incrOutput,
+            cacheReadTokens: incrCacheRead,
+            cacheWriteTokens: incrCacheWrite,
+            rawAgentPayload: event.usage as unknown as Record<string, unknown>,
+          };
+          this.emit({ type: 'cost-report', report: costReport } as any);
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/droid.ts
+++ b/packages/styrby-cli/src/agent/factories/droid.ts
@@ -38,6 +38,7 @@ import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
+import type { CostReport } from '@styrby/shared/cost';
 
 // ============================================================================
 // LiteLLM Pricing Table
@@ -420,18 +421,21 @@ class DroidBackend extends StreamingAgentBackendBase {
           const usageModel = msg.usage.model ?? this.currentModel ?? 'unknown';
           const newInput = msg.usage.prompt_tokens ?? 0;
           const newOutput = msg.usage.completion_tokens ?? 0;
+          const newCacheRead = msg.usage.cache_read_tokens ?? 0;
+          const newCacheWrite = msg.usage.cache_write_tokens ?? 0;
 
           this.inputTokens += newInput;
           this.outputTokens += newOutput;
-          this.cacheReadTokens += msg.usage.cache_read_tokens ?? 0;
-          this.cacheWriteTokens += msg.usage.cache_write_tokens ?? 0;
+          this.cacheReadTokens += newCacheRead;
+          this.cacheWriteTokens += newCacheWrite;
 
-          if (msg.usage.cost_usd !== undefined) {
-            this.totalCostUsd += msg.usage.cost_usd;
-          } else {
-            this.totalCostUsd += estimateCostFromTokens(usageModel, newInput, newOutput);
-          }
+          const hasAgentCost = msg.usage.cost_usd !== undefined;
+          const incrCost = hasAgentCost
+            ? msg.usage.cost_usd!
+            : estimateCostFromTokens(usageModel, newInput, newOutput);
+          this.totalCostUsd += incrCost;
 
+          // Emit legacy token-count (keep for existing consumers)
           this.emit({
             type: 'token-count',
             inputTokens: this.inputTokens,
@@ -440,6 +444,27 @@ class DroidBackend extends StreamingAgentBackendBase {
             cacheWriteTokens: this.cacheWriteTokens,
             costUsd: this.totalCostUsd,
           });
+
+          // WHY: Emit unified CostReport. source='agent-reported' when Droid's
+          // LiteLLM backend provides cost_usd directly; 'styrby-estimate' when
+          // we compute it from the LiteLLM pricing table (BYOK model).
+          // rawAgentPayload=null for estimates (schema refinement 3).
+          const costReport: CostReport = {
+            sessionId: this.sessionId ?? '',
+            messageId: null,
+            agentType: 'droid',
+            model: usageModel,
+            timestamp: new Date().toISOString(),
+            source: hasAgentCost ? 'agent-reported' : 'styrby-estimate',
+            billingModel: 'api-key',
+            costUsd: incrCost,
+            inputTokens: newInput,
+            outputTokens: newOutput,
+            cacheReadTokens: newCacheRead,
+            cacheWriteTokens: newCacheWrite,
+            rawAgentPayload: hasAgentCost ? (msg.usage as unknown as Record<string, unknown>) : null,
+          };
+          this.emit({ type: 'cost-report', report: costReport } as any);
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/goose.ts
+++ b/packages/styrby-cli/src/agent/factories/goose.ts
@@ -39,6 +39,7 @@ import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
+import type { CostReport } from '@styrby/shared/cost';
 
 // ============================================================================
 // Types
@@ -274,12 +275,14 @@ class GooseBackend extends StreamingAgentBackendBase {
         // WHY: Goose emits a cost event after each model response with MCP usage data.
         // We accumulate these across the session for accurate total cost reporting.
         if (event.usage) {
+          const prevCostUsd = this.totalCostUsd;
           this.inputTokens += event.usage.input_tokens ?? 0;
           this.outputTokens += event.usage.output_tokens ?? 0;
           this.cacheReadTokens += event.usage.cache_read_input_tokens ?? 0;
           this.cacheWriteTokens += event.usage.cache_creation_input_tokens ?? 0;
           this.totalCostUsd += event.usage.cost_usd ?? 0;
 
+          // Emit legacy token-count (keep for existing consumers)
           this.emit({
             type: 'token-count',
             inputTokens: this.inputTokens,
@@ -288,6 +291,28 @@ class GooseBackend extends StreamingAgentBackendBase {
             cacheWriteTokens: this.cacheWriteTokens,
             costUsd: this.totalCostUsd,
           });
+
+          // WHY: Emit unified CostReport for the cost-reporter to persist.
+          // source='agent-reported' when Goose provides cost_usd; otherwise
+          // 'styrby-estimate' since we don't have a fallback estimator here.
+          // rawAgentPayload=null for estimates (schema refinement 3 requirement).
+          const hasAgentCost = event.usage.cost_usd !== undefined;
+          const costReport: CostReport = {
+            sessionId: this.sessionId ?? '',
+            messageId: null,
+            agentType: 'goose',
+            model: this.options.model ?? 'unknown',
+            timestamp: new Date().toISOString(),
+            source: hasAgentCost ? 'agent-reported' : 'styrby-estimate',
+            billingModel: 'api-key',
+            costUsd: this.totalCostUsd - prevCostUsd, // incremental cost for this event
+            inputTokens: event.usage.input_tokens ?? 0,
+            outputTokens: event.usage.output_tokens ?? 0,
+            cacheReadTokens: event.usage.cache_read_input_tokens ?? 0,
+            cacheWriteTokens: event.usage.cache_creation_input_tokens ?? 0,
+            rawAgentPayload: hasAgentCost ? (event.usage as unknown as Record<string, unknown>) : null,
+          };
+          this.emit({ type: 'cost-report', report: costReport } as any);
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/kilo.ts
+++ b/packages/styrby-cli/src/agent/factories/kilo.ts
@@ -41,6 +41,36 @@ import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
+import type { CostReport, BillingModel } from '@styrby/shared/cost';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Detect whether the Kilo session is using a local/free model.
+ *
+ * WHY: Kilo supports 500+ models including local ones via Ollama and LM Studio.
+ * Local models have zero marginal cost — charging users for them would be wrong.
+ * We detect local usage by matching the model name pattern or checking whether
+ * the apiBaseUrl resolves to localhost/127.0.0.1.
+ *
+ * @param model - Model identifier (e.g., 'ollama/llama3', 'local-codellama')
+ * @param apiBaseUrl - Optional API base URL (e.g., 'http://localhost:11434/v1')
+ * @returns true when the model is local/free-tier
+ */
+function isKiloLocalModel(model: string | undefined, apiBaseUrl: string | undefined): boolean {
+  if (model && /ollama|^local-/i.test(model)) return true;
+  if (apiBaseUrl) {
+    try {
+      const url = new URL(apiBaseUrl);
+      return url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1';
+    } catch {
+      // Invalid URL - not local
+    }
+  }
+  return false;
+}
 
 // ============================================================================
 // Types
@@ -383,12 +413,23 @@ class KiloBackend extends StreamingAgentBackendBase {
         // WHY: Kilo emits token counts after each model request. We accumulate
         // across the session so the mobile app shows a running cost total.
         if (msg.usage) {
-          this.inputTokens += msg.usage.input_tokens ?? 0;
-          this.outputTokens += msg.usage.output_tokens ?? 0;
-          this.cacheReadTokens += msg.usage.cache_read_tokens ?? 0;
-          this.cacheWriteTokens += msg.usage.cache_write_tokens ?? 0;
-          this.totalCostUsd += msg.usage.cost_usd ?? 0;
+          const incrInput = msg.usage.input_tokens ?? 0;
+          const incrOutput = msg.usage.output_tokens ?? 0;
+          const incrCacheRead = msg.usage.cache_read_tokens ?? 0;
+          const incrCacheWrite = msg.usage.cache_write_tokens ?? 0;
 
+          // WHY: Local/free models (Ollama, LM Studio) have zero marginal cost.
+          // We detect local usage by model name or apiBaseUrl and set costUsd=0.
+          const isLocal = isKiloLocalModel(this.options.model, this.options.apiBaseUrl);
+          const incrCost = isLocal ? 0 : (msg.usage.cost_usd ?? 0);
+
+          this.inputTokens += incrInput;
+          this.outputTokens += incrOutput;
+          this.cacheReadTokens += incrCacheRead;
+          this.cacheWriteTokens += incrCacheWrite;
+          this.totalCostUsd += incrCost;
+
+          // Emit legacy token-count (keep for existing consumers)
           this.emit({
             type: 'token-count',
             inputTokens: this.inputTokens,
@@ -397,6 +438,28 @@ class KiloBackend extends StreamingAgentBackendBase {
             cacheWriteTokens: this.cacheWriteTokens,
             costUsd: this.totalCostUsd,
           });
+
+          // WHY: Emit unified CostReport. Kilo local models use billingModel='free'
+          // with costUsd=0; remote models use 'api-key'. source='agent-reported'
+          // when Kilo reports cost_usd; 'styrby-estimate' otherwise.
+          const billingModel: BillingModel = isLocal ? 'free' : 'api-key';
+          const hasAgentCost = !isLocal && msg.usage.cost_usd !== undefined;
+          const costReport: CostReport = {
+            sessionId: this.sessionId ?? '',
+            messageId: null,
+            agentType: 'kilo',
+            model: this.options.model ?? 'unknown',
+            timestamp: new Date().toISOString(),
+            source: hasAgentCost ? 'agent-reported' : 'styrby-estimate',
+            billingModel,
+            costUsd: incrCost,
+            inputTokens: incrInput,
+            outputTokens: incrOutput,
+            cacheReadTokens: incrCacheRead,
+            cacheWriteTokens: incrCacheWrite,
+            rawAgentPayload: hasAgentCost ? (msg.usage as unknown as Record<string, unknown>) : null,
+          };
+          this.emit({ type: 'cost-report', report: costReport } as any);
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/kiro.ts
+++ b/packages/styrby-cli/src/agent/factories/kiro.ts
@@ -35,6 +35,7 @@ import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
+import type { CostReport } from '@styrby/shared/cost';
 
 // ============================================================================
 // Constants
@@ -44,11 +45,13 @@ import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentB
  * USD cost per single Kiro credit.
  *
  * WHY: Kiro bills in credits rather than tokens. As of the current pricing
- * schedule, 1 credit = $0.01 USD. This constant lets us emit costUsd values
- * in our unified token-count events without requiring callers to know the
- * credit pricing model.
+ * schedule, 1 credit = $0.01 USD. This constant is exported so downstream
+ * code (e.g., future cost-reporter config) can read it without hardcoding
+ * the rate. It is also snapshotted into each CostReport for audit accuracy.
+ *
+ * @see https://kiro.dev/pricing
  */
-const KIRO_CREDIT_TO_USD = 0.01;
+export const KIRO_CREDIT_TO_USD = 0.01;
 
 // ============================================================================
 // Types
@@ -303,17 +306,19 @@ class KiroBackend extends StreamingAgentBackendBase {
         if (event.usage) {
           const credits = event.usage.credits_consumed ?? 0;
           this.creditsConsumed += credits;
-          this.inputTokens += event.usage.input_tokens ?? 0;
-          this.outputTokens += event.usage.output_tokens ?? 0;
+          const incrInput = event.usage.input_tokens ?? 0;
+          const incrOutput = event.usage.output_tokens ?? 0;
+          this.inputTokens += incrInput;
+          this.outputTokens += incrOutput;
 
           // WHY: If Kiro provides a pre-computed cost_usd, prefer it over our
           // conversion. Otherwise compute from credits * KIRO_CREDIT_TO_USD.
-          if (event.usage.cost_usd !== undefined) {
-            this.totalCostUsd += event.usage.cost_usd;
-          } else {
-            this.totalCostUsd += credits * KIRO_CREDIT_TO_USD;
-          }
+          const incrCost = event.usage.cost_usd !== undefined
+            ? event.usage.cost_usd
+            : credits * KIRO_CREDIT_TO_USD;
+          this.totalCostUsd += incrCost;
 
+          // Emit legacy token-count (keep for existing consumers)
           this.emit({
             type: 'token-count',
             inputTokens: this.inputTokens,
@@ -324,6 +329,30 @@ class KiroBackend extends StreamingAgentBackendBase {
             // Include credit count for Kiro-specific display in the dashboard
             creditsConsumed: this.creditsConsumed,
           });
+
+          // WHY: Emit unified CostReport with billingModel='credit'. The credits
+          // object snapshots the current rateUsdPerCredit so historical cost records
+          // remain accurate even if Kiro reprices their credit packs.
+          const costReport: CostReport = {
+            sessionId: this.sessionId ?? '',
+            messageId: null,
+            agentType: 'kiro',
+            model: this.options.model ?? 'unknown',
+            timestamp: new Date().toISOString(),
+            source: 'agent-reported',
+            billingModel: 'credit',
+            costUsd: incrCost,
+            inputTokens: incrInput,
+            outputTokens: incrOutput,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            credits: {
+              consumed: credits,
+              rateUsdPerCredit: KIRO_CREDIT_TO_USD,
+            },
+            rawAgentPayload: event.usage as unknown as Record<string, unknown>,
+          };
+          this.emit({ type: 'cost-report', report: costReport } as any);
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/opencode.ts
+++ b/packages/styrby-cli/src/agent/factories/opencode.ts
@@ -26,6 +26,7 @@ import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
+import type { CostReport } from '@styrby/shared/cost';
 
 /**
  * Options for creating an OpenCode backend
@@ -240,7 +241,7 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
             this.outputTokens = session.CompletionTokens;
           }
 
-          // Emit token count update
+          // Emit legacy token-count (keep for existing consumers)
           this.emit({
             type: 'token-count',
             inputTokens: this.inputTokens,
@@ -248,6 +249,30 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
             totalTokens: session.TotalTokens ?? this.inputTokens + this.outputTokens,
             costUsd: this.totalCost,
           });
+
+          // WHY: Emit unified CostReport alongside token-count so cost-reporter
+          // can persist the full source-of-truth shape to cost_records (migration 022).
+          // source='agent-reported' because OpenCode's session event carries Cost
+          // directly from the agent. rawAgentPayload preserves the session JSON for
+          // SOC2 CC7.2 audit trail.
+          if (session.Cost !== undefined) {
+            const costReport: CostReport = {
+              sessionId: this.sessionId ?? '',
+              messageId: null,
+              agentType: 'opencode',
+              model: this.options.model ?? 'unknown',
+              timestamp: new Date().toISOString(),
+              source: 'agent-reported',
+              billingModel: 'api-key',
+              costUsd: this.totalCost,
+              inputTokens: this.inputTokens,
+              outputTokens: this.outputTokens,
+              cacheReadTokens: 0,
+              cacheWriteTokens: 0,
+              rawAgentPayload: session as unknown as Record<string, unknown>,
+            };
+            this.emit({ type: 'cost-report', report: costReport } as any);
+          }
         }
         break;
 

--- a/packages/styrby-cli/src/costs/cost-reporter.ts
+++ b/packages/styrby-cli/src/costs/cost-reporter.ts
@@ -27,6 +27,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { RelayClient } from 'styrby-shared';
 import type { AgentType } from '@/auth/agent-credentials';
 import type { CostRecord } from './cost-extractor.js';
+import type { CostReport } from '@styrby/shared/cost';
 
 // ============================================================================
 // Types
@@ -57,7 +58,10 @@ export interface CostReporterConfig {
 }
 
 /**
- * Cost record ready for Supabase insertion
+ * Cost record ready for Supabase insertion.
+ *
+ * Includes migration-022 columns: billing_model, source, raw_agent_payload,
+ * subscription_fraction_used, credits_consumed, credit_rate_usd.
  */
 interface SupabaseCostRecord {
   user_id: string;
@@ -74,6 +78,19 @@ interface SupabaseCostRecord {
   recorded_at: string;
   record_date: string;
   is_pending: boolean;
+  // ---- migration-022 columns ----
+  /** Billing model enum: 'api-key' | 'subscription' | 'credit' | 'free' */
+  billing_model: string;
+  /** Cost source enum: 'agent-reported' | 'styrby-estimate' */
+  source: string;
+  /** Raw agent payload for SOC2 CC7.2 audit trail */
+  raw_agent_payload: Record<string, unknown> | null;
+  /** Subscription quota fraction used (null if not available) */
+  subscription_fraction_used: number | null;
+  /** Number of credits consumed (credit billing only) */
+  credits_consumed: number | null;
+  /** USD rate per credit (credit billing only) */
+  credit_rate_usd: number | null;
 }
 
 /**
@@ -264,8 +281,16 @@ export class CostReporter extends EventEmitter {
     const batchCostUsd = recordsToReport.reduce((sum, r) => sum + r.costUsd, 0);
 
     try {
-      // Convert to Supabase format
-      const supabaseRecords = recordsToReport.map((r) => this.toSupabaseRecord(r));
+      // Convert to Supabase format.
+      // WHY: Records that came through addCostReport() carry a __costReport extension
+      // field with the full CostReport, enabling the migration-022 column mapping.
+      // Legacy records from addRecord() fall back to toSupabaseRecord() with defaults.
+      const supabaseRecords = recordsToReport.map((r) => {
+        const ext = r as CostRecord & { __costReport?: CostReport };
+        return ext.__costReport
+          ? this.toSupabaseRecordFromCostReport(ext.__costReport)
+          : this.toSupabaseRecord(r);
+      });
 
       // Insert into cost_records table
       const { error } = await this.config.supabase
@@ -314,7 +339,10 @@ export class CostReporter extends EventEmitter {
     this.sessionTotalCostUsd += record.costUsd;
 
     try {
-      const supabaseRecord = this.toSupabaseRecord(record);
+      const ext = record as CostRecord & { __costReport?: CostReport };
+      const supabaseRecord = ext.__costReport
+        ? this.toSupabaseRecordFromCostReport(ext.__costReport)
+        : this.toSupabaseRecord(record);
 
       const { error } = await this.config.supabase
         .from('cost_records')
@@ -532,6 +560,9 @@ export class CostReporter extends EventEmitter {
   /**
    * Convert a CostRecord to Supabase format.
    *
+   * Uses migration-022 defaults for billing_model / source columns when the
+   * caller has only a legacy CostRecord and no CostReport is available.
+   *
    * @param record - Internal cost record
    * @returns Supabase-compatible record
    */
@@ -554,7 +585,130 @@ export class CostReporter extends EventEmitter {
       recorded_at: record.timestamp.toISOString(),
       record_date: dateStr,
       is_pending: false,
+      // migration-022 defaults for legacy CostRecord callers
+      billing_model: 'api-key',
+      source: 'styrby-estimate',
+      raw_agent_payload: null,
+      subscription_fraction_used: null,
+      credits_consumed: null,
+      credit_rate_usd: null,
     };
+  }
+
+  /**
+   * Convert a unified {@link CostReport} to Supabase format.
+   *
+   * This is the preferred path for all new code. It maps CostReport 1:1 to the
+   * migration-022 columns in `cost_records`, preserving billing_model, source,
+   * raw_agent_payload, and credit / subscription metadata for the cost dashboard.
+   *
+   * WHY: Migration 022 adds billing_model, source, raw_agent_payload,
+   * subscription_fraction_used, credits_consumed, and credit_rate_usd. Mapping
+   * these from CostReport (rather than re-deriving them) ensures the DB reflects
+   * exactly what the agent reported — critical for SOC2 CC7.2 audit trail.
+   *
+   * @param report - Unified CostReport from the agent factory
+   * @returns Supabase-compatible record with all migration-022 columns populated
+   */
+  toSupabaseRecordFromCostReport(report: CostReport): SupabaseCostRecord {
+    const recordedAt = report.timestamp;
+    const dateStr = recordedAt.split('T')[0]; // YYYY-MM-DD
+
+    return {
+      user_id: this.config.userId,
+      session_id: report.sessionId,
+      agent_type: report.agentType as AgentType,
+      model: report.model,
+      input_tokens: report.inputTokens,
+      output_tokens: report.outputTokens,
+      cache_read_tokens: report.cacheReadTokens,
+      cache_write_tokens: report.cacheWriteTokens,
+      cost_usd: report.costUsd,
+      price_per_input_token: null,
+      price_per_output_token: null,
+      recorded_at: recordedAt,
+      record_date: dateStr,
+      is_pending: false,
+      // ---- migration-022 columns ----
+      billing_model: report.billingModel,
+      source: report.source,
+      raw_agent_payload: report.rawAgentPayload ?? null,
+      // Subscription quota fraction — null if agent didn't expose it
+      subscription_fraction_used: report.subscriptionUsage?.fractionUsed ?? null,
+      // Credit billing fields — null for non-credit billing models
+      credits_consumed: report.credits?.consumed ?? null,
+      credit_rate_usd: report.credits?.rateUsdPerCredit ?? null,
+    };
+  }
+
+  /**
+   * Add a unified CostReport to the pending batch.
+   *
+   * This is the preferred method for new cost-report event consumers.
+   * It converts CostReport → SupabaseCostRecord using the migration-022 mapping
+   * and queues it alongside legacy CostRecord entries.
+   *
+   * WHY: Introducing addCostReport alongside addRecord lets callers gradually
+   * migrate to the CostReport path without breaking the existing batch/flush
+   * infrastructure. Both paths share the same pending queue and retry logic.
+   *
+   * @param report - Unified CostReport from the agent factory
+   */
+  addCostReport(report: CostReport): void {
+    // WHY: Cap the pending buffer to prevent unbounded memory growth when
+    // flush() keeps failing (e.g. sustained network outage). Drop the oldest
+    // record (index 0) before pushing the new one — identical policy as addRecord().
+    if (this.pendingRecords.length >= MAX_PENDING) {
+      this.pendingRecords.shift();
+      console.warn(
+        `[CostReporter] pendingRecords exceeded MAX_PENDING (${MAX_PENDING}). ` +
+          'Oldest record dropped. Check network connectivity.'
+      );
+    }
+
+    // Convert CostReport to the CostRecord shape that pendingRecords holds, then
+    // flush via the existing infrastructure. We store the Supabase record directly
+    // in a thin wrapper so flush() can insert it without branching.
+    const costUsd = report.costUsd;
+    this.sessionTotalCostUsd += costUsd;
+
+    // Build a synthetic CostRecord for the legacy pending queue so flush() can
+    // call toSupabaseRecord(). The supabaseRecord override is applied by flush()
+    // calling toSupabaseRecordFromCostReport when the item carries a costReport ref.
+    // WHY: Rather than duplicating flush() logic, we attach the CostReport to the
+    // CostRecord using an extension property so the existing batch path picks it up.
+    const syntheticRecord: CostRecord & { __costReport?: CostReport } = {
+      sessionId: report.sessionId,
+      agentType: report.agentType as AgentType,
+      model: report.model,
+      inputTokens: report.inputTokens,
+      outputTokens: report.outputTokens,
+      cacheReadTokens: report.cacheReadTokens,
+      cacheWriteTokens: report.cacheWriteTokens,
+      costUsd,
+      timestamp: new Date(report.timestamp),
+      __costReport: report,
+    };
+
+    this.pendingRecords.push(syntheticRecord);
+
+    this.log('CostReport added', {
+      agentType: report.agentType,
+      billingModel: report.billingModel,
+      source: report.source,
+      costUsd,
+      pendingCount: this.pendingRecords.length,
+    });
+
+    // Auto-flush if batch is full
+    if (this.pendingRecords.length >= this.config.maxBatchSize) {
+      this.flush().catch((error) => {
+        this.emit('error', {
+          message: 'Batch flush failed',
+          error: error instanceof Error ? error : undefined,
+        });
+      });
+    }
   }
 
   /**

--- a/packages/styrby-cli/tsconfig.json
+++ b/packages/styrby-cli/tsconfig.json
@@ -25,7 +25,8 @@
     "paths": {
       "@/*": ["./*"],
       "styrby-shared": ["../../styrby-shared/dist"],
-      "@styrby/shared/pricing": ["../../styrby-shared/dist/pricing/index"]
+      "@styrby/shared/pricing": ["../../styrby-shared/dist/pricing/index"],
+      "@styrby/shared/cost": ["../../styrby-shared/dist/cost/index"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/styrby-cli/vitest.config.ts
+++ b/packages/styrby-cli/vitest.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
       // tsconfig paths mechanism that the production esbuild build also
       // honours via tsc-alias).
       'styrby-shared': resolve(__dirname, '../styrby-shared/dist/index.js'),
+      // WHY: Mirror the tsconfig path for the cost module so vitest can
+      // resolve `import ... from '@styrby/shared/cost'` during test runs.
+      '@styrby/shared/cost': resolve(__dirname, '../styrby-shared/dist/cost/index.js'),
     },
   },
 });


### PR DESCRIPTION
## Summary
Eight agent factories now emit the unified `CostReport` shape (from PR #107), plumbed through `cost-reporter` into migration 022's new `cost_records` columns (from PR #106). This is the meat of Phase 1.6.1 — every session dispatched via one of these agents now writes a source-of-truth + billing-model-aware record to the DB.

## Factories converted (55 new tests)
| Agent | Tests | BillingModel | Source |
|-------|-------|--------------|--------|
| opencode | 3 | api-key | agent-reported |
| goose | 3 | api-key | agent-reported \| styrby-estimate fallback |
| amp | 3 | api-key | agent-reported + sub_agent_id captured |
| crush | 2 | api-key | agent-reported |
| kilo | 5 | api-key \| **free** (Ollama local detection) | agent-reported |
| kiro | 4 | **credit** (with `credits_consumed` + `credit_rate_usd`) | agent-reported |
| droid | 3 | api-key | agent-reported \| styrby-estimate fallback |
| **claude (new helper)** | 32 | api-key \| **subscription** (Claude Max OAuth detection) | agent-reported |

## New: Claude billing-model detection
- `detectClaudeBillingModel()` reads `~/.claude/auth.json` for `subscriptionType`; maps Max/Pro → `subscription`, else → `api-key`.
- Subscription mode writes `costUsd: 0` — Styrby no longer blows up a Claude Max user's budget with fake \$ estimates.
- Detection failure logs at DEBUG, defaults safely to `api-key`. PR-D will harden detection.

## cost-reporter extensions
- `SupabaseCostRecord` adds 6 new migration-022 columns
- `addCostReport(report)` public API queues a full CostReport
- `toSupabaseRecordFromCostReport()` maps 1:1 to DB
- `flush()` + `reportImmediate()` detect the `__costReport` extension

## Untouched (PR-D gap fixes)
- `parseClaudeOutput` regex (brittle, separate concern)
- Aider factory (emits no cost today)
- Codex regex parser
- Gemini ACP path (no token-count handler)

## Test plan
- [x] `pnpm --filter styrby-cli typecheck` — clean
- [x] `pnpm --filter styrby-cli test -- --run` — 1,904 pass / 81 files (was 1,849 / 79)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)