### PR TITLE
chore(sentry): emergency mute switch + noise filter

### DIFF
--- a/packages/styrby-web/sentry.client.config.ts
+++ b/packages/styrby-web/sentry.client.config.ts
@@ -21,6 +21,37 @@
  */
 import * as Sentry from '@sentry/nextjs';
 
+/**
+ * STYRBY_SENTRY_MUTED — emergency kill switch.
+ *
+ * Set `STYRBY_SENTRY_MUTED=true` (or `NEXT_PUBLIC_STYRBY_SENTRY_MUTED=true` for
+ * the client bundle) to silence the SDK regardless of environment. Flip it in
+ * Vercel env vars + redeploy to stop notification spam without a code change.
+ *
+ * WHY: real production errors can drown the founder inbox during an incident
+ * or a preview-deploy error cascade. The env-var kill switch takes effect at
+ * boot with no SDK calls going out. Unset it once the noise is handled.
+ */
+const isMuted =
+  process.env.NEXT_PUBLIC_STYRBY_SENTRY_MUTED === 'true' ||
+  process.env.STYRBY_SENTRY_MUTED === 'true';
+
+/**
+ * Noise filter — errors matching any of these patterns are dropped before
+ * reaching Sentry. Add specific pattern here when a known-benign error class
+ * is spamming notifications; keep the list short so real regressions still
+ * reach the dashboard.
+ */
+const NOISE_PATTERNS: readonly RegExp[] = [
+  /ResizeObserver loop limit exceeded/i,
+  /Non-Error promise rejection captured/i,
+  /NetworkError when attempting to fetch resource/i,
+  /Load failed/i,
+  /The operation was aborted/i,
+  // Chrome extension injection noise
+  /extension:\/\//i,
+];
+
 Sentry.init({
   /**
    * NEXT_PUBLIC_SENTRY_DSN — Public Data Source Name that routes browser errors to Sentry.
@@ -59,9 +90,34 @@ Sentry.init({
   environment: process.env.NODE_ENV,
 
   /**
-   * Only report errors in production builds.
-   * WHY: Dev errors appear in the browser console — no need to pollute the
-   * Sentry dashboard with local development noise.
+   * Only report errors in production builds AND when not muted by env var.
+   * WHY: dev noise stays in the browser console; the mute switch lets the
+   * founder stop live notification spam without a code push.
    */
-  enabled: process.env.NODE_ENV === 'production',
+  enabled: process.env.NODE_ENV === 'production' && !isMuted,
+
+  /**
+   * Hard-drop known noise before it ever becomes a Sentry event.
+   * Anything matching a NOISE_PATTERN returns null here — Sentry discards it.
+   */
+  beforeSend(event, hint) {
+    const msg =
+      (hint?.originalException instanceof Error ? hint.originalException.message : '') ||
+      event.message ||
+      '';
+    if (NOISE_PATTERNS.some((rx) => rx.test(msg))) return null;
+    return event;
+  },
+
+  /**
+   * SDK-level ignore list — stops common browser-quirk errors from even
+   * reaching `beforeSend`. Cheaper than a beforeSend check for very common
+   * noise. Keep synchronized in spirit with NOISE_PATTERNS.
+   */
+  ignoreErrors: [
+    'ResizeObserver loop limit exceeded',
+    'Non-Error promise rejection captured',
+    /^NetworkError when attempting to fetch resource/,
+    /^The operation was aborted/,
+  ],
 });

--- a/packages/styrby-web/sentry.edge.config.ts
+++ b/packages/styrby-web/sentry.edge.config.ts
@@ -21,6 +21,13 @@
  */
 import * as Sentry from '@sentry/nextjs';
 
+/**
+ * STYRBY_SENTRY_MUTED — emergency kill switch for the edge runtime.
+ * Set to 'true' in Vercel env vars + redeploy to silence the SDK without
+ * a code change when notifications are spamming the founder inbox.
+ */
+const isMuted = process.env.STYRBY_SENTRY_MUTED === 'true';
+
 Sentry.init({
   /**
    * SENTRY_DSN — Server-only DSN for the edge runtime (same key as server config).
@@ -46,9 +53,8 @@ Sentry.init({
   environment: process.env.NODE_ENV,
 
   /**
-   * Only report errors in production builds.
-   * WHY: Local middleware errors appear in the Next.js dev server terminal.
-   * Routing them to Sentry would create noise in the production dashboard.
+   * Only report errors in production builds AND when the mute kill switch
+   * is not engaged. See `STYRBY_SENTRY_MUTED` doc at the top of this file.
    */
-  enabled: process.env.NODE_ENV === 'production',
+  enabled: process.env.NODE_ENV === 'production' && !isMuted,
 });

--- a/packages/styrby-web/sentry.server.config.ts
+++ b/packages/styrby-web/sentry.server.config.ts
@@ -19,6 +19,26 @@
  */
 import * as Sentry from '@sentry/nextjs';
 
+/**
+ * STYRBY_SENTRY_MUTED — emergency kill switch for the server runtime.
+ * Set to 'true' in Vercel env vars + redeploy to silence the SDK without
+ * a code change when notifications are spamming the founder inbox.
+ */
+const isMuted = process.env.STYRBY_SENTRY_MUTED === 'true';
+
+/**
+ * Server-side noise filter — matches high-volume benign errors (bot scans,
+ * aborted requests, upstream timeouts Sentry would alert on even though the
+ * user-facing retry handles them).
+ */
+const NOISE_PATTERNS: readonly RegExp[] = [
+  /ECONNRESET/i,
+  /The operation was aborted/i,
+  /Request aborted/i,
+  /socket hang up/i,
+  /ETIMEDOUT/i,
+];
+
 Sentry.init({
   /**
    * SENTRY_DSN — Server-only Data Source Name that routes server-side errors to Sentry.
@@ -44,9 +64,20 @@ Sentry.init({
   environment: process.env.NODE_ENV,
 
   /**
-   * Only report errors in production builds.
-   * WHY: Development stack traces are visible in the terminal — no need to
-   * route them to Sentry and generate false-positive alerts.
+   * Only report errors in production builds AND when the mute kill switch
+   * is not engaged. See `STYRBY_SENTRY_MUTED` doc at the top of this file.
    */
-  enabled: process.env.NODE_ENV === 'production',
+  enabled: process.env.NODE_ENV === 'production' && !isMuted,
+
+  /** Drop known-benign server-side errors before they reach Sentry. */
+  beforeSend(event, hint) {
+    const msg =
+      (hint?.originalException instanceof Error ? hint.originalException.message : '') ||
+      event.message ||
+      '';
+    if (NOISE_PATTERNS.some((rx) => rx.test(msg))) return null;
+    return event;
+  },
+
+  ignoreErrors: [/ECONNRESET/i, /socket hang up/i, /ETIMEDOUT/i],
 });


### PR DESCRIPTION
## Summary
Founder was getting spammed with Sentry notifications. Three levers — this PR ships #1 and #2; #3 is account-side.

### 1. SDK kill switch (this PR)
`STYRBY_SENTRY_MUTED=true` silences the SDK across client / server / edge without a code change. Set it in Vercel env vars + redeploy → no more events fire. Unset → back to normal. The client also accepts `NEXT_PUBLIC_STYRBY_SENTRY_MUTED` so the mute reaches the browser bundle.

### 2. Noise filter (this PR)
Pattern-based drops via `beforeSend` + `ignoreErrors`. Known-benign classes: `ResizeObserver loop limit exceeded`, `ECONNRESET`, aborted fetches, Chrome-extension injections, socket hangups. Real regressions still fire.

### 3. Email/alert preferences (dashboard only — not in this PR)
- sentry.io → User Settings → **Notifications** → turn off per-project email or switch to weekly digest
- Project → **Alerts** → delete or throttle noisy alert rules
- Per-issue: open → right sidebar → **Mute** / **Resolve** to stop follow-up emails

## Recommended immediate action
1. Merge this PR so the kill switch is live in the codebase.
2. Set `STYRBY_SENTRY_MUTED=true` in Vercel → redeploy → notifications stop at the source.
3. Go to sentry.io → Settings → Notifications and tune your project subscriptions to match what you actually want to hear about.
4. When the noise is contained, unset `STYRBY_SENTRY_MUTED` so real prod errors flow again.

## Test plan
- [x] Web typecheck clean
- [ ] CI green
- Manual: flip `NEXT_PUBLIC_STYRBY_SENTRY_MUTED=true` locally + force a throw → no event sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)