### PR TITLE
feat(daemon): proactive reconnect on sleep/wake + network change (Phase 1.6.2 PR-6)

### DIFF
--- a/packages/styrby-cli/src/daemon/__tests__/daemonProcess.test.ts
+++ b/packages/styrby-cli/src/daemon/__tests__/daemonProcess.test.ts
@@ -64,9 +64,26 @@ vi.mock('node:os', () => ({
   default: {
     homedir: vi.fn(() => '/tmp/styrby-test'),
     hostname: vi.fn(() => 'test-machine'),
+    // WHY: WakeDetector (imported by daemonProcess) calls os.networkInterfaces()
+    // at start(). Without this entry the ESM mock throws "No networkInterfaces
+    // export defined on the node:os mock", crashing the daemon module load.
+    networkInterfaces: vi.fn(() => ({})),
   },
   homedir: vi.fn(() => '/tmp/styrby-test'),
   hostname: vi.fn(() => 'test-machine'),
+  networkInterfaces: vi.fn(() => ({})),
+}));
+
+// WHY mock wakeDetector: WakeDetector.start() sets a real setInterval that
+// fires during test teardown if not stopped. Mocking it replaces the class
+// with a no-op stub so the daemon test focuses purely on signal-handler
+// behaviour and doesn't leak live timers between test cases.
+vi.mock('../wakeDetector.js', () => ({
+  WakeDetector: vi.fn().mockImplementation(() => ({
+    on: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
 }));
 
 const mockRelayDisconnect = vi.fn<[], Promise<void>>().mockResolvedValue(undefined);

--- a/packages/styrby-cli/src/daemon/__tests__/wakeDetector.test.ts
+++ b/packages/styrby-cli/src/daemon/__tests__/wakeDetector.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for WakeDetector — sleep/wake and network-change event detection.
+ *
+ * Covers:
+ * - Sleep gap detection: wall-clock jump > pollInterval + grace → emits `'wake'`
+ * - Steady-state polling: no gap, no wake event
+ * - Network change: `os.networkInterfaces()` returns a different set → emits `'network-change'`
+ * - Same network, same timing → no event
+ * - `stop()` clears the interval (no events after stop)
+ * - `stop()` idempotent — calling twice does not throw
+ * - `start()` idempotent — calling twice does not double-fire events
+ *
+ * WHY vi.useFakeTimers() + vi.advanceTimersByTimeAsync():
+ *   WakeDetector polls every 5 seconds. Letting that run in real time would
+ *   make tests slow and flaky. Fake timers advance both `Date.now()` and
+ *   `setInterval` synchronously so the entire suite runs in microseconds.
+ *
+ * WHY vi.mock('node:os') instead of vi.spyOn(os, ...):
+ *   In ESM, `node:os` exports are defined as non-configurable properties on
+ *   the module namespace object. `vi.spyOn()` tries to redefine them via
+ *   `Object.defineProperty`, which throws "Cannot redefine property". Full
+ *   module mocking with vi.mock() replaces the entire namespace so each
+ *   exported function becomes a configurable vi.fn() that we can control
+ *   per-test with `mockReturnValue` / `mockReturnValueOnce`.
+ *
+ * @module daemon/__tests__/wakeDetector
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Module-level mock for node:os
+// WHY declared at module scope: vi.mock() is hoisted to the top of the file
+// by Vitest, so it must be called unconditionally. The factory runs once.
+// ============================================================================
+
+vi.mock('node:os', () => ({
+  default: {
+    networkInterfaces: vi.fn(),
+    uptime: vi.fn(),
+    homedir: vi.fn(() => '/tmp'),
+    hostname: vi.fn(() => 'test-host'),
+  },
+  networkInterfaces: vi.fn(),
+  uptime: vi.fn(),
+  homedir: vi.fn(() => '/tmp'),
+  hostname: vi.fn(() => 'test-host'),
+}));
+
+// Import AFTER mock is declared so we get the mocked version.
+import * as os from 'node:os';
+import { WakeDetector } from '../wakeDetector.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build a stable fake `NetworkInterfaceInfo[]` entry.
+ * @param address - IPv4 address string (default: '192.168.1.100')
+ */
+function makeInterfaces(address = '192.168.1.100'): NodeJS.Dict<os.NetworkInterfaceInfo[]> {
+  return {
+    eth0: [
+      {
+        address,
+        netmask: '255.255.255.0',
+        family: 'IPv4',
+        mac: '00:00:00:00:00:00',
+        internal: false,
+        cidr: `${address}/24`,
+      },
+    ],
+  };
+}
+
+// Cast to vi.Mock so we can call mockReturnValue / mockReturnValueOnce.
+const mockNetworkInterfaces = os.networkInterfaces as ReturnType<typeof vi.fn>;
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('WakeDetector', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Default: stable network
+    mockNetworkInterfaces.mockReturnValue(makeInterfaces('192.168.1.100'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // Sleep/wake detection
+  // --------------------------------------------------------------------------
+
+  it('emits "wake" when wall-clock delta exceeds pollInterval + grace', async () => {
+    /**
+     * WHY this approach (setSystemTime + small timer advance):
+     *
+     * `vi.advanceTimersByTimeAsync(60_000)` fires 12 poll callbacks at 5s
+     * intervals (5s, 10s, 15s... 60s). Each poll sees `elapsed ≈ 5 000ms`
+     * (the interval between consecutive polls) — never 60s — because
+     * `lastPollAt` is updated on every tick. That correctly models the
+     * steady-state case and produces no wake event.
+     *
+     * To model a real OS sleep we need `Date.now()` to jump by a large
+     * amount between two successive poll() invocations WITHOUT any
+     * intermediate poll firing. `vi.setSystemTime()` jumps the wall clock
+     * without advancing queued timers. The sequence is:
+     *
+     * 1. start() → lastPollAt = T0
+     * 2. advance 4 999ms → no interval fires yet (interval is 5 000ms)
+     * 3. setSystemTime(T0 + 4 999 + 20 000) → clock jumps 20s, no timer fires
+     * 4. advance 2ms → interval fires at T0 + 5 001ms (timer side)
+     *    elapsed = (T0 + 24 999) - T0 = 24 999ms > 5 000 + 10 000 = 15 000ms
+     *    → wake event emitted ✓
+     */
+    const detector = new WakeDetector(5_000);
+    const wakeSpy = vi.fn<[], void>();
+    detector.on('wake', wakeSpy);
+
+    detector.start();
+    const startTime = Date.now();
+
+    // Step 1: advance almost to the poll boundary (4 999ms) — no poll fires yet.
+    await vi.advanceTimersByTimeAsync(4_999);
+
+    // Step 2: jump the wall clock 20s forward (simulates sleep) without
+    // firing any timers. Timer queue still thinks only 4 999ms have passed.
+    vi.setSystemTime(startTime + 4_999 + 20_000);
+
+    // Step 3: advance the remaining 2ms to fire the interval callback.
+    // elapsed = Date.now() - lastPollAt = (T0+24 999) - T0 = 24 999ms > 15 000ms.
+    await vi.advanceTimersByTimeAsync(2);
+
+    expect(wakeSpy).toHaveBeenCalledTimes(1);
+    detector.stop();
+  });
+
+  it('does NOT emit "wake" during steady-state polling (no time gap)', async () => {
+    /**
+     * WHY no event: advancing the clock exactly 5s at a time means each
+     * successive poll sees elapsed ≈ 5 000ms, which equals pollIntervalMs
+     * and does NOT exceed pollIntervalMs + SLEEP_GRACE_MS (15 000ms).
+     */
+    const detector = new WakeDetector(5_000);
+    const wakeSpy = vi.fn<[], void>();
+    detector.on('wake', wakeSpy);
+
+    detector.start();
+
+    // Three normal ticks — elapsed per tick ≈ 5s, well under the 15s threshold.
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(wakeSpy).not.toHaveBeenCalled();
+    detector.stop();
+  });
+
+  // --------------------------------------------------------------------------
+  // Network change detection
+  // --------------------------------------------------------------------------
+
+  it('emits "network-change" when the active network interfaces change', async () => {
+    // First call during start() — set the baseline
+    mockNetworkInterfaces.mockReturnValueOnce(makeInterfaces('10.0.0.1'));
+    // Second call during the poll after advanceTimers — new address
+    mockNetworkInterfaces.mockReturnValueOnce(makeInterfaces('10.0.1.50'));
+
+    const detector = new WakeDetector(5_000);
+    const netSpy = vi.fn<[], void>();
+    detector.on('network-change', netSpy);
+
+    detector.start();
+
+    // Advance one poll interval
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(netSpy).toHaveBeenCalledTimes(1);
+    detector.stop();
+  });
+
+  it('does NOT emit "network-change" when the interfaces stay the same', async () => {
+    // Both start() and every subsequent poll return the same interface set.
+    mockNetworkInterfaces.mockReturnValue(makeInterfaces('192.168.1.100'));
+
+    const detector = new WakeDetector(5_000);
+    const netSpy = vi.fn<[], void>();
+    detector.on('network-change', netSpy);
+
+    detector.start();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(netSpy).not.toHaveBeenCalled();
+    detector.stop();
+  });
+
+  // --------------------------------------------------------------------------
+  // Combined: no event when both are stable
+  // --------------------------------------------------------------------------
+
+  it('emits no events when both uptime and network are stable', async () => {
+    mockNetworkInterfaces.mockReturnValue(makeInterfaces('192.168.1.100'));
+
+    const detector = new WakeDetector(5_000);
+    const wakeSpy = vi.fn<[], void>();
+    const netSpy = vi.fn<[], void>();
+    detector.on('wake', wakeSpy);
+    detector.on('network-change', netSpy);
+
+    detector.start();
+
+    // Three normal ticks
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(wakeSpy).not.toHaveBeenCalled();
+    expect(netSpy).not.toHaveBeenCalled();
+    detector.stop();
+  });
+
+  // --------------------------------------------------------------------------
+  // stop() clears the interval
+  // --------------------------------------------------------------------------
+
+  it('stop() prevents further events after being called', async () => {
+    // Baseline at start time
+    mockNetworkInterfaces.mockReturnValueOnce(makeInterfaces('10.0.0.1'));
+    // What would be returned if the poll fired — but it should NOT fire after stop()
+    mockNetworkInterfaces.mockReturnValue(makeInterfaces('99.99.99.99'));
+
+    const detector = new WakeDetector(5_000);
+    const wakeSpy = vi.fn<[], void>();
+    const netSpy = vi.fn<[], void>();
+    detector.on('wake', wakeSpy);
+    detector.on('network-change', netSpy);
+
+    detector.start();
+
+    // Stop immediately — before any poll tick fires
+    detector.stop();
+
+    // Advance time well past any poll + sleep-gap threshold
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(wakeSpy).not.toHaveBeenCalled();
+    expect(netSpy).not.toHaveBeenCalled();
+  });
+
+  it('stop() is idempotent — calling it twice does not throw', () => {
+    const detector = new WakeDetector(5_000);
+    detector.start();
+    expect(() => {
+      detector.stop();
+      detector.stop();
+    }).not.toThrow();
+  });
+
+  // --------------------------------------------------------------------------
+  // start() idempotency
+  // --------------------------------------------------------------------------
+
+  it('start() is idempotent — calling it twice does not double-fire events', async () => {
+    // Baseline at start()
+    mockNetworkInterfaces.mockReturnValueOnce(makeInterfaces('10.0.0.1'));
+    // Changed network — should fire exactly once (one interval, not two)
+    mockNetworkInterfaces.mockReturnValue(makeInterfaces('10.0.1.1'));
+
+    const detector = new WakeDetector(5_000);
+    const netSpy = vi.fn<[], void>();
+    detector.on('network-change', netSpy);
+
+    detector.start();
+    detector.start(); // no-op
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // Should have exactly one event — one interval, not two
+    expect(netSpy).toHaveBeenCalledTimes(1);
+    detector.stop();
+  });
+});

--- a/packages/styrby-cli/src/daemon/daemonProcess.ts
+++ b/packages/styrby-cli/src/daemon/daemonProcess.ts
@@ -27,6 +27,7 @@ import * as os from 'node:os';
 import { createClient } from '@supabase/supabase-js';
 import { createRelayClient, type RelayClient } from 'styrby-shared';
 import { loadDaemonConfig } from './configFile';
+import { WakeDetector } from './wakeDetector';
 
 // ============================================================================
 // Configuration
@@ -56,6 +57,7 @@ const DAEMON_FILES = {
 let relay: RelayClient | null = null;
 let ipcServer: net.Server | null = null;
 let statusInterval: ReturnType<typeof setInterval> | null = null;
+let wakeDetector: WakeDetector | null = null;
 const startedAt = new Date().toISOString();
 let connectionState: 'connected' | 'connecting' | 'disconnected' | 'reconnecting' | 'error' = 'disconnected';
 let errorMessage: string | undefined;
@@ -83,6 +85,7 @@ async function main(): Promise<void> {
   startIpcServer();
   await connectToRelay();
   startStatusWriter();
+  startWakeDetector();
 
   // Signal parent that we are ready.
   // WHY: The parent waits for this before disconnecting IPC and exiting.
@@ -301,6 +304,46 @@ function startStatusWriter(): void {
 }
 
 // ============================================================================
+// Wake Detector (sleep/wake + network-change proactive reconnect)
+// ============================================================================
+
+/**
+ * Start the WakeDetector and wire its events to the relay client.
+ *
+ * WHY proactive reconnect instead of waiting for the next backoff tick:
+ *   After a macOS sleep/wake or a network topology change the relay WebSocket
+ *   is silently dead. Without proactive detection the daemon waits up to 60s
+ *   (the backoff ceiling) before the heartbeat timer fires and triggers a
+ *   reconnect. With WakeDetector, the relay is back within ~5 seconds of the
+ *   wake event — before the user even opens the mobile app.
+ *
+ * WHY delayMs = 0 (immediate): There is no value in waiting. The OS has
+ *   already signalled that something changed; the sooner we attempt reconnect
+ *   the sooner the mobile link is live again. If the attempt fails it falls
+ *   through to the standard exponential-backoff path.
+ */
+function startWakeDetector(): void {
+  wakeDetector = new WakeDetector();
+
+  wakeDetector.on('wake', () => {
+    log('Wake event detected — triggering immediate relay reconnect');
+    if (relay && !shuttingDown) {
+      relay.scheduleReconnect(false, 0, 'sleep-wake');
+    }
+  });
+
+  wakeDetector.on('network-change', () => {
+    log('Network change detected — triggering immediate relay reconnect');
+    if (relay && !shuttingDown) {
+      relay.scheduleReconnect(false, 0, 'network-change');
+    }
+  });
+
+  wakeDetector.start();
+  log('WakeDetector started');
+}
+
+// ============================================================================
 // Signal Handling & Cleanup
 // ============================================================================
 
@@ -347,6 +390,8 @@ async function gracefulShutdown(reason: string): Promise<void> {
   log('Graceful shutdown initiated', { reason });
 
   if (statusInterval) { clearInterval(statusInterval); statusInterval = null; }
+
+  if (wakeDetector) { wakeDetector.stop(); wakeDetector = null; }
 
   if (relay) {
     try { await relay.disconnect(); } catch (err) {

--- a/packages/styrby-cli/src/daemon/wakeDetector.ts
+++ b/packages/styrby-cli/src/daemon/wakeDetector.ts
@@ -1,0 +1,200 @@
+/**
+ * WakeDetector
+ *
+ * Polls `os.uptime()` and `os.networkInterfaces()` at a fixed interval to
+ * detect two conditions that should trigger an immediate relay reconnect:
+ *
+ *   1. Sleep/wake: if the elapsed wall-clock time between two polls is
+ *      significantly larger than the poll interval, the system was suspended
+ *      (macOS sleep, Linux suspend, VM pause).
+ *   2. Network change: if the set of active network interfaces (name + family
+ *      + address) changes between polls, a link came up or went down.
+ *
+ * WHY uptime-delta heuristic instead of NSWorkspace / pm-utils:
+ *   Native OS sleep notifications require either a macOS-only Objective-C
+ *   native addon (`NSWorkspace`) or a Linux D-Bus dependency. Both are heavy,
+ *   brittle to cross-platform builds, and unnecessary: when a machine wakes
+ *   from sleep `os.uptime()` keeps ticking but real time jumps. If the gap
+ *   between two consecutive polls is larger than `pollIntervalMs + SLEEP_GRACE_MS`
+ *   we can reliably infer a suspend/resume cycle. This approach works on
+ *   macOS, Linux, and Windows with no native bindings, and handles both
+ *   hardware sleep and VM suspension (Docker containers never truly sleep,
+ *   so the heuristic fires only when there is an actual gap).
+ *
+ * WHY 10s grace:
+ *   A slow event-loop tick under heavy CPU load can delay a poll by a few
+ *   seconds. 10 seconds is wide enough to absorb the worst-case Node.js
+ *   event-loop jitter while still catching the shortest practical sleep
+ *   cycle (~15–20s on modern macOS).
+ *
+ * @module daemon/wakeDetector
+ */
+
+import { EventEmitter } from 'node:events';
+import * as os from 'node:os';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Default poll interval in milliseconds.
+ * WHY 5 seconds: `os.uptime()` and `os.networkInterfaces()` are cheap syscalls
+ * (< 1 ms each). Polling every 5 seconds keeps the reconnect latency under 10s
+ * (poll fires within 5s of wake, then reconnect is immediate) without
+ * measurable CPU impact even on constrained devices.
+ */
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Grace period added to the expected poll interval when checking for a sleep gap.
+ * WHY 10 seconds: Node.js timers can be delayed by event-loop saturation,
+ * GC pauses, or OS scheduling. 10s absorbs worst-case jitter while still
+ * reliably detecting any real suspend cycle.
+ */
+const SLEEP_GRACE_MS = 10_000;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Events emitted by WakeDetector. */
+interface WakeDetectorEvents {
+  /** Fired when an OS sleep/resume cycle is detected. */
+  wake: void;
+  /** Fired when the active network interfaces change (link up/down, DHCP renew). */
+  'network-change': void;
+}
+
+// ============================================================================
+// WakeDetector
+// ============================================================================
+
+/**
+ * Detects system sleep/wake and network topology changes via lightweight polling.
+ *
+ * Emits `'wake'` when a sleep gap is detected and `'network-change'` when
+ * the active network interfaces change. Both events should trigger an immediate
+ * relay reconnect in the caller.
+ *
+ * @example
+ * ```typescript
+ * const detector = new WakeDetector();
+ * detector.on('wake', () => relay.scheduleReconnect(0, 'sleep-wake'));
+ * detector.on('network-change', () => relay.scheduleReconnect(0, 'network-change'));
+ * detector.start();
+ * // later…
+ * detector.stop();
+ * ```
+ */
+export class WakeDetector extends EventEmitter {
+  private readonly pollIntervalMs: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  /** Wall-clock timestamp (Date.now()) of the most recent poll. */
+  private lastPollAt: number = 0;
+
+  /** Fingerprint of the network interfaces seen on the most recent poll. */
+  private lastNetworkHash: string = '';
+
+  /**
+   * Create a WakeDetector instance.
+   *
+   * @param pollIntervalMs - How often to poll in ms (default 5000).
+   *   Override in tests via vi.useFakeTimers() + vi.advanceTimersByTimeAsync().
+   */
+  constructor(pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS) {
+    super();
+    this.pollIntervalMs = pollIntervalMs;
+  }
+
+  // --------------------------------------------------------------------------
+  // Public API
+  // --------------------------------------------------------------------------
+
+  /**
+   * Begin polling. Safe to call multiple times — a second `start()` is a no-op
+   * if already running.
+   */
+  start(): void {
+    if (this.timer !== null) return;
+
+    this.lastPollAt = Date.now();
+    this.lastNetworkHash = hashNetworkInterfaces();
+
+    this.timer = setInterval(() => this.poll(), this.pollIntervalMs);
+  }
+
+  /**
+   * Stop polling and clear the interval. Safe to call when already stopped.
+   */
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Private
+  // --------------------------------------------------------------------------
+
+  /**
+   * Execute one poll cycle: check for sleep gap and network change.
+   * Called internally by the setInterval timer.
+   */
+  private poll(): void {
+    const now = Date.now();
+    const elapsed = now - this.lastPollAt;
+
+    // --- Sleep/wake detection ---
+    // WHY: If the wall-clock gap between polls exceeds the expected interval by
+    // more than SLEEP_GRACE_MS we can infer the system was suspended. When the
+    // machine wakes, this poll fires with `elapsed` equal to the full sleep
+    // duration (potentially hours), which far exceeds the grace threshold.
+    if (elapsed > this.pollIntervalMs + SLEEP_GRACE_MS) {
+      this.emit('wake');
+    }
+
+    // --- Network change detection ---
+    const currentHash = hashNetworkInterfaces();
+    if (currentHash !== this.lastNetworkHash) {
+      this.lastNetworkHash = currentHash;
+      this.emit('network-change');
+    }
+
+    this.lastPollAt = now;
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Produce a stable string fingerprint of the currently active network
+ * interfaces. The fingerprint covers interface name, address family, and
+ * IPv4/IPv6 address (CIDR). Order-independent: entries are sorted before
+ * joining so a reorder does not trigger a spurious event.
+ *
+ * WHY we ignore loopback and internal interfaces: loopback (`lo`, `lo0`) is
+ * always present and never changes. Including it would add noise without
+ * adding signal about real connectivity changes.
+ *
+ * @returns A deterministic string that changes iff the set of active
+ *   non-loopback interfaces changes.
+ */
+function hashNetworkInterfaces(): string {
+  const ifaces = os.networkInterfaces();
+  const entries: string[] = [];
+
+  for (const [name, addrs] of Object.entries(ifaces)) {
+    if (!addrs) continue;
+    for (const addr of addrs) {
+      if (addr.internal) continue; // skip loopback
+      entries.push(`${name}|${addr.family}|${addr.address}`);
+    }
+  }
+
+  return entries.sort().join(';');
+}

--- a/packages/styrby-shared/src/relay/client.ts
+++ b/packages/styrby-shared/src/relay/client.ts
@@ -487,8 +487,19 @@ export class RelayClient extends EventEmitter<RelayChannelEvents> {
    *
    * @param isAuthError - When true, the error is unrecoverable (401/403) and
    *   retrying will never succeed. Emits `error` with code AUTH_ERROR and stops.
+   * @param delayMsOverride - When provided, bypasses the exponential backoff
+   *   calculation and uses this value directly. Pass `0` for an immediate retry
+   *   triggered by a proactive OS event (sleep/wake, network change). The
+   *   `reconnectAttempts` counter is NOT incremented for proactive reconnects
+   *   so the backoff sequence is not perturbed — the next passive retry will
+   *   continue from where it left off.
+   * @param reason - Optional human-readable reason for logging (e.g., 'sleep-wake',
+   *   'network-change'). Defaults to 'backoff' for standard reconnect cycles.
    */
-  private scheduleReconnect(isAuthError = false): void {
+  scheduleReconnect(isAuthError?: boolean, delayMsOverride?: number, reason?: string): void;
+  /** @internal Overload used by internal callers that pass only isAuthError. */
+  scheduleReconnect(isAuthError?: boolean): void;
+  scheduleReconnect(isAuthError = false, delayMsOverride?: number, reason = 'backoff'): void {
     // WHY: 401/403 means the token is revoked or invalid. Retrying will always
     // fail and would spam Supabase auth logs. Surface it as a fatal error so
     // the daemon can notify the user to re-authenticate.
@@ -502,16 +513,29 @@ export class RelayClient extends EventEmitter<RelayChannelEvents> {
       return;
     }
 
-    this.setState('reconnecting');
-    this.reconnectAttempts++;
+    // WHY proactive reconnects skip the attempt counter: a sleep/wake or
+    // network-change event should trigger an immediate reconnect without
+    // "using up" a backoff slot. If the proactive attempt also fails, the
+    // subsequent passive retry picks up the exponential series from its
+    // current position, preventing the two-path reconnect logic from
+    // accidentally resetting or accelerating the backoff.
+    const isProactive = delayMsOverride !== undefined;
+    if (!isProactive) {
+      this.reconnectAttempts++;
+    }
 
     // Exponential backoff: 1s, 2s, 4s, 8s... capped at 60s.
     // WHY 60s ceiling (up from 30s): With unbounded retries the backoff stays
     // at its ceiling indefinitely. 60s is less aggressive on infra during long
     // outages while still recovering promptly from short drops.
-    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts - 1), 60_000);
-    this.log(`Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);
+    const delay = isProactive
+      ? delayMsOverride!
+      : Math.min(1000 * Math.pow(2, this.reconnectAttempts - 1), 60_000);
 
+    const attemptLabel = isProactive ? `proactive (${reason})` : `attempt ${this.reconnectAttempts}`;
+    this.log(`Reconnecting in ${delay}ms [${attemptLabel}]`);
+
+    this.setState('reconnecting');
     this.emit('reconnecting', { attempt: this.reconnectAttempts, delayMs: delay });
 
     setTimeout(() => {


### PR DESCRIPTION
## Summary
After PR #114 made reconnects unbounded, this PR adds proactive triggers so on Mac wake or WiFi flip the daemon reconnects within ~5s instead of waiting for the next backoff window.

### `WakeDetector` (new)
- Polls every 5s (cheap: `Date.now()` delta + `os.networkInterfaces()` hash)
- **Sleep-gap heuristic**: `Date.now()` jump past expected + 10s grace → emit `wake`. Cross-platform, no native bindings.
- **Network change**: hash of active interfaces changes → emit `network-change`.
- Docker/container loads that never truly suspend correctly never fire (elapsed always ≈ poll interval).

### Daemon wiring
- Both events → `relay.scheduleReconnect(false, 0, reason)` (immediate retry, no attempt-counter increment for proactive reconnects).
- `gracefulShutdown` stops the detector.

### RelayClient (shared)
- `scheduleReconnect()` promoted to public, optional `delayMsOverride` + `reason` params, backward compat preserved.

## Test plan
- [x] `@styrby/shared`: 1,059 tests still pass
- [x] CLI: 2,016 tests pass (+8)
- [x] Both typecheck clean
- [ ] CI green

## Combined customer impact
PR #114 (unbounded retry) + PR #113 (env injection) + PR #115 (session_id wiring) + this PR (proactive wake) = **the daemon now survives 3-day travel + macOS reboot + WiFi changes + sleep/wake without dropping the mobile link**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)