### PR TITLE
feat(daemon): push notification on reconnect after >5min offline (Phase 1.6.2 PR-7, closes 1.6.2)

### DIFF
--- a/packages/styrby-cli/src/session/__tests__/agent-session.test.ts
+++ b/packages/styrby-cli/src/session/__tests__/agent-session.test.ts
@@ -8,6 +8,11 @@
  *      SessionStorage.updateState() with the correct state and a fresh
  *      lastSeenAt timestamp.
  *
+ * PR-7 additions:
+ *   4. AgentSession emits `reconnected-after-offline` only when offline >5 min.
+ *   5. The event is suppressed for short offline periods (<= threshold).
+ *   6. lastOfflineAt resets after each emission so the next cycle is independent.
+ *
  * WHY: The `session_id = machineId` bug caused mobile to misroute session
  * history, resume, and scoped notifications. These tests pin the correct
  * behaviour so the bug cannot silently regress.
@@ -370,5 +375,143 @@ describe('AgentSession — relay events trigger SessionStorage.updateState', () 
     // by confirming updateState was never called when sessionId is empty.
     expect(session.getSessionId()).toBe('');
     expect(storage.updateState).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// PR-7: reconnected-after-offline event
+// ============================================================================
+
+describe('AgentSession — reconnected-after-offline event (PR-7)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Restore real timers in case a prior test used fake ones
+    vi.useRealTimers();
+  });
+
+  /**
+   * Helper: start a session and capture relay event listeners.
+   */
+  async function startAndCaptureListeners() {
+    const mockRelay = await getMockRelay();
+
+    const relayListeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+    (mockRelay.on as Mock).mockImplementation(
+      (event: string, cb: (...args: unknown[]) => void) => {
+        relayListeners[event] = relayListeners[event] ?? [];
+        relayListeners[event].push(cb);
+      }
+    );
+
+    const { AgentSession } = await import('../agent-session');
+    const session = new AgentSession(makeConfig());
+    await session.start();
+
+    return { session, relayListeners };
+  }
+
+  it('emits reconnected-after-offline when offline duration > OFFLINE_THRESHOLD_MS', async () => {
+    const { OFFLINE_THRESHOLD_MS } = await import('../agent-session');
+    const { session, relayListeners } = await startAndCaptureListeners();
+
+    // Collect emitted events
+    const emitted: Array<{ offlineDurationMs: number }> = [];
+    session.on('reconnected-after-offline', (payload) => {
+      emitted.push(payload);
+    });
+
+    vi.useFakeTimers();
+    const disconnectedAt = Date.now();
+
+    // Fire disconnected to record lastOfflineAt
+    relayListeners['disconnected']?.forEach((cb) => cb(undefined));
+
+    // Advance time beyond the threshold
+    vi.setSystemTime(disconnectedAt + OFFLINE_THRESHOLD_MS + 1000);
+
+    // Fire subscribed to trigger the check
+    relayListeners['subscribed']?.forEach((cb) => cb(undefined));
+    await Promise.resolve();
+
+    vi.useRealTimers();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].offlineDurationMs).toBeGreaterThan(OFFLINE_THRESHOLD_MS);
+  });
+
+  it('does NOT emit reconnected-after-offline when offline duration <= OFFLINE_THRESHOLD_MS', async () => {
+    const { OFFLINE_THRESHOLD_MS } = await import('../agent-session');
+    const { session, relayListeners } = await startAndCaptureListeners();
+
+    const emitted: Array<unknown> = [];
+    session.on('reconnected-after-offline', (payload) => {
+      emitted.push(payload);
+    });
+
+    vi.useFakeTimers();
+    const disconnectedAt = Date.now();
+
+    relayListeners['disconnected']?.forEach((cb) => cb(undefined));
+
+    // Advance time to just below the threshold (4 min 59 sec)
+    vi.setSystemTime(disconnectedAt + OFFLINE_THRESHOLD_MS - 1000);
+
+    relayListeners['subscribed']?.forEach((cb) => cb(undefined));
+    await Promise.resolve();
+
+    vi.useRealTimers();
+
+    // No notification should fire for a short blip
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('does NOT emit reconnected-after-offline on subscribed when disconnected was never fired', async () => {
+    // This covers the initial connect path — relay fires 'subscribed' on first
+    // connection when lastOfflineAt is null.
+    const { session, relayListeners } = await startAndCaptureListeners();
+
+    const emitted: Array<unknown> = [];
+    session.on('reconnected-after-offline', (payload) => {
+      emitted.push(payload);
+    });
+
+    // Fire subscribed without a prior disconnected event
+    relayListeners['subscribed']?.forEach((cb) => cb(undefined));
+    await Promise.resolve();
+
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('resets lastOfflineAt after emitting so the next offline cycle is independent', async () => {
+    const { OFFLINE_THRESHOLD_MS } = await import('../agent-session');
+    const { session, relayListeners } = await startAndCaptureListeners();
+
+    const emitted: Array<{ offlineDurationMs: number }> = [];
+    session.on('reconnected-after-offline', (payload) => {
+      emitted.push(payload);
+    });
+
+    vi.useFakeTimers();
+
+    // --- First offline cycle (> threshold) ---
+    const t0 = Date.now();
+    relayListeners['disconnected']?.forEach((cb) => cb(undefined));
+    vi.setSystemTime(t0 + OFFLINE_THRESHOLD_MS + 5000);
+    relayListeners['subscribed']?.forEach((cb) => cb(undefined));
+    await Promise.resolve();
+
+    expect(emitted).toHaveLength(1);
+
+    // --- Second cycle: short blip, should NOT emit again ---
+    const t1 = Date.now();
+    relayListeners['disconnected']?.forEach((cb) => cb(undefined));
+    vi.setSystemTime(t1 + OFFLINE_THRESHOLD_MS - 1000); // below threshold
+    relayListeners['subscribed']?.forEach((cb) => cb(undefined));
+    await Promise.resolve();
+
+    vi.useRealTimers();
+
+    // Only the first cycle should have emitted
+    expect(emitted).toHaveLength(1);
   });
 });

--- a/packages/styrby-cli/src/session/__tests__/reconnectNotifier.test.ts
+++ b/packages/styrby-cli/src/session/__tests__/reconnectNotifier.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for session/reconnectNotifier.ts
+ *
+ * Covers:
+ *   1. Calls send-push with the correct payload on reconnected-after-offline.
+ *   2. Throttle: second notification within THROTTLE_WINDOW_MS is suppressed.
+ *   3. Throttle: notification after THROTTLE_WINDOW_MS elapses is sent again.
+ *   4. User without push token (send-push returns 200 but success: false) —
+ *      no crash, no throw.
+ *   5. send-push returns 5xx — absorbed silently, no crash.
+ *   6. Missing STYRBY_SERVICE_ROLE_KEY — silently skipped, no fetch call.
+ *   7. Cleanup: off() removes the listener so further events are ignored.
+ *
+ * @module session/__tests__/reconnectNotifier
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { attachReconnectNotifier, THROTTLE_WINDOW_MS } from '../reconnectNotifier';
+
+// ============================================================================
+// Mock @/ui/logger (to keep test output clean)
+// ============================================================================
+
+vi.mock('@/ui/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ============================================================================
+// Mock @/env (provide stable supabaseUrl)
+// ============================================================================
+
+vi.mock('@/env', () => ({
+  config: { supabaseUrl: 'https://test.supabase.co' },
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Minimal AgentSession stand-in that extends EventEmitter and exposes
+ * `getSessionId()`. We use a real EventEmitter so `on`/`off`/`emit` work
+ * exactly like the production class.
+ */
+function makeSession(sessionId = 'session-uuid-001') {
+  const emitter = new EventEmitter() as EventEmitter & { getSessionId: () => string };
+  emitter.getSessionId = () => sessionId;
+  return emitter;
+}
+
+/**
+ * Build a minimal valid ReconnectNotifierConfig.
+ */
+function makeCtx(overrides: Partial<{
+  userId: string;
+  agent: string;
+  sessionId: string;
+  machineId: string;
+}> = {}) {
+  return {
+    userId: 'user-uuid-111',
+    agent: 'claude' as const,
+    sessionId: 'session-uuid-001',
+    machineId: 'machine-uuid-222',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('reconnectNotifier — send-push call', () => {
+  let fetchMock: ReturnType<typeof vi.fn<Promise<Response>, any[]>>;
+
+  beforeEach(() => {
+    // Reset module-level throttle state between tests by reimporting with
+    // vi.resetModules(). This also resets lastNotifiedAt map.
+    vi.resetModules();
+
+    // Provide the service role key
+    process.env.STYRBY_SERVICE_ROLE_KEY = 'test-service-role-key';
+
+    // Stub global fetch
+    fetchMock = vi.fn<Promise<Response>, any[]>().mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    delete process.env.STYRBY_SERVICE_ROLE_KEY;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('calls fetch with correct URL, method, and Authorization header', async () => {
+    const { attachReconnectNotifier: attach } = await import('../reconnectNotifier');
+
+    const session = makeSession();
+    const ctx = makeCtx();
+
+    attach(session as unknown as Parameters<typeof attach>[0], ctx);
+
+    // Emit the event
+    session.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+
+    // Allow microtask / promise chain to resolve
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://test.supabase.co/functions/v1/send-push-notification');
+    expect(options.method).toBe('POST');
+    expect(options.headers['Authorization']).toBe('Bearer test-service-role-key');
+  });
+
+  it('sends correct payload body (title, sessionId, type=daemon_reconnected)', async () => {
+    const { attachReconnectNotifier: attach } = await import('../reconnectNotifier');
+
+    const session = makeSession('session-abc');
+    const ctx = makeCtx({ sessionId: 'session-abc', agent: 'codex' });
+
+    attach(session as unknown as Parameters<typeof attach>[0], ctx);
+
+    session.emit('reconnected-after-offline', { offlineDurationMs: 6 * 60 * 1000 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body as string);
+
+    expect(body.userId).toBe('user-uuid-111');
+    expect(body.data.type).toBe('daemon_reconnected');
+    expect(body.data.sessionId).toBe('session-abc');
+    expect(body.data.title).toBe('Styrby is back online');
+    // Body should mention the agent name and a duration
+    expect(body.data.body).toContain('Codex');
+    expect(body.data.body).toContain('Tap to resume');
+  });
+
+  it('does NOT call fetch when STYRBY_SERVICE_ROLE_KEY is missing', async () => {
+    delete process.env.STYRBY_SERVICE_ROLE_KEY;
+    const { attachReconnectNotifier: attach } = await import('../reconnectNotifier');
+
+    const session = makeSession();
+    attach(session as unknown as Parameters<typeof attach>[0], makeCtx());
+
+    session.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('absorbs 5xx response without throwing', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 } as Response);
+    const { attachReconnectNotifier: attach } = await import('../reconnectNotifier');
+
+    const session = makeSession();
+    attach(session as unknown as Parameters<typeof attach>[0], makeCtx());
+
+    // Should not throw
+    await expect(async () => {
+      session.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+      await Promise.resolve();
+      await Promise.resolve();
+    }).not.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('absorbs network errors (fetch rejection) without throwing', async () => {
+    fetchMock.mockRejectedValue(new Error('Network failure'));
+    const { attachReconnectNotifier: attach } = await import('../reconnectNotifier');
+
+    const session = makeSession();
+    attach(session as unknown as Parameters<typeof attach>[0], makeCtx());
+
+    await expect(async () => {
+      session.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    }).not.toThrow();
+  });
+});
+
+describe('reconnectNotifier — throttle', () => {
+  let fetchMock: ReturnType<typeof vi.fn<Promise<Response>, any[]>>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.STYRBY_SERVICE_ROLE_KEY = 'test-service-role-key';
+
+    fetchMock = vi.fn<Promise<Response>, any[]>().mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    delete process.env.STYRBY_SERVICE_ROLE_KEY;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('suppresses a second notification within THROTTLE_WINDOW_MS', async () => {
+    vi.useFakeTimers();
+    const { attachReconnectNotifier: attach } = await import('../reconnectNotifier');
+
+    const session = makeSession('session-throttle-test');
+    attach(session as unknown as Parameters<typeof attach>[0], makeCtx({ sessionId: 'session-throttle-test' }));
+
+    // First event
+    session.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    // Second event within throttle window
+    vi.advanceTimersByTime(THROTTLE_WINDOW_MS - 1000);
+    session.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Still only one fetch call
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('allows a notification after THROTTLE_WINDOW_MS has elapsed', async () => {
+    vi.useFakeTimers();
+    const { attachReconnectNotifier: attach } = await import('../reconnectNotifier');
+
+    const session = makeSession('session-throttle-pass');
+    attach(session as unknown as Parameters<typeof attach>[0], makeCtx({ sessionId: 'session-throttle-pass' }));
+
+    // First event
+    session.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    // Advance past the throttle window
+    vi.advanceTimersByTime(THROTTLE_WINDOW_MS + 1000);
+
+    // Second event — should go through
+    session.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throttle is keyed by sessionId — different sessions are independent', async () => {
+    vi.useFakeTimers();
+    const { attachReconnectNotifier: attach } = await import('../reconnectNotifier');
+
+    const sessionA = makeSession('session-A');
+    const sessionB = makeSession('session-B');
+
+    attach(sessionA as unknown as Parameters<typeof attach>[0], makeCtx({ sessionId: 'session-A' }));
+    attach(sessionB as unknown as Parameters<typeof attach>[0], makeCtx({ sessionId: 'session-B' }));
+
+    sessionA.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+    sessionB.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Both sessions should have sent independently
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('reconnectNotifier — cleanup', () => {
+  let fetchMock: ReturnType<typeof vi.fn<Promise<Response>, any[]>>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.STYRBY_SERVICE_ROLE_KEY = 'test-service-role-key';
+
+    fetchMock = vi.fn<Promise<Response>, any[]>().mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    delete process.env.STYRBY_SERVICE_ROLE_KEY;
+    vi.unstubAllGlobals();
+  });
+
+  it('cleanup function removes the event listener — further events are ignored', async () => {
+    const { attachReconnectNotifier: attach } = await import('../reconnectNotifier');
+
+    const session = makeSession('session-cleanup-test');
+    const cleanup = attach(
+      session as unknown as Parameters<typeof attach>[0],
+      makeCtx({ sessionId: 'session-cleanup-test' })
+    );
+
+    // Remove the listener
+    cleanup();
+
+    // Emit the event — should not reach fetch
+    session.emit('reconnected-after-offline', { offlineDurationMs: 10 * 60 * 1000 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/styrby-cli/src/session/agent-session.ts
+++ b/packages/styrby-cli/src/session/agent-session.ts
@@ -39,6 +39,23 @@ import { RelayClient, createRelayClient } from 'styrby-shared';
 import { SessionStorage, type SessionStatus } from './session-storage';
 
 // ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Minimum offline duration (ms) before a reconnect triggers a push notification.
+ *
+ * WHY 5 minutes: Short blips (Wi-Fi handoff, sleep/wake, pocket-mode disconnects)
+ * resolve within seconds. Notifying for those would be noisy and meaningless.
+ * 5 minutes is the threshold where the user has likely switched context — moved
+ * away from their desk, gone to a meeting, put the phone down — and genuinely
+ * needs a "the daemon is back" signal to know they can resume the session.
+ * This matches the industry heuristic used by Slack, GitHub Actions, and
+ * other developer tools that suppress flap notifications below 5 minutes.
+ */
+export const OFFLINE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+
+// ============================================================================
 // Types
 // ============================================================================
 
@@ -127,6 +144,15 @@ export interface SessionEvents {
   mobileDisconnected: { deviceId: string };
   /** Message received from mobile */
   messageFromMobile: { content: string };
+  /**
+   * Daemon reconnected after being offline for longer than OFFLINE_THRESHOLD_MS.
+   *
+   * WHY: When the relay reconnects after a short blip we stay silent. Only
+   * when offline duration exceeds the threshold (5 min by default) do we emit
+   * this event, which triggers a push notification so the user knows they can
+   * resume their session. See reconnectNotifier.ts for the push logic.
+   */
+  'reconnected-after-offline': { offlineDurationMs: number };
 }
 
 // ============================================================================
@@ -147,6 +173,17 @@ export class AgentSession extends EventEmitter {
   private agentStatus: AgentStatus | null = null;
   private stats: SessionStats;
   private outputBuffer: string = '';
+
+  /**
+   * Timestamp set when the relay emits `disconnected`. Cleared (set to null)
+   * after a successful reconnect that triggers the push notification.
+   *
+   * WHY: We only want to notify when the daemon has been offline long enough
+   * that the user has likely left context. Recording `disconnected` time lets
+   * us measure exact offline duration on `subscribed` so we can suppress
+   * ephemeral blips (Wi-Fi handoff, sleep/wake) below OFFLINE_THRESHOLD_MS.
+   */
+  private lastOfflineAt: Date | null = null;
 
   /**
    * UUID for this specific agent session run.
@@ -379,6 +416,33 @@ export class AgentSession extends EventEmitter {
       this.persistRelayState('running').catch((err) =>
         this.log('Failed to persist relay connected state', { err })
       );
+
+      // Check if we were offline long enough to notify the user.
+      // WHY: Only notify when lastOfflineAt is set (i.e. we went through
+      // 'disconnected' before this 'subscribed') and the duration exceeds
+      // OFFLINE_THRESHOLD_MS. This suppresses ephemeral blips (sleep/wake,
+      // Wi-Fi handoff) that resolve in seconds and are meaningless to the user.
+      if (this.lastOfflineAt !== null) {
+        const offlineDurationMs = Date.now() - this.lastOfflineAt.getTime();
+        if (offlineDurationMs > OFFLINE_THRESHOLD_MS) {
+          this.emit('reconnected-after-offline', { offlineDurationMs });
+        }
+        // Reset regardless — each offline window is tracked independently.
+        this.lastOfflineAt = null;
+      }
+    });
+
+    this.relay.on('disconnected', () => {
+      // Record disconnect timestamp so we can measure offline duration on
+      // the next 'subscribed' event. We intentionally overwrite any previous
+      // value: if the relay bounces multiple times while still offline, the
+      // first disconnect timestamp is the one that matters for duration.
+      if (this.lastOfflineAt === null) {
+        this.lastOfflineAt = new Date();
+        this.log('Relay disconnected, tracking offline start', {
+          lastOfflineAt: this.lastOfflineAt.toISOString(),
+        });
+      }
     });
 
     this.relay.on('reconnecting', () => {

--- a/packages/styrby-cli/src/session/reconnectNotifier.ts
+++ b/packages/styrby-cli/src/session/reconnectNotifier.ts
@@ -1,0 +1,294 @@
+/**
+ * Reconnect Notifier
+ *
+ * Subscribes to AgentSession's `reconnected-after-offline` event and sends a
+ * low-priority push notification to the user's phone so they know the daemon
+ * is back online after an extended offline period.
+ *
+ * ## Design constraints
+ *
+ * - Calls the existing `send-push-notification` Supabase Edge Function — no
+ *   new infrastructure needed.
+ * - Throttles to at most one notification per session per 30 minutes so that
+ *   flaky networks (rapid connect/disconnect cycles) don't spam the user.
+ * - Silently skips if the user has no push token (no token → no notification,
+ *   not an error).
+ * - Absorbs send-push 5xx and timeout errors without crashing the daemon.
+ *
+ * @module session/reconnectNotifier
+ */
+
+import { logger } from '@/ui/logger';
+import { config } from '@/env';
+import type { AgentSession } from './agent-session';
+import type { AgentType } from '@/auth/agent-credentials';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Minimum gap between reconnect push notifications for the same session.
+ *
+ * WHY 30 minutes: On flaky networks a session can drop and reconnect several
+ * times per hour. Sending a "you're back online" push on every reconnect
+ * would be worse than no notification at all. 30 minutes is long enough that
+ * a second notification always represents a genuinely new offline episode
+ * (the user moved to a different location, not a momentary blip the 5-minute
+ * OFFLINE_THRESHOLD_MS filter already handles).
+ */
+export const THROTTLE_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Context required by the notifier to call the send-push edge function.
+ */
+export interface ReconnectNotifierConfig {
+  /** Supabase user ID — used to look up device tokens in send-push. */
+  userId: string;
+  /** Agent type label used in the notification body copy. */
+  agent: AgentType;
+  /** Session UUID used as a deep-link payload in the notification data. */
+  sessionId: string;
+  /** Machine ID forwarded as context in the notification data. */
+  machineId: string;
+}
+
+/**
+ * Shape of the request body sent to the send-push-notification edge function.
+ */
+interface SendPushBody {
+  type: string;
+  userId: string;
+  data: {
+    title: string;
+    body: string;
+    sessionId: string;
+    machineId: string;
+    agentType: string;
+    type: 'daemon_reconnected';
+  };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Formats offline duration into a human-readable string for notification body.
+ *
+ * @param ms - Duration in milliseconds
+ * @returns Human-readable string, e.g. "5 minutes", "1 hour 12 minutes"
+ */
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.round(ms / 60_000);
+  if (totalMinutes < 60) {
+    return `${totalMinutes} minute${totalMinutes !== 1 ? 's' : ''}`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const hourPart = `${hours} hour${hours !== 1 ? 's' : ''}`;
+  if (minutes === 0) return hourPart;
+  return `${hourPart} ${minutes} minute${minutes !== 1 ? 's' : ''}`;
+}
+
+// ============================================================================
+// In-Memory Throttle Map
+// ============================================================================
+
+/**
+ * Maps `sessionId -> last notification timestamp (ms epoch)`.
+ *
+ * WHY in-memory map keyed on sessionId: The daemon process is long-lived and
+ * holds a single AgentSession per invocation. An in-memory map is the simplest
+ * correct solution — no disk I/O, no Supabase round-trip, no race condition
+ * (Node.js event loop is single-threaded). The map is keyed on `sessionId`
+ * (not userId or machineId) because we want per-session throttling: two
+ * concurrent sessions on the same machine should each get their own 30-min
+ * window independently.
+ */
+const lastNotifiedAt: Map<string, number> = new Map();
+
+/**
+ * Check if a push notification for this session is within the throttle window.
+ *
+ * @param sessionId - Session UUID to check
+ * @returns true if we should suppress the notification (too soon)
+ */
+function isThrottled(sessionId: string): boolean {
+  const last = lastNotifiedAt.get(sessionId);
+  if (last === undefined) return false;
+  return Date.now() - last < THROTTLE_WINDOW_MS;
+}
+
+/**
+ * Record a notification send for throttle tracking.
+ *
+ * @param sessionId - Session UUID that was notified
+ */
+function recordNotification(sessionId: string): void {
+  lastNotifiedAt.set(sessionId, Date.now());
+}
+
+// ============================================================================
+// Push Delivery
+// ============================================================================
+
+/**
+ * Calls the `send-push-notification` Supabase Edge Function to deliver the
+ * reconnect notification.
+ *
+ * Uses the STYRBY_SERVICE_ROLE_KEY environment variable for authorization.
+ * If the key is missing, the function logs a warning and skips silently —
+ * this is expected in local development where push notifications are not
+ * configured.
+ *
+ * @param ctx - Notifier configuration context
+ * @param offlineDurationMs - How long the daemon was offline (for copy)
+ * @returns true if the HTTP request was made (regardless of response status)
+ */
+async function callSendPush(
+  ctx: ReconnectNotifierConfig,
+  offlineDurationMs: number
+): Promise<boolean> {
+  const serviceKey = process.env.STYRBY_SERVICE_ROLE_KEY;
+
+  if (!serviceKey) {
+    // WHY: Service role key is required for the edge function. In dev/CI
+    // environments that don't configure push, silently skip rather than
+    // crash the daemon.
+    logger.debug('[ReconnectNotifier] STYRBY_SERVICE_ROLE_KEY not set — skipping push');
+    return false;
+  }
+
+  const edgeFunctionUrl = `${config.supabaseUrl}/functions/v1/send-push-notification`;
+
+  const durationStr = formatDuration(offlineDurationMs);
+  const agentLabel = ctx.agent.charAt(0).toUpperCase() + ctx.agent.slice(1);
+
+  const body: SendPushBody = {
+    type: 'session_started', // Reuses existing allowed type; routing is driven by data.type
+    userId: ctx.userId,
+    data: {
+      // Explicit title/body overrides let send-push pass them through directly
+      title: 'Styrby is back online',
+      body: `Your ${agentLabel} session is connected after ${durationStr}. Tap to resume.`,
+      sessionId: ctx.sessionId,
+      machineId: ctx.machineId,
+      agentType: ctx.agent,
+      type: 'daemon_reconnected',
+    },
+  };
+
+  try {
+    const res = await fetch(edgeFunctionUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${serviceKey}`,
+      },
+      body: JSON.stringify(body),
+      // WHY 10-second timeout: Push notifications are best-effort. If the
+      // edge function is slow or unreachable, we should not block the daemon's
+      // event loop or cause timeouts that cascade into reconnect failures.
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      logger.debug('[ReconnectNotifier] send-push returned non-OK status', {
+        status: res.status,
+        sessionId: ctx.sessionId,
+      });
+    }
+
+    return true;
+  } catch (err) {
+    // WHY absorb errors: Push delivery is best-effort. A 5xx, network error,
+    // or timeout must never crash the daemon or surface to the user as a
+    // session error. We log at debug level only.
+    logger.debug('[ReconnectNotifier] send-push call failed (absorbed)', {
+      err: err instanceof Error ? err.message : String(err),
+      sessionId: ctx.sessionId,
+    });
+    return false;
+  }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Wires up the reconnect push notification trigger to an AgentSession.
+ *
+ * Should be called once per session immediately after the session is created,
+ * before `start()` is invoked. The returned cleanup function unsubscribes the
+ * event listener — call it when the session is destroyed if needed (in
+ * practice the session EventEmitter is garbage-collected with the daemon
+ * process so cleanup is optional but provided for correctness).
+ *
+ * @param session - The AgentSession to observe
+ * @param ctx - Notifier configuration (userId, agent, sessionId, machineId)
+ * @returns Cleanup function that removes the event listener
+ *
+ * @example
+ * const session = new AgentSession(config);
+ * const cleanup = attachReconnectNotifier(session, {
+ *   userId: config.userId,
+ *   agent: config.agent,
+ *   sessionId: session.getSessionId(), // Set after start()
+ *   machineId: config.machineId,
+ * });
+ * await session.start();
+ * // ...
+ * cleanup(); // optional
+ */
+export function attachReconnectNotifier(
+  session: AgentSession,
+  ctx: ReconnectNotifierConfig
+): () => void {
+  /**
+   * Handler invoked when the session has been offline > OFFLINE_THRESHOLD_MS
+   * and has just successfully reconnected.
+   */
+  const handler = ({ offlineDurationMs }: { offlineDurationMs: number }) => {
+    const sessionId = ctx.sessionId || session.getSessionId();
+
+    // Throttle: skip if we already notified within the last THROTTLE_WINDOW_MS
+    if (isThrottled(sessionId)) {
+      logger.debug('[ReconnectNotifier] throttled — skipping push', {
+        sessionId,
+        offlineDurationMs,
+      });
+      return;
+    }
+
+    // Record before the async send so that parallel events (rare but possible)
+    // don't race past the throttle check.
+    recordNotification(sessionId);
+
+    // Use the live sessionId from the session in case it was not yet set when
+    // the notifier was attached (i.e. called before start() completed).
+    const liveCtx: ReconnectNotifierConfig = {
+      ...ctx,
+      sessionId,
+    };
+
+    callSendPush(liveCtx, offlineDurationMs).catch((err) => {
+      logger.debug('[ReconnectNotifier] unexpected error in callSendPush', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    });
+  };
+
+  session.on('reconnected-after-offline', handler);
+
+  return () => {
+    session.off('reconnected-after-offline', handler);
+  };
+}
+
+export default { attachReconnectNotifier };

--- a/packages/styrby-mobile/src/hooks/useNotifications.ts
+++ b/packages/styrby-mobile/src/hooks/useNotifications.ts
@@ -47,6 +47,11 @@ interface NotificationData {
   screen?: NotificationScreen;
   /** Session ID to pass to the destination screen as a query parameter */
   sessionId?: string;
+  /**
+   * Machine ID included in daemon_reconnected payloads for context.
+   * Not used for routing but available to the screen for display.
+   */
+  machineId?: string;
 }
 
 /**
@@ -56,6 +61,9 @@ interface NotificationData {
  * and cannot be trusted. Validating with Zod prevents crashes from malformed
  * payloads while still allowing the app to handle partially valid data via
  * optional fields.
+ *
+ * `daemon_reconnected` was added in Phase 1.6.2 PR-7 to support deep-linking
+ * to a session when the CLI daemon reconnects after being offline >5 minutes.
  */
 const NotificationDataSchema = z.object({
   type: z.enum([
@@ -65,6 +73,7 @@ const NotificationDataSchema = z.object({
     'error',
     'agent_message',
     'budget_alert',
+    'daemon_reconnected',
   ]).optional(),
   screen: z.enum(['chat', 'dashboard', 'sessions', 'costs', 'settings']).optional(),
   sessionId: z.string().optional(),
@@ -239,6 +248,22 @@ export function useNotifications(): UseNotificationsResult {
 
         case 'budget_alert':
           router.push('/(tabs)/costs');
+          break;
+
+        case 'daemon_reconnected':
+          // WHY: Route daemon reconnect notifications to the chat screen for
+          // the specific session so the user can immediately resume their
+          // conversation with the agent. Falls back to the sessions list if
+          // no sessionId is present (should not happen in practice but we must
+          // handle it gracefully so the notification tap is never a dead end).
+          if (data.sessionId) {
+            router.push({
+              pathname: '/(tabs)/chat',
+              params: { sessionId: data.sessionId },
+            });
+          } else {
+            router.push('/(tabs)/sessions');
+          }
           break;
 
         default:

--- a/packages/styrby-mobile/src/services/notifications.ts
+++ b/packages/styrby-mobile/src/services/notifications.ts
@@ -11,6 +11,11 @@ import { supabase } from '@/lib/supabase';
 
 /**
  * Notification types we send from Styrby
+ *
+ * `daemon_reconnected` was added in Phase 1.6.2 PR-7. Emitted by the CLI
+ * daemon when it reconnects to the Supabase relay after being offline for
+ * longer than OFFLINE_THRESHOLD_MS (5 minutes). The mobile app deep-links
+ * to the session detail screen so the user can resume immediately.
  */
 export type NotificationType =
   | 'permission_request'
@@ -18,7 +23,8 @@ export type NotificationType =
   | 'session_ended'
   | 'error'
   | 'budget_alert'
-  | 'agent_message';
+  | 'agent_message'
+  | 'daemon_reconnected';
 
 /**
  * Notification payload structure


### PR DESCRIPTION
## Summary
**Closes Phase 1.6.2.** When the daemon recovers from a long outage and the user is AWAY from the app, fire a push so they know Styrby is back online.

### AgentSession
- `OFFLINE_THRESHOLD_MS = 5 min` (exported)
- `lastOfflineAt` field set on `disconnected` (first one wins — rapid-flap suppression)
- On `subscribed`, if offline ≥ threshold → emit `'reconnected-after-offline'` with `{ offlineDurationMs }`

### `reconnectNotifier`
- Subscribes, calls `send-push-notification` edge function
- 30-min throttle keyed on `sessionId` (concurrent sessions throttle independently)
- Handles: no token, no service-role key, 5xx/network errors, attach-before-start

### Mobile push routing
- `daemon_reconnected` notification deep-links to the session detail screen

## Test plan
- [x] CLI: 2,050 tests pass (+13)
- [x] Mobile: 1,212 tests pass
- [x] Both typecheck clean
- [ ] CI green

## Phase 1.6.2 series complete (7 PRs)
| PR | What |
|----|------|
| #113 | env injection + config fallback |
| #114 | unbounded reconnect + SIGHUP |
| #115 | session_id wiring + state persistence |
| #116 | wake detector — proactive reconnect |
| #117 | `styrby resume` |
| #118 | mobile + web connection-state badge |
| **this PR** | reconnect push notification |

The "3 days away from laptop" failure mode is fixed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)