### PR TITLE
feat(observability): Sentry CLI+mobile + structured logger (Phase 1.6.6)

### DIFF
--- a/packages/styrby-cli/package.json
+++ b/packages/styrby-cli/package.json
@@ -72,6 +72,7 @@
     "prepublishOnly": "echo 'Skipping prepublishOnly — CI handles audit+typecheck+build'"
   },
   "dependencies": {
+    "@sentry/node": "^8.55.0",
     "@agentclientprotocol/sdk": "^0.8.0",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@stablelib/base64": "^2.0.1",

--- a/packages/styrby-cli/src/cli/handlers/pair.ts
+++ b/packages/styrby-cli/src/cli/handlers/pair.ts
@@ -10,6 +10,19 @@
  */
 
 import { logger } from '@/ui/logger';
+import { Logger } from '@styrby/shared/logging';
+import { getSentryAdapter } from '@/observability/sentry';
+
+/**
+ * Structured logger for pair command events.
+ * WHY: pair events are critical — a failed pairing means the user is locked
+ * out until they re-run the command. Structured logs let the founder see
+ * pairing success/failure rates without waiting for support tickets.
+ */
+const pairLog = new Logger({
+  minLevel: process.env.STYRBY_LOG_LEVEL === 'debug' ? 'debug' : 'info',
+  sentry: getSentryAdapter(),
+});
 
 /**
  * Handle the `styrby pair` command.
@@ -134,6 +147,7 @@ export async function handlePair(): Promise<void> {
     if (paired) {
       // Send test ping
       await relay.sendCommand('ping');
+      pairLog.info('pair.success', { userId: data.userId, machineId });
       console.log(chalk.green('\nSUCCESS! Mobile paired successfully.\n'));
 
       // Save pairing timestamp
@@ -141,10 +155,16 @@ export async function handlePair(): Promise<void> {
         pairedAt: new Date().toISOString(),
       });
     } else {
+      pairLog.warn('pair.timeout_or_cancelled', { userId: data.userId, machineId });
       console.log(chalk.yellow('\nPairing timed out or cancelled.\n'));
       console.log('You can try again with: styrby pair\n');
     }
   } catch (error) {
+    pairLog.error(
+      'pair.failed',
+      { userId: data.userId, machineId },
+      error instanceof Error ? error : new Error(String(error)),
+    );
     logger.debug('Pairing error', { error });
     console.log(chalk.red('\nPairing failed. Please try again.\n'));
   } finally {

--- a/packages/styrby-cli/src/index.ts
+++ b/packages/styrby-cli/src/index.ts
@@ -24,6 +24,14 @@
  * styrby status
  */
 
+// WHY Sentry must be initialised before all other imports:
+// @sentry/node patches Node.js's process.uncaughtException and
+// unhandledRejection hooks. If any module runs first and registers its own
+// hooks (or triggers an async operation that can reject), those events could
+// escape Sentry capture. The import order here is intentional — do not move.
+import { initSentry } from '@/observability/sentry';
+initSentry();
+
 import { logger } from '@/ui/logger';
 import { runCommand } from '@/cli/commandRouter';
 

--- a/packages/styrby-cli/src/observability/__tests__/sentry.test.ts
+++ b/packages/styrby-cli/src/observability/__tests__/sentry.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for CLI Sentry initialization.
+ *
+ * @sentry/node is mocked entirely — no real SDK calls, no network traffic.
+ * Tests verify: mute switch, DSN resolution, noise filter, process handlers.
+ *
+ * WHY vi.hoisted(): vitest hoists vi.mock() calls to the top of the file at
+ * transform time, which means the mock factory runs before any const declarations
+ * in module scope. Using vi.hoisted() ensures the mock fns are created in the
+ * hoisted zone so the vi.mock() factory can safely reference them.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Hoisted mock functions (must be declared before vi.mock calls) ───────────
+const { mockSentryInit, mockAddBreadcrumb, mockCaptureException, mockReadFileSync } = vi.hoisted(() => ({
+  mockSentryInit: vi.fn(),
+  mockAddBreadcrumb: vi.fn(),
+  mockCaptureException: vi.fn().mockReturnValue('fake-event-id'),
+  mockReadFileSync: vi.fn(),
+}));
+
+// ── Mock @sentry/node before importing the module under test ────────────────
+vi.mock('@sentry/node', () => ({
+  init: mockSentryInit,
+  addBreadcrumb: mockAddBreadcrumb,
+  captureException: mockCaptureException,
+}));
+
+// ── Mock node:fs to control config.json reading ─────────────────────────────
+vi.mock('node:fs', () => ({ readFileSync: mockReadFileSync }));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+import { initSentry, getSentryAdapter } from '../sentry.js';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('initSentry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: config.json not found
+    mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    // Default environment
+    delete process.env.STYRBY_SENTRY_DSN;
+    delete process.env.STYRBY_SENTRY_MUTED;
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    // Remove any process listeners added by initSentry
+    process.removeAllListeners('uncaughtException');
+    process.removeAllListeners('unhandledRejection');
+  });
+
+  it('calls Sentry.init with the env var DSN', () => {
+    process.env.STYRBY_SENTRY_DSN = 'https://key@sentry.io/123';
+
+    initSentry();
+
+    expect(mockSentryInit).toHaveBeenCalledWith(
+      expect.objectContaining({ dsn: 'https://key@sentry.io/123' })
+    );
+  });
+
+  it('falls back to DSN from config.json when env var is absent', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ sentry: { dsn: 'https://cfg@sentry.io/999' } })
+    );
+
+    initSentry();
+
+    expect(mockSentryInit).toHaveBeenCalledWith(
+      expect.objectContaining({ dsn: 'https://cfg@sentry.io/999' })
+    );
+  });
+
+  it('passes undefined DSN when neither env var nor config.json provides one', () => {
+    initSentry();
+
+    const { dsn } = mockSentryInit.mock.calls[0][0] as { dsn: unknown };
+    expect(dsn).toBeUndefined();
+  });
+
+  it('sets enabled=false when STYRBY_SENTRY_MUTED=true', () => {
+    process.env.STYRBY_SENTRY_MUTED = 'true';
+    process.env.STYRBY_SENTRY_DSN = 'https://key@sentry.io/1';
+
+    initSentry();
+
+    const { enabled } = mockSentryInit.mock.calls[0][0] as { enabled: boolean };
+    expect(enabled).toBe(false);
+  });
+
+  it('sets enabled=false when config.json sentry.muted=true', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ sentry: { muted: true } })
+    );
+    process.env.STYRBY_SENTRY_DSN = 'https://key@sentry.io/1';
+
+    initSentry();
+
+    const { enabled } = mockSentryInit.mock.calls[0][0] as { enabled: boolean };
+    expect(enabled).toBe(false);
+  });
+
+  it('sets enabled=false in development mode', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.STYRBY_SENTRY_DSN = 'https://key@sentry.io/1';
+
+    initSentry();
+
+    const { enabled } = mockSentryInit.mock.calls[0][0] as { enabled: boolean };
+    expect(enabled).toBe(false);
+  });
+
+  it('registers uncaughtException handler', () => {
+    initSentry();
+    expect(process.listenerCount('uncaughtException')).toBeGreaterThan(0);
+  });
+
+  it('registers unhandledRejection handler', () => {
+    initSentry();
+    expect(process.listenerCount('unhandledRejection')).toBeGreaterThan(0);
+  });
+
+  it('unhandledRejection handler captures non-Error reasons as Error', () => {
+    initSentry();
+
+    const handler = process.listeners('unhandledRejection')[0] as (reason: unknown) => void;
+    handler('bare string reason');
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: { handler: 'unhandledRejection' } })
+    );
+  });
+});
+
+describe('getSentryAdapter', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns an adapter with addBreadcrumb and captureException', () => {
+    const adapter = getSentryAdapter();
+    expect(typeof adapter.addBreadcrumb).toBe('function');
+    expect(typeof adapter.captureException).toBe('function');
+  });
+
+  it('addBreadcrumb delegates to Sentry.addBreadcrumb', () => {
+    const adapter = getSentryAdapter();
+    const bc = { level: 'info' as const, message: 'test' };
+    adapter.addBreadcrumb(bc);
+    expect(mockAddBreadcrumb).toHaveBeenCalledWith(bc);
+  });
+
+  it('captureException delegates to Sentry.captureException', () => {
+    const adapter = getSentryAdapter();
+    const err = new Error('test');
+    const id = adapter.captureException(err, { tags: { foo: 'bar' } });
+    expect(mockCaptureException).toHaveBeenCalledWith(err, { tags: { foo: 'bar' } });
+    expect(id).toBe('fake-event-id');
+  });
+});

--- a/packages/styrby-cli/src/observability/sentry.ts
+++ b/packages/styrby-cli/src/observability/sentry.ts
@@ -1,0 +1,195 @@
+/**
+ * CLI Sentry Initialization
+ *
+ * Initialises `@sentry/node` for the Styrby CLI process. Must be imported
+ * BEFORE any other module at the top of `src/index.ts` so that process-level
+ * uncaughtException/unhandledRejection handlers are registered first.
+ *
+ * WHY Sentry in the CLI:
+ * The CLI is the highest-risk surface — it runs on developer machines, spawns
+ * subprocesses, holds Supabase tokens, and relays encrypted messages. Uncaught
+ * exceptions here silently kill active sessions. Sentry gives the founder
+ * visibility into crash patterns before users report them via support tickets.
+ *
+ * WHY STYRBY_SENTRY_MUTED:
+ * Same emergency kill-switch pattern as the web SDK. Set STYRBY_SENTRY_MUTED=true
+ * in the shell (or ~/.styrby/config.json) to silence the SDK without requiring
+ * a new npm publish and reinstall.
+ *
+ * WHY ignoreErrors matches the web server config:
+ * ECONNRESET / socket hang up / ETIMEDOUT happen whenever a developer's internet
+ * blips while the CLI is relaying. These are handled by the relay reconnect logic
+ * and should not generate Sentry alerts or exhaust quota.
+ *
+ * @module observability/sentry
+ */
+
+import * as Sentry from '@sentry/node';
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { SentryAdapter } from '@styrby/shared/logging';
+
+// ============================================================================
+// Config helpers
+// ============================================================================
+
+/**
+ * Reads the optional ~/.styrby/config.json file.
+ *
+ * WHY: CLI users typically don't set env vars persistently. Storing the DSN in
+ * ~/.styrby/config.json allows opt-in Sentry reporting without requiring
+ * terminal profile edits. The env var always wins — config.json is a fallback.
+ */
+function readCliConfig(): Record<string, unknown> {
+  try {
+    const configPath = join(homedir(), '.styrby', 'config.json');
+    const raw = readFileSync(configPath, 'utf-8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve the Sentry DSN for the CLI process.
+ * Priority: STYRBY_SENTRY_DSN env var > sentry.dsn in ~/.styrby/config.json
+ */
+function resolveDsn(): string | undefined {
+  if (process.env.STYRBY_SENTRY_DSN) return process.env.STYRBY_SENTRY_DSN;
+  const config = readCliConfig();
+  if (typeof config.sentry === 'object' && config.sentry !== null) {
+    const sentryConfig = config.sentry as Record<string, unknown>;
+    if (typeof sentryConfig.dsn === 'string') return sentryConfig.dsn;
+  }
+  return undefined;
+}
+
+// ============================================================================
+// Noise patterns — keep in sync with web server config
+// ============================================================================
+
+/**
+ * Known-benign error patterns for CLI network operations.
+ * ECONNRESET/socket hang up/ETIMEDOUT: relay reconnect handles recovery.
+ * EPIPE: write to closed agent process pipe (normal on agent shutdown).
+ */
+const NOISE_PATTERNS: readonly RegExp[] = [
+  /ECONNRESET/i,
+  /socket hang up/i,
+  /ETIMEDOUT/i,
+  /Request aborted/i,
+  /The operation was aborted/i,
+  /EPIPE/i,
+];
+
+// ============================================================================
+// Mute switch
+// ============================================================================
+
+/**
+ * STYRBY_SENTRY_MUTED — emergency kill switch for the CLI Sentry SDK.
+ *
+ * Set STYRBY_SENTRY_MUTED=true in the shell environment, or set
+ * `{ "sentry": { "muted": true } }` in ~/.styrby/config.json to silence the
+ * SDK. The env var takes precedence.
+ *
+ * WHY two ways to mute: a developer on a staging machine may not have easy
+ * access to edit shell profile files. config.json allows per-machine muting.
+ */
+function isMuted(): boolean {
+  if (process.env.STYRBY_SENTRY_MUTED === 'true') return true;
+  const config = readCliConfig();
+  if (typeof config.sentry === 'object' && config.sentry !== null) {
+    const sentryConfig = config.sentry as Record<string, unknown>;
+    if (sentryConfig.muted === true) return true;
+  }
+  return false;
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+/**
+ * Initialise Sentry for the CLI process.
+ *
+ * Call ONCE at the top of `src/index.ts`, before any other imports or logic.
+ * Subsequent calls are no-ops (Sentry.init is idempotent).
+ *
+ * @example
+ * ```ts
+ * import { initSentry } from '@/observability/sentry';
+ * initSentry();
+ * ```
+ */
+export function initSentry(): void {
+  const dsn = resolveDsn();
+  const muted = isMuted();
+
+  Sentry.init({
+    /**
+     * STYRBY_SENTRY_DSN — the CLI's Sentry Data Source Name.
+     * Source: sentry.io > Project Settings > Client Keys (DSN)
+     * Set via: STYRBY_SENTRY_DSN env var or ~/.styrby/config.json sentry.dsn
+     * Behavior when missing: SDK silently disables itself.
+     */
+    dsn,
+    tracesSampleRate: 0.1,
+    environment: process.env.NODE_ENV ?? 'production',
+    /**
+     * Only report in non-development AND when not muted by the kill switch.
+     * WHY: developer machines run in non-production mode; sending their errors
+     * to the production Sentry project creates noise for the founder.
+     */
+    enabled: process.env.NODE_ENV !== 'development' && !muted,
+    ignoreErrors: [/ECONNRESET/i, /socket hang up/i, /ETIMEDOUT/i, /EPIPE/i],
+    beforeSend(event, hint) {
+      const msg =
+        (hint?.originalException instanceof Error
+          ? hint.originalException.message
+          : '') ||
+        event.message ||
+        '';
+      if (NOISE_PATTERNS.some((rx) => rx.test(msg))) return null;
+      return event;
+    },
+  });
+
+  // ── Process-level uncaught error handlers ────────────────────────────────
+  //
+  // WHY register here (not in index.ts):
+  // These handlers MUST be in scope before any async code runs. index.ts calls
+  // initSentry() synchronously at the top, ensuring the handlers are registered
+  // before runCommand() is even imported.
+
+  process.on('uncaughtException', (error: Error) => {
+    Sentry.captureException(error, { tags: { handler: 'uncaughtException' } });
+    // Re-throw so Node.js default crash behaviour (non-zero exit, stderr dump) fires.
+    throw error;
+  });
+
+  process.on('unhandledRejection', (reason: unknown) => {
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+    Sentry.captureException(error, { tags: { handler: 'unhandledRejection' } });
+    // WHY no re-throw: Node 15+ already terminates on unhandled rejections.
+    // Re-throwing would cause double-termination on older versions.
+  });
+}
+
+/**
+ * Returns a SentryAdapter wrapping @sentry/node for use with the structured Logger.
+ *
+ * WHY a factory: The Logger lives in @styrby/shared and cannot import @sentry/node
+ * directly (would pull Node-only modules into mobile/web bundles). This factory
+ * creates a narrow adapter at the CLI boundary only.
+ *
+ * @returns SentryAdapter compatible with Logger constructor and Logger.setSentry()
+ */
+export function getSentryAdapter(): SentryAdapter {
+  return {
+    addBreadcrumb: (breadcrumb) => Sentry.addBreadcrumb(breadcrumb),
+    captureException: (error, context) =>
+      Sentry.captureException(error, context) ?? '',
+  };
+}

--- a/packages/styrby-cli/tsconfig.json
+++ b/packages/styrby-cli/tsconfig.json
@@ -26,7 +26,8 @@
       "@/*": ["./*"],
       "styrby-shared": ["../../styrby-shared/dist"],
       "@styrby/shared/pricing": ["../../styrby-shared/dist/pricing/index"],
-      "@styrby/shared/cost": ["../../styrby-shared/dist/cost/index"]
+      "@styrby/shared/cost": ["../../styrby-shared/dist/cost/index"],
+      "@styrby/shared/logging": ["../../styrby-shared/dist/logging/index"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/styrby-cli/vitest.config.ts
+++ b/packages/styrby-cli/vitest.config.ts
@@ -26,6 +26,12 @@ export default defineConfig({
       // WHY: Mirror the tsconfig path for the cost module so vitest can
       // resolve `import ... from '@styrby/shared/cost'` during test runs.
       '@styrby/shared/cost': resolve(__dirname, '../styrby-shared/dist/cost/index.js'),
+      // WHY (Phase 1.6.6): Mirror the tsconfig path for the logging subpath
+      // so vitest can resolve `import ... from '@styrby/shared/logging'`
+      // during test runs. The subpath export in styrby-shared's package.json
+      // points to dist/logging/index.js, but vitest's Vite resolver needs an
+      // explicit alias to find it since it doesn't traverse package.json exports.
+      '@styrby/shared/logging': resolve(__dirname, '../styrby-shared/dist/logging/index.js'),
     },
   },
 });

--- a/packages/styrby-mobile/app/_layout.tsx
+++ b/packages/styrby-mobile/app/_layout.tsx
@@ -4,6 +4,14 @@
  * Sets up the navigation stack, auth state, and global providers.
  */
 
+// WHY Sentry must be initialised before any other imports in _layout.tsx:
+// @sentry/react-native wraps React Native's global error handler and the
+// React error boundary machinery at init time. If any navigation or component
+// code runs first, JS crashes that occur before this point escape Sentry
+// capture. The import side-effect is intentional — do not move this block.
+import { initMobileSentry } from '../src/observability/sentry';
+initMobileSentry();
+
 import { useEffect, useState, useCallback } from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { Stack, useRouter, useSegments } from 'expo-router';

--- a/packages/styrby-mobile/jest.config.js
+++ b/packages/styrby-mobile/jest.config.js
@@ -35,6 +35,10 @@ module.exports = {
     // Subpath: encryption module is exported separately to keep libsodium
     // (~700KB WASM) out of bundles that don't need crypto.
     '^styrby-shared/encryption$': '<rootDir>/../styrby-shared/src/encryption.ts',
+    // WHY (Phase 1.6.6): Map @styrby/shared/logging subpath to source so
+    // babel-jest can transform it in CJS mode. The package.json exports field
+    // points at dist/logging/index.js (ESM) which Jest cannot consume directly.
+    '^@styrby/shared/logging$': '<rootDir>/../styrby-shared/src/logging/index.ts',
   },
   transform: {
     // Use babel-jest with Expo's Babel config for TypeScript support
@@ -49,7 +53,7 @@ module.exports = {
     // Transform Expo/RN packages that ship untranspiled ESM
     // WHY @supabase: @supabase/supabase-js ships ESM. We need to transform it
     // so Jest can mock the createClient export in supabase.test.ts.
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|native-base|react-native-svg|styrby-shared|@supabase)/)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|native-base|react-native-svg|styrby-shared|@styrby/shared|@supabase)/)',
   ],
   setupFiles: ['./jest.setup.js'],
   collectCoverageFrom: [

--- a/packages/styrby-mobile/package.json
+++ b/packages/styrby-mobile/package.json
@@ -21,6 +21,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@sentry/react-native": "~6.6.0",
     "@expo/metro-runtime": "~4.0.0",
     "@expo/vector-icons": "~14.0.4",
     "@react-native-community/netinfo": "11.4.1",

--- a/packages/styrby-mobile/src/observability/__tests__/sentry.test.ts
+++ b/packages/styrby-mobile/src/observability/__tests__/sentry.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for mobile Sentry initialization.
+ *
+ * @sentry/react-native is mocked entirely — no real SDK calls, no network.
+ * Tests verify: mute switch, noise filter, __DEV__ gate, adapter factory.
+ *
+ * WHY overrides parameter instead of process.env:
+ * Expo's `babel-preset-expo` applies `babel-plugin-transform-inline-
+ * environment-variables`, which inlines `process.env.EXPO_PUBLIC_*` values at
+ * Babel transform / cache time. Mutating process.env between Jest tests has no
+ * effect because the compiled code already has the values baked in.
+ *
+ * `initMobileSentry` accepts an optional `overrides` parameter that lets test
+ * code inject DSN, mute-switch, and dev-flag values without relying on
+ * compile-time env var inlining.
+ */
+
+jest.mock('@sentry/react-native', () => ({
+  init: jest.fn(),
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn().mockReturnValue('fake-event-id'),
+}));
+
+// We also mock @styrby/shared/logging to avoid pulling in the real logger.
+jest.mock('@styrby/shared/logging', () => ({
+  Logger: jest.fn().mockImplementation(() => ({})),
+}));
+
+import { initMobileSentry, getMobileSentryAdapter } from '../sentry';
+
+// Retrieve bound mock references after registration.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const SentryMock = jest.requireMock('@sentry/react-native') as {
+  init: jest.Mock;
+  addBreadcrumb: jest.Mock;
+  captureException: jest.Mock;
+};
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('initMobileSentry', () => {
+  it('calls Sentry.init with the provided DSN', () => {
+    initMobileSentry({ dsn: 'https://key@sentry.io/456', isDev: false, muted: false });
+
+    expect(SentryMock.init).toHaveBeenCalledWith(
+      expect.objectContaining({ dsn: 'https://key@sentry.io/456' })
+    );
+  });
+
+  it('sets enabled=false when muted=true', () => {
+    initMobileSentry({ dsn: 'https://key@sentry.io/1', muted: true, isDev: false });
+
+    const { enabled } = SentryMock.init.mock.calls[0][0] as { enabled: boolean };
+    expect(enabled).toBe(false);
+  });
+
+  it('sets enabled=false when isDev=true', () => {
+    initMobileSentry({ dsn: 'https://key@sentry.io/1', isDev: true, muted: false });
+
+    const { enabled } = SentryMock.init.mock.calls[0][0] as { enabled: boolean };
+    expect(enabled).toBe(false);
+  });
+
+  it('sets enabled=true in production build when not muted', () => {
+    initMobileSentry({ dsn: 'https://key@sentry.io/1', isDev: false, muted: false });
+
+    const { enabled } = SentryMock.init.mock.calls[0][0] as { enabled: boolean };
+    expect(enabled).toBe(true);
+  });
+
+  it('passes beforeSend that drops ResizeObserver noise', () => {
+    initMobileSentry({ isDev: false, muted: false });
+
+    const { beforeSend } = SentryMock.init.mock.calls[0][0] as {
+      beforeSend: (event: Record<string, unknown>, hint: { originalException?: Error }) => unknown;
+    };
+
+    const noiseEvent = { message: '' };
+    const noiseHint = { originalException: new Error('ResizeObserver loop limit exceeded') };
+    expect(beforeSend(noiseEvent, noiseHint)).toBeNull();
+  });
+
+  it('passes beforeSend that allows real errors through', () => {
+    initMobileSentry({ isDev: false, muted: false });
+
+    const { beforeSend } = SentryMock.init.mock.calls[0][0] as {
+      beforeSend: (event: Record<string, unknown>, hint: { originalException?: Error }) => unknown;
+    };
+
+    const realEvent = { message: 'session relay error' };
+    const realHint = { originalException: new Error('session relay error') };
+    expect(beforeSend(realEvent, realHint)).toBe(realEvent);
+  });
+});
+
+describe('getMobileSentryAdapter', () => {
+  it('returns an adapter with addBreadcrumb and captureException', () => {
+    const adapter = getMobileSentryAdapter();
+    expect(typeof adapter.addBreadcrumb).toBe('function');
+    expect(typeof adapter.captureException).toBe('function');
+  });
+
+  it('addBreadcrumb delegates to Sentry.addBreadcrumb', () => {
+    const adapter = getMobileSentryAdapter();
+    const bc = { level: 'warning' as const, message: 'relay reconnecting' };
+    adapter.addBreadcrumb(bc);
+    expect(SentryMock.addBreadcrumb).toHaveBeenCalledWith(bc);
+  });
+
+  it('captureException delegates to Sentry.captureException', () => {
+    const adapter = getMobileSentryAdapter();
+    const err = new Error('crash');
+    const id = adapter.captureException(err);
+    expect(SentryMock.captureException).toHaveBeenCalledWith(err, undefined);
+    expect(id).toBe('fake-event-id');
+  });
+});

--- a/packages/styrby-mobile/src/observability/sentry.ts
+++ b/packages/styrby-mobile/src/observability/sentry.ts
@@ -1,0 +1,149 @@
+/**
+ * Mobile Sentry Initialization
+ *
+ * Initialises `@sentry/react-native` for the Styrby mobile app. This module
+ * is imported in `app/_layout.tsx` before the navigation stack renders so
+ * that the SDK wraps React Native's error boundary and captures JS crashes
+ * that occur during the initial render cycle.
+ *
+ * WHY Sentry in the mobile app:
+ * Mobile crashes are silent from the founder's perspective. Sentry gives
+ * structured error reports with breadcrumbs from structured logger events
+ * that led up to the crash, with correlation to specific user/session/agent.
+ *
+ * WHY EXPO_PUBLIC_STYRBY_SENTRY_MUTED:
+ * Expo requires env vars consumed in the JS bundle to be prefixed EXPO_PUBLIC_.
+ * Toggle it in EAS secrets + trigger a new build to silence the SDK without a
+ * code change.
+ *
+ * WHY React Native-specific noise filters:
+ * The React Native / Hermes runtime emits a set of benign errors around layout
+ * measurement and async storage. We drop them at the beforeSend gate.
+ *
+ * @module observability/sentry
+ */
+
+import * as Sentry from '@sentry/react-native';
+import type { SentryAdapter } from '@styrby/shared/logging';
+
+// ============================================================================
+// Noise patterns — React Native / Hermes runtime specifics
+// ============================================================================
+
+/**
+ * Known-benign React Native error patterns to drop before reaching Sentry.
+ * - Non-Error promise rejection: Hermes surfaces bare-string Promise rejections.
+ * - ResizeObserver: RN web-compat polyfill — not actionable on native.
+ * - Invariant Violation: fires during fast-refresh hot reloads in development.
+ * - Cannot read property: Hermes layout-phase accesses handled internally.
+ */
+const NOISE_PATTERNS: readonly RegExp[] = [
+  /Non-Error promise rejection captured/i,
+  /ResizeObserver loop limit exceeded/i,
+  /Invariant Violation/i,
+  /SyntaxError.*require\(\)/i,
+  /Cannot read prop.*of null/i,
+  /The operation was aborted/i,
+];
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+/**
+ * Optional override config for testing.
+ *
+ * WHY: Expo's `babel-preset-expo` applies `babel-plugin-transform-inline-
+ * environment-variables` which inlines `process.env.EXPO_PUBLIC_*` references
+ * at Babel transform time. In Jest (and EAS Build), the compiled output has
+ * the values baked in from the time of compilation — changing `process.env`
+ * between test cases has no effect on already-transformed code.
+ *
+ * To keep the function testable we accept an optional overrides object so test
+ * suites can inject DSN and mute-switch values directly without relying on the
+ * inlined env vars.
+ */
+export interface MobileSentryInitOptions {
+  /** Override the DSN (test use only — normally baked in from EXPO_PUBLIC_SENTRY_DSN). */
+  dsn?: string;
+  /** Override the muted flag (test use only — normally from EXPO_PUBLIC_STYRBY_SENTRY_MUTED). */
+  muted?: boolean;
+  /** Override the dev flag (test use only — normally from __DEV__ global). */
+  isDev?: boolean;
+}
+
+/**
+ * Initialise the Sentry React Native SDK.
+ *
+ * Call ONCE at the TOP of `app/_layout.tsx` before any JSX renders. The RN SDK
+ * patches the global error handler and the React error boundary machinery —
+ * both must be in place before the first render cycle.
+ *
+ * @param overrides - Optional test overrides for env-var-derived values.
+ *
+ * @example
+ * ```ts
+ * import { initMobileSentry } from '../src/observability/sentry';
+ * initMobileSentry();
+ * ```
+ */
+export function initMobileSentry(overrides?: MobileSentryInitOptions): void {
+  /**
+   * EXPO_PUBLIC_SENTRY_DSN — the mobile app's Sentry Data Source Name.
+   * Source: sentry.io > Project Settings > Client Keys (DSN)
+   * Set via: EAS secrets as EXPO_PUBLIC_SENTRY_DSN (bundled at build time).
+   * Behavior when missing: SDK silently disables itself.
+   */
+  const dsn = overrides?.dsn ?? process.env.EXPO_PUBLIC_SENTRY_DSN;
+
+  /**
+   * Mute switch: EXPO_PUBLIC_STYRBY_SENTRY_MUTED=true in EAS secrets silences the SDK.
+   */
+  const muted = overrides?.muted ?? process.env.EXPO_PUBLIC_STYRBY_SENTRY_MUTED === 'true';
+
+  /**
+   * WHY __DEV__: React Native exposes `__DEV__` as a global boolean that is
+   * true when running via `expo start` / Metro development server.
+   */
+  const isDev = overrides?.isDev ?? (typeof __DEV__ !== 'undefined' ? __DEV__ : false);
+
+  Sentry.init({
+    dsn,
+    tracesSampleRate: 0.1,
+    /** Enable only on production builds AND when not muted. */
+    enabled: !isDev && !muted,
+    environment: isDev ? 'development' : 'production',
+    beforeSend(event, hint) {
+      const msg =
+        (hint?.originalException instanceof Error
+          ? hint.originalException.message
+          : '') ||
+        (event.message as string | undefined) ||
+        '';
+      if (NOISE_PATTERNS.some((rx) => rx.test(msg))) return null;
+      return event;
+    },
+    ignoreErrors: [
+      'Non-Error promise rejection captured',
+      /ResizeObserver loop limit exceeded/,
+      /Invariant Violation/,
+    ],
+  });
+}
+
+/**
+ * Returns a SentryAdapter wrapping @sentry/react-native for use with the Logger.
+ *
+ * WHY needed: The Logger lives in @styrby/shared and cannot import
+ * @sentry/react-native directly. This factory creates a narrow adapter at
+ * the mobile boundary so the Logger can forward error/warn entries to Sentry.
+ *
+ * @returns SentryAdapter compatible with Logger.setSentry()
+ */
+export function getMobileSentryAdapter(): SentryAdapter {
+  return {
+    addBreadcrumb: (breadcrumb) => Sentry.addBreadcrumb(breadcrumb),
+    captureException: (error, context) =>
+      Sentry.captureException(error, context) ?? '',
+  };
+}

--- a/packages/styrby-mobile/tsconfig.json
+++ b/packages/styrby-mobile/tsconfig.json
@@ -23,7 +23,8 @@
       // (~700KB WASM) out of bundles that don't need crypto. Points at the
       // built dist file because the package's exports map uses that path.
       "styrby-shared/encryption": ["./node_modules/@styrby/shared/dist/encryption"],
-      "styrby-shared/*": ["./node_modules/@styrby/shared/*"]
+      "styrby-shared/*": ["./node_modules/@styrby/shared/*"],
+      "@styrby/shared/logging": ["./node_modules/@styrby/shared/dist/logging/index"]
     },
     "types": ["nativewind/types", "jest", "node"],
     // WHY typeRoots: The monorepo root node_modules may contain a hoisted

--- a/packages/styrby-shared/package.json
+++ b/packages/styrby-shared/package.json
@@ -48,6 +48,10 @@
     "./team": {
       "types": "./dist/team/index.d.ts",
       "import": "./dist/team/index.js"
+    },
+    "./logging": {
+      "types": "./dist/logging/index.d.ts",
+      "import": "./dist/logging/index.js"
     }
   },
   "scripts": {

--- a/packages/styrby-shared/src/logging/__tests__/structuredLogger.test.ts
+++ b/packages/styrby-shared/src/logging/__tests__/structuredLogger.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for the structured Logger class.
+ *
+ * All Sentry SDK calls are mocked via a SentryAdapter spy — no real network
+ * traffic is generated.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Logger, type SentryAdapter, type LogEntry } from '../structuredLogger.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Collect JSON-line output into an array of parsed entries. */
+function makeCollector(): { entries: LogEntry[]; writeFn: (line: string) => void } {
+  const entries: LogEntry[] = [];
+  return {
+    entries,
+    writeFn: (line: string) => entries.push(JSON.parse(line) as LogEntry),
+  };
+}
+
+/** Build a spy SentryAdapter. */
+function makeSentryAdapter(): SentryAdapter & {
+  breadcrumbs: Parameters<SentryAdapter['addBreadcrumb']>[0][];
+  captured: unknown[];
+} {
+  const breadcrumbs: Parameters<SentryAdapter['addBreadcrumb']>[0][] = [];
+  const captured: unknown[] = [];
+  return {
+    breadcrumbs,
+    captured,
+    addBreadcrumb: (b) => { breadcrumbs.push(b); },
+    captureException: (e) => { captured.push(e); return 'fake-id'; },
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Logger', () => {
+  describe('output format', () => {
+    it('emits JSON-line entries with required fields', () => {
+      const { entries, writeFn } = makeCollector();
+      const log = new Logger({ writeFn });
+
+      log.info('hello world', { userId: 'u1' });
+
+      expect(entries).toHaveLength(1);
+      const [entry] = entries;
+      expect(entry.level).toBe('info');
+      expect(entry.message).toBe('hello world');
+      expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(entry.context.userId).toBe('u1');
+      expect(typeof entry.context.traceId).toBe('string');
+    });
+
+    it('auto-generates a stable traceId for the instance lifetime', () => {
+      const { entries, writeFn } = makeCollector();
+      const log = new Logger({ writeFn });
+
+      log.info('a');
+      log.info('b');
+
+      expect(entries[0].context.traceId).toBe(entries[1].context.traceId);
+    });
+
+    it('accepts caller-provided traceId and propagates it', () => {
+      const { entries, writeFn } = makeCollector();
+      const log = new Logger({ writeFn });
+
+      log.info('traced', { traceId: 'my-trace' });
+
+      expect(entries[0].context.traceId).toBe('my-trace');
+    });
+
+    it('emits all log levels: debug, info, warn, error', () => {
+      const { entries, writeFn } = makeCollector();
+      const log = new Logger({ writeFn, minLevel: 'debug' });
+
+      log.debug('d');
+      log.info('i');
+      log.warn('w');
+      log.error('e');
+
+      expect(entries.map((e) => e.level)).toEqual(['debug', 'info', 'warn', 'error']);
+    });
+  });
+
+  describe('minLevel filtering', () => {
+    it('drops entries below minLevel', () => {
+      const { entries, writeFn } = makeCollector();
+      const log = new Logger({ writeFn, minLevel: 'info' });
+
+      log.debug('ignored');
+      log.info('kept');
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].message).toBe('kept');
+    });
+
+    it('emits exactly at minLevel', () => {
+      const { entries, writeFn } = makeCollector();
+      const log = new Logger({ writeFn, minLevel: 'warn' });
+
+      log.warn('at boundary');
+      log.error('above');
+
+      expect(entries).toHaveLength(2);
+    });
+  });
+
+  describe('Sentry integration', () => {
+    it('sends error() to captureException', () => {
+      const { entries, writeFn } = makeCollector();
+      const sentry = makeSentryAdapter();
+      const log = new Logger({ writeFn, sentry });
+      const err = new Error('boom');
+
+      log.error('something broke', { sessionId: 's1' }, err);
+
+      expect(sentry.captured).toHaveLength(1);
+      expect(sentry.captured[0]).toBe(err);
+      // Log entry still emitted
+      expect(entries[0].level).toBe('error');
+    });
+
+    it('wraps non-Error in new Error when capturing to Sentry', () => {
+      const { writeFn } = makeCollector();
+      const sentry = makeSentryAdapter();
+      const log = new Logger({ writeFn, sentry });
+
+      log.error('plain string error', {}, 'something');
+
+      expect(sentry.captured[0]).toBeInstanceOf(Error);
+    });
+
+    it('sends warn() to addBreadcrumb with level "warning"', () => {
+      const { writeFn } = makeCollector();
+      const sentry = makeSentryAdapter();
+      const log = new Logger({ writeFn, sentry });
+
+      log.warn('reconnecting', { machineId: 'm1' });
+
+      expect(sentry.breadcrumbs).toHaveLength(1);
+      expect(sentry.breadcrumbs[0].level).toBe('warning');
+      expect(sentry.breadcrumbs[0].message).toBe('reconnecting');
+    });
+
+    it('does NOT send info() or debug() to Sentry', () => {
+      const { writeFn } = makeCollector();
+      const sentry = makeSentryAdapter();
+      const log = new Logger({ writeFn, sentry, minLevel: 'debug' });
+
+      log.debug('debug msg');
+      log.info('info msg');
+
+      expect(sentry.breadcrumbs).toHaveLength(0);
+      expect(sentry.captured).toHaveLength(0);
+    });
+
+    it('is silent when no sentry adapter provided', () => {
+      const { writeFn } = makeCollector();
+      const log = new Logger({ writeFn });
+
+      // Must not throw even though no Sentry adapter
+      expect(() => {
+        log.error('no sentry', {}, new Error('x'));
+        log.warn('also no sentry');
+      }).not.toThrow();
+    });
+
+    it('setSentry() wires in a Sentry adapter after construction', () => {
+      const { writeFn } = makeCollector();
+      const log = new Logger({ writeFn });
+      const sentry = makeSentryAdapter();
+
+      // Before wiring — no calls
+      log.error('before', {}, new Error('before'));
+      expect(sentry.captured).toHaveLength(0);
+
+      // After wiring — should capture
+      log.setSentry(sentry);
+      log.error('after', {}, new Error('after'));
+      expect(sentry.captured).toHaveLength(1);
+    });
+
+    it('swallows Sentry failures silently', () => {
+      const { writeFn } = makeCollector();
+      const brokeSentry: SentryAdapter = {
+        addBreadcrumb: () => { throw new Error('sentry down'); },
+        captureException: () => { throw new Error('sentry down'); },
+      };
+      const log = new Logger({ writeFn, sentry: brokeSentry });
+
+      // Must not throw
+      expect(() => {
+        log.warn('warn during sentry outage');
+        log.error('error during sentry outage', {}, new Error('x'));
+      }).not.toThrow();
+    });
+  });
+
+  describe('correlation fields', () => {
+    it('includes all standard correlation fields in context', () => {
+      const { entries, writeFn } = makeCollector();
+      const log = new Logger({ writeFn });
+
+      log.info('session started', {
+        sessionId: 'sess-1',
+        userId: 'user-1',
+        machineId: 'machine-1',
+        agent: 'claude',
+      });
+
+      const ctx = entries[0].context;
+      expect(ctx.sessionId).toBe('sess-1');
+      expect(ctx.userId).toBe('user-1');
+      expect(ctx.machineId).toBe('machine-1');
+      expect(ctx.agent).toBe('claude');
+    });
+
+    it('getTraceId() returns the instance trace ID', () => {
+      const log = new Logger();
+      expect(typeof log.getTraceId()).toBe('string');
+      expect(log.getTraceId().length).toBeGreaterThan(10);
+    });
+  });
+
+  describe('write failures', () => {
+    it('silently swallows errors from the write function', () => {
+      const log = new Logger({ writeFn: () => { throw new Error('disk full'); } });
+      expect(() => log.info('msg')).not.toThrow();
+    });
+  });
+});

--- a/packages/styrby-shared/src/logging/index.ts
+++ b/packages/styrby-shared/src/logging/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Structured logging module.
+ * Re-exports the Logger class and all associated types.
+ */
+export {
+  Logger,
+  type LogLevel,
+  type LogContext,
+  type LogEntry,
+  type LoggerOptions,
+  type SentryAdapter,
+} from './structuredLogger.js';

--- a/packages/styrby-shared/src/logging/structuredLogger.ts
+++ b/packages/styrby-shared/src/logging/structuredLogger.ts
@@ -1,0 +1,354 @@
+/**
+ * Structured Logger
+ *
+ * Platform-agnostic JSON-line logger consumed by styrby-cli, styrby-web, and
+ * styrby-mobile. Each log entry is a single JSON object written to stdout so
+ * that log aggregators (Papertrail, Datadog, CloudWatch) can parse structured
+ * fields without regex fragility.
+ *
+ * WHY JSON lines instead of pretty-print:
+ * Structured logs let the founder dashboard correlate errors to specific
+ * sessions, users, machines, and agents. Human-readable logs look great in
+ * a terminal but are nearly impossible to query at scale. JSON lines give
+ * us both — parseable by log aggregators AND readable in a terminal with `jq`.
+ *
+ * WHY a shared Logger vs. per-package loggers:
+ * All three surfaces (CLI, web, mobile) need the same correlation ID fields
+ * (sessionId, userId, machineId, agent, traceId). A single class keeps the
+ * schema consistent so the founder dashboard can JOIN on those fields without
+ * knowing which surface emitted the log.
+ *
+ * WHY error/warn go to Sentry while info/debug stay log-only:
+ * info and debug are high-volume diagnostic signals. Sending them to Sentry
+ * would exhaust quota with noise and obscure actionable error/warn events.
+ * Only error and warn represent conditions the founder must be aware of.
+ *
+ * @module logging/structuredLogger
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Log severity levels, ordered from least to most severe. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * Correlation context attached to every log entry.
+ * All fields are optional — callers provide as many as are relevant.
+ */
+export interface LogContext {
+  /** Active Styrby session UUID (from sessions table). */
+  sessionId?: string;
+  /** Supabase auth user UUID. */
+  userId?: string;
+  /** Registered machine UUID (from machines table). */
+  machineId?: string;
+  /** AI agent identifier ('claude' | 'codex' | 'gemini' | etc.). */
+  agent?: string;
+  /**
+   * Distributed trace identifier.
+   *
+   * WHY: A single user action (e.g. start session) can touch CLI → Supabase →
+   * Edge Function → mobile push. A traceId threaded through all log entries
+   * for that action lets the founder correlate what happened across surfaces
+   * in a single query. If the caller doesn't provide one, the logger generates
+   * a UUID per Logger instance.
+   */
+  traceId?: string;
+  /** Any additional key-value pairs for ad-hoc context. */
+  [key: string]: unknown;
+}
+
+/** A single structured log entry as written to stdout. */
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  context: LogContext & { traceId: string };
+}
+
+// ============================================================================
+// Sentry Breadcrumb Interface
+// ============================================================================
+
+/**
+ * Minimal interface for Sentry breadcrumb/capture methods.
+ *
+ * WHY a local interface instead of importing @sentry/*:
+ * structuredLogger lives in @styrby/shared and must be importable in ALL three
+ * environments without pulling in a platform-specific Sentry SDK. Callers wire
+ * their platform SDK in at construction time via the `sentry` option. The
+ * interface is narrow enough that all three SDKs satisfy it without casting.
+ */
+export interface SentryAdapter {
+  addBreadcrumb(breadcrumb: {
+    level: 'info' | 'warning' | 'error';
+    message: string;
+    data?: Record<string, unknown>;
+    timestamp?: number;
+  }): void;
+
+  captureException(
+    error: unknown,
+    captureContext?: {
+      extra?: Record<string, unknown>;
+      tags?: Record<string, string>;
+    },
+  ): string;
+}
+
+// ============================================================================
+// Logger Options
+// ============================================================================
+
+/** Configuration passed to the Logger constructor. */
+export interface LoggerOptions {
+  /**
+   * Minimum severity to emit. Entries below this level are silently dropped.
+   * Defaults to 'debug'.
+   */
+  minLevel?: LogLevel;
+
+  /**
+   * Optional Sentry adapter.
+   * When provided, `error` entries are captured as Sentry exceptions and
+   * `warn` entries are added as Sentry breadcrumbs.
+   */
+  sentry?: SentryAdapter;
+
+  /**
+   * Default trace ID for all entries emitted by this instance.
+   * If omitted, the logger auto-generates a UUID.
+   */
+  traceId?: string;
+
+  /**
+   * Custom write function. Defaults to process.stdout.write (Node) or
+   * console.log (React Native / browser).
+   * WHY injectable: makes unit testing zero-dependency.
+   */
+  writeFn?: (line: string) => void;
+}
+
+// ============================================================================
+// Level Constants
+// ============================================================================
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+// ============================================================================
+// Logger Class
+// ============================================================================
+
+/**
+ * Structured JSON-line logger for Styrby.
+ *
+ * All three packages import this class from `@styrby/shared/logging` and wire
+ * in their platform's Sentry SDK at app startup. Log entries are emitted as
+ * newline-delimited JSON to stdout and, for error/warn, forwarded to Sentry.
+ *
+ * @example CLI usage
+ * ```ts
+ * import { Logger } from '@styrby/shared/logging';
+ * import * as Sentry from '@sentry/node';
+ * export const log = new Logger({ sentry: Sentry, minLevel: 'info' });
+ * log.info('session started', { sessionId, userId, agent });
+ * log.error('relay disconnected', { sessionId }, new Error('ECONNRESET'));
+ * ```
+ */
+export class Logger {
+  private readonly instanceTraceId: string;
+  private readonly minLevel: LogLevel;
+  private sentry: SentryAdapter | undefined;
+  private readonly writeFn: (line: string) => void;
+
+  constructor(options: LoggerOptions = {}) {
+    this.instanceTraceId = options.traceId ?? generateTraceId();
+    this.minLevel = options.minLevel ?? 'debug';
+    this.sentry = options.sentry;
+    this.writeFn = options.writeFn ?? defaultWrite;
+  }
+
+  /**
+   * Log a debug-level entry (development/troubleshooting signals).
+   *
+   * @param message - Human-readable summary
+   * @param context - Correlation fields (sessionId, userId, etc.)
+   */
+  debug(message: string, context: LogContext = {}): void {
+    this.emit('debug', message, context);
+  }
+
+  /**
+   * Log an informational entry (normal operational events).
+   *
+   * @param message - Human-readable summary
+   * @param context - Correlation fields
+   */
+  info(message: string, context: LogContext = {}): void {
+    this.emit('info', message, context);
+  }
+
+  /**
+   * Log a warning and forward to Sentry as a breadcrumb.
+   *
+   * WHY breadcrumb not exception: a warn is degraded-but-recoverable.
+   * It should appear in Sentry's breadcrumb trail for context when a
+   * subsequent error event arrives, but not generate its own alert.
+   *
+   * @param message - Human-readable summary
+   * @param context - Correlation fields
+   */
+  warn(message: string, context: LogContext = {}): void {
+    this.emit('warn', message, context);
+    this.sentryBreadcrumb('warning', message, context);
+  }
+
+  /**
+   * Log an error and capture it in Sentry as a full exception event.
+   *
+   * @param message - Human-readable summary
+   * @param context - Correlation fields
+   * @param error - Optional Error object (stack trace forwarded to Sentry)
+   */
+  error(message: string, context: LogContext = {}, error?: Error | unknown): void {
+    this.emit('error', message, context);
+    this.sentryCapture(message, context, error);
+  }
+
+  /**
+   * Wire in a Sentry adapter after construction.
+   *
+   * WHY needed: on React Native, Sentry must be initialised before the JS
+   * bundle evaluates most modules, but a logger instance may be created before
+   * Sentry.init() returns. This lets callers late-bind the adapter.
+   *
+   * @param adapter - Platform Sentry SDK satisfying SentryAdapter
+   */
+  setSentry(adapter: SentryAdapter): void {
+    this.sentry = adapter;
+  }
+
+  /**
+   * Returns the auto-generated trace ID for this Logger instance.
+   */
+  getTraceId(): string {
+    return this.instanceTraceId;
+  }
+
+  // --------------------------------------------------------------------------
+  // Private helpers
+  // --------------------------------------------------------------------------
+
+  private emit(level: LogLevel, message: string, context: LogContext): void {
+    if (LEVEL_ORDER[level] < LEVEL_ORDER[this.minLevel]) return;
+
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      context: {
+        ...context,
+        traceId: context.traceId ?? this.instanceTraceId,
+      },
+    };
+
+    try {
+      this.writeFn(JSON.stringify(entry) + '\n');
+    } catch {
+      // Never let logging failures crash the process.
+    }
+  }
+
+  private sentryBreadcrumb(
+    level: 'info' | 'warning' | 'error',
+    message: string,
+    context: LogContext,
+  ): void {
+    if (!this.sentry) return;
+    try {
+      this.sentry.addBreadcrumb({
+        level,
+        message,
+        data: context as Record<string, unknown>,
+        timestamp: Date.now() / 1000,
+      });
+    } catch {
+      // Sentry failure must never crash the caller.
+    }
+  }
+
+  private sentryCapture(
+    message: string,
+    context: LogContext,
+    error?: Error | unknown,
+  ): void {
+    if (!this.sentry) return;
+    try {
+      const captureTarget =
+        error instanceof Error ? error : new Error(message);
+      this.sentry.captureException(captureTarget, {
+        extra: context as Record<string, unknown>,
+        tags: buildSentryTags(context),
+      });
+    } catch {
+      // Sentry failure must never crash the caller.
+    }
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Generate a UUID v4 trace identifier.
+ * Uses crypto.randomUUID when available, falls back to Math.random for
+ * very old React Native builds.
+ */
+function generateTraceId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Extract well-known Sentry tag fields from a LogContext.
+ * Tags must be strings in Sentry, so we coerce and omit non-string values.
+ */
+function buildSentryTags(context: LogContext): Record<string, string> {
+  const tags: Record<string, string> = {};
+  if (typeof context.sessionId === 'string') tags['session_id'] = context.sessionId;
+  if (typeof context.userId === 'string') tags['user_id'] = context.userId;
+  if (typeof context.machineId === 'string') tags['machine_id'] = context.machineId;
+  if (typeof context.agent === 'string') tags['agent'] = context.agent;
+  if (typeof context.traceId === 'string') tags['trace_id'] = context.traceId;
+  return tags;
+}
+
+/**
+ * Default write function — uses process.stdout when available (Node/CLI),
+ * falls back to console.log (browser/React Native).
+ */
+function defaultWrite(line: string): void {
+  if (
+    typeof process !== 'undefined' &&
+    process.stdout &&
+    typeof process.stdout.write === 'function'
+  ) {
+    process.stdout.write(line);
+  } else {
+    console.log(line.trimEnd());
+  }
+}

--- a/packages/styrby-web/src/app/api/auth/passkey/verify/route.ts
+++ b/packages/styrby-web/src/app/api/auth/passkey/verify/route.ts
@@ -31,6 +31,22 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { rateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { Logger } from '@styrby/shared/logging';
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * Structured logger for passkey auth flow events.
+ * WHY: Passkey verification failures are security-relevant events (SOC2 CC6.6).
+ * Structured logs let the founder detect brute-force patterns or edge function
+ * regressions without waiting for user-reported breakage.
+ */
+const authLog = new Logger({
+  minLevel: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+  sentry: {
+    addBreadcrumb: (b) => Sentry.addBreadcrumb(b),
+    captureException: (e, ctx) => Sentry.captureException(e, ctx) ?? '',
+  },
+});
 
 /**
  * Tight rate-limit for passkey verification.
@@ -107,6 +123,11 @@ export async function POST(request: NextRequest) {
       body: JSON.stringify(body),
     });
   } catch (err) {
+    authLog.error(
+      'auth.passkey_edge_unreachable',
+      { action: String(action) },
+      err instanceof Error ? err : new Error(String(err)),
+    );
     console.error('[passkey/verify] Edge function unreachable:', err);
     return NextResponse.json(
       { error: 'EDGE_FUNCTION_ERROR', message: 'Passkey service temporarily unavailable' },
@@ -115,6 +136,16 @@ export async function POST(request: NextRequest) {
   }
 
   const responseBody = await edgeResponse.text();
+
+  if (edgeResponse.status >= 400) {
+    authLog.warn('auth.passkey_verify_failed', {
+      action: String(action),
+      status: edgeResponse.status,
+    });
+  } else {
+    authLog.info('auth.passkey_verify_success', { action: String(action) });
+  }
+
   return new NextResponse(responseBody, {
     status: edgeResponse.status,
     headers: { 'Content-Type': 'application/json' },

--- a/packages/styrby-web/src/app/api/push/subscribe/route.ts
+++ b/packages/styrby-web/src/app/api/push/subscribe/route.ts
@@ -31,6 +31,21 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { z } from 'zod';
 import { rateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { Logger } from '@styrby/shared/logging';
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * Structured logger for push subscription events.
+ * WHY: Push delivery failures are silent from the user's perspective.
+ * Structured logs let the founder correlate failures to specific users.
+ */
+const pushLog = new Logger({
+  minLevel: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+  sentry: {
+    addBreadcrumb: (b) => Sentry.addBreadcrumb(b),
+    captureException: (e, ctx) => Sentry.captureException(e, ctx) ?? '',
+  },
+});
 
 // ============================================================================
 // Push Service Allowlist
@@ -184,6 +199,7 @@ export async function POST(request: NextRequest) {
       );
 
     if (upsertError) {
+      pushLog.error('push.subscribe_upsert_failed', { userId: user.id }, new Error(upsertError.message));
       console.error(
         'Failed to save push subscription:',
         upsertError.message
@@ -194,8 +210,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    pushLog.info('push.subscribed', { userId: user.id, platform: 'web' });
     return NextResponse.json({ success: true }, { status: 201 });
   } catch (error) {
+    pushLog.error(
+      'push.subscribe_unhandled_error',
+      {},
+      error instanceof Error ? error : new Error(String(error)),
+    );
     const isDev = process.env.NODE_ENV === 'development';
     console.error(
       'Push subscribe error:',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.28.0
         version: 1.28.0(zod@3.25.76)
+      '@sentry/node':
+        specifier: ^8.55.0
+        version: 8.55.1
       '@stablelib/base64':
         specifier: ^2.0.1
         version: 2.0.1
@@ -147,6 +150,9 @@ importers:
       '@react-navigation/native':
         specifier: ^7.0.0
         version: 7.1.28(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      '@sentry/react-native':
+        specifier: ~6.6.0
+        version: 6.6.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       '@styrby/shared':
         specifier: workspace:*
         version: link:../styrby-shared
@@ -2868,13 +2874,37 @@ packages:
     resolution: {integrity: sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.53.0':
+    resolution: {integrity: sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api-logs@0.57.1':
+    resolution: {integrity: sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/context-async-hooks@2.6.1':
     resolution: {integrity: sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
@@ -2890,9 +2920,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/instrumentation-amqplib@0.46.1':
+    resolution: {integrity: sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-amqplib@0.60.0':
     resolution: {integrity: sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.43.0':
+    resolution: {integrity: sha512-Q57JGpH6T4dkYHo9tKXONgLtxzsh1ZEW5M9A/OwKrZFyEpLqWgjhcZ3hIuVvDlhb426iDF1f9FPToV/mi5rpeA==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -2902,9 +2944,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-dataloader@0.16.0':
+    resolution: {integrity: sha512-88+qCHZC02up8PwKHk0UQKLLqGGURzS3hFQBZC7PnGwReuoKjHXS1o29H58S+QkXJpkTr2GACbx8j6mUoGjNPA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-dataloader@0.30.0':
     resolution: {integrity: sha512-MXHP2Q38cd2OhzEBKAIXUi9uBlPEYzF6BNJbyjUXBQ6kLaf93kRC41vNMIz0Nl5mnuwK7fDvKT+/lpx7BXRwdg==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-express@0.47.0':
+    resolution: {integrity: sha512-XFWVx6k0XlU8lu6cBlCa29ONtVt6ADEjmxtyAyeF2+rifk8uBJbk1La0yIVfI0DoKURGbaEDTNelaXG9l/lNNQ==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -2914,9 +2968,27 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-fastify@0.44.1':
+    resolution: {integrity: sha512-RoVeMGKcNttNfXMSl6W4fsYoCAYP1vi6ZAWIGhBY+o7R9Y0afA7f9JJL0j8LHbyb0P0QhSYk+6O56OwI2k4iRQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.19.0':
+    resolution: {integrity: sha512-JGwmHhBkRT2G/BYNV1aGI+bBjJu4fJUD/5/Jat0EWZa2ftrLV3YE8z84Fiij/wK32oMZ88eS8DI4ecLGZhpqsQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-fs@0.32.0':
     resolution: {integrity: sha512-koR6apx0g0wX6RRiPpjA4AFQUQUbXrK16kq4/SZjVp7u5cffJhNkY4TnITxcGA4acGSPYAfx3NHRIv4Khn1axQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.43.0':
+    resolution: {integrity: sha512-at8GceTtNxD1NfFKGAuwtqM41ot/TpcLh+YsGe4dhf7gvv1HW/ZWdq6nfRtS6UjIvZJOokViqLPJ3GVtZItAnQ==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -2926,9 +2998,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-graphql@0.47.0':
+    resolution: {integrity: sha512-Cc8SMf+nLqp0fi8oAnooNEfwZWFnzMiBHCGmDFYqmgjPylyLmi83b+NiTns/rKGwlErpW0AGPt0sMpkbNlzn8w==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-graphql@0.61.0':
     resolution: {integrity: sha512-pUiVASv6nh2XrerTvlbVHh7vKFzscpgwiQ/xvnZuAIzQ5lRjWVdRPUuXbvZJ/Yq79QsE81TZdJ7z9YsXiss1ew==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.45.1':
+    resolution: {integrity: sha512-VH6mU3YqAKTePPfUPwfq4/xr049774qWtfTuJqVHoVspCLiT3bW+fCQ1toZxt6cxRPYASoYaBsMA3CWo8B8rcw==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -2944,6 +3028,18 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-http@0.57.1':
+    resolution: {integrity: sha512-ThLmzAQDs7b/tdKI3BV2+yawuF09jF111OFsovqT1Qj3D8vjwKBwhi/rDE5xethwn4tSXtZcJ9hBsVAlWFQZ7g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.47.0':
+    resolution: {integrity: sha512-4HqP9IBC8e7pW9p90P3q4ox0XlbLGme65YTrA3UTLvqvo4Z6b0puqZQP203YFu8m9rE/luLfaG7/xrwwqMUpJw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-ioredis@0.61.0':
     resolution: {integrity: sha512-hsHDadUtAFbws1YSDc1XW0svGFKiUbqv2td1Cby+UAiwvojm1NyBo/taifH0t8CuFZ0x/2SDm0iuTwrM5pnVOg==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2956,9 +3052,27 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-kafkajs@0.7.0':
+    resolution: {integrity: sha512-LB+3xiNzc034zHfCtgs4ITWhq6Xvdo8bsq7amR058jZlf2aXXDrN9SV4si4z2ya9QX4tz6r4eZJwDkXOp14/AQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.44.0':
+    resolution: {integrity: sha512-SlT0+bLA0Lg3VthGje+bSZatlGHw/vwgQywx0R/5u9QC59FddTQSPJeWNw29M6f8ScORMeUOOTwihlQAn4GkJQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-knex@0.57.0':
     resolution: {integrity: sha512-vMCSh8kolEm5rRsc+FZeTZymWmIJwc40hjIKnXH4O0Dv/gAkJJIRXCsPX5cPbe0c0j/34+PsENd0HqKruwhVYw==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.47.0':
+    resolution: {integrity: sha512-HFdvqf2+w8sWOuwtEXayGzdZ2vWpCKEQv5F7+2DSA74Te/Cv4rvb2E5So5/lh+ok4/RAIPuvCbCb/SHQFzMmbw==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -2968,9 +3082,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
+  '@opentelemetry/instrumentation-lru-memoizer@0.44.0':
+    resolution: {integrity: sha512-Tn7emHAlvYDFik3vGU0mdwvWJDwtITtkJ+5eT2cUquct6nIs+H8M47sqMJkCpyPe5QIBJoTOHxmc6mj9lz6zDw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-lru-memoizer@0.57.0':
     resolution: {integrity: sha512-cEqpUocSKJfwDtLYTTJehRLWzkZ2eoePCxfVIgGkGkb83fMB71O+y4MvRHJPbeV2bdoWdOVrl8uO0+EynWhTEA==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.51.0':
+    resolution: {integrity: sha512-cMKASxCX4aFxesoj3WK8uoQ0YUrRvnfxaO72QWI2xLu5ZtgX/QvdGBlU3Ehdond5eb74c2s1cqRQUIptBnKz1g==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -2980,9 +3106,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-mongoose@0.46.0':
+    resolution: {integrity: sha512-mtVv6UeaaSaWTeZtLo4cx4P5/ING2obSqfWGItIFSunQBrYROfhuVe7wdIrFUs2RH1tn2YYpAJyMaRe/bnTTIQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-mongoose@0.59.0':
     resolution: {integrity: sha512-6/jWU+c1NgznkVLDU/2y0bXV2nJo3o9FWZ9mZ9nN6T/JBNRoMnVXZl2FdBmgH+a5MwaWLs5kmRJTP5oUVGIkPw==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.45.0':
+    resolution: {integrity: sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -2992,9 +3130,27 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-mysql@0.45.0':
+    resolution: {integrity: sha512-tWWyymgwYcTwZ4t8/rLDfPYbOTF3oYB8SxnYMtIQ1zEf5uDm90Ku3i6U/vhaMyfHNlIHvDhvJh+qx5Nc4Z3Acg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-mysql@0.59.0':
     resolution: {integrity: sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-nestjs-core@0.44.0':
+    resolution: {integrity: sha512-t16pQ7A4WYu1yyQJZhRKIfUNvl5PAaF2pEteLvgJb/BWdd1oNuU1rOYt4S825kMy+0q4ngiX281Ss9qiwHfxFQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.50.0':
+    resolution: {integrity: sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -3004,9 +3160,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-redis-4@0.46.0':
+    resolution: {integrity: sha512-aTUWbzbFMFeRODn3720TZO0tsh/49T8H3h8vVnVKJ+yE36AeW38Uj/8zykQ/9nO8Vrtjr5yKuX3uMiG/W8FKNw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation-redis@0.61.0':
     resolution: {integrity: sha512-JnPexA034/0UJRsvH96B0erQoNOqKJZjE2ZRSw9hiTSC23LzE0nJE/u6D+xqOhgUhRnhhcPHq4MdYtmUdYTF+Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.18.0':
+    resolution: {integrity: sha512-9zhjDpUDOtD+coeADnYEJQ0IeLVCj7w/hqzIutdp5NqS1VqTAanaEfsEcSypyvYv5DX3YOsTUoF+nr2wDXPETA==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -3015,6 +3183,12 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.10.0':
+    resolution: {integrity: sha512-vm+V255NGw9gaSsPD6CP0oGo8L55BffBc8KnxqsMuc6XiAD1L8SFNzsW0RHhxJFqy9CJaJh+YiJ5EHXuZ5rZBw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
 
   '@opentelemetry/instrumentation-undici@0.23.0':
     resolution: {integrity: sha512-LL0VySzKVR2cJSFVZaTYpZl1XTpBGnfzoQPe2W7McS2267ldsaEIqtQY6VXs2KCXN0poFjze5110PIpxHDaDGg==}
@@ -3040,9 +3214,37 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation@0.53.0':
+    resolution: {integrity: sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.57.1':
+    resolution: {integrity: sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.57.2':
+    resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/redis-common@0.36.2':
+    resolution: {integrity: sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/redis-common@0.38.2':
     resolution: {integrity: sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==}
     engines: {node: ^18.19.0 || >=20.6.0}
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/resources@2.6.1':
     resolution: {integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==}
@@ -3050,15 +3252,35 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@2.6.1':
     resolution: {integrity: sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
+  '@opentelemetry/semantic-conventions@1.27.0':
+    resolution: {integrity: sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
+
+  '@opentelemetry/sql-common@0.40.1':
+    resolution: {integrity: sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
 
   '@opentelemetry/sql-common@0.41.2':
     resolution: {integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==}
@@ -3084,6 +3306,9 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
+
+  '@prisma/instrumentation@5.22.0':
+    resolution: {integrity: sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==}
 
   '@prisma/instrumentation@7.4.2':
     resolution: {integrity: sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==}
@@ -4518,17 +4743,37 @@ packages:
     resolution: {integrity: sha512-WB1gBT9G13V02ekZ6NpUhoI1aGHV2eNfjEPthkU2bGBvFpQKnstwzjg7waIRGR7cu+YSW2Q6UI6aQLgBeOPD1g==}
     engines: {node: '>=18'}
 
+  '@sentry-internal/browser-utils@8.53.0':
+    resolution: {integrity: sha512-TmW/UFtVm1I9tCCtRIGO3chuCVFE3jxOoV/q1HYiB+5rYk3ljVFxkUoch83IVMLJWz2hZtagKDaFoPhq65KSyQ==}
+    engines: {node: '>=14.18'}
+
   '@sentry-internal/feedback@10.46.0':
     resolution: {integrity: sha512-c4pI/z9nZCQXe9GYEw/hE/YTY9AxGBp8/wgKI+T8zylrN35SGHaXv63szzE1WbI8lacBY8lBF7rstq9bQVCaHw==}
     engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@8.53.0':
+    resolution: {integrity: sha512-ZGqcxExSlezdy6gPu7ztvfrrgeUYYxvl90SC5cnNSAduNH4uHGySmYVLmCpz3HLkkYRGX7Na21A7Gx6ZLXLygw==}
+    engines: {node: '>=14.18'}
 
   '@sentry-internal/replay-canvas@10.46.0':
     resolution: {integrity: sha512-ub314MWUsekVCuoH0/HJbbimlI24SkV745UW2pj9xRbxOAEf1wjkmIzxKrMDbTgJGuEunug02XZVdJFJUzOcDw==}
     engines: {node: '>=18'}
 
+  '@sentry-internal/replay-canvas@8.53.0':
+    resolution: {integrity: sha512-DvXf+gutg31O+VyuMhPIPF8wbWLrtWsyn+6npE32SdThRKp4YJdXdWRtinI9Y5VN0AR89saX2zFNqzCySzFZ7Q==}
+    engines: {node: '>=14.18'}
+
   '@sentry-internal/replay@10.46.0':
     resolution: {integrity: sha512-JBsWeXG6bRbxBFK8GzWymWGOB9QE7Kl57BeF3jzgdHTuHSWZ2mRnAmb1K05T4LU+gVygk6yW0KmdC8Py9Qzg9A==}
     engines: {node: '>=18'}
+
+  '@sentry-internal/replay@8.53.0':
+    resolution: {integrity: sha512-aFhJYK2Ky1ByIXooYep13skE8yaHtEIfjA0cFY6UsU9nDR3woxv3CtXOH+le2y9lmZSbNNFcpFfAGEMgryM8zQ==}
+    engines: {node: '>=14.18'}
+
+  '@sentry/babel-plugin-component-annotate@2.20.1':
+    resolution: {integrity: sha512-4mhEwYTK00bIb5Y9UWIELVUfru587Vaeg0DQGswv4aIRHIiMKLyNqCEejaaybQ/fNChIZOKmvyqXk430YVd7Qg==}
+    engines: {node: '>= 14'}
 
   '@sentry/babel-plugin-component-annotate@5.1.1':
     resolution: {integrity: sha512-x2wEpBHwsTyTF2rWsLKJlzrRF1TTIGOfX+ngdE+Yd5DBkoS58HwQv824QOviPGQRla4/ypISqAXzjdDPL/zalg==}
@@ -4538,14 +4783,29 @@ packages:
     resolution: {integrity: sha512-80DmGlTk5Z2/OxVOzLNxwolMyouuAYKqG8KUcoyintZqHbF6kO1RulI610HmyUt3OagKeBCqt9S7w0VIfCRL+Q==}
     engines: {node: '>=18'}
 
+  '@sentry/browser@8.53.0':
+    resolution: {integrity: sha512-EUipXIq5Os5w1o17AAMg5Uy9wC2ah7WYbaBZjAyaxdXF7sMWF1OWwUo7BZxbYF44nvxZ69j+pjBKwqicjiJhcQ==}
+    engines: {node: '>=14.18'}
+
   '@sentry/bundler-plugin-core@5.1.1':
     resolution: {integrity: sha512-F+itpwR9DyQR7gEkrXd2tigREPTvtF5lC8qu6e4anxXYRTui1+dVR0fXNwjpyAZMhIesLfXRN7WY7ggdj7hi0Q==}
     engines: {node: '>= 18'}
+
+  '@sentry/cli-darwin@2.41.1':
+    resolution: {integrity: sha512-7pS3pu/SuhE6jOn3wptstAg6B5nUP878O6s+2svT7b5fKNfYUi/6NPK6dAveh2Ca0rwVq40TO4YFJabWMgTpdQ==}
+    engines: {node: '>=10'}
+    os: [darwin]
 
   '@sentry/cli-darwin@2.58.5':
     resolution: {integrity: sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==}
     engines: {node: '>=10'}
     os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.41.1':
+    resolution: {integrity: sha512-EzYCEnnENBnS5kpNW+2dBcrPZn1MVfywh2joGVQZTpmgDL5YFJ59VOd+K0XuEwqgFI8BSNI14KXZ75s4DD1/Vw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd]
 
   '@sentry/cli-linux-arm64@2.58.5':
     resolution: {integrity: sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==}
@@ -4553,17 +4813,35 @@ packages:
     cpu: [arm64]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-arm@2.41.1':
+    resolution: {integrity: sha512-wNUvquD6qjOCczvuBGf9OiD29nuQ6yf8zzfyPJa5Bdx1QXuteKsKb6HBrMwuIR3liyuu0duzHd+H/+p1n541Hg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd]
+
   '@sentry/cli-linux-arm@2.58.5':
     resolution: {integrity: sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-i686@2.41.1':
+    resolution: {integrity: sha512-urpQCWrdYnSAsZY3udttuMV88wTJzKZL10xsrp7sjD/Hd+O6qSLVLkxebIlxts70jMLLFHYrQ2bkRg5kKuX6Fg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd]
+
   '@sentry/cli-linux-i686@2.58.5':
     resolution: {integrity: sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.41.1':
+    resolution: {integrity: sha512-ZqpYwHXAaK4MMEFlyaLYr6mJTmpy9qP6n30jGhLTW7kHKS3s6GPLCSlNmIfeClrInEt0963fM633ZRnXa04VPw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd]
 
   '@sentry/cli-linux-x64@2.58.5':
     resolution: {integrity: sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==}
@@ -4577,10 +4855,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@sentry/cli-win32-i686@2.41.1':
+    resolution: {integrity: sha512-AuRimCeVsx99DIOr9cwdYBHk39tlmAuPDdy2r16iNzY0InXs4xOys4gGzM7N4vlFQvFkzuc778Su0HkfasgprA==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
   '@sentry/cli-win32-i686@2.58.5':
     resolution: {integrity: sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.41.1':
+    resolution: {integrity: sha512-6JcPvXGye61+wPp0xdzfc2YLE/Dcud8JdaK8VxLM3b/8+Em7E+UyliDu3uF8+YGUqizY5JYTd3fs17DC8DZhLw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
     os: [win32]
 
   '@sentry/cli-win32-x64@2.58.5':
@@ -4588,6 +4878,11 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
+
+  '@sentry/cli@2.41.1':
+    resolution: {integrity: sha512-0GVmDiTV7R1492wkVY4bGcfC0fSmRmQjuxaaPI8CIV9B2VP9pBVCUizi1mevXaaE4I3fM60LI+XYrKFEneuVog==}
+    engines: {node: '>= 10'}
+    hasBin: true
 
   '@sentry/cli@2.58.5':
     resolution: {integrity: sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==}
@@ -4597,6 +4892,14 @@ packages:
   '@sentry/core@10.46.0':
     resolution: {integrity: sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q==}
     engines: {node: '>=18'}
+
+  '@sentry/core@8.53.0':
+    resolution: {integrity: sha512-u6p5JeGSgvcoDqVcPve2gcJuhks8EQXPELzeYKuW3rHpsUfkLG6X5RVtk32dKOqqL2qzvMelnknBN7tyIf5PiA==}
+    engines: {node: '>=14.18'}
+
+  '@sentry/core@8.55.1':
+    resolution: {integrity: sha512-0ea+yDOgaijR3ba2al1QZxY0bZ9MBZq2a0G+2A0uCBpBkiXnpLFGVAo9UAlEikN1C4M8ROZYiuFU7yZCqacgLQ==}
+    engines: {node: '>=14.18'}
 
   '@sentry/nextjs@10.46.0':
     resolution: {integrity: sha512-DVS6vHOhgFuvcos9OXrj1wcLi9iv859bmQ5lVLpbotAmPd63+kX82aQzATk1CBr3ygZrlA2lSYHDbpRzTAvIaA==}
@@ -4635,6 +4938,10 @@ packages:
     resolution: {integrity: sha512-vF+7FrUXEtmYWuVcnvBjlWKeyLw/kwHpwnGj9oUmO/a2uKjDmUr53ZVcapggNxCjivavGYr9uHOY64AGdeUyzA==}
     engines: {node: '>=18'}
 
+  '@sentry/node@8.55.1':
+    resolution: {integrity: sha512-s8ydn/OxZFIxc9Fvt23gJkrXkCvPnUu2bDKwjQBCx0M1b4DdNdp4FaimT6B9reya7buj+tsNkZAoT11KqFhG/g==}
+    engines: {node: '>=14.18'}
+
   '@sentry/opentelemetry@10.46.0':
     resolution: {integrity: sha512-dzzV2ovruGsx9jzusGGr6cNPvMgYRu2BIrF8aMZ3rkQ1OpPJjPStqtA1l1fw0aoxHOxIjFU7ml4emF+xdmMl3g==}
     engines: {node: '>=18'}
@@ -4645,11 +4952,47 @@ packages:
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
       '@opentelemetry/semantic-conventions': ^1.39.0
 
+  '@sentry/opentelemetry@8.55.1':
+    resolution: {integrity: sha512-ipiM/k3Hzt8visoBfkDb4AQBWHkJeou3SjoPec7NlDabH/Jj8x6VlK5Hex4z+WOv99rRy+5MUtga/CZnOjvh0A==}
+    engines: {node: '>=14.18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1
+      '@opentelemetry/core': ^1.30.1
+      '@opentelemetry/instrumentation': ^0.57.1
+      '@opentelemetry/sdk-trace-base': ^1.30.1
+      '@opentelemetry/semantic-conventions': ^1.28.0
+
+  '@sentry/react-native@6.6.0':
+    resolution: {integrity: sha512-/pJqRQWv8q8bRJfEBDEE30ylqwjOH8YvLXrgq0IeiQkrHa/ixk3QwEKhYc8iKBmvjUDasjNtxcUl7n4jBSFbCw==}
+    hasBin: true
+    peerDependencies:
+      expo: '>=49.0.0'
+      react: '>=17.0.0'
+      react-native: '>=0.65.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
   '@sentry/react@10.46.0':
     resolution: {integrity: sha512-Rb1S+9OuUPVwsz7GWnQ6Kgf3azbsseUymIegg3JZHNcW/fM1nPpaljzTBnuineia113DH0pgMBcdrrZDLaosFQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/react@8.53.0':
+    resolution: {integrity: sha512-phiU/Tj9I9X0TbdhpPo7jUhV8zRs+YOG1hPJd1jgtBHW5ijXdfcat92dyRtsgwTM6nkFdsWidNzH+Q7ClfZVGg==}
+    engines: {node: '>=14.18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/types@8.53.0':
+    resolution: {integrity: sha512-HJtREx7JWRW1UzKQdHSE7E7ZVT+3XEHMuNk0JzYka2SLXvN/wbeGYWDGYLVCcbUfO5S4EtoaLTrF94DML2O0Pw==}
+    engines: {node: '>=14.18'}
+
+  '@sentry/utils@8.53.0':
+    resolution: {integrity: sha512-CKZkuyqIbuGdMYeyBWEzquvum9he/q7dctA4lcEf9Fctfy3MPDAH0XKAJV/5A9n1tuQbt/Pq9FjfMA9kCRtUCQ==}
+    engines: {node: '>=14.18'}
 
   '@sentry/vercel-edge@10.46.0':
     resolution: {integrity: sha512-A50gQM5ZoEwR6V3sKbq4S0RxGeKllpWTZfN+vemXh+XGi+F5U3QpEQufJgd+xHP7cxxbc1BiJIYuLmIjGbxjQA==}
@@ -4850,6 +5193,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/connect@3.4.36':
+    resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -4937,6 +5283,9 @@ packages:
   '@types/libsodium-wrappers@0.7.14':
     resolution: {integrity: sha512-5Kv68fXuXK0iDuUir1WPGw2R9fOZUlYlSAa0ztMcL0s0BfIDTqg9GXz8K30VJpPP3sxWhbolnQma2x+/TfkzDQ==}
 
+  '@types/mysql@2.15.26':
+    resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
+
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
@@ -4952,11 +5301,17 @@ packages:
   '@types/node@22.19.9':
     resolution: {integrity: sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==}
 
+  '@types/pg-pool@2.0.6':
+    resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
+
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
 
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
+
+  '@types/pg@8.6.1':
+    resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
 
   '@types/phoenix@1.6.7':
     resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
@@ -4980,6 +5335,9 @@ packages:
 
   '@types/react@19.2.13':
     resolution: {integrity: sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==}
+
+  '@types/shimmer@1.2.0':
+    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -7465,6 +7823,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
   import-in-the-middle@2.0.6:
     resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
 
@@ -9458,6 +9819,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
+
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
@@ -9717,6 +10082,9 @@ packages:
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -13256,11 +13624,32 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.53.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.57.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -13272,12 +13661,31 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
 
+  '@opentelemetry/instrumentation-amqplib@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-amqplib@0.60.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.43.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/connect': 3.4.36
     transitivePeerDependencies:
       - supports-color
 
@@ -13291,10 +13699,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-dataloader@0.16.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-dataloader@0.30.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-express@0.47.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13307,11 +13731,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-fastify@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.19.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-fs@0.32.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.43.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13322,10 +13770,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-graphql@0.47.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-graphql@0.61.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
 
@@ -13348,6 +13812,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-http@0.57.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+      forwarded-parse: 2.1.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.47.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-ioredis@0.61.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -13365,10 +13849,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-kafkajs@0.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.44.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-knex@0.57.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.47.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -13382,6 +13891,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-lru-memoizer@0.44.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-lru-memoizer@0.57.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -13389,10 +13905,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-mongodb@0.51.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-mongodb@0.66.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.46.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -13406,6 +13939,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-mysql2@0.45.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-mysql2@0.59.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -13415,12 +13957,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-mysql@0.45.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/mysql': 2.15.26
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-mysql@0.59.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/mysql': 2.15.27
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-nestjs-core@0.44.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.50.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.27.0
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+      '@types/pg': 8.6.1
+      '@types/pg-pool': 2.0.6
     transitivePeerDependencies:
       - supports-color
 
@@ -13436,6 +14007,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-redis-4@0.46.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-redis@0.61.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -13445,12 +14025,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation-tedious@0.18.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation-tedious@0.32.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13490,13 +14087,64 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.53.0
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.7.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.57.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.1
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.7.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.7.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/redis-common@0.36.2': {}
+
   '@opentelemetry/redis-common@0.38.2': {}
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -13505,7 +14153,16 @@ snapshots:
       '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
+  '@opentelemetry/semantic-conventions@1.27.0': {}
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -13525,6 +14182,14 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.28.0(zod@3.25.76)
+
+  '@prisma/instrumentation@5.22.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.53.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@prisma/instrumentation@7.4.2(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -15071,19 +15736,39 @@ snapshots:
     dependencies:
       '@sentry/core': 10.46.0
 
+  '@sentry-internal/browser-utils@8.53.0':
+    dependencies:
+      '@sentry/core': 8.53.0
+
   '@sentry-internal/feedback@10.46.0':
     dependencies:
       '@sentry/core': 10.46.0
+
+  '@sentry-internal/feedback@8.53.0':
+    dependencies:
+      '@sentry/core': 8.53.0
 
   '@sentry-internal/replay-canvas@10.46.0':
     dependencies:
       '@sentry-internal/replay': 10.46.0
       '@sentry/core': 10.46.0
 
+  '@sentry-internal/replay-canvas@8.53.0':
+    dependencies:
+      '@sentry-internal/replay': 8.53.0
+      '@sentry/core': 8.53.0
+
   '@sentry-internal/replay@10.46.0':
     dependencies:
       '@sentry-internal/browser-utils': 10.46.0
       '@sentry/core': 10.46.0
+
+  '@sentry-internal/replay@8.53.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 8.53.0
+      '@sentry/core': 8.53.0
+
+  '@sentry/babel-plugin-component-annotate@2.20.1': {}
 
   '@sentry/babel-plugin-component-annotate@5.1.1': {}
 
@@ -15094,6 +15779,14 @@ snapshots:
       '@sentry-internal/replay': 10.46.0
       '@sentry-internal/replay-canvas': 10.46.0
       '@sentry/core': 10.46.0
+
+  '@sentry/browser@8.53.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 8.53.0
+      '@sentry-internal/feedback': 8.53.0
+      '@sentry-internal/replay': 8.53.0
+      '@sentry-internal/replay-canvas': 8.53.0
+      '@sentry/core': 8.53.0
 
   '@sentry/bundler-plugin-core@5.1.1':
     dependencies:
@@ -15108,16 +15801,31 @@ snapshots:
       - encoding
       - supports-color
 
+  '@sentry/cli-darwin@2.41.1':
+    optional: true
+
   '@sentry/cli-darwin@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.41.1':
     optional: true
 
   '@sentry/cli-linux-arm64@2.58.5':
     optional: true
 
+  '@sentry/cli-linux-arm@2.41.1':
+    optional: true
+
   '@sentry/cli-linux-arm@2.58.5':
     optional: true
 
+  '@sentry/cli-linux-i686@2.41.1':
+    optional: true
+
   '@sentry/cli-linux-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.41.1':
     optional: true
 
   '@sentry/cli-linux-x64@2.58.5':
@@ -15126,11 +15834,36 @@ snapshots:
   '@sentry/cli-win32-arm64@2.58.5':
     optional: true
 
+  '@sentry/cli-win32-i686@2.41.1':
+    optional: true
+
   '@sentry/cli-win32-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.41.1':
     optional: true
 
   '@sentry/cli-win32-x64@2.58.5':
     optional: true
+
+  '@sentry/cli@2.41.1':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.41.1
+      '@sentry/cli-linux-arm': 2.41.1
+      '@sentry/cli-linux-arm64': 2.41.1
+      '@sentry/cli-linux-i686': 2.41.1
+      '@sentry/cli-linux-x64': 2.41.1
+      '@sentry/cli-win32-i686': 2.41.1
+      '@sentry/cli-win32-x64': 2.41.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@sentry/cli@2.58.5':
     dependencies:
@@ -15153,6 +15886,10 @@ snapshots:
       - supports-color
 
   '@sentry/core@10.46.0': {}
+
+  '@sentry/core@8.53.0': {}
+
+  '@sentry/core@8.55.1': {}
 
   '@sentry/nextjs@10.46.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.0)':
     dependencies:
@@ -15233,6 +15970,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@sentry/node@8.55.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.43.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.16.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express': 0.47.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fastify': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.19.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.43.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.47.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.57.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.47.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.44.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.47.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.44.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.51.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.46.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.45.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.45.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-nestjs-core': 0.44.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.50.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis-4': 0.46.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.18.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@prisma/instrumentation': 5.22.0
+      '@sentry/core': 8.55.1
+      '@sentry/opentelemetry': 8.55.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 1.15.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@sentry/opentelemetry@10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -15242,11 +16019,53 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.40.0
       '@sentry/core': 10.46.0
 
+  '@sentry/opentelemetry@8.55.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 8.55.1
+
+  '@sentry/react-native@6.6.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@sentry/babel-plugin-component-annotate': 2.20.1
+      '@sentry/browser': 8.53.0
+      '@sentry/cli': 2.41.1
+      '@sentry/core': 8.53.0
+      '@sentry/react': 8.53.0(react@18.3.1)
+      '@sentry/types': 8.53.0
+      '@sentry/utils': 8.53.0
+      react: 18.3.1
+      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@sentry/react@10.46.0(react@19.2.4)':
     dependencies:
       '@sentry/browser': 10.46.0
       '@sentry/core': 10.46.0
       react: 19.2.4
+
+  '@sentry/react@8.53.0(react@18.3.1)':
+    dependencies:
+      '@sentry/browser': 8.53.0
+      '@sentry/core': 8.53.0
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
+
+  '@sentry/types@8.53.0':
+    dependencies:
+      '@sentry/core': 8.53.0
+
+  '@sentry/utils@8.53.0':
+    dependencies:
+      '@sentry/core': 8.53.0
 
   '@sentry/vercel-edge@10.46.0':
     dependencies:
@@ -15485,6 +16304,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.36':
+    dependencies:
+      '@types/node': 22.15.35
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.15.35
@@ -15576,6 +16399,10 @@ snapshots:
 
   '@types/libsodium-wrappers@0.7.14': {}
 
+  '@types/mysql@2.15.26':
+    dependencies:
+      '@types/node': 22.15.35
+
   '@types/mysql@2.15.27':
     dependencies:
       '@types/node': 22.15.35
@@ -15597,11 +16424,21 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg-pool@2.0.6':
+    dependencies:
+      '@types/pg': 8.15.6
+
   '@types/pg-pool@2.0.7':
     dependencies:
       '@types/pg': 8.15.6
 
   '@types/pg@8.15.6':
+    dependencies:
+      '@types/node': 22.15.35
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
+  '@types/pg@8.6.1':
     dependencies:
       '@types/node': 22.15.35
       pg-protocol: 1.13.0
@@ -15629,6 +16466,8 @@ snapshots:
   '@types/react@19.2.13':
     dependencies:
       csstype: 3.2.3
+
+  '@types/shimmer@1.2.0': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -16144,7 +16983,7 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   acorn@8.15.0: {}
 
@@ -17515,9 +18354,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       eslint: 9.39.2(jiti@1.21.7)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-expo: 0.1.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
       eslint-plugin-react-hooks: 4.6.2(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
@@ -17554,21 +18393,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
-      get-tsconfig: 4.13.6
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -17584,14 +18408,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@1.21.7)
+      get-tsconfig: 4.13.6
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3)
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -17614,7 +18453,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -17625,7 +18464,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7)))(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -18641,6 +19480,13 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
 
   import-in-the-middle@2.0.6:
     dependencies:
@@ -21018,6 +21864,14 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+      resolve: 1.22.11
+    transitivePeerDependencies:
+      - supports-color
+
   require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3
@@ -21360,6 +22214,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  shimmer@1.2.1: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -21770,7 +22626,7 @@ snapshots:
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 


### PR DESCRIPTION
## Summary
Three new observability pillars:

### 1. `@styrby/shared/logging` (new)
- `Logger` class consumed by all packages, JSON-line output, optional Sentry breadcrumbs for error/warn
- `SentryAdapter` interface keeps `Logger` platform-agnostic
- Auto traceId per logger
- +16 tests

### 2. CLI Sentry
- `@sentry/node@^8.55.0`
- `initSentry()` in `cli/index.ts` before dispatch
- `STYRBY_SENTRY_MUTED` kill switch matches PR #110 pattern
- Same noise filter (ECONNRESET, socket hang up, ETIMEDOUT)
- `uncaughtException` + `unhandledRejection` wired
- +12 tests
- `cli/handlers/pair.ts` adopts structured logger for pair lifecycle

### 3. Mobile Sentry
- `@sentry/react-native@~6.6.0`
- `initMobileSentry()` in `app/_layout.tsx`
- `EXPO_PUBLIC_STYRBY_SENTRY_MUTED` kill switch
- `MobileSentryInitOptions` overrides to work around Expo babel env var inlining
- +9 tests

### Web (already had Sentry)
- Wired `pushLog` + `authLog` structured loggers in push/subscribe and auth/passkey/verify routes

## Test plan
- [x] @styrby/shared: 1,075 tests pass (+16)
- [x] styrby-cli: 2,062 tests pass; typecheck clean
- [x] styrby-mobile: 1,221 tests pass (+9); typecheck clean
- [x] styrby-web: typecheck clean
- [ ] CI green

## Deferred
- agent-session.ts dual-logging additions (conflicted with PR-7's reconnect work; will follow up on top of #119's merge)
- Founder dashboard / alert rules in Sentry (UI-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)