### PR TITLE
feat(teams): admin UI - members + policies + founder teams panel (Phase 2.3)

### DIFF
--- a/packages/styrby-mobile/app/team/members.tsx
+++ b/packages/styrby-mobile/app/team/members.tsx
@@ -1,0 +1,546 @@
+/**
+ * Team Members Screen (Mobile) - Phase 2.3
+ *
+ * /team/members
+ *
+ * Mobile parity of the web /dashboard/team/[teamId]/members page.
+ * Displays a compacted list of team members with role badge, join date,
+ * last active, and cost MTD. Role change and member removal are available
+ * to owners/admins via an action sheet.
+ *
+ * Navigation:
+ *   - Deep-links back to the invitations screen (Phase 2.2)
+ *   - Accessible from the Team tab
+ *
+ * WHY this is a standalone route (not embedded in the Team tab):
+ *   The Team tab already handles the create-team / no-team states. Having
+ *   members as a separate route allows deep-linking from push notifications
+ *   (e.g. "New member joined your team") and keeps the team tab lightweight.
+ *
+ * Data source: useTeamManagement hook (existing, Phase 2.1).
+ * Enrichment (last_active_at, cost_mtd_usd): fetched here via Supabase
+ * because useTeamManagement returns the basic RPC member shape only.
+ *
+ * @module app/team/members
+ */
+
+import {
+  View,
+  Text,
+  FlatList,
+  RefreshControl,
+  ActivityIndicator,
+  Pressable,
+  Alert,
+} from 'react-native';
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useTeamManagement } from '../../src/hooks/useTeamManagement';
+import { supabase } from '../../src/lib/supabase';
+import { getApiBaseUrl } from '../../src/lib/config';
+import type { ValidatedTeamMember } from '../../src/lib/schemas';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Member row enriched with last-active and cost MTD for the admin view.
+ */
+interface EnrichedMember extends ValidatedTeamMember {
+  /** ISO timestamp of most recent session, or null */
+  last_active_at: string | null;
+  /** Month-to-date cost in USD, or null if no sessions */
+  cost_mtd_usd: number | null;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Formats an ISO date string as a short human-readable date.
+ *
+ * @param iso - ISO 8601 date string
+ * @returns Formatted date string (e.g. "Jun 1, 2025") or "-" if null
+ */
+function fmtDate(iso: string | null): string {
+  if (!iso) return '-';
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Formats a nullable USD cost as "$X.XX" or "-".
+ *
+ * @param usd - Cost in USD, or null
+ * @returns Formatted cost string
+ */
+function fmtCost(usd: number | null): string {
+  if (usd === null) return '-';
+  return `$${usd.toFixed(2)}`;
+}
+
+/**
+ * Returns initials from a name or email for the avatar.
+ *
+ * @param name - Display name (may be null)
+ * @param email - Email address (fallback)
+ * @returns 1-2 character uppercase initials
+ */
+function getInitials(name: string | null, email: string): string {
+  if (name) {
+    return name.split(' ').map((n) => n[0]).join('').toUpperCase().slice(0, 2);
+  }
+  return email[0].toUpperCase();
+}
+
+// ============================================================================
+// Role Badge
+// ============================================================================
+
+/**
+ * Renders a coloured role indicator pill.
+ *
+ * @param props.role - Member's role string
+ * @returns Coloured badge view
+ */
+function RoleBadge({ role }: { role: string }) {
+  const colours: Record<string, { bg: string; text: string }> = {
+    owner: { bg: 'rgba(249, 115, 22, 0.12)', text: '#f97316' },
+    admin: { bg: 'rgba(168, 85, 247, 0.12)', text: '#a855f7' },
+    member: { bg: 'rgba(113, 113, 122, 0.12)', text: '#71717a' },
+  };
+  const { bg, text } = colours[role] ?? colours.member;
+
+  return (
+    <View className="px-2 py-0.5 rounded-full" style={{ backgroundColor: bg }}>
+      <Text className="text-xs font-medium" style={{ color: text }}>
+        {role.charAt(0).toUpperCase() + role.slice(1)}
+      </Text>
+    </View>
+  );
+}
+
+// ============================================================================
+// Member Row
+// ============================================================================
+
+interface MemberRowProps {
+  /** The enriched member data */
+  member: EnrichedMember;
+  /** Whether this member is the current user */
+  isSelf: boolean;
+  /** Whether the current user can manage this member */
+  canManage: boolean;
+  /** Callback to change role */
+  onChangeRole: (member: EnrichedMember) => void;
+  /** Callback to remove */
+  onRemove: (member: EnrichedMember) => void;
+}
+
+/**
+ * Renders a single member row in the compact mobile list.
+ *
+ * @param props - See {@link MemberRowProps}
+ */
+function MemberRow({ member, isSelf, canManage, onChangeRole, onRemove }: MemberRowProps) {
+  return (
+    <View className="px-4 py-3 border-b border-zinc-800/50">
+      <View className="flex-row items-center">
+        {/* Avatar */}
+        <View className="w-9 h-9 rounded-full bg-zinc-700 items-center justify-center mr-3 flex-shrink-0">
+          <Text className="text-xs font-medium text-zinc-300">
+            {getInitials(member.display_name, member.email)}
+          </Text>
+        </View>
+
+        {/* Identity */}
+        <View className="flex-1 min-w-0">
+          <View className="flex-row items-center gap-1.5">
+            <Text className="text-white font-medium text-sm flex-shrink" numberOfLines={1}>
+              {member.display_name ?? member.email}
+            </Text>
+            {isSelf && (
+              <Text className="text-zinc-500 text-xs flex-shrink-0">(you)</Text>
+            )}
+          </View>
+          {member.display_name && (
+            <Text className="text-zinc-500 text-xs" numberOfLines={1}>
+              {member.email}
+            </Text>
+          )}
+        </View>
+
+        {/* Role */}
+        <RoleBadge role={member.role} />
+
+        {/* Actions menu */}
+        {canManage && member.role !== 'owner' && !isSelf && (
+          <Pressable
+            onPress={() => {
+              Alert.alert(
+                member.display_name ?? member.email,
+                'Choose an action',
+                [
+                  {
+                    text: member.role === 'admin' ? 'Change to Member' : 'Change to Admin',
+                    onPress: () => onChangeRole(member),
+                  },
+                  {
+                    text: 'Remove from Team',
+                    style: 'destructive',
+                    onPress: () => onRemove(member),
+                  },
+                  { text: 'Cancel', style: 'cancel' },
+                ],
+              );
+            }}
+            className="ml-2 p-1.5"
+            accessibilityRole="button"
+            accessibilityLabel={`Manage ${member.display_name ?? member.email}`}
+          >
+            <Ionicons name="ellipsis-vertical" size={18} color="#71717a" />
+          </Pressable>
+        )}
+      </View>
+
+      {/* Metadata row */}
+      <View className="flex-row gap-4 mt-1.5 ml-12">
+        <Text className="text-zinc-600 text-xs">
+          Joined {fmtDate(member.joined_at)}
+        </Text>
+        {member.last_active_at && (
+          <Text className="text-zinc-600 text-xs">
+            Active {fmtDate(member.last_active_at)}
+          </Text>
+        )}
+        {member.cost_mtd_usd !== null && (
+          <Text className="text-zinc-600 text-xs">
+            {fmtCost(member.cost_mtd_usd)} MTD
+          </Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+// ============================================================================
+// Screen
+// ============================================================================
+
+/**
+ * Team members screen.
+ *
+ * Loads team data via useTeamManagement, enriches each member with
+ * last_active_at and cost_mtd_usd from direct Supabase queries, then
+ * renders a FlatList with per-member action menus for owners/admins.
+ *
+ * Role changes and member removals call the web API routes (not direct Supabase)
+ * so the server-side permission checks and audit_log writes are always executed.
+ */
+export default function TeamMembersScreen() {
+  const router = useRouter();
+  const {
+    team,
+    members,
+    currentUserRole,
+    isLoading,
+    error: hookError,
+    currentUserId,
+    refresh,
+  } = useTeamManagement();
+
+  const [enrichedMembers, setEnrichedMembers] = useState<EnrichedMember[]>([]);
+  const [isEnriching, setIsEnriching] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // ── Enrich members with last-active and cost MTD ──────────────────────────
+
+  /**
+   * Fetches last_active_at and cost_mtd_usd for each member and merges them
+   * into the enrichedMembers state.
+   *
+   * WHY direct Supabase (not API route): enrichment is a read-only aggregation.
+   * The user's own Supabase session is scoped to team data via RLS, so this is
+   * safe to call client-side. Mutations (role change, remove) still go through
+   * the API route.
+   */
+  const enrichMembers = useCallback(async () => {
+    if (!team || members.length === 0) {
+      setEnrichedMembers(members.map((m) => ({ ...m, last_active_at: null, cost_mtd_usd: null })));
+      return;
+    }
+
+    setIsEnriching(true);
+    try {
+      const now = new Date();
+      const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+      const userIds = members.map((m) => m.user_id);
+
+      const [sessionsResult, costsResult] = await Promise.all([
+        supabase
+          .from('sessions')
+          .select('user_id, started_at')
+          .eq('team_id', team.id)
+          .in('user_id', userIds)
+          .order('started_at', { ascending: false }),
+        supabase
+          .from('cost_records')
+          .select('user_id, cost_usd')
+          .eq('team_id', team.id)
+          .in('user_id', userIds)
+          .gte('recorded_at', monthStart),
+      ]);
+
+      // Build last-active lookup (sessions are ordered desc so first hit wins)
+      const lastActiveByUser: Record<string, string> = {};
+      for (const s of (sessionsResult.data ?? [])) {
+        if (!lastActiveByUser[s.user_id as string]) {
+          lastActiveByUser[s.user_id as string] = s.started_at as string;
+        }
+      }
+
+      // Build cost MTD lookup
+      const costByUser: Record<string, number> = {};
+      for (const c of (costsResult.data ?? [])) {
+        costByUser[c.user_id as string] =
+          (costByUser[c.user_id as string] ?? 0) + Number(c.cost_usd);
+      }
+
+      setEnrichedMembers(
+        members.map((m) => ({
+          ...m,
+          last_active_at: lastActiveByUser[m.user_id] ?? null,
+          cost_mtd_usd:
+            costByUser[m.user_id] !== undefined
+              ? Math.round(costByUser[m.user_id] * 100) / 100
+              : null,
+        })),
+      );
+    } catch {
+      // Fall back to unenriched on error (still shows member list)
+      setEnrichedMembers(members.map((m) => ({ ...m, last_active_at: null, cost_mtd_usd: null })));
+    } finally {
+      setIsEnriching(false);
+    }
+  }, [team, members]);
+
+  useEffect(() => {
+    void enrichMembers();
+  }, [enrichMembers]);
+
+  // ── Refresh handler ───────────────────────────────────────────────────────
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await refresh();
+    setIsRefreshing(false);
+  }, [refresh]);
+
+  // ── Role change via API route ─────────────────────────────────────────────
+
+  /**
+   * Sends a PATCH to the web API to change a member's role.
+   * The server writes audit_log on success.
+   *
+   * @param member - The member to change
+   */
+  const handleChangeRole = useCallback(
+    async (member: EnrichedMember) => {
+      if (!team) return;
+      const newRole = member.role === 'admin' ? 'member' : 'admin';
+      setActionError(null);
+
+      try {
+        const res = await fetch(
+          `${getApiBaseUrl()}/api/teams/${team.id}/members/${member.user_id}`,
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ role: newRole }),
+          },
+        );
+
+        if (!res.ok) {
+          const data = (await res.json()) as { error?: string };
+          setActionError(data.error ?? 'Failed to update role');
+          return;
+        }
+
+        await refresh();
+      } catch {
+        setActionError('Network error - please try again');
+      }
+    },
+    [team, refresh],
+  );
+
+  // ── Remove via API route ──────────────────────────────────────────────────
+
+  /**
+   * Prompts confirmation then sends a DELETE to remove a member.
+   * The server writes audit_log on success.
+   *
+   * @param member - The member to remove
+   */
+  const handleRemove = useCallback(
+    (member: EnrichedMember) => {
+      if (!team) return;
+      Alert.alert(
+        'Remove member?',
+        `${member.display_name ?? member.email} will lose access immediately.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Remove',
+            style: 'destructive',
+            onPress: async () => {
+              setActionError(null);
+              try {
+                const res = await fetch(
+                  `${getApiBaseUrl()}/api/teams/${team.id}/members/${member.user_id}`,
+                  { method: 'DELETE' },
+                );
+                if (!res.ok) {
+                  const data = (await res.json()) as { error?: string };
+                  setActionError(data.error ?? 'Failed to remove member');
+                  return;
+                }
+                await refresh();
+              } catch {
+                setActionError('Network error - please try again');
+              }
+            },
+          },
+        ],
+      );
+    },
+    [team, refresh],
+  );
+
+  // ── Permission check ──────────────────────────────────────────────────────
+
+  /**
+   * Determines if the current user can manage the target member.
+   * Mirrors the web MembersTable canManageMember logic.
+   *
+   * @param member - The target member
+   * @returns True if the current user can manage the target
+   */
+  function canManageMember(member: EnrichedMember): boolean {
+    if (member.role === 'owner') return false;
+    if (member.user_id === currentUserId) return false;
+    if (currentUserRole === 'owner') return true;
+    if (currentUserRole === 'admin' && member.role === 'member') return true;
+    return false;
+  }
+
+  // ── Loading / error states ────────────────────────────────────────────────
+
+  if (isLoading || isEnriching) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center">
+        <ActivityIndicator size="large" color="#f97316" />
+        <Text className="text-zinc-500 mt-4 text-sm">Loading members...</Text>
+      </View>
+    );
+  }
+
+  if (!team) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center px-6">
+        <Ionicons name="people-outline" size={48} color="#52525b" />
+        <Text className="text-white text-lg font-semibold mt-4">No Team Found</Text>
+        <Text className="text-zinc-500 text-center mt-2 text-sm">
+          Create or join a team first.
+        </Text>
+        <Pressable
+          onPress={() => router.back()}
+          className="bg-brand px-6 py-3 rounded-xl mt-6 active:opacity-80"
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
+          <Text className="text-white font-semibold">Go back</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  // ── Main render ───────────────────────────────────────────────────────────
+
+  return (
+    <View className="flex-1 bg-background">
+      {/* Header */}
+      <View className="px-4 py-4 border-b border-zinc-800 flex-row items-center justify-between">
+        <View>
+          <Text className="text-white text-lg font-semibold">
+            {team.name} - Members
+          </Text>
+          <Text className="text-zinc-500 text-sm">
+            {enrichedMembers.length} member{enrichedMembers.length !== 1 ? 's' : ''}
+          </Text>
+        </View>
+
+        {/* Link to Invitations panel (2.2) */}
+        <Pressable
+          onPress={() => router.push('/team/invitations' as never)}
+          className="px-3 py-1.5 bg-orange-500/10 border border-orange-500/30 rounded-lg active:opacity-80"
+          accessibilityRole="link"
+          accessibilityLabel="Go to invitations"
+        >
+          <Text className="text-orange-400 text-xs font-medium">Invitations</Text>
+        </Pressable>
+      </View>
+
+      {/* Action error banner */}
+      {actionError && (
+        <View className="mx-4 mt-2 bg-red-500/10 rounded-lg px-3 py-2">
+          <Text className="text-red-400 text-sm">{actionError}</Text>
+        </View>
+      )}
+
+      {hookError && (
+        <View className="mx-4 mt-2 bg-red-500/10 rounded-lg px-3 py-2">
+          <Text className="text-red-400 text-sm">{hookError}</Text>
+        </View>
+      )}
+
+      {/* Members list */}
+      <FlatList
+        data={enrichedMembers}
+        keyExtractor={(item) => item.member_id}
+        renderItem={({ item }) => (
+          <MemberRow
+            member={item}
+            isSelf={item.user_id === currentUserId}
+            canManage={canManageMember(item)}
+            onChangeRole={handleChangeRole}
+            onRemove={handleRemove}
+          />
+        )}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={handleRefresh}
+            tintColor="#f97316"
+            colors={['#f97316']}
+          />
+        }
+        ListEmptyComponent={
+          <View className="items-center justify-center py-16">
+            <Ionicons name="people-outline" size={40} color="#52525b" />
+            <Text className="text-zinc-500 mt-4">No members yet</Text>
+          </View>
+        }
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 32 }}
+      />
+    </View>
+  );
+}

--- a/packages/styrby-mobile/app/team/policies.tsx
+++ b/packages/styrby-mobile/app/team/policies.tsx
@@ -1,0 +1,446 @@
+/**
+ * Team Policies Screen (Mobile) - Phase 2.3
+ *
+ * /team/policies
+ *
+ * Mobile parity of the web /dashboard/team/[teamId]/policies page.
+ * Allows team owners and admins to view and edit:
+ *   - auto_approve_rules (tool names)
+ *   - blocked_tools (tool names)
+ *   - budget_per_seat_usd
+ *
+ * All saves go through the web API route (PATCH /api/teams/[id]/policies)
+ * so the server-side validation and audit_log writes are always executed.
+ *
+ * Navigation:
+ *   - Deep-links back to the invitations screen (Phase 2.2) and members screen
+ *
+ * @module app/team/policies
+ */
+
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  TextInput,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useTeamManagement } from '../../src/hooks/useTeamManagement';
+import { getApiBaseUrl } from '../../src/lib/config';
+import type { TeamPolicySettings } from '@styrby/shared';
+import { PatchTeamPolicyBodySchema } from '@styrby/shared';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Fetches the team's current policy settings from the web API.
+ *
+ * @param teamId - Team UUID
+ * @returns Policy settings or null on error
+ */
+async function fetchPolicies(teamId: string): Promise<TeamPolicySettings | null> {
+  try {
+    const res = await fetch(`${getApiBaseUrl()}/api/teams/${teamId}/policies`);
+    if (!res.ok) return null;
+    const data = (await res.json()) as { policies: TeamPolicySettings };
+    return data.policies;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Tag List Editor
+// ============================================================================
+
+interface TagListEditorProps {
+  /** Current list of tags */
+  tags: string[];
+  /** Called when the list changes */
+  onChange: (next: string[]) => void;
+  /** Whether the field is read-only */
+  readOnly: boolean;
+  /** Accessible label for the text input */
+  inputLabel: string;
+  /** Placeholder text */
+  placeholder: string;
+}
+
+/**
+ * Mobile-friendly tag input for editing string arrays.
+ *
+ * Tags are displayed as chips. New tags are added by typing and tapping
+ * the "Add" button (mobile lacks a keyboard Enter equivalent for this pattern).
+ *
+ * @param props - See {@link TagListEditorProps}
+ */
+function TagListEditor({ tags, onChange, readOnly, inputLabel, placeholder }: TagListEditorProps) {
+  const [draft, setDraft] = useState('');
+
+  /**
+   * Adds the current draft as a new tag.
+   */
+  function addTag() {
+    const trimmed = draft.trim();
+    if (trimmed && !tags.includes(trimmed)) {
+      onChange([...tags, trimmed]);
+      setDraft('');
+    }
+  }
+
+  /**
+   * Removes a tag by index.
+   *
+   * @param idx - Index of the tag to remove
+   */
+  function removeTag(idx: number) {
+    onChange(tags.filter((_, i) => i !== idx));
+  }
+
+  return (
+    <View>
+      {/* Chips */}
+      <View className="flex-row flex-wrap gap-2 mb-2">
+        {tags.map((tag, idx) => (
+          <View
+            key={idx}
+            className="flex-row items-center bg-zinc-800 rounded-lg px-2.5 py-1 gap-1.5"
+          >
+            <Text className="text-zinc-200 text-xs font-mono">{tag}</Text>
+            {!readOnly && (
+              <Pressable
+                onPress={() => removeTag(idx)}
+                accessibilityRole="button"
+                accessibilityLabel={`Remove ${tag}`}
+                className="ml-0.5"
+              >
+                <Ionicons name="close" size={12} color="#71717a" />
+              </Pressable>
+            )}
+          </View>
+        ))}
+        {tags.length === 0 && (
+          <Text className="text-zinc-600 text-xs">None configured.</Text>
+        )}
+      </View>
+
+      {/* New tag input */}
+      {!readOnly && (
+        <View className="flex-row items-center gap-2">
+          <TextInput
+            value={draft}
+            onChangeText={setDraft}
+            placeholder={placeholder}
+            placeholderTextColor="#52525b"
+            className="flex-1 bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-zinc-300 text-sm font-mono"
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="done"
+            onSubmitEditing={addTag}
+            accessibilityLabel={inputLabel}
+          />
+          <Pressable
+            onPress={addTag}
+            disabled={!draft.trim()}
+            className="bg-zinc-700 px-3 py-2 rounded-lg active:opacity-80 disabled:opacity-40"
+            accessibilityRole="button"
+            accessibilityLabel="Add tag"
+          >
+            <Ionicons name="add" size={18} color="#f97316" />
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ============================================================================
+// Screen
+// ============================================================================
+
+/**
+ * Team policies screen.
+ *
+ * Loads team data via useTeamManagement, then fetches the current policy
+ * settings from the API. Renders an editable form for owners/admins and a
+ * read-only view for plain members.
+ */
+export default function TeamPoliciesScreen() {
+  const router = useRouter();
+  const {
+    team,
+    currentUserRole,
+    isLoading: teamLoading,
+  } = useTeamManagement();
+
+  const [policies, setPolicies] = useState<TeamPolicySettings | null>(null);
+  const [isLoadingPolicies, setIsLoadingPolicies] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Editable state (mirrors the fetched policies)
+  const [autoApprove, setAutoApprove] = useState<string[]>([]);
+  const [blockedTools, setBlockedTools] = useState<string[]>([]);
+  const [budgetPerSeat, setBudgetPerSeat] = useState<string>('');
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  const canEdit = currentUserRole === 'owner' || currentUserRole === 'admin';
+
+  // ── Load policies ─────────────────────────────────────────────────────────
+
+  const loadPolicies = useCallback(async () => {
+    if (!team) return;
+    setIsLoadingPolicies(true);
+    setLoadError(null);
+
+    const result = await fetchPolicies(team.id);
+    if (result) {
+      setPolicies(result);
+      setAutoApprove(result.auto_approve_rules);
+      setBlockedTools(result.blocked_tools);
+      setBudgetPerSeat(result.budget_per_seat_usd !== null ? String(result.budget_per_seat_usd) : '');
+    } else {
+      setLoadError('Failed to load team policies. Pull to retry.');
+    }
+    setIsLoadingPolicies(false);
+  }, [team]);
+
+  useEffect(() => {
+    void loadPolicies();
+  }, [loadPolicies]);
+
+  // ── Save handler ──────────────────────────────────────────────────────────
+
+  /**
+   * Validates and sends the changed policy fields to the API.
+   * Validates with the same Zod schema the server uses.
+   */
+  async function handleSave() {
+    if (!team) return;
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    const budgetNum = budgetPerSeat === '' ? null : parseFloat(budgetPerSeat);
+    if (budgetPerSeat !== '' && (Number.isNaN(budgetNum) || (budgetNum !== null && budgetNum < 0))) {
+      setSaveError('Budget per seat must be a number 0 or greater');
+      return;
+    }
+
+    const patch = {
+      auto_approve_rules: autoApprove,
+      blocked_tools: blockedTools,
+      budget_per_seat_usd: budgetNum,
+    };
+
+    const result = PatchTeamPolicyBodySchema.safeParse(patch);
+    if (!result.success) {
+      setSaveError(result.error.errors.map((e) => e.message).join(', '));
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/api/teams/${team.id}/policies`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+
+      if (!res.ok) {
+        const data = (await res.json()) as { error?: string };
+        setSaveError(data.error ?? 'Failed to save policies');
+        return;
+      }
+
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 3000);
+      // Reload policies to confirm server accepted
+      await loadPolicies();
+    } catch {
+      setSaveError('Network error - please try again');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  // ── Loading states ────────────────────────────────────────────────────────
+
+  if (teamLoading || isLoadingPolicies) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center">
+        <ActivityIndicator size="large" color="#f97316" />
+        <Text className="text-zinc-500 mt-4 text-sm">Loading policies...</Text>
+      </View>
+    );
+  }
+
+  if (!team) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center px-6">
+        <Ionicons name="shield-outline" size={48} color="#52525b" />
+        <Text className="text-white text-lg font-semibold mt-4">No Team Found</Text>
+        <Pressable
+          onPress={() => router.back()}
+          className="bg-brand px-6 py-3 rounded-xl mt-6 active:opacity-80"
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
+          <Text className="text-white font-semibold">Go back</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  // ── Main render ───────────────────────────────────────────────────────────
+
+  return (
+    <ScrollView className="flex-1 bg-background" contentContainerStyle={{ paddingBottom: 48 }}>
+      {/* Header */}
+      <View className="px-4 py-4 border-b border-zinc-800 flex-row items-center justify-between">
+        <View>
+          <Text className="text-white text-lg font-semibold">{team.name}</Text>
+          <Text className="text-zinc-500 text-sm">Team Policies</Text>
+        </View>
+
+        {/* Navigation links */}
+        <View className="flex-row gap-2">
+          <Pressable
+            onPress={() => router.push('/team/members' as never)}
+            className="px-3 py-1.5 bg-zinc-800 rounded-lg active:opacity-80"
+            accessibilityRole="link"
+            accessibilityLabel="Go to members"
+          >
+            <Text className="text-zinc-300 text-xs font-medium">Members</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => router.push('/team/invitations' as never)}
+            className="px-3 py-1.5 bg-orange-500/10 border border-orange-500/30 rounded-lg active:opacity-80"
+            accessibilityRole="link"
+            accessibilityLabel="Go to invitations"
+          >
+            <Text className="text-orange-400 text-xs font-medium">Invitations</Text>
+          </Pressable>
+        </View>
+      </View>
+
+      {loadError && (
+        <View className="mx-4 mt-4 bg-red-500/10 rounded-lg px-3 py-2">
+          <Text className="text-red-400 text-sm">{loadError}</Text>
+        </View>
+      )}
+
+      {policies && (
+        <View className="px-4 py-6 space-y-8">
+          {/* Auto-approve rules */}
+          <View className="space-y-2">
+            <View className="flex-row items-center gap-2 mb-1">
+              <Ionicons name="checkmark-circle" size={16} color="#22c55e" />
+              <Text className="text-zinc-200 font-medium text-sm">Auto-approve rules</Text>
+            </View>
+            <Text className="text-zinc-500 text-xs mb-3">
+              Tool names that run without human review.
+            </Text>
+            <TagListEditor
+              tags={autoApprove}
+              onChange={setAutoApprove}
+              readOnly={!canEdit}
+              inputLabel="New auto-approve tool name"
+              placeholder="e.g. read_file"
+            />
+          </View>
+
+          <View className="h-px bg-zinc-800 my-2" />
+
+          {/* Blocked tools */}
+          <View className="space-y-2">
+            <View className="flex-row items-center gap-2 mb-1">
+              <Ionicons name="ban" size={16} color="#ef4444" />
+              <Text className="text-zinc-200 font-medium text-sm">Blocked tools</Text>
+            </View>
+            <Text className="text-zinc-500 text-xs mb-3">
+              Tool names blocked outright. Overrides auto-approve.
+            </Text>
+            <TagListEditor
+              tags={blockedTools}
+              onChange={setBlockedTools}
+              readOnly={!canEdit}
+              inputLabel="New blocked tool name"
+              placeholder="e.g. delete_file"
+            />
+          </View>
+
+          <View className="h-px bg-zinc-800 my-2" />
+
+          {/* Budget per seat */}
+          <View>
+            <Text className="text-zinc-200 font-medium text-sm mb-1">
+              Budget per seat (USD/month)
+            </Text>
+            <Text className="text-zinc-500 text-xs mb-3">
+              Leave blank for no limit.
+            </Text>
+            <View className="flex-row items-center">
+              <Text className="text-zinc-500 text-sm mr-1">$</Text>
+              <TextInput
+                value={budgetPerSeat}
+                onChangeText={setBudgetPerSeat}
+                placeholder="Unlimited"
+                placeholderTextColor="#52525b"
+                keyboardType="numeric"
+                editable={canEdit}
+                className="bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-zinc-300 text-sm w-32"
+                accessibilityLabel="Budget per seat in USD per month"
+              />
+            </View>
+          </View>
+
+          {/* Save button */}
+          {canEdit && (
+            <View className="pt-2">
+              <Pressable
+                onPress={() => void handleSave()}
+                disabled={isSaving}
+                className={`py-3 rounded-xl items-center ${isSaving ? 'bg-zinc-700' : 'bg-brand active:opacity-80'}`}
+                accessibilityRole="button"
+                accessibilityLabel="Save policy changes"
+              >
+                {isSaving ? (
+                  <ActivityIndicator color="#ffffff" size="small" />
+                ) : (
+                  <Text className="text-white font-semibold">Save changes</Text>
+                )}
+              </Pressable>
+
+              {saveSuccess && (
+                <Text className="text-green-400 text-sm text-center mt-3" accessibilityRole="none">
+                  Saved successfully
+                </Text>
+              )}
+
+              {saveError && (
+                <Text className="text-red-400 text-sm text-center mt-3" accessibilityRole="alert">
+                  {saveError}
+                </Text>
+              )}
+            </View>
+          )}
+
+          {!canEdit && (
+            <Text className="text-zinc-600 text-xs text-center pt-2">
+              Only team owners and admins can edit policies.
+            </Text>
+          )}
+        </View>
+      )}
+    </ScrollView>
+  );
+}

--- a/packages/styrby-shared/src/team/admin-types.ts
+++ b/packages/styrby-shared/src/team/admin-types.ts
@@ -1,0 +1,214 @@
+/**
+ * Admin UI types for Phase 2.3 — Team Admin UI (web + mobile parity).
+ *
+ * These types are the contract between:
+ *   - `/api/teams/[id]/members` (PATCH/DELETE)
+ *   - `/api/teams/[id]/policies` (GET/PATCH)
+ *   - `/api/admin/founder-team-metrics` (GET)
+ *   - Web dashboard: `/dashboard/team/[teamId]/members` and `../policies`
+ *   - Mobile: `/team/members` and `/team/policies`
+ *
+ * WHY in @styrby/shared:
+ *   Web and mobile must show identical data with identical validation. Any
+ *   divergence between surfaces is a UX defect and a SOC2 CC6 (Logical Access)
+ *   audit risk. Colocating shapes here enforces parity at the type level.
+ *
+ * @module team/admin-types
+ */
+
+import { z } from 'zod';
+import type { DbRole } from './types.js';
+
+// ============================================================================
+// Team Member Admin View
+// ============================================================================
+
+/**
+ * A team member as seen by an admin — includes cost MTD and last-active
+ * timestamp that plain members cannot see.
+ *
+ * WHY cost_mtd_usd is nullable: members without sessions in the current month
+ * return null rather than 0 to distinguish "no sessions" from "$0 cost sessions".
+ */
+export const TeamMemberAdminRowSchema = z.object({
+  /** team_members.id (UUID) */
+  member_id: z.string().uuid(),
+  /** auth.users.id */
+  user_id: z.string().uuid(),
+  /** Role in the team */
+  role: z.enum(['owner', 'admin', 'member']),
+  /** Display name from profiles, nullable */
+  display_name: z.string().nullable(),
+  /** Email from auth.users */
+  email: z.string().email(),
+  /** Avatar URL from profiles */
+  avatar_url: z.string().url().nullable(),
+  /** ISO timestamp — when the member joined */
+  joined_at: z.string(),
+  /** ISO timestamp — most recent session start, nullable if no sessions */
+  last_active_at: z.string().nullable(),
+  /** Month-to-date cost in USD, nullable if no sessions this month */
+  cost_mtd_usd: z.number().nullable(),
+});
+
+/** Admin view of a team member. */
+export type TeamMemberAdminRow = z.infer<typeof TeamMemberAdminRowSchema>;
+
+// ============================================================================
+// Team Policy Admin View
+// ============================================================================
+
+/**
+ * Editable fields of a team's top-level policy settings.
+ *
+ * WHY auto_approve_rules is string[] not a complex object:
+ *   The rules are stored as jsonb in team_policies but the admin UI only
+ *   exposes the tool-name strings (allowlist) to keep the form manageable.
+ *   Full rule-type/threshold editing lives in a future Phase (2.4 approval chain).
+ */
+export const TeamPolicySettingsSchema = z.object({
+  /**
+   * List of tool names that are auto-approved without requiring human review.
+   * Empty array means no tools are auto-approved.
+   */
+  auto_approve_rules: z.array(z.string().min(1).max(100)).max(200),
+  /**
+   * List of tool names that are blocked outright. Takes precedence over
+   * auto_approve_rules for the same tool name.
+   */
+  blocked_tools: z.array(z.string().min(1).max(100)).max(200),
+  /**
+   * Monthly budget per seat in USD (0 = unlimited).
+   * WHY nullable: null means no budget limit is set (unlimited).
+   */
+  budget_per_seat_usd: z.number().min(0).max(100_000).nullable(),
+});
+
+/** Editable team policy settings. */
+export type TeamPolicySettings = z.infer<typeof TeamPolicySettingsSchema>;
+
+/**
+ * Validation schema for the PATCH /api/teams/[id]/policies request body.
+ * All fields are optional — callers send only what they want to change.
+ */
+export const PatchTeamPolicyBodySchema = TeamPolicySettingsSchema.partial();
+
+/** Partial policy update body. */
+export type PatchTeamPolicyBody = z.infer<typeof PatchTeamPolicyBodySchema>;
+
+// ============================================================================
+// Founder Team Metrics
+// ============================================================================
+
+/**
+ * Per-team summary in the founder dashboard Teams card.
+ */
+export const FounderTeamSummarySchema = z.object({
+  /** teams.id */
+  team_id: z.string().uuid(),
+  /** teams.name */
+  team_name: z.string(),
+  /** Number of active members */
+  member_count: z.number().int().nonnegative(),
+  /** Subscription tier of the team owner */
+  owner_tier: z.string(),
+  /** Whether this team has had any member churn in the last 30 days */
+  had_churn_30d: z.boolean(),
+  /** ISO timestamp of team creation */
+  created_at: z.string(),
+});
+
+/** Per-team summary. */
+export type FounderTeamSummary = z.infer<typeof FounderTeamSummarySchema>;
+
+/**
+ * Aggregate team metrics for the founder dashboard.
+ */
+export const FounderTeamMetricsSchema = z.object({
+  /** Total number of teams in the system */
+  team_count: z.number().int().nonnegative(),
+  /** Average member count across all teams */
+  avg_team_size: z.number(),
+  /**
+   * Number of teams that lost at least one member in the last 30 days.
+   * WHY rolling 30d: matches the solo churn-rate window in founder-metrics so
+   * the founder can compare team vs. individual churn in the same period.
+   */
+  churned_teams_30d: z.number().int().nonnegative(),
+  /**
+   * Fraction of teams that had churn in the last 30d (0-1).
+   * Null when there are no teams.
+   */
+  churn_rate_per_team_30d: z.number().nullable(),
+  /** Breakdown of individual teams */
+  teams: z.array(FounderTeamSummarySchema),
+  /** ISO timestamp when this payload was computed */
+  computed_at: z.string(),
+});
+
+/** Founder-facing team aggregate metrics. */
+export type FounderTeamMetrics = z.infer<typeof FounderTeamMetricsSchema>;
+
+// ============================================================================
+// Role-change request
+// ============================================================================
+
+/**
+ * Body schema for PATCH /api/teams/[id]/members/[userId].
+ *
+ * WHY no 'owner' in the enum: ownership transfer is a deliberate, separate
+ * multi-step operation that this endpoint does not handle.
+ *
+ * Re-exported from admin-types rather than duplicating in the route file.
+ */
+export const PatchMemberRoleBodySchema = z.object({
+  role: z.enum(['admin', 'member'], {
+    errorMap: () => ({ message: 'Role must be "admin" or "member"' }),
+  }),
+});
+
+/** Role-change request body. */
+export type PatchMemberRoleBody = z.infer<typeof PatchMemberRoleBodySchema>;
+
+// ============================================================================
+// Audit log entry (lightweight, for this module)
+// ============================================================================
+
+/**
+ * Action types recorded when team admins mutate policy or membership.
+ *
+ * WHY: Audit entries are written to the `audit_log` table by every mutating
+ * route. Centralising the action-string constants prevents typos that would
+ * break log-query dashboards.
+ */
+export const TEAM_ADMIN_AUDIT_ACTIONS = {
+  MEMBER_ROLE_CHANGED: 'team.member.role_changed',
+  MEMBER_REMOVED: 'team.member.removed',
+  POLICY_UPDATED: 'team.policy.updated',
+} as const;
+
+/** Union of team admin audit action strings. */
+export type TeamAdminAuditAction =
+  (typeof TEAM_ADMIN_AUDIT_ACTIONS)[keyof typeof TEAM_ADMIN_AUDIT_ACTIONS];
+
+// ============================================================================
+// Helper: map DB role string to PolicyRole
+// ============================================================================
+
+/**
+ * Narrows a raw DB role string to {@link DbRole}.
+ *
+ * Returns 'member' as a safe default for any unrecognised value so
+ * UI components never crash on an unexpected role from the database.
+ *
+ * @param raw - Raw string from team_members.role
+ * @returns Validated DbRole
+ *
+ * @example
+ * parseDbRole('owner'); // 'owner'
+ * parseDbRole('unknown'); // 'member'
+ */
+export function parseDbRole(raw: string | null | undefined): DbRole {
+  if (raw === 'owner' || raw === 'admin' || raw === 'member') return raw;
+  return 'member';
+}

--- a/packages/styrby-shared/src/team/index.ts
+++ b/packages/styrby-shared/src/team/index.ts
@@ -13,6 +13,9 @@ export * from './role-matrix.js';
 export * from './approval-chain.js';
 export * from './seat-cap.js';
 
+// Phase 2.3 — admin UI types (member admin view, policy settings, founder team metrics)
+export * from './admin-types.js';
+
 // WHY invite-rate-limit is NOT re-exported from the barrel:
 // It imports @upstash/redis (~20-30 KB gzipped), which would be transitively
 // pulled into the web client bundle anywhere @styrby/shared is imported.

--- a/packages/styrby-web/src/app/api/admin/founder-team-metrics/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-team-metrics/__tests__/route.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Unit tests for the founder-team-metrics API route.
+ *
+ * WHY: The route sits behind two critical access gates — authentication and
+ * the is_admin flag. A regression in either would expose cross-team business
+ * intelligence (member counts, churn, subscription tiers) to non-admin users.
+ * These tests verify the gates fire before any DB query runs.
+ *
+ * We also validate the happy-path aggregation logic to ensure churn detection,
+ * average team size, and per-team summaries compute correctly given controlled
+ * mock data.
+ *
+ * Boundary testing pattern: mock Supabase client; assert HTTP responses only.
+ *
+ * @module api/admin/founder-team-metrics/__tests__/route
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+  createAdminClient: vi.fn(),
+}));
+
+vi.mock('@/lib/admin', () => ({
+  isAdmin: vi.fn(),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn().mockResolvedValue({ allowed: true, retryAfter: null }),
+  rateLimitResponse: vi.fn(
+    (retryAfter: number) =>
+      new Response(JSON.stringify({ error: 'RATE_LIMITED', retryAfter }), { status: 429 }),
+  ),
+  RATE_LIMITS: {
+    sensitive: { windowMs: 60_000, maxRequests: 10 },
+    standard: { windowMs: 60_000, maxRequests: 20 },
+  },
+}));
+
+import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { isAdmin } from '@/lib/admin';
+import { rateLimit } from '@/lib/rateLimit';
+import { GET } from '../route';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(): Request {
+  return new Request('http://localhost/api/admin/founder-team-metrics');
+}
+
+/**
+ * Configures the user-scoped Supabase client mock.
+ *
+ * @param user - Authenticated user, or null to simulate no session
+ */
+function mockSupabaseUser(user: { id: string } | null) {
+  (createClient as Mock).mockResolvedValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+        error: user ? null : new Error('Not authenticated'),
+      }),
+    },
+  });
+}
+
+/**
+ * Builds a chainable Supabase admin mock for a sequence of from() calls.
+ *
+ * Each call to adminDb.from(tableName) dequeues the next pre-configured
+ * response. The builder is thenable (awaitable at any chain depth) so it
+ * works regardless of whether the route ends the chain at .select(), .eq(),
+ * .gte(), or .order().
+ *
+ * WHY thenable builder: Supabase query builders implement PromiseLike, so
+ * the route awaits them at whatever method terminates the chain. Our mock
+ * must do the same — every builder method returns `this`, and `then` carries
+ * the pre-configured response.
+ *
+ * Queue order matches the route's Promise.all() sequence:
+ *   0: teams (.select().order())
+ *   1: team_members (.select())
+ *   2: subscriptions (.select().eq())
+ *   3: audit_log (.select().eq().gte())
+ *
+ * @param queue - Array of { data, error } objects in call order
+ */
+function mockAdminClient(
+  queue: { data: unknown; error: null | { message: string } }[],
+) {
+  let callIndex = 0;
+
+  (createAdminClient as Mock).mockReturnValue({
+    from: vi.fn().mockImplementation(() => {
+      const response = queue[callIndex++] ?? { data: [], error: null };
+
+      // WHY: make the builder a PromiseLike so it resolves when awaited at
+      // any terminal method, not just .order(). This mirrors the real Supabase
+      // PostgREST builder which is itself a PromiseLike.
+      const builder = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        then: (
+          resolve: (value: typeof response) => unknown,
+          _reject?: (reason: unknown) => unknown,
+        ) => Promise.resolve(response).then(resolve, _reject),
+      };
+
+      return builder;
+    }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Reusable mock data
+// ---------------------------------------------------------------------------
+
+const TEAMS = [
+  { id: 'team-1', name: 'Alpha Squad', owner_id: 'owner-1', created_at: '2026-01-01T00:00:00Z' },
+  { id: 'team-2', name: 'Beta Corps', owner_id: 'owner-2', created_at: '2026-02-01T00:00:00Z' },
+];
+
+const MEMBER_ROWS = [
+  { team_id: 'team-1' },
+  { team_id: 'team-1' },
+  { team_id: 'team-1' },
+  { team_id: 'team-2' },
+  { team_id: 'team-2' },
+];
+
+const SUBSCRIPTIONS = [
+  { user_id: 'owner-1', tier: 'team' },
+  { user_id: 'owner-2', tier: 'power' },
+];
+
+const NO_CHURN: { resource_id: string }[] = [];
+
+// ---------------------------------------------------------------------------
+// Auth + rate-limit gates
+// ---------------------------------------------------------------------------
+
+describe('GET /api/admin/founder-team-metrics — access gates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // WHY: clearAllMocks resets mockResolvedValue set in the module vi.mock() factory;
+    // re-establish the default allow behavior before each test.
+    (rateLimit as Mock).mockResolvedValue({ allowed: true, retryAfter: null });
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockSupabaseUser(null);
+    (isAdmin as Mock).mockResolvedValue(false);
+
+    const res = await GET(makeRequest() as never);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when user is authenticated but not admin', async () => {
+    mockSupabaseUser({ id: 'user-123' });
+    (isAdmin as Mock).mockResolvedValue(false);
+
+    const res = await GET(makeRequest() as never);
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Forbidden');
+  });
+
+  it('returns 429 when rate limited', async () => {
+    (rateLimit as Mock).mockResolvedValue({ allowed: false, retryAfter: 30 });
+
+    const res = await GET(makeRequest() as never);
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe('RATE_LIMITED');
+  });
+
+  it('does not call createAdminClient for non-admin users', async () => {
+    mockSupabaseUser({ id: 'attacker' });
+    (isAdmin as Mock).mockResolvedValue(false);
+
+    await GET(makeRequest() as never);
+
+    // WHY: Service-role client must never run for non-admins; prevents privilege escalation.
+    expect(createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('does not call createAdminClient when unauthenticated', async () => {
+    mockSupabaseUser(null);
+    (isAdmin as Mock).mockResolvedValue(false);
+
+    await GET(makeRequest() as never);
+
+    expect(createAdminClient).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy-path aggregation
+// ---------------------------------------------------------------------------
+
+describe('GET /api/admin/founder-team-metrics — aggregation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (rateLimit as Mock).mockResolvedValue({ allowed: true, retryAfter: null });
+    mockSupabaseUser({ id: 'admin-user' });
+    (isAdmin as Mock).mockResolvedValue(true);
+  });
+
+  /**
+   * Mounts the admin client with a fixed queue matching the route's
+   * Promise.all() call order: teams → team_members → subscriptions → audit_log.
+   *
+   * WHY this ordering matters: the route calls these four queries in parallel
+   * but the mock dequeues based on call order of .from(). The test assertions
+   * must match the implementation's query sequence.
+   */
+  function setupSuccessQueue(overrides: {
+    teams?: typeof TEAMS;
+    members?: typeof MEMBER_ROWS;
+    subs?: typeof SUBSCRIPTIONS;
+    churn?: typeof NO_CHURN;
+  } = {}) {
+    mockAdminClient([
+      { data: overrides.teams ?? TEAMS, error: null },
+      { data: overrides.members ?? MEMBER_ROWS, error: null },
+      { data: overrides.subs ?? SUBSCRIPTIONS, error: null },
+      { data: overrides.churn ?? NO_CHURN, error: null },
+    ]);
+  }
+
+  it('returns 200 with correct top-level counts', async () => {
+    setupSuccessQueue();
+
+    const res = await GET(makeRequest() as never);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.team_count).toBe(2);
+    // 3 members in team-1, 2 in team-2 → total 5, avg 2.5
+    expect(body.avg_team_size).toBe(2.5);
+    expect(body.churned_teams_30d).toBe(0);
+    expect(body.churn_rate_per_team_30d).toBe(0);
+  });
+
+  it('includes per-team summaries with correct member counts', async () => {
+    setupSuccessQueue();
+
+    const res = await GET(makeRequest() as never);
+    const body = await res.json();
+
+    expect(body.teams).toHaveLength(2);
+    const alpha = body.teams.find((t: { team_name: string }) => t.team_name === 'Alpha Squad');
+    const beta = body.teams.find((t: { team_name: string }) => t.team_name === 'Beta Corps');
+
+    expect(alpha.member_count).toBe(3);
+    expect(alpha.owner_tier).toBe('team');
+    expect(alpha.had_churn_30d).toBe(false);
+
+    expect(beta.member_count).toBe(2);
+    expect(beta.owner_tier).toBe('power');
+    expect(beta.had_churn_30d).toBe(false);
+  });
+
+  it('flags teams that had churn in last 30d', async () => {
+    setupSuccessQueue({
+      churn: [{ resource_id: 'team-1' }],
+    });
+
+    const res = await GET(makeRequest() as never);
+    const body = await res.json();
+
+    expect(body.churned_teams_30d).toBe(1);
+    // 1 churned out of 2 teams = 0.5
+    expect(body.churn_rate_per_team_30d).toBe(0.5);
+
+    const alpha = body.teams.find((t: { team_name: string }) => t.team_name === 'Alpha Squad');
+    const beta = body.teams.find((t: { team_name: string }) => t.team_name === 'Beta Corps');
+    expect(alpha.had_churn_30d).toBe(true);
+    expect(beta.had_churn_30d).toBe(false);
+  });
+
+  it('returns churn_rate_per_team_30d = null when there are no teams', async () => {
+    setupSuccessQueue({
+      teams: [],
+      members: [],
+      subs: [],
+      churn: [],
+    });
+
+    const res = await GET(makeRequest() as never);
+    const body = await res.json();
+
+    expect(body.team_count).toBe(0);
+    expect(body.avg_team_size).toBe(0);
+    expect(body.churn_rate_per_team_30d).toBeNull();
+    expect(body.teams).toHaveLength(0);
+  });
+
+  it('defaults owner_tier to "free" when owner has no active subscription', async () => {
+    setupSuccessQueue({
+      subs: [], // no active subscriptions
+    });
+
+    const res = await GET(makeRequest() as never);
+    const body = await res.json();
+
+    for (const team of body.teams) {
+      expect(team.owner_tier).toBe('free');
+    }
+  });
+
+  it('defaults member_count to 0 for teams with no members', async () => {
+    setupSuccessQueue({
+      members: [], // no members at all
+    });
+
+    const res = await GET(makeRequest() as never);
+    const body = await res.json();
+
+    for (const team of body.teams) {
+      expect(team.member_count).toBe(0);
+    }
+    expect(body.avg_team_size).toBe(0);
+  });
+
+  it('rounds avg_team_size to 2 decimal places', async () => {
+    // 3 teams, 1 member each + 1 extra = 4 total → 4/3 = 1.333...
+    setupSuccessQueue({
+      teams: [
+        { id: 't1', name: 'T1', owner_id: 'o1', created_at: '2026-01-01T00:00:00Z' },
+        { id: 't2', name: 'T2', owner_id: 'o2', created_at: '2026-01-01T00:00:00Z' },
+        { id: 't3', name: 'T3', owner_id: 'o3', created_at: '2026-01-01T00:00:00Z' },
+      ],
+      members: [
+        { team_id: 't1' },
+        { team_id: 't2' },
+        { team_id: 't3' },
+        { team_id: 't1' }, // extra for t1
+      ],
+    });
+
+    const res = await GET(makeRequest() as never);
+    const body = await res.json();
+
+    // 4 members / 3 teams = 1.3333... → rounds to 1.33
+    expect(body.avg_team_size).toBe(1.33);
+  });
+
+  it('includes computed_at as a valid ISO 8601 timestamp', async () => {
+    setupSuccessQueue();
+
+    const res = await GET(makeRequest() as never);
+    const body = await res.json();
+
+    expect(typeof body.computed_at).toBe('string');
+    expect(() => new Date(body.computed_at).toISOString()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe('GET /api/admin/founder-team-metrics — error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (rateLimit as Mock).mockResolvedValue({ allowed: true, retryAfter: null });
+    mockSupabaseUser({ id: 'admin-user' });
+    (isAdmin as Mock).mockResolvedValue(true);
+  });
+
+  it('returns 500 when createAdminClient throws', async () => {
+    (createAdminClient as Mock).mockImplementation(() => {
+      throw new Error('DB connection refused');
+    });
+
+    const res = await GET(makeRequest() as never);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('INTERNAL_ERROR');
+  });
+});

--- a/packages/styrby-web/src/app/api/admin/founder-team-metrics/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-team-metrics/route.ts
@@ -1,0 +1,196 @@
+/**
+ * Founder Team Metrics API
+ *
+ * GET /api/admin/founder-team-metrics
+ *
+ * Returns aggregated team-tier business metrics for the founder dashboard:
+ *   - Total number of teams
+ *   - Average team size (member count)
+ *   - Number of teams with member churn in the last 30 days
+ *   - Churn rate per team (rolling 30d)
+ *   - Per-team breakdown (name, member count, owner tier, churn flag)
+ *
+ * WHY separate from /api/admin/founder-metrics:
+ *   The existing founder-metrics route aggregates solo-user metrics (MRR,
+ *   funnel, LTV). Team metrics are a distinct Phase 2.3 surface. Keeping them
+ *   separate allows the founder dashboard to load them independently and avoids
+ *   bloating the already-complex founder-metrics payload.
+ *
+ * WHY service-role for DB queries:
+ *   Team metrics aggregate data across ALL teams and ALL users. Supabase RLS is
+ *   user-scoped — it cannot cross user boundaries. We use createAdminClient()
+ *   (service role) only after verifying the is_admin gate at the API layer.
+ *
+ * WHY is_admin gate (not VITE_FOUNDER_USER_IDS):
+ *   The is_admin column on profiles is set via service role only (no RLS UPDATE
+ *   policy for users). This is the same pattern as founder-metrics and is more
+ *   robust than environment-variable allowlists which can drift across deploys.
+ *
+ * @auth Required - Supabase Auth JWT via cookie (is_admin = true)
+ * @rateLimit 10 requests per minute (sensitive bucket)
+ *
+ * @returns 200 {@link FounderTeamMetrics}
+ *
+ * @error 401 { error: 'Unauthorized' }
+ * @error 403 { error: 'Forbidden' }
+ * @error 429 { error: 'RATE_LIMITED', retryAfter: number }
+ * @error 500 { error: 'INTERNAL_ERROR', message: string }
+ *
+ * @module api/admin/founder-team-metrics
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { isAdmin } from '@/lib/admin';
+import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
+import type { FounderTeamMetrics, FounderTeamSummary } from '@styrby/shared';
+
+// ============================================================================
+// DB row types (internal, not exported)
+// ============================================================================
+
+/** Raw team row from admin client. */
+interface TeamDbRow {
+  id: string;
+  name: string;
+  owner_id: string;
+  created_at: string;
+}
+
+/** team_members aggregation row. */
+interface MemberCountRow {
+  team_id: string;
+  count: number;
+}
+
+/** Subscription row for owner tier. */
+interface SubscriptionRow {
+  user_id: string;
+  tier: string;
+}
+
+/** audit_log row for churn detection. */
+interface AuditChurnRow {
+  resource_id: string;
+}
+
+// ============================================================================
+// Route handler
+// ============================================================================
+
+export async function GET(request: NextRequest) {
+  // Rate limit first, before any DB call.
+  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.sensitive, 'founder-team-metrics');
+  if (!allowed) return rateLimitResponse(retryAfter!);
+
+  // Auth gate: must be a signed-in user.
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Admin gate: must have is_admin = true in profiles.
+  const adminStatus = await isAdmin(user.id);
+  if (!adminStatus) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  try {
+    const adminDb = createAdminClient();
+    const now = new Date();
+    const thirtyDaysAgo = new Date(now);
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    // ── Fetch all data in parallel ──────────────────────────────────────────
+    // WHY Promise.all: each query is independent; serial would multiply p99.
+    const [teamsResult, membersResult, subsResult, churnResult] = await Promise.all([
+      // All teams
+      adminDb
+        .from('teams')
+        .select('id, name, owner_id, created_at')
+        .order('created_at', { ascending: false }),
+
+      // Member count per team (via team_members)
+      adminDb
+        .from('team_members')
+        .select('team_id'),
+
+      // Owner subscription tiers (for tier labelling)
+      adminDb
+        .from('subscriptions')
+        .select('user_id, tier')
+        .eq('status', 'active'),
+
+      // Teams that had a member-removal audit event in the last 30d.
+      // WHY audit_log not team_members deletions: deleted rows are gone.
+      // The audit_log entry written by DELETE /api/teams/[id]/members/[userId]
+      // is the only durable record of historical membership churn.
+      adminDb
+        .from('audit_log')
+        .select('resource_id')
+        .eq('action', 'team.member.removed')
+        .gte('created_at', thirtyDaysAgo.toISOString()),
+    ]);
+
+    const teams = (teamsResult.data ?? []) as TeamDbRow[];
+    const memberRows = (membersResult.data ?? []) as { team_id: string }[];
+    const subs = (subsResult.data ?? []) as SubscriptionRow[];
+    const churnRows = (churnResult.data ?? []) as AuditChurnRow[];
+
+    // ── Build lookup maps ───────────────────────────────────────────────────
+
+    /** member count per team_id */
+    const memberCountByTeam: Record<string, number> = {};
+    for (const row of memberRows) {
+      memberCountByTeam[row.team_id] = (memberCountByTeam[row.team_id] ?? 0) + 1;
+    }
+
+    /** active subscription tier per user_id */
+    const tierByOwner: Record<string, string> = {};
+    for (const sub of subs) {
+      tierByOwner[sub.user_id] = sub.tier;
+    }
+
+    /** set of team_ids that had churn in the last 30d */
+    const churnedTeamIds = new Set(churnRows.map((r) => r.resource_id));
+
+    // ── Compute per-team summaries ──────────────────────────────────────────
+
+    const teamSummaries: FounderTeamSummary[] = teams.map((team) => ({
+      team_id: team.id,
+      team_name: team.name,
+      member_count: memberCountByTeam[team.id] ?? 0,
+      owner_tier: tierByOwner[team.owner_id] ?? 'free',
+      had_churn_30d: churnedTeamIds.has(team.id),
+      created_at: team.created_at,
+    }));
+
+    // ── Aggregate metrics ───────────────────────────────────────────────────
+
+    const teamCount = teams.length;
+    const totalMembers = teamSummaries.reduce((sum, t) => sum + t.member_count, 0);
+    const avgTeamSize = teamCount > 0 ? totalMembers / teamCount : 0;
+    const churnedTeams30d = teamSummaries.filter((t) => t.had_churn_30d).length;
+    const churnRatePerTeam30d = teamCount > 0 ? churnedTeams30d / teamCount : null;
+
+    const metrics: FounderTeamMetrics = {
+      team_count: teamCount,
+      avg_team_size: Math.round(avgTeamSize * 100) / 100, // 2 decimal places
+      churned_teams_30d: churnedTeams30d,
+      churn_rate_per_team_30d: churnRatePerTeam30d,
+      teams: teamSummaries,
+      computed_at: now.toISOString(),
+    };
+
+    return NextResponse.json(metrics);
+  } catch (err) {
+    const isDev = process.env.NODE_ENV === 'development';
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[founder-team-metrics] Error:', isDev ? err : message);
+    return NextResponse.json(
+      { error: 'INTERNAL_ERROR', message: isDev ? message : 'Metrics computation failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/styrby-web/src/app/api/teams/[id]/policies/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/policies/__tests__/route.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Team Policies API Route Tests
+ *
+ * Tests GET and PATCH /api/teams/[id]/policies
+ *
+ * WHY: The policies endpoint is a governance-critical surface:
+ *   - Wrong auto_approve_rules means tools bypass human review
+ *   - Wrong blocked_tools means forbidden tools can run
+ *   - Wrong budget thresholds means overspend goes undetected
+ *   - Every mutation must be logged (audit_log) for SOC2 compliance
+ *
+ * Test coverage:
+ *   - Authentication: 401 for unauthenticated callers
+ *   - Membership: 403 for non-members
+ *   - Role gating: 403 for 'member' role on PATCH
+ *   - Zod validation: 400 for invalid body
+ *   - Success cases: GET returns normalized arrays, PATCH updates + returns new state
+ *   - Audit log: PATCH fires audit insert (non-blocking)
+ *   - Edge cases: empty arrays, null budget, no-op PATCH (no fields)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetUser = vi.fn();
+const fromCallQueue: Array<{ data?: unknown; error?: unknown; count?: number }> = [];
+
+/**
+ * Creates a chainable Supabase mock that pops from the fromCallQueue.
+ *
+ * WHY: Each .from() call in the route pops the next queued result, letting
+ * tests control each sequential DB call precisely without complex mock state.
+ */
+function createChainMock() {
+  const result = fromCallQueue.shift() ?? { data: null, error: null };
+  const chain: Record<string, unknown> = {};
+  const methods = [
+    'select', 'eq', 'neq', 'gte', 'lte', 'order', 'limit', 'insert',
+    'update', 'delete', 'is', 'not', 'in',
+  ];
+  for (const m of methods) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  chain['single'] = vi.fn().mockResolvedValue(result);
+  chain['then'] = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: vi.fn(() => createChainMock()),
+  })),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn(() => ({ allowed: true, remaining: 29 })),
+  RATE_LIMITS: { budgetAlerts: { windowMs: 60000, maxRequests: 30 } },
+  rateLimitResponse: vi.fn((retryAfter: number) =>
+    new Response(JSON.stringify({ error: 'RATE_LIMITED' }), {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfter) },
+    })
+  ),
+}));
+
+import { GET, PATCH } from '../route';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const TEAM_ID = 'team-uuid-abc';
+const AUTH_USER = { id: 'user-uuid-owner', email: 'owner@example.com' };
+const MEMBER_USER = { id: 'user-uuid-member', email: 'member@example.com' };
+const ADMIN_USER = { id: 'user-uuid-admin', email: 'admin@example.com' };
+
+function createRouteContext(id: string = TEAM_ID) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function createGetRequest(): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/teams/${TEAM_ID}/policies`, {
+    method: 'GET',
+    headers: { 'x-forwarded-for': '10.0.0.1' },
+  });
+}
+
+function createPatchRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/teams/${TEAM_ID}/policies`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-forwarded-for': '10.0.0.1',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockAuthenticated(user = AUTH_USER) {
+  mockGetUser.mockResolvedValue({ data: { user }, error: null });
+}
+
+function mockUnauthenticated() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'Not authenticated' } });
+}
+
+/** A full team policies DB row */
+const MOCK_TEAM_ROW = {
+  id: TEAM_ID,
+  auto_approve_rules: ['read_file', 'list_dir'],
+  blocked_tools: ['delete_file'],
+  budget_per_seat_usd: 50,
+};
+
+// ============================================================================
+// GET Tests
+// ============================================================================
+
+describe('GET /api/teams/[id]/policies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromCallQueue.length = 0;
+  });
+
+  it('returns 401 for unauthenticated caller', async () => {
+    mockUnauthenticated();
+    const res = await GET(createGetRequest(), createRouteContext());
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when caller is not a team member', async () => {
+    mockAuthenticated();
+    // 1. team_members.select().eq().eq().single() => not found
+    fromCallQueue.push({ data: null, error: null });
+    const res = await GET(createGetRequest(), createRouteContext());
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Not a member');
+  });
+
+  it('returns 404 when team does not exist', async () => {
+    mockAuthenticated();
+    // 1. membership => owner
+    fromCallQueue.push({ data: { role: 'owner' }, error: null });
+    // 2. teams.select => not found
+    fromCallQueue.push({ data: null, error: { code: 'PGRST116', message: 'Not found' } });
+
+    const res = await GET(createGetRequest(), createRouteContext());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 with normalised policies for a member', async () => {
+    mockAuthenticated(MEMBER_USER);
+    // 1. membership => member role (members can view)
+    fromCallQueue.push({ data: { role: 'member' }, error: null });
+    // 2. team row
+    fromCallQueue.push({ data: MOCK_TEAM_ROW, error: null });
+
+    const res = await GET(createGetRequest(), createRouteContext());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { policies: { auto_approve_rules: string[]; blocked_tools: string[]; budget_per_seat_usd: number | null } };
+    expect(body.policies.auto_approve_rules).toEqual(['read_file', 'list_dir']);
+    expect(body.policies.blocked_tools).toEqual(['delete_file']);
+    expect(body.policies.budget_per_seat_usd).toBe(50);
+  });
+
+  it('normalises null jsonb arrays to empty arrays', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: { role: 'owner' }, error: null });
+    fromCallQueue.push({
+      data: { id: TEAM_ID, auto_approve_rules: null, blocked_tools: null, budget_per_seat_usd: null },
+      error: null,
+    });
+
+    const res = await GET(createGetRequest(), createRouteContext());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { policies: { auto_approve_rules: string[]; blocked_tools: string[]; budget_per_seat_usd: number | null } };
+    expect(body.policies.auto_approve_rules).toEqual([]);
+    expect(body.policies.blocked_tools).toEqual([]);
+    expect(body.policies.budget_per_seat_usd).toBeNull();
+  });
+});
+
+// ============================================================================
+// PATCH Tests
+// ============================================================================
+
+describe('PATCH /api/teams/[id]/policies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromCallQueue.length = 0;
+  });
+
+  it('returns 401 for unauthenticated caller', async () => {
+    mockUnauthenticated();
+    const res = await PATCH(createPatchRequest({ auto_approve_rules: [] }), createRouteContext());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when caller is not a team member', async () => {
+    mockAuthenticated();
+    // 1. membership => not found
+    fromCallQueue.push({ data: null, error: null });
+
+    const res = await PATCH(createPatchRequest({ auto_approve_rules: [] }), createRouteContext());
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Not a member');
+  });
+
+  it('returns 403 when caller is a plain member (not owner/admin)', async () => {
+    mockAuthenticated(MEMBER_USER);
+    // 1. membership => member role
+    fromCallQueue.push({ data: { role: 'member' }, error: null });
+
+    const res = await PATCH(createPatchRequest({ blocked_tools: ['rm'] }), createRouteContext());
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('owners and admins');
+  });
+
+  it('returns 400 for invalid body (auto_approve_rules not array)', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: { role: 'owner' }, error: null });
+
+    const res = await PATCH(
+      createPatchRequest({ auto_approve_rules: 'not-an-array' }),
+      createRouteContext(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when budget_per_seat_usd is negative', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: { role: 'owner' }, error: null });
+
+    const res = await PATCH(
+      createPatchRequest({ budget_per_seat_usd: -100 }),
+      createRouteContext(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when no fields are provided', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: { role: 'owner' }, error: null });
+
+    const res = await PATCH(createPatchRequest({}), createRouteContext());
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('No fields to update');
+  });
+
+  it('owner can update auto_approve_rules successfully', async () => {
+    mockAuthenticated();
+    // 1. membership
+    fromCallQueue.push({ data: { role: 'owner' }, error: null });
+    // 2. current team (before-state for audit)
+    fromCallQueue.push({ data: MOCK_TEAM_ROW, error: null });
+    // 3. update result
+    fromCallQueue.push({
+      data: { ...MOCK_TEAM_ROW, auto_approve_rules: ['read_file'] },
+      error: null,
+    });
+
+    const res = await PATCH(
+      createPatchRequest({ auto_approve_rules: ['read_file'] }),
+      createRouteContext(),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { policies: { auto_approve_rules: string[] } };
+    expect(body.policies.auto_approve_rules).toEqual(['read_file']);
+  });
+
+  it('admin can update blocked_tools successfully', async () => {
+    mockAuthenticated(ADMIN_USER);
+    // 1. membership
+    fromCallQueue.push({ data: { role: 'admin' }, error: null });
+    // 2. current team
+    fromCallQueue.push({ data: MOCK_TEAM_ROW, error: null });
+    // 3. update result
+    fromCallQueue.push({
+      data: { ...MOCK_TEAM_ROW, blocked_tools: ['rm', 'dd'] },
+      error: null,
+    });
+
+    const res = await PATCH(
+      createPatchRequest({ blocked_tools: ['rm', 'dd'] }),
+      createRouteContext(),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { policies: { blocked_tools: string[] } };
+    expect(body.policies.blocked_tools).toEqual(['rm', 'dd']);
+  });
+
+  it('can set budget_per_seat_usd to null (unlimited)', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: { role: 'owner' }, error: null });
+    fromCallQueue.push({ data: MOCK_TEAM_ROW, error: null });
+    fromCallQueue.push({
+      data: { ...MOCK_TEAM_ROW, budget_per_seat_usd: null },
+      error: null,
+    });
+
+    const res = await PATCH(
+      createPatchRequest({ budget_per_seat_usd: null }),
+      createRouteContext(),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { policies: { budget_per_seat_usd: number | null } };
+    expect(body.policies.budget_per_seat_usd).toBeNull();
+  });
+
+  it('returns 404 when team is not found during fetch', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: { role: 'owner' }, error: null });
+    // current team query => not found
+    fromCallQueue.push({ data: null, error: { code: 'PGRST116', message: 'Not found' } });
+
+    const res = await PATCH(
+      createPatchRequest({ blocked_tools: ['rm'] }),
+      createRouteContext(),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 500 when the update query fails', async () => {
+    mockAuthenticated();
+    fromCallQueue.push({ data: { role: 'owner' }, error: null });
+    fromCallQueue.push({ data: MOCK_TEAM_ROW, error: null });
+    // update fails
+    fromCallQueue.push({ data: null, error: { message: 'DB error' } });
+
+    const res = await PATCH(
+      createPatchRequest({ blocked_tools: ['rm'] }),
+      createRouteContext(),
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/styrby-web/src/app/api/teams/[id]/policies/route.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/policies/route.ts
@@ -1,0 +1,304 @@
+/**
+ * Team Policies API Route
+ *
+ * GET  /api/teams/[id]/policies — fetch the team's current policy settings
+ * PATCH /api/teams/[id]/policies — update auto_approve_rules, blocked_tools,
+ *                                   budget_per_seat_usd (owner/admin only)
+ *
+ * WHY a dedicated /policies endpoint rather than PATCH /api/teams/[id]:
+ *   Policy edits are a higher-stakes governance action than team-name changes.
+ *   Separating them gives us a clean audit-log target, a distinct rate-limit
+ *   bucket, and lets us add field-level Zod validation without complicating
+ *   the general team PATCH schema.
+ *
+ * WHY audit_log on every mutation:
+ *   Policy changes affect every member's tool access. SOC2 CC6.2 (Logical and
+ *   Physical Access Controls) requires audit trails for access-policy modifications.
+ *   We record before + after values so diffs are reconstructable.
+ *
+ * @auth Required - Supabase Auth JWT via cookie (must be team owner or admin)
+ * @rateLimit 30 requests per minute (standard bucket)
+ *
+ * @module api/teams/[id]/policies
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
+import {
+  PatchTeamPolicyBodySchema,
+  TeamPolicySettingsSchema,
+  TEAM_ADMIN_AUDIT_ACTIONS,
+} from '@styrby/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Shape of the teams table row we read/write for policy fields.
+ *
+ * WHY auto_approve_rules/blocked_tools as unknown[]:
+ *   Supabase returns jsonb columns as unknown[]. We validate through Zod before
+ *   using so the type is intentionally loose here.
+ */
+interface TeamPolicyRow {
+  id: string;
+  auto_approve_rules: unknown;
+  blocked_tools: unknown;
+  budget_per_seat_usd: number | null;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Verifies the caller is an authenticated member of the team and returns
+ * their role. Returns null if the caller is not a member.
+ *
+ * @param supabase - Authenticated Supabase client
+ * @param userId - Caller user ID
+ * @param teamId - Team being accessed
+ * @returns The caller's role, or null if not a member
+ */
+async function getCallerRole(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string,
+  teamId: string,
+): Promise<'owner' | 'admin' | 'member' | null> {
+  const { data: membership } = await supabase
+    .from('team_members')
+    .select('role')
+    .eq('team_id', teamId)
+    .eq('user_id', userId)
+    .single();
+
+  if (!membership) return null;
+  const role = membership.role as string;
+  if (role === 'owner' || role === 'admin' || role === 'member') return role;
+  return 'member';
+}
+
+// ============================================================================
+// GET /api/teams/[id]/policies
+// ============================================================================
+
+/**
+ * GET /api/teams/[id]/policies
+ *
+ * Returns the team's current editable policy settings (auto_approve_rules,
+ * blocked_tools, budget_per_seat_usd). Accessible to all team members.
+ *
+ * @auth Required - Supabase Auth JWT via cookie (any team member)
+ *
+ * @returns 200 {
+ *   policies: {
+ *     auto_approve_rules: string[],
+ *     blocked_tools: string[],
+ *     budget_per_seat_usd: number | null
+ *   }
+ * }
+ *
+ * @error 401 { error: 'Unauthorized' }
+ * @error 403 { error: 'Not a member of this team' }
+ * @error 404 { error: 'Team not found' }
+ * @error 500 { error: 'Failed to fetch team policies' }
+ */
+export async function GET(
+  _request: NextRequest,
+  context: RouteContext,
+) {
+  try {
+    const { id: teamId } = await context.params;
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const callerRole = await getCallerRole(supabase, user.id, teamId);
+    if (!callerRole) {
+      return NextResponse.json({ error: 'Not a member of this team' }, { status: 403 });
+    }
+
+    // RLS will gate access — only fetch the policy columns we expose.
+    // SEC-API-004: Explicit column list avoids leaking future columns.
+    const { data: team, error: teamError } = await supabase
+      .from('teams')
+      .select('id, auto_approve_rules, blocked_tools, budget_per_seat_usd')
+      .eq('id', teamId)
+      .single() as { data: TeamPolicyRow | null; error: unknown };
+
+    if (teamError || !team) {
+      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+    }
+
+    // Normalise jsonb arrays from Supabase (may be null or non-array).
+    const policies = TeamPolicySettingsSchema.parse({
+      auto_approve_rules: Array.isArray(team.auto_approve_rules) ? team.auto_approve_rules : [],
+      blocked_tools: Array.isArray(team.blocked_tools) ? team.blocked_tools : [],
+      budget_per_seat_usd: team.budget_per_seat_usd ?? null,
+    });
+
+    return NextResponse.json({ policies });
+  } catch (err) {
+    const isDev = process.env.NODE_ENV === 'development';
+    console.error('[policies GET]', isDev ? err : err instanceof Error ? err.message : 'Unknown');
+    return NextResponse.json({ error: 'Failed to fetch team policies' }, { status: 500 });
+  }
+}
+
+// ============================================================================
+// PATCH /api/teams/[id]/policies
+// ============================================================================
+
+/**
+ * PATCH /api/teams/[id]/policies
+ *
+ * Updates the team's policy settings. Owner or admin access required.
+ * All fields are optional — send only the fields you want to change.
+ * Every successful mutation is recorded in audit_log with before/after values.
+ *
+ * @auth Required - Supabase Auth JWT via cookie (must be owner or admin)
+ * @rateLimit 30 requests per minute
+ *
+ * @body {
+ *   auto_approve_rules?: string[],
+ *   blocked_tools?: string[],
+ *   budget_per_seat_usd?: number | null
+ * }
+ *
+ * @returns 200 {
+ *   policies: {
+ *     auto_approve_rules: string[],
+ *     blocked_tools: string[],
+ *     budget_per_seat_usd: number | null
+ *   }
+ * }
+ *
+ * @error 400 { error: string } - Validation failure
+ * @error 401 { error: 'Unauthorized' }
+ * @error 403 { error: string } - Not a member, or insufficient role
+ * @error 404 { error: 'Team not found' }
+ * @error 500 { error: 'Failed to update team policies' }
+ */
+export async function PATCH(
+  request: NextRequest,
+  context: RouteContext,
+) {
+  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.budgetAlerts, 'team-policies');
+  if (!allowed) return rateLimitResponse(retryAfter!);
+
+  try {
+    const { id: teamId } = await context.params;
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Only owner or admin can edit policies.
+    const callerRole = await getCallerRole(supabase, user.id, teamId);
+    if (!callerRole) {
+      return NextResponse.json({ error: 'Not a member of this team' }, { status: 403 });
+    }
+    if (callerRole === 'member') {
+      return NextResponse.json(
+        { error: 'Only team owners and admins can edit policies' },
+        { status: 403 },
+      );
+    }
+
+    // Validate request body.
+    const rawBody = await request.json();
+    const parseResult = PatchTeamPolicyBodySchema.safeParse(rawBody);
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: parseResult.error.errors.map((e) => e.message).join(', ') },
+        { status: 400 },
+      );
+    }
+
+    const patch = parseResult.data;
+    if (Object.keys(patch).length === 0) {
+      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+    }
+
+    // Fetch current values for audit_log before-state.
+    const { data: currentTeam, error: fetchError } = await supabase
+      .from('teams')
+      .select('id, auto_approve_rules, blocked_tools, budget_per_seat_usd')
+      .eq('id', teamId)
+      .single() as { data: TeamPolicyRow | null; error: unknown };
+
+    if (fetchError || !currentTeam) {
+      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+    }
+
+    // Build the update payload (only changed fields).
+    const updatePayload: Record<string, unknown> = {};
+    if (patch.auto_approve_rules !== undefined) updatePayload.auto_approve_rules = patch.auto_approve_rules;
+    if (patch.blocked_tools !== undefined) updatePayload.blocked_tools = patch.blocked_tools;
+    if (patch.budget_per_seat_usd !== undefined) updatePayload.budget_per_seat_usd = patch.budget_per_seat_usd;
+
+    // Apply the update.
+    const { data: updatedTeam, error: updateError } = await supabase
+      .from('teams')
+      .update(updatePayload)
+      .eq('id', teamId)
+      .select('id, auto_approve_rules, blocked_tools, budget_per_seat_usd')
+      .single() as { data: TeamPolicyRow | null; error: unknown };
+
+    if (updateError || !updatedTeam) {
+      console.error('[policies PATCH] update failed:', updateError);
+      return NextResponse.json({ error: 'Failed to update team policies' }, { status: 500 });
+    }
+
+    // Write audit log.
+    // WHY we fire-and-forget the audit_log insert: a logging failure must not
+    // roll back a policy change that succeeded. The audit is for compliance;
+    // the operation itself is already committed.
+    supabase
+      .from('audit_log')
+      .insert({
+        user_id: user.id,
+        action: TEAM_ADMIN_AUDIT_ACTIONS.POLICY_UPDATED,
+        resource_type: 'team',
+        resource_id: teamId,
+        metadata: {
+          before: {
+            auto_approve_rules: currentTeam.auto_approve_rules,
+            blocked_tools: currentTeam.blocked_tools,
+            budget_per_seat_usd: currentTeam.budget_per_seat_usd,
+          },
+          after: updatePayload,
+          changed_by_role: callerRole,
+        },
+      })
+      .then(({ error: auditError }) => {
+        if (auditError) {
+          // Non-fatal: log but do not reject
+          console.error('[policies PATCH] audit_log insert failed:', auditError.message);
+        }
+      });
+
+    const policies = TeamPolicySettingsSchema.parse({
+      auto_approve_rules: Array.isArray(updatedTeam.auto_approve_rules) ? updatedTeam.auto_approve_rules : [],
+      blocked_tools: Array.isArray(updatedTeam.blocked_tools) ? updatedTeam.blocked_tools : [],
+      budget_per_seat_usd: updatedTeam.budget_per_seat_usd ?? null,
+    });
+
+    return NextResponse.json({ policies });
+  } catch (err) {
+    const isDev = process.env.NODE_ENV === 'development';
+    console.error('[policies PATCH]', isDev ? err : err instanceof Error ? err.message : 'Unknown');
+    return NextResponse.json({ error: 'Failed to update team policies' }, { status: 500 });
+  }
+}

--- a/packages/styrby-web/src/app/dashboard/founder/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/founder/page.tsx
@@ -11,7 +11,8 @@ import { isAdmin } from '@/lib/admin';
 // to document the dependency boundary and will be used if we add client-side
 // projections in a future iteration. Remove if still unused at Phase 2.
 // import { calcRunRate, normalizeTier } from '@styrby/shared';
-import { MrrCard, FunnelChart, TierMixTable, CohortRetentionTable } from '@/components/dashboard/founder';
+import { MrrCard, FunnelChart, TierMixTable, CohortRetentionTable, TeamsCard } from '@/components/dashboard/founder';
+import type { FounderTeamMetrics } from '@styrby/shared';
 
 export const metadata: Metadata = {
   title: 'Founder Ops | Styrby',
@@ -88,6 +89,7 @@ export default async function FounderPage() {
 
   let data: FounderMetrics | null = null;
   let fetchError: string | null = null;
+  let teamMetrics: FounderTeamMetrics | null = null;
 
   try {
     // Forward the cookie header so the API route can verify the auth session.
@@ -97,17 +99,31 @@ export default async function FounderPage() {
       .map((c) => `${c.name}=${c.value}`)
       .join('; ');
 
-    const response = await fetch(`${baseUrl}/api/admin/founder-metrics`, {
-      headers: { Cookie: cookieHeader },
-      // WHY no-store: We want live data every render, not a cached response.
-      cache: 'no-store',
-    });
+    // Fetch core metrics and team metrics in parallel to minimise TTFB.
+    // WHY parallel: both are independent admin-gated queries; serial fetches
+    // would double server-render latency for the founder dashboard.
+    const [metricsResponse, teamMetricsResponse] = await Promise.all([
+      fetch(`${baseUrl}/api/admin/founder-metrics`, {
+        headers: { Cookie: cookieHeader },
+        // WHY no-store: We want live data every render, not a cached response.
+        cache: 'no-store',
+      }),
+      fetch(`${baseUrl}/api/admin/founder-team-metrics`, {
+        headers: { Cookie: cookieHeader },
+        cache: 'no-store',
+      }),
+    ]);
 
-    if (!response.ok) {
-      const body = await response.json().catch(() => ({}));
-      fetchError = (body as { message?: string }).message ?? `HTTP ${response.status}`;
+    if (!metricsResponse.ok) {
+      const body = await metricsResponse.json().catch(() => ({}));
+      fetchError = (body as { message?: string }).message ?? `HTTP ${metricsResponse.status}`;
     } else {
-      data = (await response.json()) as FounderMetrics;
+      data = (await metricsResponse.json()) as FounderMetrics;
+    }
+
+    // Team metrics failure is non-fatal — page still shows core metrics.
+    if (teamMetricsResponse.ok) {
+      teamMetrics = (await teamMetricsResponse.json()) as FounderTeamMetrics;
     }
   } catch (err) {
     fetchError = err instanceof Error ? err.message : 'Failed to fetch founder metrics';
@@ -155,9 +171,16 @@ export default async function FounderPage() {
       </div>
 
       {/* Row 4: Cohort retention */}
-      <div className="mt-6 mb-8">
+      <div className="mt-6">
         <CohortRetentionTable cohorts={data.cohortRetention} />
       </div>
+
+      {/* Row 5: Teams — Phase 2.3 */}
+      {teamMetrics && (
+        <div className="mt-6 mb-8">
+          <TeamsCard metrics={teamMetrics} />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/styrby-web/src/app/dashboard/team/[teamId]/members/members-dynamic.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/[teamId]/members/members-dynamic.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+/**
+ * MembersDynamic
+ *
+ * Client wrapper that owns optimistic member-list state and provides
+ * onRoleChanged / onMemberRemoved callbacks to the dynamically imported
+ * MembersTable component.
+ *
+ * WHY this wrapper exists (not inline in page.tsx):
+ *   The parent page is a Server Component. Server Components cannot pass
+ *   function props (callbacks) to Client Components because functions are
+ *   not serialisable across the server/client boundary. This wrapper is the
+ *   Client Component boundary — it receives the server-fetched initial members
+ *   as a serialisable prop array and manages all interactive state from there.
+ *
+ * WHY dynamic import here (not in page.tsx):
+ *   MembersTable imports lucide-react icons and uses useState for the
+ *   confirm-remove dialog. The admin members page is a rare-visit surface.
+ *   Dynamic import defers the component bundle until needed, keeping the
+ *   shared dashboard chunk lean. Follows the same pattern as
+ *   cost-charts-dynamic.tsx (Phase 1.6.13).
+ *
+ * WHY ssr: false not used here (unlike cost-charts):
+ *   MembersTable has no browser-only APIs — it only uses fetch and React
+ *   state. SSR is safe and gives an initial render with server-side HTML.
+ *
+ * @module dashboard/team/[teamId]/members/members-dynamic
+ */
+
+import { useState, useCallback } from 'react';
+import dynamic from 'next/dynamic';
+import type { TeamMemberAdminRow } from '@styrby/shared';
+
+// ============================================================================
+// Props
+// ============================================================================
+
+interface MembersDynamicProps {
+  /** Initial member list fetched on the server. */
+  initialMembers: TeamMemberAdminRow[];
+  /** The authenticated user's ID (to disable self-mutation controls). */
+  currentUserId: string;
+  /** The authenticated user's role in this team. */
+  currentUserRole: 'owner' | 'admin' | 'member';
+  /** The team ID — used to construct API call URLs in MembersTable. */
+  teamId: string;
+}
+
+// ============================================================================
+// Skeleton
+// ============================================================================
+
+/** Skeleton shown while the MembersTable JS bundle is loading. */
+function MembersTableSkeleton() {
+  return (
+    <div className="p-6 space-y-3" aria-busy="true" aria-label="Loading members">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="flex items-center gap-4 animate-pulse">
+          <div className="w-8 h-8 rounded-full bg-zinc-800" />
+          <div className="flex-1 space-y-1">
+            <div className="h-3 bg-zinc-800 rounded w-40" />
+            <div className="h-2.5 bg-zinc-800 rounded w-28" />
+          </div>
+          <div className="h-5 bg-zinc-800 rounded-full w-16 hidden md:block" />
+          <div className="h-3 bg-zinc-800 rounded w-20 hidden lg:block" />
+          <div className="h-3 bg-zinc-800 rounded w-14 hidden lg:block" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// Dynamic import
+// ============================================================================
+
+const MembersTableLazy = dynamic(
+  () => import('@/components/team/members').then((mod) => ({ default: mod.MembersTable })),
+  { loading: () => <MembersTableSkeleton /> },
+);
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Client boundary component that owns member list state.
+ *
+ * Provides optimistic update callbacks to MembersTable so role changes and
+ * removals are reflected immediately without a full page reload.
+ *
+ * @param props - Initial server-fetched data + current user identity
+ */
+export function MembersDynamic({
+  initialMembers,
+  currentUserId,
+  currentUserRole,
+  teamId,
+}: MembersDynamicProps) {
+  // WHY useState with initialMembers: mutations (role change, remove) update
+  // local state optimistically so the UI reflects changes immediately without
+  // a full server-side re-render. The source of truth is always the API;
+  // on error the component shows a toast and leaves state unchanged.
+  const [members, setMembers] = useState<TeamMemberAdminRow[]>(initialMembers);
+
+  /**
+   * Updates a member's role in local state after a successful API call.
+   *
+   * @param userId - The member whose role changed
+   * @param newRole - The new role value
+   */
+  const handleRoleChanged = useCallback((userId: string, newRole: 'admin' | 'member') => {
+    setMembers((prev) =>
+      prev.map((m) => (m.user_id === userId ? { ...m, role: newRole } : m)),
+    );
+  }, []);
+
+  /**
+   * Removes a member from local state after a successful API call.
+   *
+   * @param userId - The member to remove
+   */
+  const handleMemberRemoved = useCallback((userId: string) => {
+    setMembers((prev) => prev.filter((m) => m.user_id !== userId));
+  }, []);
+
+  return (
+    <MembersTableLazy
+      members={members}
+      currentUserId={currentUserId}
+      currentUserRole={currentUserRole}
+      teamId={teamId}
+      onRoleChanged={handleRoleChanged}
+      onMemberRemoved={handleMemberRemoved}
+    />
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/team/[teamId]/members/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/[teamId]/members/page.tsx
@@ -1,0 +1,235 @@
+/**
+ * Team Members Admin Page
+ *
+ * /dashboard/team/[teamId]/members
+ *
+ * Server Component that fetches all team members with admin-view fields
+ * (email, role, join date, last active, cost MTD) and renders the
+ * MembersTable client component.
+ *
+ * Orchestrator pattern: page is a thin server shell. All interactive
+ * mutations (role change, remove) live in the MembersTable client component.
+ * Page file stays well under the 400-line limit.
+ *
+ * WHY last_active_at via subquery on sessions:
+ *   There is no dedicated last_active_at column on team_members. We compute
+ *   it as MAX(sessions.started_at) per member so the value is always fresh.
+ *   A dedicated materialized view is a Phase 2.5 optimization.
+ *
+ * WHY cost_mtd_usd via direct query:
+ *   We sum cost_records.cost_usd for the current calendar month. The
+ *   mv_daily_cost_summary materialized view aggregates by day, not month,
+ *   and is not scoped per-team. Direct sum is simpler for now.
+ *
+ * @module dashboard/team/[teamId]/members/page
+ */
+
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+import { MembersDynamic } from './members-dynamic';
+import type { TeamMemberAdminRow } from '@styrby/shared';
+import { parseDbRole } from '@styrby/shared';
+
+// ============================================================================
+// Metadata
+// ============================================================================
+
+export const metadata: Metadata = {
+  title: 'Team Members | Styrby',
+  description: 'Manage team members, roles, and access for your Styrby team.',
+};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface MembersPageProps {
+  params: Promise<{ teamId: string }>;
+}
+
+/** get_team_members RPC row shape */
+interface TeamMemberRpcRow {
+  member_id: string;
+  user_id: string;
+  role: string;
+  display_name: string | null;
+  email: string;
+  avatar_url: string | null;
+  joined_at: string;
+}
+
+/** sessions table row for last-active lookup */
+interface SessionLastActiveRow {
+  user_id: string;
+  started_at: string;
+}
+
+/** cost_records aggregate row */
+interface CostMtdRow {
+  user_id: string;
+  cost_usd: number;
+}
+
+// ============================================================================
+// Page Component
+// ============================================================================
+
+/**
+ * Team members admin page — server component.
+ *
+ * Fetches membership + last-active + cost MTD data in parallel, then passes
+ * the enriched member rows to the MembersTable client component.
+ *
+ * Access control:
+ *   - Must be authenticated
+ *   - Must be a member of the team (RLS enforces this for data queries)
+ *   - Non-members are redirected to /dashboard
+ *
+ * @param props - Page props (teamId from URL params)
+ */
+export default async function MembersPage({ params }: MembersPageProps) {
+  const { teamId } = await params;
+  const supabase = await createClient();
+
+  // ── Auth ──────────────────────────────────────────────────────────────────
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    redirect('/login');
+  }
+
+  // ── Verify membership ─────────────────────────────────────────────────────
+
+  const { data: membership } = await supabase
+    .from('team_members')
+    .select('role')
+    .eq('team_id', teamId)
+    .eq('user_id', user.id)
+    .single();
+
+  if (!membership) {
+    redirect('/dashboard');
+  }
+
+  const callerRole = parseDbRole(membership.role);
+
+  // ── Team name ─────────────────────────────────────────────────────────────
+
+  const { data: team } = await supabase
+    .from('teams')
+    .select('id, name')
+    .eq('id', teamId)
+    .single();
+
+  if (!team) {
+    redirect('/dashboard');
+  }
+
+  // ── Fetch members + enrichment in parallel ────────────────────────────────
+
+  // WHY parallel: member list, last-active, and cost queries are independent.
+  // Serial fetches would triple the server-render latency.
+  const now = new Date();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+
+  const [membersResult, sessionsResult, costsResult] = await Promise.all([
+    // Core member list via the get_team_members RPC (already exists, returns emails)
+    supabase.rpc('get_team_members', { p_team_id: teamId }),
+
+    // Most recent session per user for the team
+    supabase
+      .from('sessions')
+      .select('user_id, started_at')
+      .eq('team_id', teamId)
+      .order('started_at', { ascending: false }),
+
+    // Cost MTD: sum cost_usd per user for the current month
+    supabase
+      .from('cost_records')
+      .select('user_id, cost_usd')
+      .eq('team_id', teamId)
+      .gte('recorded_at', monthStart),
+  ]);
+
+  const rpcMembers = (membersResult.data ?? []) as TeamMemberRpcRow[];
+  const sessions = (sessionsResult.data ?? []) as SessionLastActiveRow[];
+  const costRows = (costsResult.data ?? []) as CostMtdRow[];
+
+  // ── Build lookup maps ─────────────────────────────────────────────────────
+
+  /** Latest session timestamp per user_id */
+  const lastActiveByUser: Record<string, string> = {};
+  for (const s of sessions) {
+    if (!lastActiveByUser[s.user_id]) {
+      lastActiveByUser[s.user_id] = s.started_at;
+    }
+  }
+
+  /** Total cost MTD per user_id */
+  const costByUser: Record<string, number> = {};
+  for (const c of costRows) {
+    costByUser[c.user_id] = (costByUser[c.user_id] ?? 0) + Number(c.cost_usd);
+  }
+
+  // ── Merge into admin view ─────────────────────────────────────────────────
+
+  const members: TeamMemberAdminRow[] = rpcMembers.map((m) => ({
+    member_id: m.member_id,
+    user_id: m.user_id,
+    role: parseDbRole(m.role),
+    display_name: m.display_name,
+    email: m.email,
+    avatar_url: m.avatar_url ?? null,
+    joined_at: m.joined_at,
+    last_active_at: lastActiveByUser[m.user_id] ?? null,
+    cost_mtd_usd: costByUser[m.user_id] !== undefined
+      ? Math.round(costByUser[m.user_id] * 100) / 100
+      : null,
+  }));
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8 space-y-6">
+      {/* Page header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 text-zinc-500 text-sm mb-1">
+            <Link
+              href={`/dashboard/team/${teamId}/invitations`}
+              className="hover:text-zinc-300 transition-colors"
+            >
+              Invitations
+            </Link>
+            <span>/</span>
+            <span className="text-zinc-300">Members</span>
+          </div>
+          <h1 className="text-2xl font-bold text-zinc-100">Team Members</h1>
+          <p className="text-zinc-400 mt-1">
+            {members.length} member{members.length !== 1 ? 's' : ''} in{' '}
+            <strong className="text-zinc-200">{team.name}</strong>
+          </p>
+        </div>
+
+        <Link
+          href={`/dashboard/team/${teamId}/invitations`}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-orange-500 hover:bg-orange-600 text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          Invite member
+        </Link>
+      </div>
+
+      {/* Members table — dynamically imported to reduce first-load bundle */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+        <MembersDynamic
+          initialMembers={members}
+          currentUserId={user.id}
+          currentUserRole={callerRole}
+          teamId={teamId}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/team/[teamId]/policies/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/[teamId]/policies/page.tsx
@@ -1,0 +1,171 @@
+/**
+ * Team Policies Admin Page
+ *
+ * /dashboard/team/[teamId]/policies
+ *
+ * Server Component that fetches the team's current policy settings and renders
+ * the PoliciesForm client component. The form allows owners/admins to edit
+ * auto_approve_rules, blocked_tools, and budget_per_seat_usd.
+ *
+ * Access control:
+ *   - Any team member can VIEW the current policies (transparency)
+ *   - Only owners/admins can EDIT (the form hides save controls for members)
+ *
+ * Orchestrator pattern: this page is thin. All interactivity (form state,
+ * save mutation) lives in PoliciesForm. Page stays under 400 lines.
+ *
+ * @module dashboard/team/[teamId]/policies/page
+ */
+
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+import { PoliciesDynamic } from './policies-dynamic';
+import type { TeamPolicySettings } from '@styrby/shared';
+import { parseDbRole } from '@styrby/shared';
+
+// ============================================================================
+// Metadata
+// ============================================================================
+
+export const metadata: Metadata = {
+  title: 'Team Policies | Styrby',
+  description: 'Manage auto-approve rules, blocked tools, and budget limits for your Styrby team.',
+};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface PoliciesPageProps {
+  params: Promise<{ teamId: string }>;
+}
+
+/** Team policies columns from DB */
+interface TeamPoliciesDbRow {
+  id: string;
+  name: string;
+  auto_approve_rules: unknown;
+  blocked_tools: unknown;
+  budget_per_seat_usd: number | null;
+}
+
+// ============================================================================
+// Page Component
+// ============================================================================
+
+/**
+ * Team policies admin page - server component.
+ *
+ * Fetches current policy settings and passes them to the form client component.
+ * Determines whether the caller can edit (owner/admin) and passes the flag down.
+ *
+ * @param props - Page props (teamId from URL params)
+ */
+export default async function PoliciesPage({ params }: PoliciesPageProps) {
+  const { teamId } = await params;
+  const supabase = await createClient();
+
+  // ── Auth ──────────────────────────────────────────────────────────────────
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    redirect('/login');
+  }
+
+  // ── Verify membership ─────────────────────────────────────────────────────
+
+  const { data: membership } = await supabase
+    .from('team_members')
+    .select('role')
+    .eq('team_id', teamId)
+    .eq('user_id', user.id)
+    .single();
+
+  if (!membership) {
+    redirect('/dashboard');
+  }
+
+  const callerRole = parseDbRole(membership.role);
+  const canEdit = callerRole === 'owner' || callerRole === 'admin';
+
+  // ── Fetch team name + current policies ───────────────────────────────────
+
+  const { data: team } = await supabase
+    .from('teams')
+    .select('id, name, auto_approve_rules, blocked_tools, budget_per_seat_usd')
+    .eq('id', teamId)
+    .single() as { data: TeamPoliciesDbRow | null };
+
+  if (!team) {
+    redirect('/dashboard');
+  }
+
+  // Normalise jsonb arrays from Supabase (may be null or non-array on fresh teams)
+  const initial: TeamPolicySettings = {
+    auto_approve_rules: Array.isArray(team.auto_approve_rules)
+      ? (team.auto_approve_rules as string[])
+      : [],
+    blocked_tools: Array.isArray(team.blocked_tools)
+      ? (team.blocked_tools as string[])
+      : [],
+    budget_per_seat_usd: team.budget_per_seat_usd ?? null,
+  };
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      {/* Page header */}
+      <div>
+        <div className="flex items-center gap-2 text-zinc-500 text-sm mb-1">
+          <Link
+            href={`/dashboard/team/${teamId}/members`}
+            className="hover:text-zinc-300 transition-colors"
+          >
+            Members
+          </Link>
+          <span>/</span>
+          <span className="text-zinc-300">Policies</span>
+        </div>
+        <h1 className="text-2xl font-bold text-zinc-100">Team Policies</h1>
+        <p className="text-zinc-400 mt-1">
+          Configure auto-approve rules, blocked tools, and budget limits for{' '}
+          <strong className="text-zinc-200">{team.name}</strong>.
+        </p>
+      </div>
+
+      {/* Policy form */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+        <PoliciesDynamic
+          initial={initial}
+          teamId={teamId}
+          canEdit={canEdit}
+        />
+      </div>
+
+      {/* Contextual guidance */}
+      <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-5 text-sm text-zinc-400 space-y-2">
+        <p className="font-medium text-zinc-300">How policies work</p>
+        <ul className="list-disc list-inside space-y-1 text-xs">
+          <li>
+            <strong className="text-zinc-300">Auto-approve rules</strong> - tools on this list run
+            without requiring human review in the CLI approval flow.
+          </li>
+          <li>
+            <strong className="text-zinc-300">Blocked tools</strong> - tools on this list are
+            rejected outright, even if they appear in auto-approve rules.
+          </li>
+          <li>
+            <strong className="text-zinc-300">Budget per seat</strong> - members who exceed
+            this monthly spend receive an alert; leave blank for no limit.
+          </li>
+          <li>
+            Every policy change is recorded in the audit log with before/after values.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/team/[teamId]/policies/policies-dynamic.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/[teamId]/policies/policies-dynamic.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+/**
+ * Lazy-loaded wrapper for the PoliciesForm client component.
+ *
+ * WHY dynamic import:
+ *   PoliciesForm uses useState, fetch, and lucide-react icons. Deferring its
+ *   load via next/dynamic keeps the team sub-page bundle separate from the
+ *   core dashboard chunk and contributes to the 700 KB ratchet target.
+ *
+ * @module dashboard/team/[teamId]/policies/policies-dynamic
+ */
+
+import dynamic from 'next/dynamic';
+import type { PoliciesFormProps } from '@/components/team/policies';
+
+/** Skeleton shown while the PoliciesForm JS is loading. */
+function PoliciesFormSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse" aria-busy="true" aria-label="Loading policies">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="space-y-2">
+          <div className="h-4 bg-zinc-800 rounded w-40" />
+          <div className="h-3 bg-zinc-800 rounded w-64" />
+          <div className="h-10 bg-zinc-800 rounded-lg" />
+        </div>
+      ))}
+      <div className="h-9 bg-zinc-800 rounded-lg w-32 mt-4" />
+    </div>
+  );
+}
+
+/**
+ * Dynamically imported PoliciesForm with loading skeleton.
+ */
+export const PoliciesDynamic = dynamic<PoliciesFormProps>(
+  () => import('@/components/team/policies').then((mod) => ({ default: mod.PoliciesForm })),
+  { loading: () => <PoliciesFormSkeleton /> },
+);

--- a/packages/styrby-web/src/components/dashboard/founder/TeamsCard.tsx
+++ b/packages/styrby-web/src/components/dashboard/founder/TeamsCard.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+/**
+ * TeamsCard
+ *
+ * Displays the Phase 2.3 team aggregate metrics on the founder dashboard:
+ *   - Total team count
+ *   - Average team size
+ *   - Teams with churn in the last 30 days
+ *   - Churn rate per team (rolling 30d)
+ *   - Per-team breakdown table
+ *
+ * Data is fetched from /api/admin/founder-team-metrics by the parent server
+ * component and passed as props. This component is purely presentational.
+ *
+ * WHY client component:
+ *   The teams table supports toggling an expand/collapse for the per-team rows
+ *   (using useState). If no interactivity is needed in the future, this can
+ *   be converted to a server component.
+ *
+ * @module components/dashboard/founder/TeamsCard
+ */
+
+import { useState } from 'react';
+import { Users, ChevronDown, ChevronUp } from 'lucide-react';
+import type { FounderTeamMetrics, FounderTeamSummary } from '@styrby/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface TeamsCardProps {
+  /** Team metrics payload from /api/admin/founder-team-metrics */
+  metrics: FounderTeamMetrics;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Formats a fractional rate (0-1) as "X.X%" for display.
+ *
+ * @param rate - Fractional rate, or null
+ * @returns Formatted percentage string or "-"
+ */
+function fmtPct(rate: number | null): string {
+  if (rate === null) return '-';
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+/**
+ * Formats an ISO date string to a short readable form.
+ *
+ * @param iso - ISO 8601 string
+ * @returns Short date (e.g. "Jun 1, 2025")
+ */
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+/**
+ * A single summary stat cell (label + value).
+ *
+ * @param props.label - Stat label
+ * @param props.value - Stat value string
+ * @param props.sub - Optional sub-label
+ * @returns Rendered stat cell
+ */
+function StatCell({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div>
+      <p className="text-muted-foreground text-xs uppercase tracking-wide">{label}</p>
+      <p className="text-foreground text-2xl font-bold mt-0.5">{value}</p>
+      {sub && <p className="text-muted-foreground text-xs">{sub}</p>}
+    </div>
+  );
+}
+
+/**
+ * Per-team row in the breakdown table.
+ *
+ * @param props.team - Team summary row
+ * @returns Rendered table row
+ */
+function TeamRow({ team }: { team: FounderTeamSummary }) {
+  return (
+    <tr className="border-b border-border/40 hover:bg-muted/20 transition-colors">
+      <td className="py-2.5 px-4">
+        <span className="text-foreground text-sm font-medium">{team.team_name}</span>
+        <span className="text-muted-foreground text-xs ml-2 font-mono">
+          {team.team_id.slice(0, 8)}
+        </span>
+      </td>
+      <td className="py-2.5 px-4">
+        <span className="text-muted-foreground text-xs capitalize">{team.owner_tier}</span>
+      </td>
+      <td className="py-2.5 px-4 text-center text-sm text-foreground">
+        {team.member_count}
+      </td>
+      <td className="py-2.5 px-4 text-center">
+        {team.had_churn_30d ? (
+          <span className="text-destructive text-xs font-medium">Yes</span>
+        ) : (
+          <span className="text-muted-foreground text-xs">-</span>
+        )}
+      </td>
+      <td className="py-2.5 px-4 text-muted-foreground text-xs hidden md:table-cell">
+        {fmtDate(team.created_at)}
+      </td>
+    </tr>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+/**
+ * Teams aggregate metrics card for the founder dashboard.
+ *
+ * Shows summary stats (total teams, avg size, churn) and a collapsible
+ * per-team breakdown table.
+ *
+ * @param props - See {@link TeamsCardProps}
+ */
+export function TeamsCard({ metrics }: TeamsCardProps) {
+  const [expanded, setExpanded] = useState(metrics.teams.length <= 10);
+
+  return (
+    <section aria-labelledby="teams-card-heading" className="space-y-4">
+      {/* Card header */}
+      <div className="flex items-center gap-2">
+        <Users size={16} className="text-muted-foreground" aria-hidden />
+        <h2 id="teams-card-heading" className="text-sm font-semibold text-foreground">
+          Teams
+        </h2>
+        <span className="text-muted-foreground text-xs ml-auto">
+          Computed {new Date(metrics.computed_at).toLocaleString('en-US', { timeZone: 'America/Chicago' })} CT
+        </span>
+      </div>
+
+      {/* Summary stats */}
+      <div className="rounded-xl border border-border/40 bg-card/60 p-5">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-6">
+          <StatCell
+            label="Total teams"
+            value={String(metrics.team_count)}
+          />
+          <StatCell
+            label="Avg team size"
+            value={metrics.avg_team_size.toFixed(1)}
+            sub="members"
+          />
+          <StatCell
+            label="Teams w/ churn"
+            value={String(metrics.churned_teams_30d)}
+            sub="last 30 days"
+          />
+          <StatCell
+            label="Team churn rate"
+            value={fmtPct(metrics.churn_rate_per_team_30d)}
+            sub="rolling 30d"
+          />
+        </div>
+      </div>
+
+      {/* Per-team breakdown table */}
+      {metrics.teams.length > 0 && (
+        <div className="rounded-xl border border-border/40 bg-card/60 overflow-hidden">
+          {/* Collapsible toggle */}
+          <button
+            onClick={() => setExpanded((prev) => !prev)}
+            className="w-full flex items-center justify-between px-4 py-3 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/20 transition-colors"
+            aria-expanded={expanded}
+            aria-controls="team-breakdown-table"
+          >
+            <span className="font-medium">
+              Per-team breakdown ({metrics.teams.length} teams)
+            </span>
+            {expanded ? (
+              <ChevronUp size={16} aria-hidden />
+            ) : (
+              <ChevronDown size={16} aria-hidden />
+            )}
+          </button>
+
+          {expanded && (
+            <div id="team-breakdown-table" className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border/40 border-t">
+                    <th className="text-left text-muted-foreground font-medium py-2.5 px-4">Team</th>
+                    <th className="text-left text-muted-foreground font-medium py-2.5 px-4">Owner tier</th>
+                    <th className="text-center text-muted-foreground font-medium py-2.5 px-4">Members</th>
+                    <th className="text-center text-muted-foreground font-medium py-2.5 px-4">Churn (30d)</th>
+                    <th className="text-left text-muted-foreground font-medium py-2.5 px-4 hidden md:table-cell">
+                      Created
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {metrics.teams.map((team) => (
+                    <TeamRow key={team.team_id} team={team} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {metrics.teams.length === 0 && (
+        <div className="rounded-xl border border-border/40 bg-card/60 p-8 text-center">
+          <Users size={32} className="text-muted-foreground mx-auto mb-3" aria-hidden />
+          <p className="text-muted-foreground text-sm">No teams created yet.</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/styrby-web/src/components/dashboard/founder/index.ts
+++ b/packages/styrby-web/src/components/dashboard/founder/index.ts
@@ -18,3 +18,7 @@ export type { TierMixTableProps, TierCount, AgentUsage } from './TierMixTable';
 
 export { CohortRetentionTable } from './CohortRetentionTable';
 export type { CohortRetentionTableProps, CohortRow } from './CohortRetentionTable';
+
+// Phase 2.3 — Teams card for the founder dashboard
+export { TeamsCard } from './TeamsCard';
+export type { TeamsCardProps } from './TeamsCard';

--- a/packages/styrby-web/src/components/team/members/MembersTable.tsx
+++ b/packages/styrby-web/src/components/team/members/MembersTable.tsx
@@ -1,0 +1,447 @@
+'use client';
+
+/**
+ * MembersTable
+ *
+ * Renders the team members data table with role dropdown, remove action,
+ * and cost MTD column.
+ *
+ * Actions are gated by the policyEngine role-matrix:
+ *   - Only owners can promote/demote admins
+ *   - Owners and admins can remove members (admins cannot remove other admins)
+ *   - Nobody can remove the owner
+ *   - Users cannot modify their own role
+ *
+ * WHY client component: role-change and remove are interactive mutations
+ * that require useState (confirmation dialog) and fetch calls.
+ *
+ * @module components/team/members/MembersTable
+ */
+
+import { useState } from 'react';
+import {
+  Users,
+  UserMinus,
+  Edit,
+  Shield,
+} from 'lucide-react';
+import {
+  canRevokeMember,
+  parseDbRole,
+  TEAM_ADMIN_AUDIT_ACTIONS,
+} from '@styrby/shared';
+import type { TeamMemberAdminRow } from '@styrby/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface MembersTableProps {
+  /** Full list of team members with admin-view fields. */
+  members: TeamMemberAdminRow[];
+  /** The authenticated user's ID (to disable self-mutation controls). */
+  currentUserId: string;
+  /** The authenticated user's role (to gate action visibility). */
+  currentUserRole: 'owner' | 'admin' | 'member';
+  /** The team ID — used to construct API call URLs. */
+  teamId: string;
+  /** Called after a successful role change so the parent can refresh. */
+  onRoleChanged: (userId: string, newRole: 'admin' | 'member') => void;
+  /** Called after a successful member removal so the parent can refresh. */
+  onMemberRemoved: (userId: string) => void;
+}
+
+// ============================================================================
+// Helper: format date
+// ============================================================================
+
+/**
+ * Formats an ISO date string as "MMM D, YYYY" for display.
+ *
+ * @param iso - ISO 8601 date string
+ * @returns Human-readable date string
+ *
+ * @example
+ * formatDate('2025-06-01T10:00:00Z'); // "Jun 1, 2025"
+ */
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Formats a nullable cost value as "$X.XX" or "-" if null.
+ *
+ * @param usd - Cost in USD, or null
+ * @returns Formatted cost string
+ */
+function formatCost(usd: number | null): string {
+  if (usd === null) return '-';
+  return `$${usd.toFixed(2)}`;
+}
+
+// ============================================================================
+// Role Badge
+// ============================================================================
+
+/**
+ * Renders a coloured role chip.
+ *
+ * @param props.role - The member's role string
+ * @returns Styled role badge span
+ */
+function RoleBadge({ role }: { role: string }) {
+  const styles: Record<string, string> = {
+    owner: 'bg-orange-500/10 text-orange-400 border-orange-500/30',
+    admin: 'bg-purple-500/10 text-purple-400 border-purple-500/30',
+    member: 'bg-zinc-700/50 text-zinc-400 border-zinc-600/30',
+  };
+  const cls = styles[role] ?? styles.member;
+  return (
+    <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium border ${cls}`}>
+      {role === 'owner' || role === 'admin' ? <Shield size={11} aria-hidden /> : null}
+      {role.charAt(0).toUpperCase() + role.slice(1)}
+    </span>
+  );
+}
+
+// ============================================================================
+// Confirm Remove Dialog
+// ============================================================================
+
+interface ConfirmRemoveDialogProps {
+  member: TeamMemberAdminRow;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isRemoving: boolean;
+}
+
+/**
+ * Inline confirmation dialog for member removal.
+ * 2-step confirm pattern: prevents accidental destructive actions.
+ *
+ * @param props - Dialog props
+ * @returns Confirmation card
+ */
+function ConfirmRemoveDialog({ member, onConfirm, onCancel, isRemoving }: ConfirmRemoveDialogProps) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="remove-dialog-title"
+    >
+      <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-6 max-w-sm w-full shadow-2xl">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 bg-red-500/10 rounded-full flex items-center justify-center flex-shrink-0">
+            <UserMinus size={20} className="text-red-400" aria-hidden />
+          </div>
+          <div>
+            <h2 id="remove-dialog-title" className="text-zinc-100 font-semibold">
+              Remove member?
+            </h2>
+            <p className="text-zinc-400 text-sm mt-0.5">This action cannot be undone.</p>
+          </div>
+        </div>
+        <p className="text-zinc-300 text-sm mb-6">
+          <strong>{member.display_name ?? member.email}</strong> will lose access to this
+          team immediately. Their sessions and cost history are preserved.
+        </p>
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            disabled={isRemoving}
+            className="flex-1 px-4 py-2 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm font-medium transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isRemoving}
+            className="flex-1 px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors disabled:opacity-50"
+          >
+            {isRemoving ? 'Removing...' : 'Remove'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+/**
+ * Team members data table with role management and member removal.
+ *
+ * All mutations go through the Next.js API routes which enforce RLS + role
+ * checks server-side. The client-side permission gating here is a UX layer
+ * only — it hides controls for actions the server would reject anyway.
+ *
+ * @param props - See {@link MembersTableProps}
+ */
+export function MembersTable({
+  members,
+  currentUserId,
+  currentUserRole,
+  teamId,
+  onRoleChanged,
+  onMemberRemoved,
+}: MembersTableProps) {
+  const [confirmRemove, setConfirmRemove] = useState<TeamMemberAdminRow | null>(null);
+  const [isRemoving, setIsRemoving] = useState(false);
+  const [changingRoleFor, setChangingRoleFor] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // ── Can current user change this member's role? ──────────────────────────
+  /**
+   * Determines if the current user can change the target member's role.
+   *
+   * WHY: Role changes are restricted to:
+   *   - Owners can change any non-owner role
+   *   - Admins CANNOT change other admins or owner (prevents privilege escalation)
+   *   - Nobody can change their own role (UX guard, server also enforces)
+   *
+   * @param target - The target member
+   * @returns True if the current user can change the target's role
+   */
+  function canChangeRole(target: TeamMemberAdminRow): boolean {
+    if (target.user_id === currentUserId) return false;
+    if (target.role === 'owner') return false;
+    if (currentUserRole === 'owner') return true;
+    // Admins cannot change other admins (prevent privilege escalation)
+    if (currentUserRole === 'admin' && target.role === 'member') return true;
+    return false;
+  }
+
+  /**
+   * Determines if the current user can remove the target member.
+   * Delegates to the shared role-matrix's canRevokeMember helper.
+   *
+   * @param target - The target member
+   * @returns True if the current user can remove the target
+   */
+  function canRemove(target: TeamMemberAdminRow): boolean {
+    if (target.role === 'owner') return false;
+    return canRevokeMember(parseDbRole(currentUserRole));
+  }
+
+  // ── Role change handler ──────────────────────────────────────────────────
+
+  /**
+   * Sends a PATCH to /api/teams/[id]/members/[userId] to change the role.
+   * Writes audit_log on the server side.
+   *
+   * @param member - The member whose role to change
+   * @param newRole - The new role to assign
+   */
+  async function handleRoleChange(member: TeamMemberAdminRow, newRole: 'admin' | 'member') {
+    setChangingRoleFor(member.user_id);
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/teams/${teamId}/members/${member.user_id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role: newRole }),
+      });
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        setActionError(data.error ?? 'Failed to update role');
+        return;
+      }
+      onRoleChanged(member.user_id, newRole);
+    } catch {
+      setActionError('Network error - please try again');
+    } finally {
+      setChangingRoleFor(null);
+    }
+  }
+
+  // ── Remove handler ───────────────────────────────────────────────────────
+
+  /**
+   * Executes the member removal after the 2-step confirm dialog.
+   * The server also writes audit_log (action: team.member.removed).
+   */
+  async function handleConfirmRemove() {
+    if (!confirmRemove) return;
+    setIsRemoving(true);
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/teams/${teamId}/members/${confirmRemove.user_id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        setActionError(data.error ?? 'Failed to remove member');
+        setConfirmRemove(null);
+        return;
+      }
+      onMemberRemoved(confirmRemove.user_id);
+      setConfirmRemove(null);
+    } catch {
+      setActionError('Network error - please try again');
+      setConfirmRemove(null);
+    } finally {
+      setIsRemoving(false);
+    }
+  }
+
+  if (members.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Users size={40} className="text-zinc-400 mb-3" aria-hidden />
+        <p className="text-zinc-400 font-medium">No members yet</p>
+        <p className="text-zinc-500 text-sm mt-1">
+          Invite your first team member from the Invitations panel.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Action error banner */}
+      {actionError && (
+        <div
+          className="mb-4 px-4 py-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm"
+          role="alert"
+        >
+          {actionError}
+          <button
+            className="ml-3 underline hover:no-underline text-red-300"
+            onClick={() => setActionError(null)}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Desktop table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800">
+              <th className="text-left text-zinc-400 font-medium py-3 px-4">Member</th>
+              <th className="text-left text-zinc-400 font-medium py-3 px-4">Role</th>
+              <th className="text-left text-zinc-400 font-medium py-3 px-4 hidden md:table-cell">Joined</th>
+              <th className="text-left text-zinc-400 font-medium py-3 px-4 hidden lg:table-cell">Last Active</th>
+              <th className="text-right text-zinc-400 font-medium py-3 px-4 hidden lg:table-cell">Cost MTD</th>
+              <th className="text-right text-zinc-400 font-medium py-3 px-4">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {members.map((member) => {
+              const isSelf = member.user_id === currentUserId;
+              const isChangingRole = changingRoleFor === member.user_id;
+
+              return (
+                <tr
+                  key={member.member_id}
+                  className="border-b border-zinc-800/50 hover:bg-zinc-900/50 transition-colors"
+                >
+                  {/* Member identity */}
+                  <td className="py-3 px-4">
+                    <div className="flex items-center gap-3">
+                      <div className="w-8 h-8 rounded-full bg-zinc-700 flex items-center justify-center flex-shrink-0">
+                        <span className="text-xs font-medium text-zinc-300">
+                          {(member.display_name ?? member.email)[0].toUpperCase()}
+                        </span>
+                      </div>
+                      <div>
+                        <div className="text-zinc-200 font-medium flex items-center gap-1.5">
+                          {member.display_name ?? member.email}
+                          {isSelf && <span className="text-zinc-500 text-xs">(you)</span>}
+                        </div>
+                        {member.display_name && (
+                          <div className="text-zinc-500 text-xs">{member.email}</div>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+
+                  {/* Role — dropdown for editable roles */}
+                  <td className="py-3 px-4">
+                    {canChangeRole(member) ? (
+                      <select
+                        value={member.role}
+                        disabled={isChangingRole}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          if (val === 'admin' || val === 'member') {
+                            void handleRoleChange(member, val);
+                          }
+                        }}
+                        className="bg-zinc-800 border border-zinc-700 rounded-md text-zinc-300 text-xs px-2 py-1 pr-7 focus:outline-none focus:ring-1 focus:ring-orange-500 cursor-pointer disabled:opacity-50"
+                        aria-label={`Change role for ${member.display_name ?? member.email}`}
+                      >
+                        <option value="admin">Admin</option>
+                        <option value="member">Member</option>
+                      </select>
+                    ) : (
+                      <RoleBadge role={member.role} />
+                    )}
+                    {isChangingRole && (
+                      <span className="text-zinc-500 text-xs ml-2">Saving...</span>
+                    )}
+                  </td>
+
+                  {/* Joined date */}
+                  <td className="py-3 px-4 text-zinc-400 hidden md:table-cell">
+                    {formatDate(member.joined_at)}
+                  </td>
+
+                  {/* Last active */}
+                  <td className="py-3 px-4 text-zinc-400 hidden lg:table-cell">
+                    {member.last_active_at ? formatDate(member.last_active_at) : '-'}
+                  </td>
+
+                  {/* Cost MTD */}
+                  <td className="py-3 px-4 text-right text-zinc-300 font-mono text-xs hidden lg:table-cell">
+                    {formatCost(member.cost_mtd_usd)}
+                  </td>
+
+                  {/* Actions */}
+                  <td className="py-3 px-4 text-right">
+                    {canRemove(member) && (
+                      <button
+                        onClick={() => setConfirmRemove(member)}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-red-400 hover:text-red-300 hover:bg-red-500/10 transition-colors"
+                        aria-label={`Remove ${member.display_name ?? member.email} from team`}
+                      >
+                        <UserMinus size={14} aria-hidden />
+                        Remove
+                      </button>
+                    )}
+                    {canChangeRole(member) && (
+                      <Edit
+                        size={14}
+                        className="inline text-zinc-400 ml-1"
+                        aria-label="Role editable via dropdown"
+                        aria-hidden
+                      />
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 2-step confirm dialog */}
+      {confirmRemove && (
+        <ConfirmRemoveDialog
+          member={confirmRemove}
+          onConfirm={() => void handleConfirmRemove()}
+          onCancel={() => setConfirmRemove(null)}
+          isRemoving={isRemoving}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/styrby-web/src/components/team/members/index.ts
+++ b/packages/styrby-web/src/components/team/members/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Team members components barrel — Phase 2.3.
+ *
+ * WHY: Per CLAUDE.md component-first architecture, every component directory
+ * exposes a barrel so the page orchestrator imports a flat surface area.
+ *
+ * @module components/team/members
+ */
+
+export { MembersTable } from './MembersTable';
+export type { MembersTableProps } from './MembersTable';

--- a/packages/styrby-web/src/components/team/policies/PoliciesForm.tsx
+++ b/packages/styrby-web/src/components/team/policies/PoliciesForm.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+/**
+ * PoliciesForm
+ *
+ * Editable form for team policy settings: auto_approve_rules, blocked_tools,
+ * and budget_per_seat_usd. Changes are saved via PATCH /api/teams/[id]/policies.
+ *
+ * WHY client component: all inputs require useState; the save button triggers
+ * a fetch mutation. Server-rendering a form with no interactivity would defeat
+ * the purpose.
+ *
+ * WHY Zod validation in the client too:
+ *   We validate client-side to give instant feedback before a network round-trip.
+ *   The server re-validates with the same Zod schema — client validation is UX
+ *   only, server validation is the security boundary.
+ *
+ * @module components/team/policies/PoliciesForm
+ */
+
+import { useState, useCallback } from 'react';
+import { Shield, Plus, Trash2, Save } from 'lucide-react';
+import { PatchTeamPolicyBodySchema } from '@styrby/shared';
+import type { TeamPolicySettings } from '@styrby/shared';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PoliciesFormProps {
+  /** Current policy settings fetched by the server component. */
+  initial: TeamPolicySettings;
+  /** Team ID — used in the PATCH API URL. */
+  teamId: string;
+  /** Whether the current user is allowed to edit (owner/admin). */
+  canEdit: boolean;
+}
+
+// ============================================================================
+// Helper: Tag Input
+// ============================================================================
+
+/**
+ * A simple chip-based tag input for editing string arrays.
+ *
+ * @param props.value - Current list of strings
+ * @param props.onChange - Called when the list changes
+ * @param props.placeholder - Placeholder text for the new-item input
+ * @param props.disabled - Whether editing is disabled
+ * @param props.ariaLabel - Accessible label for the text input
+ * @returns Rendered tag input
+ */
+function TagInput({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  ariaLabel,
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder: string;
+  disabled: boolean;
+  ariaLabel: string;
+}) {
+  const [draft, setDraft] = useState('');
+
+  /**
+   * Adds the current draft as a new tag on Enter or comma.
+   *
+   * @param e - KeyboardEvent from the input
+   */
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      const trimmed = draft.trim().replace(/,$/, '');
+      if (trimmed && !value.includes(trimmed)) {
+        onChange([...value, trimmed]);
+        setDraft('');
+      }
+    }
+    if (e.key === 'Backspace' && draft === '' && value.length > 0) {
+      onChange(value.slice(0, -1));
+    }
+  }
+
+  /**
+   * Removes a tag by index.
+   *
+   * @param idx - Index of the tag to remove
+   */
+  function removeTag(idx: number) {
+    onChange(value.filter((_, i) => i !== idx));
+  }
+
+  return (
+    <div
+      className={`min-h-10 flex flex-wrap gap-1.5 items-center p-2 bg-zinc-900 border border-zinc-700 rounded-lg focus-within:border-orange-500 transition-colors ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+    >
+      {value.map((tag, idx) => (
+        <span
+          key={idx}
+          className="inline-flex items-center gap-1 px-2 py-0.5 bg-zinc-700 rounded-md text-zinc-200 text-xs font-mono"
+        >
+          {tag}
+          {!disabled && (
+            <button
+              onClick={() => removeTag(idx)}
+              className="hover:text-red-400 transition-colors ml-0.5"
+              aria-label={`Remove ${tag}`}
+              type="button"
+            >
+              <Trash2 size={10} aria-hidden />
+            </button>
+          )}
+        </span>
+      ))}
+      {!disabled && (
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          className="bg-transparent text-zinc-300 text-xs placeholder-zinc-600 outline-none flex-1 min-w-20"
+        />
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+/**
+ * Team policies editor.
+ *
+ * Shows current policy settings and, for owners/admins, allows editing them.
+ * Validates inputs client-side before sending to the server. All saves are
+ * partial — only changed fields are sent.
+ *
+ * @param props - See {@link PoliciesFormProps}
+ */
+export function PoliciesForm({ initial, teamId, canEdit }: PoliciesFormProps) {
+  const [autoApproveRules, setAutoApproveRules] = useState<string[]>(initial.auto_approve_rules);
+  const [blockedTools, setBlockedTools] = useState<string[]>(initial.blocked_tools);
+  const [budgetPerSeat, setBudgetPerSeat] = useState<string>(
+    initial.budget_per_seat_usd !== null ? String(initial.budget_per_seat_usd) : '',
+  );
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  /**
+   * Returns true when local state differs from the initial (committed) values.
+   * Prevents unnecessary API calls when nothing changed.
+   */
+  const isDirty = useCallback((): boolean => {
+    const budgetNum = budgetPerSeat === '' ? null : parseFloat(budgetPerSeat);
+    return (
+      JSON.stringify(autoApproveRules) !== JSON.stringify(initial.auto_approve_rules) ||
+      JSON.stringify(blockedTools) !== JSON.stringify(initial.blocked_tools) ||
+      budgetNum !== initial.budget_per_seat_usd
+    );
+  }, [autoApproveRules, blockedTools, budgetPerSeat, initial]);
+
+  /**
+   * Validates and sends changed fields to PATCH /api/teams/[id]/policies.
+   * Uses Zod schema on the client for instant feedback before the round-trip.
+   */
+  async function handleSave() {
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    const budgetNum = budgetPerSeat === '' ? null : parseFloat(budgetPerSeat);
+
+    // Client-side Zod validation (same schema the server uses)
+    const patch = {
+      auto_approve_rules: autoApproveRules,
+      blocked_tools: blockedTools,
+      budget_per_seat_usd: budgetNum,
+    };
+
+    const result = PatchTeamPolicyBodySchema.safeParse(patch);
+    if (!result.success) {
+      setSaveError(result.error.errors.map((e) => e.message).join(', '));
+      return;
+    }
+
+    if (!Number.isNaN(budgetNum) && budgetNum !== null && budgetNum < 0) {
+      setSaveError('Budget per seat must be 0 or greater');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const res = await fetch(`/api/teams/${teamId}/policies`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        setSaveError(data.error ?? 'Failed to save policies');
+        return;
+      }
+
+      setSaveSuccess(true);
+      // Clear success indicator after 3 seconds
+      setTimeout(() => setSaveSuccess(false), 3000);
+    } catch {
+      setSaveError('Network error - please try again');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Auto-approve rules */}
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <Shield size={16} className="text-green-400" aria-hidden />
+          <h3 className="text-zinc-200 font-medium text-sm">Auto-approve rules</h3>
+        </div>
+        <p className="text-zinc-500 text-xs mb-3">
+          Tool names that are automatically allowed without requiring human review.
+          Press Enter or comma to add a tool name.
+        </p>
+        <TagInput
+          value={autoApproveRules}
+          onChange={setAutoApproveRules}
+          placeholder={canEdit ? 'Add tool name and press Enter...' : 'No rules configured'}
+          disabled={!canEdit}
+          ariaLabel="Auto-approve rule tool name"
+        />
+        {autoApproveRules.length === 0 && (
+          <p className="text-zinc-400 text-xs mt-1.5 flex items-center gap-1">
+            <Plus size={11} aria-hidden />
+            No tools are auto-approved - all tool calls require human review.
+          </p>
+        )}
+      </div>
+
+      {/* Blocked tools */}
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <Shield size={16} className="text-red-400" aria-hidden />
+          <h3 className="text-zinc-200 font-medium text-sm">Blocked tools</h3>
+        </div>
+        <p className="text-zinc-500 text-xs mb-3">
+          Tool names that are blocked outright. Takes precedence over auto-approve rules.
+          Press Enter or comma to add.
+        </p>
+        <TagInput
+          value={blockedTools}
+          onChange={setBlockedTools}
+          placeholder={canEdit ? 'Add tool name and press Enter...' : 'No blocked tools'}
+          disabled={!canEdit}
+          ariaLabel="Blocked tool name"
+        />
+        {blockedTools.length === 0 && (
+          <p className="text-zinc-400 text-xs mt-1.5">
+            No tools are blocked.
+          </p>
+        )}
+      </div>
+
+      {/* Budget per seat */}
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <h3 className="text-zinc-200 font-medium text-sm">Budget per seat (USD/month)</h3>
+        </div>
+        <p className="text-zinc-500 text-xs mb-3">
+          Monthly spend limit per member. Leave blank for no limit. Triggers an alert
+          when any member exceeds this threshold.
+        </p>
+        <div className="relative max-w-40">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500 text-sm pointer-events-none">
+            $
+          </span>
+          <input
+            type="number"
+            min="0"
+            max="100000"
+            step="1"
+            value={budgetPerSeat}
+            onChange={(e) => setBudgetPerSeat(e.target.value)}
+            disabled={!canEdit}
+            placeholder="Unlimited"
+            aria-label="Budget per seat in USD per month"
+            className="w-full pl-6 pr-3 py-2 bg-zinc-900 border border-zinc-700 rounded-lg text-zinc-300 text-sm focus:outline-none focus:border-orange-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          />
+        </div>
+      </div>
+
+      {/* Save button + feedback */}
+      {canEdit && (
+        <div className="flex items-center gap-4 pt-2 border-t border-zinc-800">
+          <button
+            onClick={() => void handleSave()}
+            disabled={isSaving || !isDirty()}
+            className="inline-flex items-center gap-2 px-5 py-2 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+          >
+            <Save size={15} aria-hidden />
+            {isSaving ? 'Saving...' : 'Save changes'}
+          </button>
+
+          {saveSuccess && (
+            <span className="text-green-400 text-sm" role="status">
+              Saved successfully
+            </span>
+          )}
+
+          {saveError && (
+            <span className="text-red-400 text-sm" role="alert">
+              {saveError}
+            </span>
+          )}
+        </div>
+      )}
+
+      {!canEdit && (
+        <p className="text-zinc-500 text-xs pt-2 border-t border-zinc-800">
+          Only team owners and admins can edit policies.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/styrby-web/src/components/team/policies/index.ts
+++ b/packages/styrby-web/src/components/team/policies/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Team policies components barrel — Phase 2.3.
+ *
+ * WHY: Per CLAUDE.md component-first architecture, every component directory
+ * exposes a barrel so the page orchestrator imports a flat surface area.
+ *
+ * @module components/team/policies
+ */
+
+export { PoliciesForm } from './PoliciesForm';
+export type { PoliciesFormProps } from './PoliciesForm';


### PR DESCRIPTION
## Summary

- **Shared types** - `admin-types.ts` in `@styrby/shared`: `TeamMemberAdminRow`, `TeamPolicySettings`, `PatchTeamPolicyBody`, `FounderTeamMetrics`, `FounderTeamSummary`, `TEAM_ADMIN_AUDIT_ACTIONS`, `parseDbRole()`
- **Web - members page** - `/dashboard/team/[teamId]/members`: member table with role dropdown (owner/admin gated), 2-step remove confirm dialog, last_active_at (computed from sessions), cost MTD (summed from cost_records); `MembersDynamic` client boundary owns optimistic state + callbacks; lazy bundle via `next/dynamic`
- **Web - policies page** - `/dashboard/team/[teamId]/policies`: TagInput chip editors for `auto_approve_rules` and `blocked_tools`; budget number input; Zod client+server validation; `PoliciesForm` dynamically imported; audit_log fire-and-forget on every save (SOC2 CC6.2)
- **Web - founder dashboard** - `TeamsCard` added to `/dashboard/founder`: team_count, avg_team_size, churned_teams_30d, churn_rate_per_team_30d, collapsible per-team breakdown; parallel-fetched non-fatally alongside existing core metrics
- **API - GET+PATCH /api/teams/[id]/policies** - membership-gated GET, owner/admin-only PATCH, `PatchTeamPolicyBodySchema` Zod validation, audit_log before/after values, rate limited
- **API - GET /api/admin/founder-team-metrics** - is_admin gate, createAdminClient (service role), `Promise.all()` for 4 parallel DB queries, churn detection via audit_log (only durable record after row deletion)
- **Mobile - /team/members** - enriched member list (parallel Supabase enrichment for last_active + cost), role/remove via web API (server-side permission checks enforced), `canManageMember()` gate mirrors web role matrix
- **Mobile - /team/policies** - `TagListEditor` chips, GET/PATCH via `getApiBaseUrl()`, Zod validation before save, navigation to invitations panel

## Test plan

- [ ] Web: 14 policies API route tests (401/403/400/200/500 coverage) - all pass
- [ ] Web: 14 founder-team-metrics API route tests (access gates + aggregation + edge cases) - all pass
- [ ] Web: 1882 total tests pass (including a11y regression - text-zinc-400 enforced)
- [ ] Mobile: 1498 total tests pass
- [ ] TypeScript: web `tsc --noEmit` clean; mobile clean on authored files (pre-existing upstream errors in `invite-rate-limit.ts`, `e2e/cold-start.test.ts`, `storage-quota.ts` are unrelated to Phase 2.3 and documented as blocked-by-upstream)
- [ ] Next.js build: succeeds, all new routes registered as dynamic (ƒ)
- [ ] Bundle: dynamic imports on MembersTable + PoliciesForm + TeamsCard defer admin surfaces from first-load chunk
- [ ] Manual: Visit `/dashboard/team/[id]/members` as owner - verify role dropdown, remove confirm, cost MTD column
- [ ] Manual: Visit `/dashboard/team/[id]/policies` as member - verify read-only view; as owner - verify save + audit_log entry
- [ ] Manual: Visit `/dashboard/founder` as admin - verify TeamsCard renders with per-team breakdown

## Notes

- No changes to billing routes, polar routes, or subscriptions migrations (Phase 2.6 concurrent agent boundary respected)
- Churn detection uses `audit_log` action `team.member.removed` (not deleted rows - those are gone); this is the durable record written by `DELETE /api/teams/[id]/members/[userId]`
- `MembersDynamic` is a client boundary component that receives serialisable `initialMembers` from the server page and owns optimistic update state; server components cannot pass function callbacks across the boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)