### PR TITLE
fix(migrations): production-blocker fixes for migrations 026, 027, 033

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ ARCHITECTURE.md
 .launch-reports/
 .claude/
 .subagent-dev-reports/
+.clone/

--- a/packages/styrby-web/src/__tests__/feedback/migration-027.test.ts
+++ b/packages/styrby-web/src/__tests__/feedback/migration-027.test.ts
@@ -59,8 +59,8 @@ describe('Migration 027: feedback_loop', () => {
     expect(sql).toContain('score >= 0 AND score <= 10');
   });
 
-  it('adds window column to user_feedback', () => {
-    expect(sql).toContain("ADD COLUMN IF NOT EXISTS window TEXT");
+  it('adds nps_window column to user_feedback', () => {
+    expect(sql).toContain("ADD COLUMN IF NOT EXISTS nps_window TEXT");
     expect(sql).toContain("'7d', '30d'");
   });
 

--- a/packages/styrby-web/src/app/api/admin/founder-feedback/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-feedback/route.ts
@@ -22,7 +22,7 @@
  * @rateLimit 10 requests per minute
  *
  * @query tab - 'nps' | 'general' | 'postmortems' (default: 'nps')
- * @query window - '7d' | '30d' | 'all' for NPS filtering (default: 'all')
+ * @query nps_window - '7d' | '30d' | 'all' for NPS filtering (default: 'all')
  * @query agent - agent_type filter for postmortems (optional)
  * @query rating - 'useful' | 'not_useful' filter for postmortems (optional)
  * @query weeks - number of weeks for NPS trend (default: 12)
@@ -46,7 +46,7 @@ import { calcNPS, groupNpsByWeek } from '@styrby/shared';
 // ============================================================================
 
 interface NpsTabData {
-  /** Current NPS across all time or selected window */
+  /** Current NPS across all time or selected nps_window */
   currentNps: {
     score: number;
     promoters: number;
@@ -71,7 +71,7 @@ interface NpsTabData {
     id: string;
     score: number;
     followup: string;
-    window: string | null;
+    nps_window: string | null;
     created_at: string;
   }>;
 }
@@ -133,7 +133,7 @@ export async function GET(request: NextRequest) {
   // ── Query params ──────────────────────────────────────────────────────────
   const { searchParams } = new URL(request.url);
   const tab = (searchParams.get('tab') ?? 'nps') as 'nps' | 'general' | 'postmortems';
-  const window = (searchParams.get('window') ?? 'all') as '7d' | '30d' | 'all';
+  const nps_window = (searchParams.get('nps_window') ?? 'all') as '7d' | '30d' | 'all';
   const agentFilter = searchParams.get('agent');
   const ratingFilter = searchParams.get('rating') as 'useful' | 'not_useful' | null;
   const weeksBack = Math.min(52, parseInt(searchParams.get('weeks') ?? '12', 10));
@@ -142,7 +142,7 @@ export async function GET(request: NextRequest) {
 
   try {
     if (tab === 'nps') {
-      const data = await fetchNpsData(adminSupabase, window, weeksBack);
+      const data = await fetchNpsData(adminSupabase, nps_window, weeksBack);
       return NextResponse.json({ tab, data });
     }
 
@@ -168,12 +168,12 @@ export async function GET(request: NextRequest) {
  * Fetch NPS tab data: current score, weekly trend, latest comments.
  *
  * @param supabase - Admin client
- * @param window - Filter to specific NPS window ('7d', '30d', or 'all')
+ * @param nps_window - Filter to specific NPS nps_window ('7d', '30d', or 'all')
  * @param weeksBack - Number of weeks of trend data to include
  */
 async function fetchNpsData(
   supabase: ReturnType<typeof createAdminClient>,
-  window: '7d' | '30d' | 'all',
+  nps_window: '7d' | '30d' | 'all',
   weeksBack: number
 ): Promise<NpsTabData> {
   // WHY: Fetch all NPS rows in the trend period to compute both the overall
@@ -183,15 +183,15 @@ async function fetchNpsData(
 
   let query = supabase
     .from('user_feedback')
-    .select('id, score, followup, window, created_at')
+    .select('id, score, followup, nps_window, created_at')
     .eq('kind', 'nps')
     .not('score', 'is', null)
     .gte('created_at', since.toISOString())
     .order('created_at', { ascending: false })
     .limit(5000); // Safety cap
 
-  if (window !== 'all') {
-    query = query.eq('window', window);
+  if (nps_window !== 'all') {
+    query = query.eq('nps_window', nps_window);
   }
 
   const { data: rows, error } = await query;
@@ -217,7 +217,7 @@ async function fetchNpsData(
       id: r.id as string,
       score: r.score as number,
       followup: r.followup as string,
-      window: r.window as string | null,
+      nps_window: r.nps_window as string | null,
       created_at: r.created_at as string,
     }));
 

--- a/packages/styrby-web/src/app/api/feedback/submit/route.ts
+++ b/packages/styrby-web/src/app/api/feedback/submit/route.ts
@@ -27,7 +27,7 @@
  *   kind: 'nps' | 'general' | 'session_postmortem',
  *   score?: number,         // 0-10 (NPS)
  *   followup?: string,      // NPS follow-up free text (max 2000 chars)
- *   window?: '7d' | '30d', // NPS window
+ *   nps_window?: '7d' | '30d', // NPS window
  *   promptId?: string,      // UUID of user_feedback_prompts row (NPS)
  *   message?: string,       // General feedback text (max 2000 chars)
  *   replyEmail?: string,    // Optional reply-to for general feedback
@@ -86,7 +86,7 @@ const FeedbackSubmitSchema = z
       kind: z.literal('nps'),
       score: z.number().int().min(0).max(10),
       followup: z.string().max(2000).optional(),
-      window: z.enum(['7d', '30d']),
+      nps_window: z.enum(['7d', '30d']),
       promptId: z.string().uuid().optional(),
       contextJson: ContextJsonSchema,
     }),
@@ -193,7 +193,7 @@ export async function POST(request: NextRequest) {
       metadata: {
         feedback_id: feedbackId,
         kind: input.kind,
-        ...(input.kind === 'nps' && { window: input.window, score: input.score }),
+        ...(input.kind === 'nps' && { nps_window: input.nps_window, score: input.score }),
         ...(input.kind === 'session_postmortem' && {
           rating: input.rating,
           session_id: input.sessionId,
@@ -239,7 +239,7 @@ function buildFeedbackRow(
       feedback_type: 'nps',
       score: input.score,
       followup: input.followup ?? null,
-      window: input.window,
+      nps_window: input.nps_window,
       prompt_id: input.promptId ?? null,
       // Backwards compat: also set rating INT for old queries
       rating: input.score,

--- a/packages/styrby-web/src/app/dashboard/founder/feedback/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/founder/feedback/page.tsx
@@ -129,7 +129,7 @@ export default async function FounderFeedbackPage({
 
       {/* Tab content */}
       {activeTab === 'nps' && (
-        <NpsTab initialData={safeNps} window="all" />
+        <NpsTab initialData={safeNps} nps_window="all" />
       )}
       {activeTab === 'general' && (
         <GeneralTab initialItems={safeGeneral.items} initialTotal={safeGeneral.total} />

--- a/packages/styrby-web/src/components/dashboard/founder-feedback/NpsTab.tsx
+++ b/packages/styrby-web/src/components/dashboard/founder-feedback/NpsTab.tsx
@@ -29,7 +29,7 @@ interface NpsComment {
   id: string;
   score: number;
   followup: string;
-  window: string | null;
+  nps_window: string | null;
   created_at: string;
 }
 
@@ -54,7 +54,7 @@ interface NpsTabProps {
   /** Initial server-fetched data (avoids loading flash) */
   initialData: NpsTabData;
   /** Window filter for this view */
-  window: '7d' | '30d' | 'all';
+  nps_window: '7d' | '30d' | 'all';
 }
 
 // ============================================================================
@@ -66,7 +66,7 @@ interface NpsTabProps {
  *
  * @param props - NpsTabProps
  */
-export function NpsTab({ initialData, window }: NpsTabProps) {
+export function NpsTab({ initialData, nps_window }: NpsTabProps) {
   const [data, setData] = React.useState<NpsTabData>(initialData);
   const [loading, setLoading] = React.useState(false);
 
@@ -76,7 +76,7 @@ export function NpsTab({ initialData, window }: NpsTabProps) {
       try {
         setLoading(true);
         const res = await fetch(
-          `/api/admin/founder-feedback?tab=nps&window=${window}&weeks=12`,
+          `/api/admin/founder-feedback?tab=nps&nps_window=${nps_window}&weeks=12`,
           { credentials: 'include' }
         );
         if (res.ok) {
@@ -91,7 +91,7 @@ export function NpsTab({ initialData, window }: NpsTabProps) {
     }, 60_000);
 
     return () => clearInterval(interval);
-  }, [window]);
+  }, [nps_window]);
 
   const { currentNps, trend, latestComments } = data;
 
@@ -158,9 +158,9 @@ export function NpsTab({ initialData, window }: NpsTabProps) {
                   <span className="rounded bg-indigo-900/40 px-1.5 py-0.5 text-xs font-semibold text-indigo-300">
                     {formatNpsScore(comment.score)}
                   </span>
-                  {comment.window && (
+                  {comment.nps_window && (
                     <span className="text-xs text-zinc-500">
-                      {comment.window === '7d' ? '7-day survey' : '30-day survey'}
+                      {comment.nps_window === '7d' ? '7-day survey' : '30-day survey'}
                     </span>
                   )}
                   <span className="ml-auto text-xs text-zinc-400">

--- a/supabase/migrations/026_retention_hooks.sql
+++ b/supabase/migrations/026_retention_hooks.sql
@@ -247,9 +247,12 @@ CREATE TABLE IF NOT EXISTS referral_events (
   is_disposable_email  BOOLEAN  DEFAULT FALSE,
   rejection_reason     TEXT,
 
-  -- Conversion window: 30 days from click
-  expires_at           TIMESTAMPTZ NOT NULL
-                       GENERATED ALWAYS AS (clicked_at + INTERVAL '30 days') STORED,
+  -- Conversion window: 30 days from click.
+  -- WHY not GENERATED ALWAYS: Postgres classifies `timestamptz + interval`
+  -- as STABLE (timezone-dependent), not IMMUTABLE, so it can't be used in
+  -- a stored generated column (fails 42P17). Populated via BEFORE INSERT
+  -- trigger fn_referral_events_set_expires_at defined after this table.
+  expires_at           TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '30 days'),
 
   -- Tier of the upgrade that triggered the reward
   upgraded_to_tier     TEXT CHECK (upgraded_to_tier IN ('pro', 'power', 'team', 'business', 'enterprise')),
@@ -257,6 +260,28 @@ CREATE TABLE IF NOT EXISTS referral_events (
   created_at           TIMESTAMPTZ DEFAULT NOW() NOT NULL,
   updated_at           TIMESTAMPTZ DEFAULT NOW() NOT NULL
 );
+
+-- WHY trigger-maintained expires_at: the DEFAULT above handles the common
+-- case (expires_at computed at INSERT time as NOW()+30d). This trigger
+-- ensures that when clicked_at is explicitly supplied (e.g., backfill),
+-- expires_at is recomputed from it rather than from NOW(). Idempotent.
+CREATE OR REPLACE FUNCTION fn_referral_events_set_expires_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- If caller supplied expires_at explicitly, keep it.
+  -- Otherwise derive from clicked_at (or NOW if clicked_at is null).
+  IF NEW.expires_at IS NULL OR NEW.expires_at = (NOW() + INTERVAL '30 days') THEN
+    NEW.expires_at := COALESCE(NEW.clicked_at, NOW()) + INTERVAL '30 days';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_referral_events_set_expires_at ON referral_events;
+CREATE TRIGGER trg_referral_events_set_expires_at
+  BEFORE INSERT ON referral_events
+  FOR EACH ROW
+  EXECUTE FUNCTION fn_referral_events_set_expires_at();
 
 CREATE INDEX IF NOT EXISTS idx_referral_events_referrer
   ON referral_events(referrer_user_id, status);
@@ -443,16 +468,25 @@ SELECT cron.schedule(
 
 -- WHY: The budget threshold route joins cost_records → sessions → profiles
 -- filtered on billing period. The sessions index already exists from 022.
--- Add a compound on cost_records(user_id, created_at) for MTD aggregation.
+-- Add a compound on cost_records(user_id, recorded_at) for MTD aggregation.
+-- WHY recorded_at (not created_at): cost_records uses `recorded_at` as its
+-- timestamp column (see migration 001). The partial-index predicate is
+-- redundant because recorded_at is NOT NULL in the base schema, but we
+-- keep the form for documentary intent.
 CREATE INDEX IF NOT EXISTS idx_cost_records_user_mtd
-  ON cost_records(user_id, created_at DESC)
-  WHERE created_at IS NOT NULL;
+  ON cost_records(user_id, recorded_at DESC);
 
 -- WHY: The agent-finished notification edge function queries sessions by
 -- user + status + ended_at to find recently-completed sessions.
+-- WHY status IN ('stopped','expired'): the session_status enum from
+-- migration 001 doesn't have 'ended'. Terminated sessions are either
+-- 'stopped' (clean user-initiated) or 'expired' (timed out). Both are
+-- "agent-finished" for the notification trigger.
+-- WHY no deleted_at predicate: sessions table doesn't have a deleted_at
+-- column (sessions are hard-deleted or retained per retention policy).
 CREATE INDEX IF NOT EXISTS idx_sessions_user_ended
   ON sessions(user_id, ended_at DESC)
-  WHERE status = 'ended' AND deleted_at IS NULL;
+  WHERE status IN ('stopped', 'expired');
 
 -- WHY: notifications feed is queried as "unread first, then all" — index
 -- already created above in Step 2. Index for read-mark queries:

--- a/supabase/migrations/027_feedback_loop.sql
+++ b/supabase/migrations/027_feedback_loop.sql
@@ -7,14 +7,14 @@
 --        - kind TEXT ENUM('nps','general','session_postmortem','icp_soft')
 --        - score INT (0-10 NPS score, 1-2 session rating encoded)
 --        - followup TEXT (NPS follow-up free text)
---        - window ENUM('7d','30d') for NPS window tagging
+--        - nps_window ENUM('7d','30d') for NPS nps_window tagging
 --        - rating ENUM('useful','not_useful') for session post-mortems
 --        - reason TEXT for post-mortem negative reason
 --        - context_json JSONB for screen/route context (no PII)
 --        - prompt_id UUID FK to user_feedback_prompts (link prompt → response)
 --
 --   2. user_feedback_prompts table
---        Scheduled NPS prompt rows (one per user per window).
+--        Scheduled NPS prompt rows (one per user per nps_window).
 --        pg_cron polls every 15 min and enqueues push + in-app notification
 --        for each due prompt.
 --
@@ -67,9 +67,9 @@ ALTER TABLE user_feedback
   -- Optional NPS free-text follow-up ("What's the #1 thing we could improve?")
   ADD COLUMN IF NOT EXISTS followup TEXT,
 
-  -- NPS window: '7d' (day-7 survey) or '30d' (day-30 survey)
-  ADD COLUMN IF NOT EXISTS window TEXT
-    CHECK (window IN ('7d', '30d')),
+  -- NPS nps_window: '7d' (day-7 survey) or '30d' (day-30 survey)
+  ADD COLUMN IF NOT EXISTS nps_window TEXT
+    CHECK (nps_window IN ('7d', '30d')),
 
   -- Session post-mortem: 'useful' or 'not_useful'
   ADD COLUMN IF NOT EXISTS rating TEXT
@@ -85,9 +85,9 @@ ALTER TABLE user_feedback
   -- Set NULL for general and post-mortem feedback
   ADD COLUMN IF NOT EXISTS prompt_id UUID;
 
--- Index: NPS window queries for founder dashboard trend chart
+-- Index: NPS nps_window queries for founder dashboard trend chart
 CREATE INDEX IF NOT EXISTS idx_user_feedback_kind_window
-  ON user_feedback(kind, window, created_at DESC)
+  ON user_feedback(kind, nps_window, created_at DESC)
   WHERE kind = 'nps';
 
 -- Index: post-mortem listing for founder dashboard (filter by agent)
@@ -105,8 +105,8 @@ COMMENT ON COLUMN user_feedback.score IS
 COMMENT ON COLUMN user_feedback.followup IS
   'NPS follow-up free text: "What is the #1 thing we could do to raise that score?"';
 
-COMMENT ON COLUMN user_feedback.window IS
-  'NPS survey window: 7d (7-day post-signup) or 30d (30-day post-signup).';
+COMMENT ON COLUMN user_feedback.nps_window IS
+  'NPS survey nps_window: 7d (7-day post-signup) or 30d (30-day post-signup).';
 
 COMMENT ON COLUMN user_feedback.rating IS
   'Session post-mortem one-tap: useful | not_useful.';
@@ -126,8 +126,8 @@ COMMENT ON COLUMN user_feedback.prompt_id IS
 -- ============================================================================
 -- Step 2: user_feedback_prompts table
 -- ============================================================================
--- WHY: We need to track scheduled NPS prompts per user per window:
---   - Prevent duplicates (one prompt per window per user)
+-- WHY: We need to track scheduled NPS prompts per user per nps_window:
+--   - Prevent duplicates (one prompt per nps_window per user)
 --   - Know when to dispatch (due_at timestamp)
 --   - Know if already dispatched (dispatched_at, response_id)
 --   - Know if dismissed without answering (dismissed_at)
@@ -139,7 +139,7 @@ CREATE TABLE IF NOT EXISTS user_feedback_prompts (
   id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id           UUID        NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
 
-  -- Which NPS window this prompt represents
+  -- Which NPS nps_window this prompt represents
   -- 'nps_7d' fires 7 days after signup; 'nps_30d' fires 30 days after signup
   kind              TEXT        NOT NULL CHECK (kind IN ('nps_7d', 'nps_30d')),
 
@@ -189,7 +189,7 @@ CREATE POLICY feedback_prompts_delete_service ON user_feedback_prompts
   FOR DELETE USING (true);
 
 COMMENT ON TABLE user_feedback_prompts IS
-  'Scheduled NPS prompt delivery queue. One row per user per NPS window (7d, 30d). '
+  'Scheduled NPS prompt delivery queue. One row per user per NPS nps_window (7d, 30d). '
   'The fn_dispatch_due_nps_prompts() cron function polls every 15 min, picks '
   'due rows, sends push + in-app notification, and stamps dispatched_at. '
   'Idempotency enforced by UNIQUE (user_id, kind).';
@@ -388,7 +388,7 @@ ON CONFLICT (user_id, kind) DO NOTHING;
 -- blocked for users (founder dashboard uses service role client which bypasses RLS).
 
 COMMENT ON TABLE user_feedback_prompts IS
-  'NPS prompt scheduler. One row per user per window (nps_7d, nps_30d). '
+  'NPS prompt scheduler. One row per user per nps_window (nps_7d, nps_30d). '
   'Trigger fn_schedule_nps_prompts() inserts on profile creation. '
   'fn_dispatch_due_nps_prompts() cron marks dispatched_at and queues in-app notification. '
   'Idempotency: UNIQUE(user_id, kind) prevents duplicate schedules.';

--- a/supabase/migrations/033_mv_team_cost_summary.sql
+++ b/supabase/migrations/033_mv_team_cost_summary.sql
@@ -88,10 +88,10 @@ COMMENT ON MATERIALIZED VIEW mv_team_cost_summary IS
 -- WHY schedule at minute :05: Offset from the top of the hour so the MV
 -- refresh does not compete with other cron jobs (e.g. pg_cron defaults at :00).
 -- WHY pg_catalog.cron: Supabase pins pg_cron to pg_catalog (not the extensions
--- schema). Referencing pg_catalog.cron.schedule() is required per project
+-- schema). Referencing cron.schedule() is required per project
 -- memory feedback_supabase_pg_cron_schema.md.
 
-SELECT pg_catalog.cron.schedule(
+SELECT cron.schedule(
   'refresh-mv-team-cost-summary',
   '5 * * * *',
   $$REFRESH MATERIALIZED VIEW CONCURRENTLY mv_team_cost_summary$$


### PR DESCRIPTION
## Summary

4 production-blocker SQL errors surfaced during the first end-to-end deploy of migrations 020-034 to prod Supabase. All fixed; all 15 migrations now applied to prod (akmtmxunjhsgldjztdtt).

## The bugs

| # | Migration | Error | Fix |
|---|-----------|-------|-----|
| 1 | 026 | 42P17: `timestamptz + interval` isn't IMMUTABLE → can't use in `GENERATED ALWAYS AS (...) STORED` | Plain column with `DEFAULT (NOW() + INTERVAL '30 days')` + BEFORE INSERT trigger |
| 2 | 026 | 42703: `cost_records.created_at` doesn't exist | Use correct column name `recorded_at` (from migration 001) |
| 3 | 026 | 22P02: `session_status` enum has no `'ended'` value | Use `status IN ('stopped', 'expired')` |
| 4 | 027 | 42601: `window` is a reserved Postgres keyword | Rename column to `nps_window` across DDL + 3 app files |
| 5 | 033 | 0A000: `pg_catalog.cron.schedule()` is a cross-database reference | Use bare `cron.schedule()` (search_path resolves it) |

## Why these weren't caught pre-merge

Neither tsc nor vitest actually applies migrations against a Postgres instance. The SQL linter catches syntax but not:
- Reserved-word column names (valid SQL syntax, invalid at execution)
- Enum-value existence (cross-migration reference)
- Immutability classification (Postgres version-specific)
- Extension schema resolution (Supabase-specific pinning)

Recommendation: add a CI job that spins a Postgres container + runs `supabase db reset` to catch this class of bug pre-merge.

## Verification

- All 15 migrations (020-034) now applied to prod Supabase
- `supabase migration list` shows Local + Remote columns match through 034
- 3 app files updated for the `window → nps_window` rename

## Test plan

- [ ] CI green (lint, typecheck, tests)
- [ ] Tests updated for `nps_window` column rename still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)