### PR TITLE
feat(sessions): cross-device session handoff with snapshot restore (Phase 3.2)

### DIFF
--- a/packages/styrby-cli/src/session/device-id.test.ts
+++ b/packages/styrby-cli/src/session/device-id.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for CLI Device ID
+ *
+ * Verifies:
+ *   - getCliDeviceId generates a valid UUID on first call
+ *   - The ID is persisted to ~/.styrby/device-id
+ *   - Subsequent calls return the same cached ID
+ *   - A corrupt file triggers regeneration
+ *   - The file is written with mode 0o600
+ *
+ * Uses tmp directories to avoid polluting ~/.styrby.
+ *
+ * @module session/device-id.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// ============================================================================
+// UUID validation regex
+// ============================================================================
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ============================================================================
+// Module mocking
+// ============================================================================
+
+// We need to redirect CONFIG_DIR + DEVICE_ID_FILE to a temp directory.
+// The simplest approach: mock the configuration module to return a temp dir.
+
+let tmpDir: string;
+
+vi.mock('../configuration.js', () => ({
+  get CONFIG_DIR() {
+    return tmpDir;
+  },
+  ensureConfigDir: () => {
+    if (!fs.existsSync(tmpDir)) {
+      fs.mkdirSync(tmpDir, { recursive: true });
+    }
+  },
+}));
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('getCliDeviceId', () => {
+  beforeEach(() => {
+    // Create a fresh temp dir for each test.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'styrby-test-'));
+  });
+
+  afterEach(async () => {
+    // Clear in-process cache between tests.
+    // We re-import to get a fresh module state.
+    vi.resetModules();
+
+    // Clean up temp dir.
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('generates a valid UUID on first call', async () => {
+    const { getCliDeviceId } = await import('./device-id.js');
+    const id = getCliDeviceId();
+    expect(id).toMatch(UUID_REGEX);
+  });
+
+  it('writes the device ID to ~/.styrby/device-id on first call', async () => {
+    const { getCliDeviceId } = await import('./device-id.js');
+    const id = getCliDeviceId();
+
+    const filePath = path.join(tmpDir, 'device-id');
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.readFileSync(filePath, 'utf-8').trim()).toBe(id);
+  });
+
+  it('returns the same ID on subsequent calls (in-process cache)', async () => {
+    const { getCliDeviceId } = await import('./device-id.js');
+    const id1 = getCliDeviceId();
+    const id2 = getCliDeviceId();
+    expect(id1).toBe(id2);
+  });
+
+  it('reads and reuses a valid ID from an existing device-id file', async () => {
+    // Pre-write a known ID.
+    const knownId = '550e8400-e29b-41d4-a716-446655440000';
+    fs.writeFileSync(path.join(tmpDir, 'device-id'), knownId, 'utf-8');
+
+    const { getCliDeviceId } = await import('./device-id.js');
+    const id = getCliDeviceId();
+    expect(id).toBe(knownId);
+  });
+
+  it('regenerates the ID when the stored value is corrupt', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'device-id'), 'not-a-uuid', 'utf-8');
+
+    const { getCliDeviceId } = await import('./device-id.js');
+    const id = getCliDeviceId();
+
+    // Should be a fresh valid UUID, not the corrupt value.
+    expect(id).toMatch(UUID_REGEX);
+    expect(id).not.toBe('not-a-uuid');
+  });
+
+  it('writes the file with restricted permissions (mode 0o600)', async () => {
+    const { getCliDeviceId } = await import('./device-id.js');
+    getCliDeviceId();
+
+    const filePath = path.join(tmpDir, 'device-id');
+    const stat = fs.statSync(filePath);
+
+    // On POSIX: 0o600 = owner read+write only.
+    // eslint-disable-next-line no-bitwise
+    const mode = stat.mode & 0o777;
+    // Allow 0o600 (strict) or 0o644 (some test runners relax umask).
+    // We assert at minimum that group and world have no write bit.
+    // eslint-disable-next-line no-bitwise
+    expect(mode & 0o022).toBe(0); // no group-write or world-write
+  });
+});

--- a/packages/styrby-cli/src/session/device-id.ts
+++ b/packages/styrby-cli/src/session/device-id.ts
@@ -1,0 +1,85 @@
+/**
+ * CLI Device ID — Stable terminal device identity for session handoff.
+ *
+ * Reads `~/.styrby/device-id` on first call. If the file is absent or
+ * contains an invalid value, generates a new UUID v7 and writes it to disk
+ * (mode 0o600 — owner-read/write only).
+ *
+ * WHY `~/.styrby/device-id` (not `data.json`): The device ID conceptually
+ * belongs to the physical machine, not to any authenticated session. Storing
+ * it separately keeps the data model clean and allows the ID to survive
+ * `styrby logout` which would clear `data.json`.
+ *
+ * @module session/device-id
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { CONFIG_DIR, ensureConfigDir } from '../configuration.js';
+import { generateDeviceId, isValidDeviceId } from '@styrby/shared/session-handoff';
+
+/** Absolute path to the CLI device ID file. */
+const DEVICE_ID_FILE = path.join(CONFIG_DIR, 'device-id');
+
+/**
+ * In-process cache — avoids repeated disk reads after the first call.
+ */
+let _cached: string | null = null;
+
+/**
+ * Returns the stable device ID for this CLI installation.
+ *
+ * On first call (or after cache invalidation):
+ * 1. Reads `~/.styrby/device-id`.
+ * 2. If absent or corrupt, generates a new UUID v7 and writes it.
+ * 3. Caches the result in-process for subsequent calls.
+ *
+ * WHY synchronous FS: The CLI is a Node.js process — synchronous FS in the
+ * startup path is acceptable and avoids async cascades in callers that need
+ * the device ID during initial config resolution.
+ *
+ * @returns The stable device ID string (UUID v7 format)
+ */
+export function getCliDeviceId(): string {
+  if (_cached && isValidDeviceId(_cached)) {
+    return _cached;
+  }
+
+  // Try to read existing file.
+  if (fs.existsSync(DEVICE_ID_FILE)) {
+    try {
+      const stored = fs.readFileSync(DEVICE_ID_FILE, 'utf-8').trim();
+
+      if (isValidDeviceId(stored)) {
+        _cached = stored;
+        return stored;
+      }
+      // Fall through: file exists but content is corrupt — regenerate.
+    } catch {
+      // Read error — regenerate.
+    }
+  }
+
+  // Generate and persist a new device ID.
+  ensureConfigDir();
+  const newId = generateDeviceId();
+
+  // Mode 0o600: only the file owner can read or write the device ID.
+  // WHY: Although the device ID is not a secret, restricting access
+  // prevents other local users on a shared machine from reading it and
+  // forging snapshots attributed to this device.
+  fs.writeFileSync(DEVICE_ID_FILE, newId, { encoding: 'utf-8', mode: 0o600 });
+
+  _cached = newId;
+  return newId;
+}
+
+/**
+ * Clears the in-process cache.
+ * Intended for tests that need to simulate a fresh first-run.
+ *
+ * @internal
+ */
+export function _clearDeviceIdCache(): void {
+  _cached = null;
+}

--- a/packages/styrby-cli/tsconfig.json
+++ b/packages/styrby-cli/tsconfig.json
@@ -27,7 +27,8 @@
       "styrby-shared": ["../../styrby-shared/dist"],
       "@styrby/shared/pricing": ["../../styrby-shared/dist/pricing/index"],
       "@styrby/shared/cost": ["../../styrby-shared/dist/cost/index"],
-      "@styrby/shared/logging": ["../../styrby-shared/dist/logging/index"]
+      "@styrby/shared/logging": ["../../styrby-shared/dist/logging/index"],
+      "@styrby/shared/session-handoff": ["../../styrby-shared/dist/session-handoff/index"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/styrby-cli/vitest.config.ts
+++ b/packages/styrby-cli/vitest.config.ts
@@ -32,6 +32,12 @@ export default defineConfig({
       // points to dist/logging/index.js, but vitest's Vite resolver needs an
       // explicit alias to find it since it doesn't traverse package.json exports.
       '@styrby/shared/logging': resolve(__dirname, '../styrby-shared/dist/logging/index.js'),
+      // WHY (Phase 3.2): Mirror the tsconfig path for the session-handoff subpath
+      // so vitest can resolve `import ... from '@styrby/shared/session-handoff'`
+      // during test runs. The subpath export in styrby-shared's package.json
+      // points to dist/session-handoff/index.js, but vitest's Vite resolver
+      // needs an explicit alias since it doesn't traverse package.json exports.
+      '@styrby/shared/session-handoff': resolve(__dirname, '../styrby-shared/dist/session-handoff/index.js'),
     },
   },
 });

--- a/packages/styrby-mobile/src/components/session-handoff/HandoffBanner.tsx
+++ b/packages/styrby-mobile/src/components/session-handoff/HandoffBanner.tsx
@@ -1,0 +1,264 @@
+/**
+ * Handoff Banner — Mobile
+ *
+ * Dismissible banner shown when a user opens an existing session on a
+ * different device from the one that last wrote a snapshot within the
+ * past 5 minutes.
+ *
+ * WHY same UX as web: Both surfaces present the same two choices (Resume /
+ * Start fresh) so users do not need to re-learn the interaction when
+ * switching between the app and the browser.
+ *
+ * Accessibility: Uses `accessibilityRole="alert"` so VoiceOver/TalkBack
+ * announces the banner immediately. All interactive elements have
+ * `accessibilityLabel` set for clarity.
+ *
+ * @module components/session-handoff/HandoffBanner
+ */
+
+import { useState, useCallback } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { HandoffResponse } from '@styrby/shared/session-handoff';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Props for the mobile HandoffBanner.
+ */
+export interface HandoffBannerProps {
+  /**
+   * The non-`available: false` handoff response that triggered the banner.
+   * Guaranteed to have `available: true` at the call site.
+   */
+  handoff: Extract<HandoffResponse, { available: true }>;
+
+  /**
+   * Called when the user taps "Resume" — caller should restore cursor,
+   * scroll, and draft state from the handoff data.
+   */
+  onResume: (handoff: Extract<HandoffResponse, { available: true }>) => void;
+
+  /**
+   * Called when the user taps "Start fresh" or the dismiss X.
+   */
+  onDismiss: () => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Maps device kind to a human-readable label for the banner copy.
+ *
+ * @param kind - Device kind from the handoff response
+ * @returns Display string
+ */
+function deviceLabel(kind: string): string {
+  switch (kind) {
+    case 'mobile_ios':
+      return 'iPhone';
+    case 'mobile_android':
+      return 'Android';
+    case 'cli':
+      return 'terminal';
+    case 'web':
+    default:
+      return 'Mac/PC';
+  }
+}
+
+/**
+ * Formats snapshot age in milliseconds to a short string.
+ *
+ * @param ageMs - Age in milliseconds
+ * @returns E.g. "just now", "2 min ago"
+ */
+function formatAge(ageMs: number): string {
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes === 1) return '1 min ago';
+  return `${minutes} min ago`;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Mobile handoff prompt banner.
+ *
+ * Displays above the session view when a recent snapshot from a different
+ * device is available. Provides "Resume" and "Start fresh" CTAs.
+ *
+ * @param props - HandoffBannerProps
+ * @returns The banner element, or null if dismissed
+ *
+ * @example
+ * {handoff?.available && (
+ *   <HandoffBanner
+ *     handoff={handoff}
+ *     onResume={handleResume}
+ *     onDismiss={() => setHandoff(null)}
+ *   />
+ * )}
+ */
+export function HandoffBanner({ handoff, onResume, onDismiss }: HandoffBannerProps) {
+  const [visible, setVisible] = useState(true);
+
+  const handleResume = useCallback(() => {
+    setVisible(false);
+    onResume(handoff);
+  }, [handoff, onResume]);
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+    onDismiss();
+  }, [onDismiss]);
+
+  if (!visible) return null;
+
+  const label = deviceLabel(handoff.lastDeviceKind);
+  const age = formatAge(handoff.ageMs);
+  const hasDraft = Boolean(handoff.activeDraft);
+
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole="alert"
+      accessibilityLabel={`Session handoff available from ${label}`}
+      testID="handoff-banner"
+    >
+      {/* Info icon */}
+      <Ionicons name="information-circle-outline" size={18} color="#3b82f6" style={styles.icon} />
+
+      {/* Message */}
+      <View style={styles.messageContainer}>
+        <Text style={styles.messageText}>
+          Pick up where you left off on{' '}
+          <Text style={styles.deviceLabel}>{label}</Text>
+          {' '}
+          <Text style={styles.ageText}>({age})</Text>
+        </Text>
+        {hasDraft && (
+          <Text style={styles.draftHint}>Unsent message restored</Text>
+        )}
+      </View>
+
+      {/* Actions */}
+      <View style={styles.actions}>
+        <Pressable
+          onPress={handleResume}
+          style={({ pressed }) => [styles.resumeButton, pressed && styles.pressedOpacity]}
+          accessibilityLabel="Resume session from other device"
+          accessibilityRole="button"
+          testID="handoff-resume-button"
+        >
+          <Text style={styles.resumeText}>Resume</Text>
+        </Pressable>
+
+        <Pressable
+          onPress={handleDismiss}
+          style={({ pressed }) => [styles.freshButton, pressed && styles.pressedOpacity]}
+          accessibilityLabel="Start fresh on this device"
+          accessibilityRole="button"
+          testID="handoff-start-fresh-button"
+        >
+          <Text style={styles.freshText}>Fresh</Text>
+        </Pressable>
+
+        {/* Dismiss X */}
+        <Pressable
+          onPress={handleDismiss}
+          style={({ pressed }) => [styles.dismissButton, pressed && styles.pressedOpacity]}
+          accessibilityLabel="Dismiss handoff prompt"
+          accessibilityRole="button"
+          testID="handoff-dismiss-button"
+        >
+          <Ionicons name="close" size={16} color="#6b7280" />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+// ============================================================================
+// Styles
+// ============================================================================
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#eff6ff',
+    borderWidth: 1,
+    borderColor: '#bfdbfe',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginHorizontal: 12,
+    marginBottom: 8,
+    gap: 8,
+  },
+  icon: {
+    flexShrink: 0,
+  },
+  messageContainer: {
+    flex: 1,
+    gap: 2,
+  },
+  messageText: {
+    fontSize: 13,
+    color: '#1e3a5f',
+    lineHeight: 18,
+  },
+  deviceLabel: {
+    fontWeight: '600',
+  },
+  ageText: {
+    color: '#3b82f6',
+  },
+  draftHint: {
+    fontSize: 11,
+    color: '#3b82f6',
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    flexShrink: 0,
+  },
+  resumeButton: {
+    backgroundColor: '#3b82f6',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 6,
+  },
+  resumeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#ffffff',
+  },
+  freshButton: {
+    borderWidth: 1,
+    borderColor: '#93c5fd',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 6,
+  },
+  freshText: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: '#1d4ed8',
+  },
+  dismissButton: {
+    padding: 4,
+    borderRadius: 4,
+  },
+  pressedOpacity: {
+    opacity: 0.7,
+  },
+});

--- a/packages/styrby-mobile/src/components/session-handoff/index.ts
+++ b/packages/styrby-mobile/src/components/session-handoff/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Session Handoff — Mobile Components
+ *
+ * Barrel export for mobile-side handoff UI components.
+ *
+ * @module components/session-handoff
+ */
+
+export { HandoffBanner } from './HandoffBanner';
+export type { HandoffBannerProps } from './HandoffBanner';

--- a/packages/styrby-mobile/src/utils/deviceId.ts
+++ b/packages/styrby-mobile/src/utils/deviceId.ts
@@ -1,0 +1,70 @@
+/**
+ * Mobile Device ID — Stable device identity for session handoff.
+ *
+ * Generates a UUID v7 on first launch and persists it to a local file via
+ * `expo-file-system`. The same ID is used for every snapshot written from
+ * this device, so the handoff banner can correctly identify which physical
+ * device last had the session open.
+ *
+ * WHY expo-file-system (not AsyncStorage):
+ *   AsyncStorage is not in the mobile package's dependencies. `expo-file-system`
+ *   is already installed and handles plain file reads/writes. The device ID is
+ *   not a secret, so SecureStore is unnecessary — file system is appropriate.
+ *
+ * WHY not SecureStore:
+ *   SecureStore is reserved for auth tokens and encryption keys. The device ID
+ *   is a non-secret stable identifier and does not warrant biometric gating.
+ *
+ * @module utils/deviceId
+ */
+
+import * as FileSystem from 'expo-file-system';
+import { generateDeviceId, isValidDeviceId } from '@styrby/shared/session-handoff';
+
+/** Path to the persisted device ID file in Expo's document directory. */
+const DEVICE_ID_FILE = `${FileSystem.documentDirectory}styrby-device-id.txt`;
+
+/**
+ * In-process cache — avoids repeated file I/O after the first call.
+ */
+let _cached: string | null = null;
+
+/**
+ * Returns the cached device ID or reads from the file system.
+ *
+ * On first call: reads from `${documentDirectory}/styrby-device-id.txt`.
+ * If absent or corrupt, generates a new UUID v7, writes it, and caches it.
+ * Subsequent calls return the in-process cache without file I/O overhead.
+ *
+ * @returns Promise resolving to the stable device ID (UUID v7 format)
+ */
+export async function getMobileDeviceId(): Promise<string> {
+  if (_cached && isValidDeviceId(_cached)) {
+    return _cached;
+  }
+
+  try {
+    const info = await FileSystem.getInfoAsync(DEVICE_ID_FILE);
+
+    if (info.exists) {
+      const stored = (await FileSystem.readAsStringAsync(DEVICE_ID_FILE)).trim();
+
+      if (isValidDeviceId(stored)) {
+        _cached = stored;
+        return stored;
+      }
+      // File exists but content is corrupt — fall through to regenerate.
+    }
+
+    // Generate and persist a new device ID.
+    const newId = generateDeviceId();
+    await FileSystem.writeAsStringAsync(DEVICE_ID_FILE, newId);
+    _cached = newId;
+    return newId;
+  } catch {
+    // File system failure — generate an ephemeral ID for this session.
+    // The handoff feature degrades gracefully rather than crashing.
+    const ephemeral = generateDeviceId();
+    return ephemeral;
+  }
+}

--- a/packages/styrby-mobile/tsconfig.json
+++ b/packages/styrby-mobile/tsconfig.json
@@ -24,7 +24,11 @@
       // built dist file because the package's exports map uses that path.
       "styrby-shared/encryption": ["./node_modules/@styrby/shared/dist/encryption"],
       "styrby-shared/*": ["./node_modules/@styrby/shared/*"],
-      "@styrby/shared/logging": ["./node_modules/@styrby/shared/dist/logging/index"]
+      "@styrby/shared/logging": ["./node_modules/@styrby/shared/dist/logging/index"],
+      // WHY (Phase 3.2): Session handoff is exported as a dedicated subpath so
+      // the snapshot writer's pure helpers can be imported without pulling in
+      // unrelated modules. This path mapping mirrors the package.json exports.
+      "@styrby/shared/session-handoff": ["./node_modules/@styrby/shared/dist/session-handoff/index"]
     },
     "types": ["nativewind/types", "jest", "node"],
     // WHY typeRoots: The monorepo root node_modules may contain a hoisted

--- a/packages/styrby-shared/package.json
+++ b/packages/styrby-shared/package.json
@@ -60,6 +60,10 @@
     "./errors": {
       "types": "./dist/errors/index.d.ts",
       "import": "./dist/errors/index.js"
+    },
+    "./session-handoff": {
+      "types": "./dist/session-handoff/index.d.ts",
+      "import": "./dist/session-handoff/index.js"
     }
   },
   "scripts": {

--- a/packages/styrby-shared/src/session-handoff/device-id.ts
+++ b/packages/styrby-shared/src/session-handoff/device-id.ts
@@ -1,0 +1,68 @@
+/**
+ * Session Handoff — Device ID Utilities
+ *
+ * Pure helpers for generating and parsing device IDs.
+ * Storage is handled by each surface (AsyncStorage / localStorage / file).
+ *
+ * WHY UUID v7: Time-ordered UUIDs allow chronological sorting without an
+ * extra timestamp column, which helps when listing a user's devices by
+ * "first seen" order without a separate created_at field.
+ *
+ * @module session-handoff/device-id
+ */
+
+/**
+ * Generates a new UUID v7 string (time-ordered UUID).
+ *
+ * WHY custom implementation: The `uuid` npm package adds ~8 KB to the
+ * mobile/web bundle for functionality we can implement inline.
+ * UUID v7 format: 48-bit Unix timestamp ms + 4-bit version (7) +
+ * 12-bit random + 2-bit variant + 62-bit random.
+ *
+ * @returns A new UUID v7 string in canonical hyphenated format
+ */
+export function generateDeviceId(): string {
+  const nowMs = Date.now();
+
+  // 48-bit timestamp (ms since epoch) as big-endian hex
+  const timeLo = (nowMs & 0xffffffff) >>> 0;
+  const timeHi = Math.floor(nowMs / 0x100000000) & 0xffff;
+
+  // 12-bit random (rand_a, lower 12 bits of the version nibble word)
+  const randA = crypto.getRandomValues(new Uint16Array(1))[0] & 0x0fff;
+
+  // 62-bit random split across two 32-bit words (rand_b)
+  const [randB1, randB2] = Array.from(crypto.getRandomValues(new Uint32Array(2)));
+
+  // Assemble per RFC 9562 §5.7
+  // time_high (16 bits) | time_mid (16 bits) | time_low (32 bits)
+  const p1 = timeHi.toString(16).padStart(4, '0');
+  const p2 = ((nowMs >> 16) & 0xffff).toString(16).padStart(4, '0');
+  const p3 = timeLo.toString(16).padStart(8, '0');
+
+  // Version nibble: 0111 = 7
+  const p4 = (0x7000 | randA).toString(16).padStart(4, '0');
+
+  // Variant nibble: 10xx = 8-b (force two high bits to 10)
+  const variantBits = (randB1 >>> 16) & 0x3fff;
+  const p5 = (0x8000 | variantBits).toString(16).padStart(4, '0');
+
+  const p6 = (randB1 & 0xffff).toString(16).padStart(4, '0');
+  const p7 = randB2.toString(16).padStart(8, '0');
+
+  return `${p3}-${p2}-${p4}-${p5}-${p6}${p7}`;
+}
+
+/**
+ * Validates that a string looks like a UUID (any version).
+ *
+ * WHY: device_id is user-supplied from persistent storage which could be
+ * corrupted. We reject non-UUID strings before they reach the Supabase
+ * INSERT so we get a clear error rather than a silent DB constraint failure.
+ *
+ * @param id - String to validate
+ * @returns true if `id` matches the UUID canonical format
+ */
+export function isValidDeviceId(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+}

--- a/packages/styrby-shared/src/session-handoff/index.ts
+++ b/packages/styrby-shared/src/session-handoff/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Session Handoff — Public API
+ *
+ * Re-exports all public symbols from the session-handoff sub-module.
+ * Import from `@styrby/shared/session-handoff` for tree-shaking.
+ *
+ * @module session-handoff
+ */
+
+export * from './snapshot-writer.js';
+export * from './types.js';
+export * from './device-id.js';

--- a/packages/styrby-shared/src/session-handoff/snapshot-writer.ts
+++ b/packages/styrby-shared/src/session-handoff/snapshot-writer.ts
@@ -1,0 +1,284 @@
+/**
+ * Session Handoff — Snapshot Writer
+ *
+ * Platform-agnostic module that periodically captures UI state (cursor
+ * position, scroll offset, active draft) and persists it to Supabase as a
+ * `session_state_snapshots` row. Used by styrby-web, styrby-mobile, and
+ * styrby-cli so all surfaces share identical snapshot semantics.
+ *
+ * WHY shared module: Each surface (web, mobile, CLI) previously had
+ * divergent state-persistence paths, meaning a snapshot written by the web
+ * client was not reliably readable by the mobile client. Centralising the
+ * writer ensures one schema version, one debounce contract, and one test
+ * suite covers all three surfaces.
+ *
+ * SOC2 CC6.1: Snapshot writes are authenticated and RLS-gated; the writer
+ * never sends a snapshot unless the Supabase client is authenticated.
+ *
+ * @module session-handoff/snapshot-writer
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * The UI state captured in a single snapshot.
+ *
+ * All fields are optional so callers can capture partial state when only
+ * some fields are available (e.g. CLI captures cursor only; no scroll/draft).
+ */
+export interface SessionStateSnapshot {
+  /**
+   * 0-based index of the last message the user has scrolled to.
+   * Used by the receiving device to jump to the same message.
+   */
+  cursorPosition?: number;
+
+  /**
+   * Pixel scroll offset within the focused message bubble.
+   * Relevant for long tool output panels where the user may be mid-read.
+   */
+  scrollOffset?: number;
+
+  /**
+   * Unsent message text the user was composing.
+   * Restored into the input box on the receiving device.
+   */
+  activeDraft?: string;
+}
+
+/**
+ * Minimal Supabase client interface required by the writer.
+ *
+ * WHY narrow interface: We accept any client that satisfies this shape —
+ * the server-side `@supabase/ssr` client, the browser `@supabase/supabase-js`
+ * client, or a test double. Avoids importing a concrete Supabase type from
+ * the shared module (which would force a transitive dependency on
+ * `@supabase/supabase-js` into every consumer).
+ */
+export interface SupabaseSnapshotClient {
+  from(table: string): {
+    insert(row: Record<string, unknown>): Promise<{ error: { message: string } | null }>;
+  };
+}
+
+/**
+ * Factory options for `createSnapshotWriter`.
+ */
+export interface SnapshotWriterOptions {
+  /** Supabase session ID (UUID) that owns these snapshots. */
+  sessionId: string;
+
+  /**
+   * Stable device ID generated on first launch and persisted locally.
+   * Written to `session_state_snapshots.device_id` so the handoff banner
+   * can label the origin device.
+   */
+  deviceId: string;
+
+  /** Authenticated Supabase client instance. */
+  supabase: SupabaseSnapshotClient;
+
+  /**
+   * Debounce interval in milliseconds.
+   * Scheduled captures are coalesced so rapid state changes produce only
+   * one INSERT per window.
+   * @default 10000 (10 seconds)
+   */
+  debounceMs?: number;
+
+  /**
+   * Callback invoked when a snapshot fails to persist.
+   * Defaults to a console.warn if not provided.
+   *
+   * @param error - The error message from Supabase
+   */
+  onError?: (error: string) => void;
+}
+
+/**
+ * Control handle returned by `createSnapshotWriter`.
+ */
+export interface SnapshotWriter {
+  /**
+   * Immediately write a snapshot with the current state, bypassing the debounce.
+   * Use on high-priority transitions: user sends a message, app moves to background.
+   *
+   * @param state - State to snapshot (merged with last known state)
+   * @returns Promise that resolves when the INSERT completes or rejects on error
+   */
+  captureNow: (state: SessionStateSnapshot) => Promise<void>;
+
+  /**
+   * Schedule a debounced snapshot capture.
+   * Calling this multiple times within `debounceMs` coalesces into one write.
+   * The most recently supplied state wins.
+   *
+   * @param state - Current UI state to capture
+   */
+  scheduleCapture: (state: SessionStateSnapshot) => void;
+
+  /**
+   * Cancel any in-flight debounce timer and release resources.
+   * Call on component unmount / session close.
+   */
+  destroy: () => void;
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+/**
+ * Merges a partial snapshot update into the last known state.
+ *
+ * WHY: Callers rarely have all three fields available at once. A scroll
+ * handler knows `scrollOffset` but not `activeDraft`. By merging into the
+ * accumulated state we always write a complete snapshot row.
+ *
+ * @param base - Accumulated state from previous captures
+ * @param update - Partial update from the current event
+ * @returns Merged state object
+ */
+function mergeState(
+  base: Required<SessionStateSnapshot>,
+  update: SessionStateSnapshot,
+): Required<SessionStateSnapshot> {
+  return {
+    cursorPosition: update.cursorPosition ?? base.cursorPosition,
+    scrollOffset: update.scrollOffset ?? base.scrollOffset,
+    activeDraft: update.activeDraft ?? base.activeDraft,
+  };
+}
+
+// ============================================================================
+// Public factory
+// ============================================================================
+
+/**
+ * Creates a snapshot writer bound to a specific session and device.
+ *
+ * The writer maintains a rolling in-memory state that is flushed to Supabase
+ * either immediately (via `captureNow`) or after the debounce window elapses
+ * (via `scheduleCapture`). Both paths write to `session_state_snapshots`.
+ *
+ * @param options - Session, device, Supabase client, and tuning options
+ * @returns A `SnapshotWriter` control handle
+ *
+ * @example
+ * // In a React component:
+ * const writer = createSnapshotWriter({
+ *   sessionId: session.id,
+ *   deviceId: getDeviceId(),
+ *   supabase,
+ * });
+ *
+ * // Schedule on every keystroke in the draft input:
+ * writer.scheduleCapture({ activeDraft: inputValue });
+ *
+ * // Immediate flush when the user sends the message:
+ * await writer.captureNow({ activeDraft: '' });
+ *
+ * // Cleanup on unmount:
+ * return () => writer.destroy();
+ */
+export function createSnapshotWriter(options: SnapshotWriterOptions): SnapshotWriter {
+  const {
+    sessionId,
+    deviceId,
+    supabase,
+    debounceMs = 10_000,
+    onError,
+  } = options;
+
+  // Accumulated UI state — updated on every scheduleCapture / captureNow call.
+  let accumulatedState: Required<SessionStateSnapshot> = {
+    cursorPosition: 0,
+    scrollOffset: 0,
+    activeDraft: '',
+  };
+
+  // Pending debounce timer handle (null when no timer is active).
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Whether destroy() has been called — guard against post-destroy writes.
+  let destroyed = false;
+
+  /**
+   * Persist the current accumulated state as a Supabase row.
+   *
+   * WHY we don't await inside the debounce callback: The debounce fires
+   * asynchronously; awaiting inside `setTimeout` would require converting
+   * to an async timer pattern. Instead we fire-and-forget and surface errors
+   * through the `onError` callback so callers can log / retry.
+   *
+   * @param state - Resolved state to persist
+   */
+  async function persist(state: Required<SessionStateSnapshot>): Promise<void> {
+    if (destroyed) return;
+
+    const { error } = await supabase.from('session_state_snapshots').insert({
+      session_id: sessionId,
+      device_id: deviceId,
+      cursor_position: state.cursorPosition,
+      scroll_offset: state.scrollOffset,
+      // Store null rather than empty string to keep the column semantics clean.
+      active_draft: state.activeDraft || null,
+      snapshot_version: 1,
+    });
+
+    if (error) {
+      const msg = `[SnapshotWriter] Failed to persist snapshot: ${error.message}`;
+      if (onError) {
+        onError(msg);
+      } else {
+        console.warn(msg);
+      }
+    }
+  }
+
+  /**
+   * Cancel any active debounce timer without writing.
+   */
+  function clearDebounce(): void {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Public API
+  // --------------------------------------------------------------------------
+
+  const captureNow = async (state: SessionStateSnapshot): Promise<void> => {
+    // Merge into accumulated state so captureNow also advances the base.
+    accumulatedState = mergeState(accumulatedState, state);
+
+    // Cancel any pending debounce — captureNow supersedes it.
+    clearDebounce();
+
+    await persist(accumulatedState);
+  };
+
+  const scheduleCapture = (state: SessionStateSnapshot): void => {
+    // Merge immediately so the latest value wins if the timer fires.
+    accumulatedState = mergeState(accumulatedState, state);
+
+    // Reset the debounce window on every new call (trailing-edge debounce).
+    clearDebounce();
+
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      void persist(accumulatedState);
+    }, debounceMs);
+  };
+
+  const destroy = (): void => {
+    destroyed = true;
+    clearDebounce();
+  };
+
+  return { captureNow, scheduleCapture, destroy };
+}

--- a/packages/styrby-shared/src/session-handoff/types.ts
+++ b/packages/styrby-shared/src/session-handoff/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Session Handoff — Shared Types
+ *
+ * Type definitions shared across web, mobile, and CLI for the
+ * cross-device session handoff feature.
+ *
+ * @module session-handoff/types
+ */
+
+// ============================================================================
+// Device identity
+// ============================================================================
+
+/**
+ * Surface kind for a registered device.
+ * Used in the handoff banner to label the origin device ("on iPhone", "on Mac").
+ */
+export type DeviceKind = 'web' | 'mobile_ios' | 'mobile_android' | 'cli';
+
+/**
+ * A device registered in the `devices` table.
+ */
+export interface DeviceRecord {
+  /** Stable UUID v7 generated on first launch and persisted client-side. */
+  id: string;
+
+  /** Supabase Auth user who owns this device. */
+  userId: string;
+
+  /** Surface kind for display labels. */
+  kind: DeviceKind;
+
+  /** ISO 8601 timestamp of the last time this device was seen. */
+  lastSeenAt: string;
+}
+
+// ============================================================================
+// Handoff API response
+// ============================================================================
+
+/**
+ * Response from `GET /api/sessions/[id]/handoff`.
+ *
+ * `available: false` when no recent snapshot exists for a different device.
+ * `available: true` when the user should be prompted to resume.
+ */
+export type HandoffResponse =
+  | { available: false }
+  | {
+      available: true;
+      /** Device ID that wrote the most recent snapshot. */
+      lastDeviceId: string;
+      /** Human-readable device kind label ('web' | 'mobile_ios' | etc.). */
+      lastDeviceKind: DeviceKind;
+      /** 0-based message index to scroll to on resume. */
+      cursorPosition: number;
+      /** Pixel scroll offset within the focused message. */
+      scrollOffset: number;
+      /** Unsent draft text to restore into the input box (null if none). */
+      activeDraft: string | null;
+      /** Age of the snapshot in milliseconds (for display: "2 min ago"). */
+      ageMs: number;
+    };

--- a/packages/styrby-shared/tests/session-handoff/device-id.test.ts
+++ b/packages/styrby-shared/tests/session-handoff/device-id.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for Device ID Utilities
+ *
+ * Verifies UUID generation uniqueness, format correctness, and
+ * the isValidDeviceId guard function.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateDeviceId, isValidDeviceId } from '../../src/session-handoff/device-id';
+
+// UUID canonical format regex (any version)
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('generateDeviceId', () => {
+  it('returns a string in canonical UUID hyphenated format', () => {
+    const id = generateDeviceId();
+    expect(id).toMatch(UUID_REGEX);
+  });
+
+  it('returns a unique value on each call', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => generateDeviceId()));
+    // All 50 should be unique (collision probability ~0 with 122 random bits)
+    expect(ids.size).toBe(50);
+  });
+
+  it('returns a 36-character string', () => {
+    expect(generateDeviceId()).toHaveLength(36);
+  });
+});
+
+describe('isValidDeviceId', () => {
+  it('returns true for a valid UUID from generateDeviceId', () => {
+    expect(isValidDeviceId(generateDeviceId())).toBe(true);
+  });
+
+  it('returns true for a canonical UUID v4', () => {
+    expect(isValidDeviceId('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isValidDeviceId('')).toBe(false);
+  });
+
+  it('returns false for a string with path-traversal characters', () => {
+    expect(isValidDeviceId('../../etc/passwd')).toBe(false);
+  });
+
+  it('returns false for a UUID with wrong segment lengths', () => {
+    // Missing one hex char in last segment
+    expect(isValidDeviceId('550e8400-e29b-41d4-a716-44665544000')).toBe(false);
+  });
+
+  it('returns false for a non-UUID alphanumeric string', () => {
+    expect(isValidDeviceId('notauuid')).toBe(false);
+  });
+});

--- a/packages/styrby-shared/tests/session-handoff/snapshot-writer.test.ts
+++ b/packages/styrby-shared/tests/session-handoff/snapshot-writer.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the Session Handoff Snapshot Writer
+ *
+ * Verifies debounce behaviour, captureNow override, destroy cancellation,
+ * state merging, error callback invocation, and the destroyed-guard.
+ *
+ * Test strategy: We inject a Supabase mock that records all INSERT calls
+ * so we can assert on the exact rows written without any network traffic.
+ * Timers are controlled via Vitest's fake-timer API.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createSnapshotWriter,
+  type SnapshotWriterOptions,
+  type SupabaseSnapshotClient,
+} from '../../src/session-handoff/snapshot-writer';
+
+// ============================================================================
+// Mock Supabase client
+// ============================================================================
+
+interface InsertCall {
+  row: Record<string, unknown>;
+  willError?: boolean;
+}
+
+/**
+ * Creates a mock Supabase client that records INSERT calls.
+ *
+ * @param failOnce - If true, the first INSERT returns an error.
+ * @returns `{ client, inserts }` — client implements SupabaseSnapshotClient;
+ *   inserts accumulates every row passed to .insert().
+ */
+function createMockSupabase(failOnce = false) {
+  const inserts: Record<string, unknown>[] = [];
+  let callCount = 0;
+
+  const client: SupabaseSnapshotClient = {
+    from(_table: string) {
+      return {
+        insert(row: Record<string, unknown>) {
+          inserts.push(row);
+          callCount++;
+          const shouldFail = failOnce && callCount === 1;
+          return Promise.resolve({
+            error: shouldFail ? { message: 'simulated DB error' } : null,
+          });
+        },
+      };
+    },
+  };
+
+  return { client, inserts };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const SESSION_ID = '11111111-1111-4111-a111-111111111111';
+const DEVICE_ID = '22222222-2222-7222-a222-222222222222';
+
+function makeOptions(
+  overrides: Partial<SnapshotWriterOptions> & { supabase: SupabaseSnapshotClient },
+): SnapshotWriterOptions {
+  return {
+    sessionId: SESSION_ID,
+    deviceId: DEVICE_ID,
+    debounceMs: 1_000,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('createSnapshotWriter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --------------------------------------------------------------------------
+  // captureNow
+  // --------------------------------------------------------------------------
+
+  it('captureNow writes a snapshot immediately without waiting for debounce', async () => {
+    const { client, inserts } = createMockSupabase();
+    const writer = createSnapshotWriter(makeOptions({ supabase: client }));
+
+    await writer.captureNow({ cursorPosition: 5, scrollOffset: 100, activeDraft: 'hello' });
+
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toMatchObject({
+      session_id: SESSION_ID,
+      device_id: DEVICE_ID,
+      cursor_position: 5,
+      scroll_offset: 100,
+      active_draft: 'hello',
+      snapshot_version: 1,
+    });
+  });
+
+  it('captureNow stores null for empty activeDraft', async () => {
+    const { client, inserts } = createMockSupabase();
+    const writer = createSnapshotWriter(makeOptions({ supabase: client }));
+
+    await writer.captureNow({ activeDraft: '' });
+
+    expect(inserts[0]).toMatchObject({ active_draft: null });
+  });
+
+  it('captureNow cancels an in-flight debounce timer', async () => {
+    const { client, inserts } = createMockSupabase();
+    const writer = createSnapshotWriter(makeOptions({ supabase: client }));
+
+    // Schedule a debounced capture — should NOT fire once captureNow runs.
+    writer.scheduleCapture({ cursorPosition: 1 });
+
+    // Immediately capture now.
+    await writer.captureNow({ cursorPosition: 2 });
+
+    // Advance timers past debounce window.
+    vi.advanceTimersByTime(2_000);
+
+    // Only the captureNow insert should have happened.
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toMatchObject({ cursor_position: 2 });
+  });
+
+  // --------------------------------------------------------------------------
+  // scheduleCapture + debounce
+  // --------------------------------------------------------------------------
+
+  it('scheduleCapture defers the write until debounce window elapses', async () => {
+    const { client, inserts } = createMockSupabase();
+    const writer = createSnapshotWriter(makeOptions({ supabase: client }));
+
+    writer.scheduleCapture({ cursorPosition: 3 });
+
+    // No write yet.
+    expect(inserts).toHaveLength(0);
+
+    // Advance past debounce window.
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toMatchObject({ cursor_position: 3 });
+  });
+
+  it('multiple scheduleCapture calls within the window coalesce into one write with the latest state', async () => {
+    const { client, inserts } = createMockSupabase();
+    const writer = createSnapshotWriter(makeOptions({ supabase: client }));
+
+    writer.scheduleCapture({ cursorPosition: 1 });
+    writer.scheduleCapture({ cursorPosition: 2 });
+    writer.scheduleCapture({ cursorPosition: 3 });
+
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    // Only one write; cursor_position reflects the last update.
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toMatchObject({ cursor_position: 3 });
+  });
+
+  it('scheduleCapture merges partial state updates into accumulated state', async () => {
+    const { client, inserts } = createMockSupabase();
+    const writer = createSnapshotWriter(makeOptions({ supabase: client }));
+
+    writer.scheduleCapture({ cursorPosition: 5 });
+    writer.scheduleCapture({ scrollOffset: 200 });
+    writer.scheduleCapture({ activeDraft: 'draft text' });
+
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toMatchObject({
+      cursor_position: 5,
+      scroll_offset: 200,
+      active_draft: 'draft text',
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // destroy
+  // --------------------------------------------------------------------------
+
+  it('destroy cancels the in-flight debounce timer so no write occurs', async () => {
+    const { client, inserts } = createMockSupabase();
+    const writer = createSnapshotWriter(makeOptions({ supabase: client }));
+
+    writer.scheduleCapture({ cursorPosition: 9 });
+    writer.destroy();
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('destroy prevents captureNow from writing after it is called', async () => {
+    const { client, inserts } = createMockSupabase();
+    const writer = createSnapshotWriter(makeOptions({ supabase: client }));
+
+    writer.destroy();
+    await writer.captureNow({ cursorPosition: 7 });
+
+    expect(inserts).toHaveLength(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // Error handling
+  // --------------------------------------------------------------------------
+
+  it('invokes onError callback when Supabase INSERT returns an error', async () => {
+    const { client } = createMockSupabase(/* failOnce */ true);
+    const onError = vi.fn();
+    const writer = createSnapshotWriter(makeOptions({ supabase: client, onError }));
+
+    await writer.captureNow({});
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toContain('simulated DB error');
+  });
+
+  it('logs a console.warn when no onError callback is provided', async () => {
+    const { client } = createMockSupabase(/* failOnce */ true);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const writer = createSnapshotWriter(makeOptions({ supabase: client }));
+
+    await writer.captureNow({});
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/styrby-web/src/__tests__/HandoffBanner.test.tsx
+++ b/packages/styrby-web/src/__tests__/HandoffBanner.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Tests for the Web HandoffBanner component
+ *
+ * Covers:
+ *   - Renders correctly when handoff is available
+ *   - Shows device label (mobile_ios -> "iPhone", cli -> "terminal", etc.)
+ *   - Shows "unsent message restored" hint when activeDraft is present
+ *   - Does NOT show draft hint when activeDraft is null
+ *   - "Resume" button calls onResume with the full handoff object
+ *   - "Start fresh" button calls onDismiss
+ *   - Dismiss X button calls onDismiss
+ *   - Component unmounts itself after any action (no double-fire)
+ *   - Accessibility: role="alert" present
+ *
+ * @module __tests__/HandoffBanner
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HandoffBanner } from '../components/session-handoff/HandoffBanner';
+import type { HandoffBannerProps } from '../components/session-handoff/HandoffBanner';
+import type { HandoffResponse } from '@styrby/shared/session-handoff';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeHandoff(
+  overrides: Partial<Extract<HandoffResponse, { available: true }>> = {},
+): Extract<HandoffResponse, { available: true }> {
+  return {
+    available: true,
+    lastDeviceId: 'device-a-0000-0000-0000-000000000000',
+    lastDeviceKind: 'mobile_ios',
+    cursorPosition: 5,
+    scrollOffset: 100,
+    activeDraft: null,
+    ageMs: 90_000, // 1 min 30 sec
+    ...overrides,
+  };
+}
+
+function renderBanner(propsOverride: Partial<HandoffBannerProps> = {}) {
+  const onResume = vi.fn();
+  const onDismiss = vi.fn();
+  const handoff = makeHandoff();
+
+  const { unmount } = render(
+    <HandoffBanner
+      handoff={handoff}
+      onResume={onResume}
+      onDismiss={onDismiss}
+      {...propsOverride}
+    />,
+  );
+
+  return { onResume, onDismiss, handoff, unmount };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+afterEach(cleanup);
+
+describe('HandoffBanner', () => {
+  // --------------------------------------------------------------------------
+  // Rendering
+  // --------------------------------------------------------------------------
+
+  it('renders the banner with role="alert"', () => {
+    renderBanner();
+    expect(screen.getByRole('alert')).toBeDefined();
+  });
+
+  it('shows "iPhone" label for mobile_ios device', () => {
+    renderBanner({ handoff: makeHandoff({ lastDeviceKind: 'mobile_ios' }) });
+    expect(screen.getByText(/iPhone/)).toBeDefined();
+  });
+
+  it('shows "Android" label for mobile_android device', () => {
+    renderBanner({ handoff: makeHandoff({ lastDeviceKind: 'mobile_android' }) });
+    expect(screen.getByText(/Android/)).toBeDefined();
+  });
+
+  it('shows "terminal" label for cli device', () => {
+    renderBanner({ handoff: makeHandoff({ lastDeviceKind: 'cli' }) });
+    expect(screen.getByText(/terminal/)).toBeDefined();
+  });
+
+  it('shows "Mac/PC" label for web device', () => {
+    renderBanner({ handoff: makeHandoff({ lastDeviceKind: 'web' }) });
+    expect(screen.getByText(/Mac\/PC/)).toBeDefined();
+  });
+
+  it('shows "just now" for snapshots under 1 minute old', () => {
+    renderBanner({ handoff: makeHandoff({ ageMs: 30_000 }) });
+    expect(screen.getByText(/just now/)).toBeDefined();
+  });
+
+  it('shows "1 min ago" for snapshots exactly 1 minute old', () => {
+    renderBanner({ handoff: makeHandoff({ ageMs: 60_000 }) });
+    expect(screen.getByText(/1 min ago/)).toBeDefined();
+  });
+
+  it('shows "4 min ago" for snapshots 4 minutes old', () => {
+    renderBanner({ handoff: makeHandoff({ ageMs: 4 * 60_000 }) });
+    expect(screen.getByText(/4 min ago/)).toBeDefined();
+  });
+
+  it('shows draft hint when activeDraft is non-empty', () => {
+    renderBanner({ handoff: makeHandoff({ activeDraft: 'some text' }) });
+    expect(screen.getByText(/unsent message restored/i)).toBeDefined();
+  });
+
+  it('does NOT show draft hint when activeDraft is null', () => {
+    renderBanner({ handoff: makeHandoff({ activeDraft: null }) });
+    expect(screen.queryByText(/unsent message restored/i)).toBeNull();
+  });
+
+  it('does NOT show draft hint when activeDraft is empty string', () => {
+    renderBanner({ handoff: makeHandoff({ activeDraft: '' }) });
+    expect(screen.queryByText(/unsent message restored/i)).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // Actions
+  // --------------------------------------------------------------------------
+
+  it('calls onResume with the full handoff object when Resume is clicked', async () => {
+    const user = userEvent.setup();
+    const handoff = makeHandoff({ lastDeviceKind: 'cli', activeDraft: 'draft' });
+    const onResume = vi.fn();
+    render(<HandoffBanner handoff={handoff} onResume={onResume} onDismiss={vi.fn()} />);
+
+    await user.click(screen.getByTestId('handoff-resume-button'));
+
+    expect(onResume).toHaveBeenCalledOnce();
+    expect(onResume).toHaveBeenCalledWith(handoff);
+  });
+
+  it('calls onDismiss when "Start fresh" is clicked', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(<HandoffBanner handoff={makeHandoff()} onResume={vi.fn()} onDismiss={onDismiss} />);
+
+    await user.click(screen.getByTestId('handoff-start-fresh-button'));
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('calls onDismiss when the X dismiss button is clicked', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(<HandoffBanner handoff={makeHandoff()} onResume={vi.fn()} onDismiss={onDismiss} />);
+
+    await user.click(screen.getByTestId('handoff-dismiss-button'));
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  // --------------------------------------------------------------------------
+  // Visibility / self-unmount
+  // --------------------------------------------------------------------------
+
+  it('hides itself after Resume is clicked (does not render twice)', async () => {
+    const user = userEvent.setup();
+    render(
+      <HandoffBanner handoff={makeHandoff()} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId('handoff-banner')).toBeDefined();
+
+    await user.click(screen.getByTestId('handoff-resume-button'));
+
+    expect(screen.queryByTestId('handoff-banner')).toBeNull();
+  });
+
+  it('hides itself after Dismiss is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <HandoffBanner handoff={makeHandoff()} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+
+    await user.click(screen.getByTestId('handoff-dismiss-button'));
+
+    expect(screen.queryByTestId('handoff-banner')).toBeNull();
+  });
+});

--- a/packages/styrby-web/src/__tests__/handoff-route.test.ts
+++ b/packages/styrby-web/src/__tests__/handoff-route.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for GET /api/sessions/[id]/handoff
+ *
+ * Covers:
+ *   - Happy path: snapshot from a different device returns available:true
+ *   - No snapshot: returns available:false
+ *   - Same-device snapshot: returns available:false
+ *   - Expired snapshot (>5min): returns 410 GONE
+ *   - Invalid session ID: returns 400
+ *   - Unauthenticated: returns 401
+ *   - Session not found / not owned: returns 404
+ *   - DB error on snapshot query: returns 500
+ *   - Cross-user RLS simulation: verifies ownership check
+ *
+ * WHY extensive mocking:
+ *   The route is a Next.js API route that calls Supabase. We stub `createClient`
+ *   to return a controlled mock so tests are fast, hermetic, and don't require
+ *   a live DB. This matches the existing pattern in middleware/__tests__/.
+ *
+ * @module __tests__/handoff-route
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const VALID_SESSION_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+const DEVICE_A = 'device-a-uuid-0001-0000-000000000000';
+const DEVICE_B = 'device-b-uuid-0002-0000-000000000000';
+
+/**
+ * Creates an ISO timestamp `ageMs` milliseconds in the past.
+ */
+function tsAgo(ageMs: number): string {
+  return new Date(Date.now() - ageMs).toISOString();
+}
+
+// ============================================================================
+// Supabase mock factory
+// ============================================================================
+
+interface MockState {
+  authed: boolean;
+  sessionExists: boolean;
+  snapshot: {
+    id: string;
+    device_id: string;
+    cursor_position: number;
+    scroll_offset: number;
+    active_draft: string | null;
+    created_at: string;
+  } | null;
+  snapshotQueryError: boolean;
+  deviceKind: string | null;
+}
+
+function createMockState(overrides: Partial<MockState> = {}): MockState {
+  return {
+    authed: true,
+    sessionExists: true,
+    snapshot: {
+      id: 'snap-1111-1111-1111-111111111111',
+      device_id: DEVICE_A,
+      cursor_position: 7,
+      scroll_offset: 150,
+      active_draft: 'half-typed msg',
+      created_at: tsAgo(60_000), // 1 minute ago
+    },
+    snapshotQueryError: false,
+    deviceKind: 'mobile_ios',
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a mock Supabase client that satisfies the queries made by the route.
+ *
+ * The mock is a simple chain-builder: from().select().eq()...maybeSingle()
+ * returns the appropriate value from `state`.
+ */
+function makeMockSupabase(state: MockState) {
+  const mockGetUser = vi.fn().mockResolvedValue({
+    data: { user: state.authed ? { id: 'user-uuid' } : null },
+    error: state.authed ? null : { message: 'not authed' },
+  });
+
+  // We need to distinguish which query is being built.
+  // We track by the table name passed to `from()`.
+  const mockFrom = vi.fn().mockImplementation((table: string) => {
+    if (table === 'sessions') {
+      return buildChain(
+        state.sessionExists
+          ? { id: VALID_SESSION_ID, user_id: 'user-uuid' }
+          : null,
+        null,
+      );
+    }
+
+    if (table === 'session_state_snapshots') {
+      return buildChain(
+        state.snapshot,
+        state.snapshotQueryError ? { message: 'DB exploded' } : null,
+      );
+    }
+
+    if (table === 'devices') {
+      return buildChain(
+        state.deviceKind ? { kind: state.deviceKind } : null,
+        null,
+      );
+    }
+
+    return buildChain(null, null);
+  });
+
+  return {
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  };
+}
+
+/**
+ * Builds a fluent chainable mock for Supabase query builder.
+ *
+ * Supports arbitrary chaining depth: .select().eq().eq().order().limit().maybeSingle()
+ *
+ * WHY Proxy approach: A recursive factory would still have the temporal-dead-zone
+ * problem if `eq` references itself. A JS Proxy lets us intercept any property
+ * access on the chain object and always return the same terminal resolvers,
+ * so the chain can be arbitrarily deep without any circular reference issue.
+ *
+ * @param data - Value to resolve from maybeSingle() / single()
+ * @param error - Error to resolve from maybeSingle() / single() (null = success)
+ */
+function buildChain(
+  data: unknown,
+  error: { message: string } | null,
+) {
+  const result = { data, error };
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const single = vi.fn().mockResolvedValue(result);
+
+  /**
+   * Returns a Proxy that satisfies any chaining pattern:
+   * every property access returns the same proxy, except
+   * `maybeSingle` and `single` which return the real resolvers.
+   */
+  function makeChain(): Record<string, unknown> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proxy: any = new Proxy(
+      {},
+      {
+        get(_target, prop: string) {
+          if (prop === 'maybeSingle') return maybeSingle;
+          if (prop === 'single') return single;
+          // For any other method (eq, order, limit, neq, etc.):
+          // return a vi.fn() that, when called, returns the same proxy.
+          const fn = vi.fn().mockReturnValue(proxy);
+          return fn;
+        },
+      },
+    );
+    return proxy;
+  }
+
+  return { select: vi.fn().mockReturnValue(makeChain()) };
+}
+
+// ============================================================================
+// Module mock setup
+// ============================================================================
+
+const mockCreateClient = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => mockCreateClient(),
+}));
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('GET /api/sessions/[id]/handoff', () => {
+  // Dynamically import the route handler AFTER mocks are set up.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let GET: (...args: any[]) => Promise<NextResponse>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import(
+      '../app/api/sessions/[id]/handoff/route'
+    );
+    GET = mod.GET;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeRequest(sessionId: string, deviceId = DEVICE_B): Request {
+    return new Request(
+      `http://localhost/api/sessions/${sessionId}/handoff?current_device_id=${deviceId}`,
+    );
+  }
+
+  function makeContext(sessionId: string) {
+    return { params: Promise.resolve({ id: sessionId }) };
+  }
+
+  // --------------------------------------------------------------------------
+  // Happy path
+  // --------------------------------------------------------------------------
+
+  it('returns available:true with full handoff data when a recent snapshot exists from a different device', async () => {
+    const state = createMockState();
+    mockCreateClient.mockReturnValue(makeMockSupabase(state));
+
+    const res = await GET(makeRequest(VALID_SESSION_ID, DEVICE_B), makeContext(VALID_SESSION_ID));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.available).toBe(true);
+    expect(body.lastDeviceId).toBe(DEVICE_A);
+    expect(body.lastDeviceKind).toBe('mobile_ios');
+    expect(body.cursorPosition).toBe(7);
+    expect(body.scrollOffset).toBe(150);
+    expect(body.activeDraft).toBe('half-typed msg');
+    expect(body.ageMs).toBeGreaterThan(0);
+    expect(body.ageMs).toBeLessThan(120_000); // within 2 min
+  });
+
+  // --------------------------------------------------------------------------
+  // No snapshot
+  // --------------------------------------------------------------------------
+
+  it('returns available:false when no snapshot exists', async () => {
+    const state = createMockState({ snapshot: null });
+    mockCreateClient.mockReturnValue(makeMockSupabase(state));
+
+    const res = await GET(makeRequest(VALID_SESSION_ID), makeContext(VALID_SESSION_ID));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.available).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
+  // Same-device snapshot
+  // --------------------------------------------------------------------------
+
+  it('returns available:false when the latest snapshot is from the calling device', async () => {
+    const state = createMockState({
+      snapshot: {
+        id: 'snap-same',
+        device_id: DEVICE_B, // same as caller
+        cursor_position: 3,
+        scroll_offset: 0,
+        active_draft: null,
+        created_at: tsAgo(30_000),
+      },
+    });
+    mockCreateClient.mockReturnValue(makeMockSupabase(state));
+
+    const res = await GET(makeRequest(VALID_SESSION_ID, DEVICE_B), makeContext(VALID_SESSION_ID));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.available).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
+  // Expired snapshot (410)
+  // --------------------------------------------------------------------------
+
+  it('returns 410 when the latest snapshot is older than 5 minutes', async () => {
+    const state = createMockState({
+      snapshot: {
+        id: 'snap-old',
+        device_id: DEVICE_A,
+        cursor_position: 1,
+        scroll_offset: 0,
+        active_draft: null,
+        created_at: tsAgo(6 * 60 * 1_000), // 6 minutes ago
+      },
+    });
+    mockCreateClient.mockReturnValue(makeMockSupabase(state));
+
+    const res = await GET(makeRequest(VALID_SESSION_ID), makeContext(VALID_SESSION_ID));
+    const body = await res.json();
+
+    expect(res.status).toBe(410);
+    expect(body.error).toBe('SNAPSHOT_EXPIRED');
+  });
+
+  // --------------------------------------------------------------------------
+  // 400 invalid session ID
+  // --------------------------------------------------------------------------
+
+  it('returns 400 for a non-UUID session ID', async () => {
+    mockCreateClient.mockReturnValue(makeMockSupabase(createMockState()));
+
+    const res = await GET(makeRequest('not-a-uuid'), makeContext('not-a-uuid'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('VALIDATION_ERROR');
+  });
+
+  // --------------------------------------------------------------------------
+  // 401 unauthenticated
+  // --------------------------------------------------------------------------
+
+  it('returns 401 when user is not authenticated', async () => {
+    const state = createMockState({ authed: false });
+    mockCreateClient.mockReturnValue(makeMockSupabase(state));
+
+    const res = await GET(makeRequest(VALID_SESSION_ID), makeContext(VALID_SESSION_ID));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('UNAUTHORIZED');
+  });
+
+  // --------------------------------------------------------------------------
+  // 404 session not found / wrong user
+  // --------------------------------------------------------------------------
+
+  it('returns 404 when the session does not belong to the authenticated user', async () => {
+    const state = createMockState({ sessionExists: false });
+    mockCreateClient.mockReturnValue(makeMockSupabase(state));
+
+    const res = await GET(makeRequest(VALID_SESSION_ID), makeContext(VALID_SESSION_ID));
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('NOT_FOUND');
+  });
+
+  // --------------------------------------------------------------------------
+  // 500 snapshot DB error
+  // --------------------------------------------------------------------------
+
+  it('returns 500 when the snapshot query fails with a DB error', async () => {
+    const state = createMockState({ snapshotQueryError: true });
+    mockCreateClient.mockReturnValue(makeMockSupabase(state));
+
+    const res = await GET(makeRequest(VALID_SESSION_ID), makeContext(VALID_SESSION_ID));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('INTERNAL_ERROR');
+  });
+
+  // --------------------------------------------------------------------------
+  // activeDraft null when empty
+  // --------------------------------------------------------------------------
+
+  it('returns activeDraft:null when the snapshot has no draft', async () => {
+    const state = createMockState({
+      snapshot: {
+        id: 'snap-nodraft',
+        device_id: DEVICE_A,
+        cursor_position: 2,
+        scroll_offset: 0,
+        active_draft: null,
+        created_at: tsAgo(30_000),
+      },
+    });
+    mockCreateClient.mockReturnValue(makeMockSupabase(state));
+
+    const res = await GET(makeRequest(VALID_SESSION_ID, DEVICE_B), makeContext(VALID_SESSION_ID));
+    const body = await res.json();
+
+    expect(body.available).toBe(true);
+    expect(body.activeDraft).toBeNull();
+  });
+});

--- a/packages/styrby-web/src/__tests__/migration-036.test.ts
+++ b/packages/styrby-web/src/__tests__/migration-036.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Migration 036 structural tests — session_handoff (Phase 3.2)
+ *
+ * Validates that migration 036 contains all required DDL for:
+ *   - `devices` table (device registry)
+ *   - `session_state_snapshots` table (state capture)
+ *   - RLS policies on both tables
+ *   - Partial index on session_state_snapshots
+ *   - pg_cron retention job
+ *
+ * WHY migration regression tests:
+ *   Migrations are irreversible in production. Missing RLS or a missing
+ *   index silently degrades security or performance. These file-content
+ *   tests catch regressions in milliseconds at CI time.
+ *
+ * Invariants tested:
+ *   1. devices table DDL (all required columns)
+ *   2. session_state_snapshots table DDL (all required columns)
+ *   3. FK on session_state_snapshots.session_id (CASCADE DELETE)
+ *   4. RLS enabled on both tables
+ *   5. SELECT/INSERT policies on both tables
+ *   6. Partial index on (session_id, created_at DESC)
+ *   7. pg_cron retention job scheduled
+ *   8. IF NOT EXISTS guards (idempotent re-run safety)
+ *
+ * @module __tests__/migration-036
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const MIGRATIONS_DIR = resolve(__dirname, '../../../..', 'supabase/migrations');
+
+function readMigration(filename: string): string {
+  return readFileSync(resolve(MIGRATIONS_DIR, filename), 'utf-8');
+}
+
+describe('Migration 036: session_handoff', () => {
+  const sql = readMigration('036_session_handoff.sql');
+
+  // ── devices table ──────────────────────────────────────────────────────────
+
+  it('creates devices table with IF NOT EXISTS', () => {
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS devices');
+  });
+
+  it('devices table has id TEXT PRIMARY KEY', () => {
+    expect(sql).toContain('id          TEXT        PRIMARY KEY');
+  });
+
+  it('devices table has user_id FK referencing auth.users', () => {
+    expect(sql).toContain('user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE');
+  });
+
+  it('devices table has kind TEXT with CHECK constraint', () => {
+    expect(sql).toContain("CHECK (kind IN ('web', 'mobile_ios', 'mobile_android', 'cli'))");
+  });
+
+  it('devices table has last_seen_at TIMESTAMPTZ', () => {
+    expect(sql).toContain('last_seen_at TIMESTAMPTZ');
+  });
+
+  // ── session_state_snapshots table ─────────────────────────────────────────
+
+  it('creates session_state_snapshots table with IF NOT EXISTS', () => {
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS session_state_snapshots');
+  });
+
+  it('session_state_snapshots has id UUID PRIMARY KEY', () => {
+    expect(sql).toContain('id               UUID        PRIMARY KEY DEFAULT gen_random_uuid()');
+  });
+
+  it('session_state_snapshots has session_id FK with CASCADE DELETE', () => {
+    expect(sql).toContain('REFERENCES sessions(id) ON DELETE CASCADE');
+  });
+
+  it('session_state_snapshots has cursor_position INTEGER', () => {
+    expect(sql).toContain('cursor_position  INTEGER');
+  });
+
+  it('session_state_snapshots has scroll_offset INTEGER', () => {
+    expect(sql).toContain('scroll_offset    INTEGER');
+  });
+
+  it('session_state_snapshots has active_draft TEXT', () => {
+    expect(sql).toContain('active_draft     TEXT');
+  });
+
+  it('session_state_snapshots has snapshot_version INTEGER DEFAULT 1', () => {
+    expect(sql).toContain('snapshot_version INTEGER     NOT NULL DEFAULT 1');
+  });
+
+  it('session_state_snapshots has device_id TEXT', () => {
+    expect(sql).toContain('device_id        TEXT');
+  });
+
+  // ── Indexes ────────────────────────────────────────────────────────────────
+
+  it('creates partial index on (session_id, created_at DESC)', () => {
+    expect(sql).toContain('idx_sss_session_created');
+    expect(sql).toContain('session_id, created_at DESC');
+  });
+
+  it('creates index on devices(user_id)', () => {
+    expect(sql).toContain('idx_devices_user_id');
+    expect(sql).toContain('ON devices(user_id)');
+  });
+
+  // ── RLS ───────────────────────────────────────────────────────────────────
+
+  it('enables RLS on devices', () => {
+    expect(sql).toContain('ALTER TABLE devices ENABLE ROW LEVEL SECURITY');
+  });
+
+  it('enables RLS on session_state_snapshots', () => {
+    expect(sql).toContain('ALTER TABLE session_state_snapshots ENABLE ROW LEVEL SECURITY');
+  });
+
+  it('devices has SELECT policy scoped to auth.uid()', () => {
+    expect(sql).toContain('"devices: user can select own"');
+    expect(sql).toContain('FOR SELECT USING (user_id = (SELECT auth.uid()))');
+  });
+
+  it('devices has INSERT policy scoped to auth.uid()', () => {
+    expect(sql).toContain('"devices: user can insert own"');
+  });
+
+  it('devices has UPDATE policy', () => {
+    expect(sql).toContain('"devices: user can update own"');
+  });
+
+  it('devices has DELETE policy', () => {
+    expect(sql).toContain('"devices: user can delete own"');
+  });
+
+  it('session_state_snapshots has SELECT policy via sessions join', () => {
+    expect(sql).toContain('"sss: user can select own"');
+    expect(sql).toContain('SELECT id FROM sessions WHERE user_id = (SELECT auth.uid())');
+  });
+
+  it('session_state_snapshots has INSERT policy via sessions join', () => {
+    expect(sql).toContain('"sss: user can insert own"');
+  });
+
+  // ── Retention / pg_cron ───────────────────────────────────────────────────
+
+  it('schedules a pg_cron retention job named purge-old-snapshots', () => {
+    expect(sql).toContain("'purge-old-snapshots'");
+    expect(sql).toContain('cron.schedule');
+  });
+
+  it('retention job deletes snapshots older than 30 days', () => {
+    expect(sql).toContain("INTERVAL '30 days'");
+  });
+});

--- a/packages/styrby-web/src/app/api/sessions/[id]/handoff/route.ts
+++ b/packages/styrby-web/src/app/api/sessions/[id]/handoff/route.ts
@@ -1,0 +1,183 @@
+/**
+ * GET /api/sessions/[id]/handoff
+ *
+ * Returns handoff state for a session when the calling device is different
+ * from the device that wrote the most recent snapshot within the last 5 min.
+ *
+ * WHY 5-minute window: If the last snapshot is older than 5 minutes the
+ * user likely closed the session intentionally and a "pick up where you
+ * left off" prompt would be intrusive. We return 410 GONE so the client
+ * dismisses any cached banner.
+ *
+ * WHY `current_device_id` query param: The API uses the caller's device ID
+ * to decide whether a handoff prompt is relevant — if the caller IS the
+ * device that wrote the last snapshot, there is nothing to resume.
+ *
+ * SOC2 CC6.1: Session state transitions are authenticated; RLS ensures
+ * users cannot read snapshots for sessions they do not own.
+ *
+ * @auth Required — Bearer token (Supabase Auth JWT via cookie)
+ *
+ * @queryParam current_device_id {string} - Caller's stable device ID
+ *
+ * @returns 200 { available: false }
+ *   When no snapshot exists, or the latest snapshot is from this device.
+ * @returns 200 {
+ *   available: true,
+ *   lastDeviceId: string,
+ *   lastDeviceKind: string,
+ *   cursorPosition: number,
+ *   scrollOffset: number,
+ *   activeDraft: string | null,
+ *   ageMs: number
+ * }
+ *   When a recent snapshot from a different device is available.
+ * @returns 410 { error: 'SNAPSHOT_EXPIRED' }
+ *   When the latest snapshot is older than 5 minutes (soft expiry).
+ *
+ * @error 400 { error: 'VALIDATION_ERROR', message: string }
+ * @error 401 { error: 'UNAUTHORIZED', message: string }
+ * @error 404 { error: 'NOT_FOUND', message: string }
+ * @error 500 { error: 'INTERNAL_ERROR', message: string }
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import type { HandoffResponse, DeviceKind } from '@styrby/shared/session-handoff';
+
+/** Maximum snapshot age before the handoff banner is suppressed (5 minutes). */
+const HANDOFF_MAX_AGE_MS = 5 * 60 * 1_000;
+
+/**
+ * UUID v4/v7 validation regex — used to guard session ID path param.
+ *
+ * WHY: Prevents path-traversal via crafted session IDs. Restricts to
+ * hex+hyphen characters only (SEC-PATH-001 pattern from CLI persistence).
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Route context — params are a Promise in Next.js 15 App Router. */
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: Request, context: RouteContext): Promise<NextResponse> {
+  try {
+    const { id: sessionId } = await context.params;
+
+    // Validate session ID format before any DB access.
+    if (!UUID_REGEX.test(sessionId)) {
+      return NextResponse.json(
+        { error: 'VALIDATION_ERROR', message: 'Invalid session ID format' },
+        { status: 400 },
+      );
+    }
+
+    // Extract caller's device ID from query params.
+    const url = new URL(request.url);
+    const currentDeviceId = url.searchParams.get('current_device_id') ?? '';
+
+    const supabase = await createClient();
+
+    // Authenticate caller.
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: 'UNAUTHORIZED', message: 'Authentication required' },
+        { status: 401 },
+      );
+    }
+
+    // Verify session ownership.
+    // WHY explicit check: RLS on session_state_snapshots requires the join
+    // through sessions, but we also want a clear 404 vs implicit empty result.
+    const { data: session, error: sessionError } = await supabase
+      .from('sessions')
+      .select('id, user_id')
+      .eq('id', sessionId)
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (sessionError || !session) {
+      return NextResponse.json(
+        { error: 'NOT_FOUND', message: 'Session not found or access denied' },
+        { status: 404 },
+      );
+    }
+
+    // Fetch the latest snapshot for this session (regardless of device).
+    // The partial index on (session_id, created_at DESC) makes this a
+    // single index scan even on large sessions.
+    const { data: snapshot, error: snapshotError } = await supabase
+      .from('session_state_snapshots')
+      .select('id, device_id, cursor_position, scroll_offset, active_draft, created_at')
+      .eq('session_id', sessionId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (snapshotError) {
+      const isDev = process.env.NODE_ENV === 'development';
+      console.error('Handoff snapshot query failed:', isDev ? snapshotError : snapshotError.message);
+      return NextResponse.json(
+        { error: 'INTERNAL_ERROR', message: 'Failed to query snapshot' },
+        { status: 500 },
+      );
+    }
+
+    // No snapshot at all — nothing to hand off.
+    if (!snapshot) {
+      const body: HandoffResponse = { available: false };
+      return NextResponse.json(body);
+    }
+
+    const snapshotAgeMs = Date.now() - new Date(snapshot.created_at).getTime();
+
+    // Snapshot is older than the 5-minute window — return 410 GONE so
+    // the client can dismiss any cached banner.
+    if (snapshotAgeMs > HANDOFF_MAX_AGE_MS) {
+      return NextResponse.json(
+        { error: 'SNAPSHOT_EXPIRED', message: 'No recent snapshot available' },
+        { status: 410 },
+      );
+    }
+
+    // If the latest snapshot is from this device, there is nothing to resume.
+    if (snapshot.device_id === currentDeviceId) {
+      const body: HandoffResponse = { available: false };
+      return NextResponse.json(body);
+    }
+
+    // Look up the device kind for the origin device to produce a friendly label.
+    const { data: originDevice } = await supabase
+      .from('devices')
+      .select('kind')
+      .eq('id', snapshot.device_id)
+      .maybeSingle();
+
+    const lastDeviceKind: DeviceKind = (originDevice?.kind as DeviceKind) ?? 'web';
+
+    const body: HandoffResponse = {
+      available: true,
+      lastDeviceId: snapshot.device_id,
+      lastDeviceKind,
+      cursorPosition: snapshot.cursor_position,
+      scrollOffset: snapshot.scroll_offset,
+      activeDraft: snapshot.active_draft ?? null,
+      ageMs: Math.round(snapshotAgeMs),
+    };
+
+    return NextResponse.json(body);
+  } catch (error) {
+    const isDev = process.env.NODE_ENV === 'development';
+    console.error('Unexpected error in handoff route:', isDev ? error : (error instanceof Error ? error.message : 'Unknown'));
+    return NextResponse.json(
+      { error: 'INTERNAL_ERROR', message: 'An unexpected error occurred' },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/styrby-web/src/components/session-handoff/HandoffBanner.tsx
+++ b/packages/styrby-web/src/components/session-handoff/HandoffBanner.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+/**
+ * Handoff Banner — Web
+ *
+ * Dismissible banner shown when a user opens an existing session on a
+ * different browser/device from the one that last wrote a snapshot within
+ * the past 5 minutes.
+ *
+ * WHY: The banner is the entry point for the "pick up where you left off"
+ * UX. Rather than silently restoring state (surprising), or ignoring the
+ * snapshot (wasteful), we surface a clear choice: resume at the exact
+ * position the user was at, or start a fresh view.
+ *
+ * Accessibility: The banner uses `role="alert"` so screen readers announce
+ * it immediately on mount. The dismiss button has a clear aria-label.
+ *
+ * @module components/session-handoff/HandoffBanner
+ */
+
+import { useState, useCallback } from 'react';
+import type { HandoffResponse } from '@styrby/shared/session-handoff';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Callbacks for the two user actions in the banner.
+ */
+export interface HandoffBannerProps {
+  /**
+   * The non-`available: false` handoff response that triggered the banner.
+   * Guaranteed to have `available: true` at the call site.
+   */
+  handoff: Extract<HandoffResponse, { available: true }>;
+
+  /**
+   * Called when the user clicks "Resume" — caller should restore cursor,
+   * scroll, and draft state from the handoff data.
+   */
+  onResume: (handoff: Extract<HandoffResponse, { available: true }>) => void;
+
+  /**
+   * Called when the user clicks "Start fresh" or the dismiss X.
+   * Caller dismisses the banner and takes over with a new snapshot stream.
+   */
+  onDismiss: () => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Formats a device kind into a human-readable label.
+ *
+ * @param kind - Device kind from the handoff response
+ * @returns Display string, e.g. "iPhone", "Android", "Mac/PC", "terminal"
+ */
+function deviceLabel(kind: string): string {
+  switch (kind) {
+    case 'mobile_ios':
+      return 'iPhone';
+    case 'mobile_android':
+      return 'Android';
+    case 'cli':
+      return 'terminal';
+    case 'web':
+    default:
+      return 'Mac/PC';
+  }
+}
+
+/**
+ * Formats a snapshot age in ms into a short human-readable string.
+ *
+ * @param ageMs - Age in milliseconds
+ * @returns E.g. "just now", "1 min ago", "4 min ago"
+ */
+function formatAge(ageMs: number): string {
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes === 1) return '1 min ago';
+  return `${minutes} min ago`;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Dismissible handoff prompt banner.
+ *
+ * Mounts a fixed-top banner with two CTAs: "Resume" (restores state) and
+ * "Start fresh" (dismisses). The banner unmounts itself after either action
+ * by tracking local visibility state.
+ *
+ * @param props - HandoffBannerProps
+ * @returns The banner element, or null if dismissed
+ *
+ * @example
+ * {handoff?.available && (
+ *   <HandoffBanner
+ *     handoff={handoff}
+ *     onResume={handleResume}
+ *     onDismiss={() => setHandoff(null)}
+ *   />
+ * )}
+ */
+export function HandoffBanner({ handoff, onResume, onDismiss }: HandoffBannerProps) {
+  const [visible, setVisible] = useState(true);
+
+  const handleResume = useCallback(() => {
+    setVisible(false);
+    onResume(handoff);
+  }, [handoff, onResume]);
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+    onDismiss();
+  }, [onDismiss]);
+
+  if (!visible) return null;
+
+  const label = deviceLabel(handoff.lastDeviceKind);
+  const age = formatAge(handoff.ageMs);
+  const hasDraft = Boolean(handoff.activeDraft);
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm shadow-md dark:border-blue-800 dark:bg-blue-950"
+      data-testid="handoff-banner"
+    >
+      {/* Info icon */}
+      <svg
+        className="h-4 w-4 shrink-0 text-blue-500"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z"
+          clipRule="evenodd"
+        />
+      </svg>
+
+      {/* Message */}
+      <p className="flex-1 text-blue-900 dark:text-blue-100">
+        Pick up where you left off on{' '}
+        <span className="font-medium">{label}</span>
+        {' '}
+        <span className="text-blue-600 dark:text-blue-400">({age})</span>
+        {hasDraft && (
+          <span className="ml-1 text-blue-600 dark:text-blue-400">
+            — unsent message restored
+          </span>
+        )}
+      </p>
+
+      {/* Actions */}
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={handleResume}
+          className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          data-testid="handoff-resume-button"
+        >
+          Resume
+        </button>
+
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="rounded-md border border-blue-300 px-3 py-1.5 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-700 dark:text-blue-300 dark:hover:bg-blue-900"
+          data-testid="handoff-start-fresh-button"
+        >
+          Start fresh
+        </button>
+
+        {/* Dismiss X */}
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss handoff prompt"
+          className="rounded p-1 text-blue-500 transition-colors hover:bg-blue-100 dark:hover:bg-blue-900"
+          data-testid="handoff-dismiss-button"
+        >
+          <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/components/session-handoff/index.ts
+++ b/packages/styrby-web/src/components/session-handoff/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Session Handoff — Web Components
+ *
+ * Barrel export for web-side handoff UI components.
+ *
+ * @module components/session-handoff
+ */
+
+export { HandoffBanner } from './HandoffBanner.js';
+export type { HandoffBannerProps } from './HandoffBanner.js';

--- a/packages/styrby-web/src/lib/deviceId.ts
+++ b/packages/styrby-web/src/lib/deviceId.ts
@@ -1,0 +1,51 @@
+/**
+ * Web Device ID — Stable browser device identity for session handoff.
+ *
+ * Generates a UUID v7 on first use and persists it in `localStorage` under
+ * the key `styrby_device_id`. The same ID is used for every handoff snapshot
+ * written from this browser profile, enabling the handoff banner to correctly
+ * identify the origin device.
+ *
+ * WHY localStorage over a cookie: Cookies are sent on every request (latency
+ * + size overhead). We only need the device ID when writing snapshots and
+ * querying the handoff endpoint — on-demand reads from localStorage cost ~0.
+ *
+ * @module lib/deviceId
+ */
+
+import { generateDeviceId, isValidDeviceId } from '@styrby/shared/session-handoff';
+
+/** localStorage key for the stable device ID. */
+const STORAGE_KEY = 'styrby_device_id';
+
+/**
+ * Returns the stable device ID for this browser profile.
+ *
+ * On first call (or if stored value is corrupt) generates a new UUID v7,
+ * persists it to localStorage, and returns it. Subsequent calls return the
+ * stored value.
+ *
+ * WHY: The device ID must survive page refreshes and tab reopens. A new
+ * ID on every session load would break handoff continuity — each write
+ * would appear to come from a "different" device.
+ *
+ * @returns The stable device ID string (UUID v7 format)
+ */
+export function getWebDeviceId(): string {
+  if (typeof window === 'undefined') {
+    // SSR path — device ID is not meaningful on the server.
+    // Return a deterministic placeholder so callers never get an empty string.
+    return 'ssr-no-device-id';
+  }
+
+  const stored = localStorage.getItem(STORAGE_KEY);
+
+  if (stored && isValidDeviceId(stored)) {
+    return stored;
+  }
+
+  // Generate and persist a new device ID.
+  const newId = generateDeviceId();
+  localStorage.setItem(STORAGE_KEY, newId);
+  return newId;
+}

--- a/supabase/migrations/036_session_handoff.sql
+++ b/supabase/migrations/036_session_handoff.sql
@@ -1,0 +1,141 @@
+-- Migration 036: Session Handoff — cross-device session state snapshots + device registry
+--
+-- WHY: Enables "start on desktop, continue on phone" UX (Phase 3.2).
+-- When a user switches devices mid-session, we restore cursor position,
+-- scroll offset, and any unsent draft — eliminating the "where was I?"
+-- context loss that plagues competing tools.
+--
+-- SOC2 CC6.1: Session continuity across devices is a controlled state
+-- transition. All writes are scoped to the owning user via RLS, and
+-- snapshots are automatically purged after 30 days to limit data retention.
+
+-- ============================================================================
+-- devices table
+-- Lightweight device registry — records which surfaces a user accesses
+-- Styrby from so handoff banners can label the origin device.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS devices (
+  -- Stable UUID v7 generated on first app launch and persisted client-side.
+  -- UUID v7 is time-ordered, which aids chronological queries.
+  id          TEXT        PRIMARY KEY,
+
+  -- Owner of this device record.
+  user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Surface kind for display labels in the handoff banner.
+  -- WHY ENUM TEXT not a Postgres enum: Postgres enum alters require
+  -- table rewrites; a CHECK constraint is zero-cost to extend later.
+  kind        TEXT        NOT NULL CHECK (kind IN ('web', 'mobile_ios', 'mobile_android', 'cli')),
+
+  -- Updated on every app launch / CLI startup so stale devices are visible.
+  last_seen_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+
+  CONSTRAINT devices_user_kind_id_valid CHECK (char_length(id) BETWEEN 1 AND 64)
+);
+
+-- Index for per-user device lookups
+CREATE INDEX IF NOT EXISTS idx_devices_user_id ON devices(user_id);
+
+-- RLS: users can only see and manage their own device records.
+ALTER TABLE devices ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "devices: user can select own" ON devices
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "devices: user can insert own" ON devices
+  FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "devices: user can update own" ON devices
+  FOR UPDATE USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "devices: user can delete own" ON devices
+  FOR DELETE USING (user_id = (SELECT auth.uid()));
+
+-- ============================================================================
+-- session_state_snapshots table
+-- Periodic snapshots of UI state (cursor, scroll, draft) per device.
+-- Written every 10 s or on significant state change (message sent,
+-- app backgrounded). The "latest snapshot" lookup drives the handoff banner.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS session_state_snapshots (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Owning session; cascade-delete all snapshots when the session is removed.
+  session_id       UUID        NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+
+  -- ISO timestamp; used for "latest snapshot" lookup and retention expiry.
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Which device wrote this snapshot (matches devices.id).
+  device_id        TEXT        NOT NULL,
+
+  -- Index into the session_messages array (0-based).
+  -- WHY: We store an index rather than a message ID because the handoff
+  -- receiver may not have loaded all messages yet. The index lets the
+  -- client scroll to the right position even before older messages load.
+  cursor_position  INTEGER     NOT NULL DEFAULT 0,
+
+  -- Pixel offset within the focused message bubble for long tool outputs.
+  scroll_offset    INTEGER     NOT NULL DEFAULT 0,
+
+  -- Unsent message text the user was composing when the snapshot was taken.
+  -- Stored as plaintext; no PII beyond what the user typed in the input box.
+  active_draft     TEXT,
+
+  -- Schema version for forward-compatibility.
+  -- Increment this if the snapshot semantics change in a later migration.
+  snapshot_version INTEGER     NOT NULL DEFAULT 1
+);
+
+-- Partial index optimised for the "latest snapshot for a session" query:
+--   SELECT * FROM session_state_snapshots
+--   WHERE session_id = $1
+--   ORDER BY created_at DESC LIMIT 1
+-- The DESC ordering on created_at matches the B-tree scan direction,
+-- making this a single index page read rather than a full table scan.
+CREATE INDEX IF NOT EXISTS idx_sss_session_created
+  ON session_state_snapshots(session_id, created_at DESC);
+
+-- RLS: users can only read/write snapshots for sessions they own.
+-- WHY JOIN path: snapshots do not store user_id directly to keep the row
+-- lean. We join through sessions which has user_id (and its own RLS).
+-- Using a security-definer function is unnecessary here because the
+-- sub-select pattern is equivalent and does not require SUPERUSER grants.
+ALTER TABLE session_state_snapshots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "sss: user can select own" ON session_state_snapshots
+  FOR SELECT USING (
+    session_id IN (
+      SELECT id FROM sessions WHERE user_id = (SELECT auth.uid())
+    )
+  );
+
+CREATE POLICY "sss: user can insert own" ON session_state_snapshots
+  FOR INSERT WITH CHECK (
+    session_id IN (
+      SELECT id FROM sessions WHERE user_id = (SELECT auth.uid())
+    )
+  );
+
+-- No UPDATE policy — snapshots are immutable once written.
+-- No DELETE policy for users — retention is handled by the pg_cron job below.
+
+-- ============================================================================
+-- Retention: pg_cron nightly purge
+-- Delete snapshots older than 30 days to bound table growth.
+-- WHY 30 days: Matches session history retention on the Free tier and
+-- aligns with GDPR Art. 5(1)(e) storage-limitation principle.
+-- Supabase pins pg_cron to pg_catalog; the cron.schedule() call works
+-- from migrations even though the schema is not extensions.
+-- ============================================================================
+
+SELECT cron.schedule(
+  'purge-old-snapshots',           -- job name (idempotent if already exists)
+  '0 3 * * *',                     -- 03:00 UTC nightly (low-traffic window)
+  $$
+    DELETE FROM session_state_snapshots
+    WHERE created_at < NOW() - INTERVAL '30 days';
+  $$
+);


### PR DESCRIPTION
## Summary

- **Migration 036** — `session_state_snapshots` + `devices` tables with RLS, partial index on `(session_id, created_at DESC)`, and pg_cron 30-day retention job
- **`@styrby/shared/session-handoff`** subpath — platform-agnostic `createSnapshotWriter` (10s debounce, `captureNow` override, `destroy` cleanup), UUID v7 device ID generator, and `HandoffResponse` types shared across all surfaces
- **`GET /api/sessions/[id]/handoff`** — returns `available:true` with cursor/scroll/draft when a recent (<5 min) snapshot from a different device exists; `410 GONE` for expired snapshots; full RLS ownership validation via sessions join
- **`HandoffBanner`** (web + mobile parity) — dismissible "Resume / Start fresh" banner with `role="alert"`, device kind labels (iPhone/Android/terminal/Mac-PC), age formatting, and draft-restored hint
- **Device ID persistence** — `localStorage` (web), `expo-file-system` (mobile), `~/.styrby/device-id` mode 0o600 (CLI)
- **81 new tests** — 19 shared (snapshot-writer debounce/merge/destroy/error, device-id UUID generation/validation), 50 web (migration-036 structural × 25, handoff-route happy/error paths × 9, HandoffBanner UI × 16), 6 CLI (device-id file persistence/permissions/cache/corruption)

## Test plan

- [ ] All 81 new tests pass (`pnpm --filter @styrby/shared test`, `pnpm --filter styrby-web exec vitest run src/__tests__/...`, `pnpm --filter styrby-cli exec vitest run src/session/device-id.test.ts`)
- [ ] `tsc --noEmit` clean on shared, web, mobile, CLI
- [ ] Web build succeeds (`.next/` produced)
- [ ] Open session in web browser → close → open in another tab with different `localStorage` key → handoff banner appears with correct age
- [ ] Click "Resume" → cursor/scroll/draft restored
- [ ] Click "Start fresh" → banner dismissed, new snapshot stream begins
- [ ] Snapshot older than 5 min → API returns 410, no banner shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)