### PR TITLE
feat(sessions): cross-agent context sync with auto-injection on focus change (Phase 3.5)

### DIFF
--- a/packages/styrby-cli/src/cli/commandRouter.ts
+++ b/packages/styrby-cli/src/cli/commandRouter.ts
@@ -29,6 +29,7 @@ import { handleCosts } from '@/cli/handlers/costs';
 import {
   handleAuth,
   handleCheckpointCommand,
+  handleContextCommand,
   handleDaemonCommand,
   handleDeleteAccountCommand,
   handleDoctor,
@@ -165,6 +166,10 @@ export async function runCommand(argv: string[]): Promise<void> {
 
     case 'mcp':
       await handleMcpCommand(rest);
+      break;
+
+    case 'context':
+      await handleContextCommand(rest);
       break;
 
     case 'help':

--- a/packages/styrby-cli/src/cli/handlers/simple.ts
+++ b/packages/styrby-cli/src/cli/handlers/simple.ts
@@ -204,3 +204,20 @@ export async function handleDeleteAccountCommand(args: string[]): Promise<void> 
   const { handleDeleteAccount } = await import('@/commands/privacy');
   await handleDeleteAccount(args);
 }
+
+/**
+ * Handle the `styrby context` subcommand (Phase 3.5).
+ *
+ * Routes to context show, sync, export, and import subcommands for
+ * cross-agent context synchronisation within a session group.
+ *
+ * WHY a dedicated handler: context commands require the Phase 3.5 summarizer
+ * and are new enough that keeping them separate from other "simple" delegates
+ * avoids polluting the existing module namespace during review.
+ *
+ * @param args - Arguments after `styrby context`.
+ */
+export async function handleContextCommand(args: string[]): Promise<void> {
+  const { handleContextCommand: contextCmd } = await import('@/commands/context');
+  await contextCmd(args);
+}

--- a/packages/styrby-cli/src/cli/helpScreen.ts
+++ b/packages/styrby-cli/src/cli/helpScreen.ts
@@ -71,6 +71,12 @@ Commands:
     checkpoint restore <n>  Show restore info for a checkpoint
     checkpoint delete <n>   Delete a checkpoint (--force to skip confirmation)
 
+  Cross-Agent Context Sync (Phase 3.5)
+    context show            --group <groupId>            Display current context memory
+    context sync            --group <groupId>            Recompute memory from recent messages
+    context export          --session <sessionId>        Export memory for a session
+    context import          --session <target> --from <source>  Copy memory between sessions
+
   Daemon
     daemon install          Install daemon to start automatically on boot
     daemon uninstall        Remove daemon from auto-start

--- a/packages/styrby-cli/src/commands/__tests__/context.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/context.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Context Command Handler Tests (Phase 3.5)
+ *
+ * Tests for the `styrby context` subcommand arg parsers and the
+ * `dbRowToContextMemory` DB mapper.
+ *
+ * Test strategy:
+ *   - parseContextShowArgs: --group required, UUID validation, --json flag
+ *   - parseContextSyncArgs: --group required, UUID validation, --budget parsing + clamping
+ *   - parseContextExportArgs: --session required, UUID validation, --json flag
+ *   - parseContextImportArgs: --session + --from required, UUID validation, --task capture
+ *   - dbRowToContextMemory: field mapping, defaults for missing fields
+ *   - handleContextCommand: unknown subcommand exits, no subcommand exits
+ *
+ * WHY mock Supabase + persistence:
+ *   Unit tests for arg parsers do not need DB access. The DB interaction code
+ *   is covered by integration tests and the focus route tests. Mocking keeps
+ *   these tests fast (<100ms) and CI-safe (no Supabase credentials needed).
+ *
+ * @module commands/__tests__/context.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('@/persistence', () => ({
+  loadPersistedData: vi.fn().mockReturnValue({
+    userId: 'user-uuid-001',
+    accessToken: 'test-access-token',
+    machineId: 'machine-001',
+  }),
+}));
+
+vi.mock('@/env', () => ({
+  config: {
+    supabaseUrl: 'https://test.supabase.co',
+    supabaseAnonKey: 'test-anon-key',
+    isDev: true,
+    isProd: false,
+    env: 'development',
+  },
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock @supabase/supabase-js — not needed for arg parsing tests
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+      then: vi.fn().mockResolvedValue({ error: null }),
+    }),
+  })),
+}));
+
+// ============================================================================
+// Subject under test
+// ============================================================================
+
+import {
+  parseContextShowArgs,
+  parseContextSyncArgs,
+  parseContextExportArgs,
+  parseContextImportArgs,
+  dbRowToContextMemory,
+  handleContextCommand,
+} from '../context';
+import { TOKEN_BUDGET_DEFAULT, TOKEN_BUDGET_MAX, TOKEN_BUDGET_MIN } from '@styrby/shared/context-sync';
+
+// ============================================================================
+// Test data
+// ============================================================================
+
+const VALID_GROUP_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const VALID_SESSION_ID = 'b1ffcd00-1d1c-4ef9-aa7e-7cc0ce491b22';
+const VALID_SESSION_ID_2 = 'c2aade11-2e2d-4ef0-bb8f-8dd1df502c33';
+const INVALID_ID = 'not-a-uuid';
+
+// ============================================================================
+// parseContextShowArgs
+// ============================================================================
+
+describe('parseContextShowArgs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns options when --group is a valid UUID', () => {
+    const opts = parseContextShowArgs(['--group', VALID_GROUP_ID]);
+    expect(opts).not.toBeNull();
+    expect(opts!.groupId).toBe(VALID_GROUP_ID);
+  });
+
+  it('returns null when --group is missing', () => {
+    const opts = parseContextShowArgs([]);
+    expect(opts).toBeNull();
+  });
+
+  it('returns null when --group has no value', () => {
+    const opts = parseContextShowArgs(['--group']);
+    expect(opts).toBeNull();
+  });
+
+  it('returns null when --group is not a valid UUID', () => {
+    const opts = parseContextShowArgs(['--group', INVALID_ID]);
+    expect(opts).toBeNull();
+  });
+
+  it('sets json: true when --json flag is present', () => {
+    const opts = parseContextShowArgs(['--group', VALID_GROUP_ID, '--json']);
+    expect(opts).not.toBeNull();
+    expect(opts!.json).toBe(true);
+  });
+
+  it('defaults json to false when --json is absent', () => {
+    const opts = parseContextShowArgs(['--group', VALID_GROUP_ID]);
+    expect(opts!.json).toBeFalsy();
+  });
+});
+
+// ============================================================================
+// parseContextSyncArgs
+// ============================================================================
+
+describe('parseContextSyncArgs', () => {
+  it('returns options when --group is a valid UUID', () => {
+    const opts = parseContextSyncArgs(['--group', VALID_GROUP_ID]);
+    expect(opts).not.toBeNull();
+    expect(opts!.groupId).toBe(VALID_GROUP_ID);
+  });
+
+  it('returns null when --group is missing', () => {
+    expect(parseContextSyncArgs([])).toBeNull();
+  });
+
+  it('returns null when --group is invalid UUID', () => {
+    expect(parseContextSyncArgs(['--group', INVALID_ID])).toBeNull();
+  });
+
+  it('parses --budget when valid number provided', () => {
+    const opts = parseContextSyncArgs(['--group', VALID_GROUP_ID, '--budget', '2000']);
+    expect(opts!.tokenBudget).toBe(2000);
+  });
+
+  it('clamps --budget below TOKEN_BUDGET_MIN to TOKEN_BUDGET_MIN', () => {
+    const opts = parseContextSyncArgs(['--group', VALID_GROUP_ID, '--budget', '10']);
+    expect(opts!.tokenBudget).toBe(TOKEN_BUDGET_MIN);
+  });
+
+  it('clamps --budget above TOKEN_BUDGET_MAX to TOKEN_BUDGET_MAX', () => {
+    const opts = parseContextSyncArgs(['--group', VALID_GROUP_ID, '--budget', '99999']);
+    expect(opts!.tokenBudget).toBe(TOKEN_BUDGET_MAX);
+  });
+
+  it('leaves tokenBudget undefined when --budget not provided', () => {
+    const opts = parseContextSyncArgs(['--group', VALID_GROUP_ID]);
+    expect(opts!.tokenBudget).toBeUndefined();
+  });
+
+  it('ignores non-numeric --budget', () => {
+    const opts = parseContextSyncArgs(['--group', VALID_GROUP_ID, '--budget', 'huge']);
+    expect(opts!.tokenBudget).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// parseContextExportArgs
+// ============================================================================
+
+describe('parseContextExportArgs', () => {
+  it('returns options when --session is a valid UUID', () => {
+    const opts = parseContextExportArgs(['--session', VALID_SESSION_ID]);
+    expect(opts).not.toBeNull();
+    expect(opts!.sessionId).toBe(VALID_SESSION_ID);
+  });
+
+  it('returns null when --session is missing', () => {
+    expect(parseContextExportArgs([])).toBeNull();
+  });
+
+  it('returns null when --session has no value', () => {
+    expect(parseContextExportArgs(['--session'])).toBeNull();
+  });
+
+  it('returns null when --session is not a valid UUID', () => {
+    expect(parseContextExportArgs(['--session', INVALID_ID])).toBeNull();
+  });
+
+  it('sets json: true when --json flag is present', () => {
+    const opts = parseContextExportArgs(['--session', VALID_SESSION_ID, '--json']);
+    expect(opts!.json).toBe(true);
+  });
+
+  it('defaults json to false when --json is absent', () => {
+    const opts = parseContextExportArgs(['--session', VALID_SESSION_ID]);
+    expect(opts!.json).toBeFalsy();
+  });
+});
+
+// ============================================================================
+// parseContextImportArgs
+// ============================================================================
+
+describe('parseContextImportArgs', () => {
+  it('returns options when both --session and --from are valid UUIDs', () => {
+    const opts = parseContextImportArgs([
+      '--session', VALID_SESSION_ID,
+      '--from', VALID_SESSION_ID_2,
+    ]);
+    expect(opts).not.toBeNull();
+    expect(opts!.sessionId).toBe(VALID_SESSION_ID);
+    expect(opts!.fromSessionId).toBe(VALID_SESSION_ID_2);
+  });
+
+  it('returns null when --session is missing', () => {
+    expect(parseContextImportArgs(['--from', VALID_SESSION_ID_2])).toBeNull();
+  });
+
+  it('returns null when --from is missing', () => {
+    expect(parseContextImportArgs(['--session', VALID_SESSION_ID])).toBeNull();
+  });
+
+  it('returns null when --session is invalid UUID', () => {
+    expect(
+      parseContextImportArgs(['--session', INVALID_ID, '--from', VALID_SESSION_ID_2])
+    ).toBeNull();
+  });
+
+  it('returns null when --from is invalid UUID', () => {
+    expect(
+      parseContextImportArgs(['--session', VALID_SESSION_ID, '--from', INVALID_ID])
+    ).toBeNull();
+  });
+
+  it('captures --task when provided', () => {
+    const opts = parseContextImportArgs([
+      '--session', VALID_SESSION_ID,
+      '--from', VALID_SESSION_ID_2,
+      '--task', 'Refactor the auth system',
+    ]);
+    expect(opts!.task).toBe('Refactor the auth system');
+  });
+
+  it('leaves task undefined when --task not provided', () => {
+    const opts = parseContextImportArgs([
+      '--session', VALID_SESSION_ID,
+      '--from', VALID_SESSION_ID_2,
+    ]);
+    expect(opts!.task).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// dbRowToContextMemory
+// ============================================================================
+
+describe('dbRowToContextMemory', () => {
+  it('maps snake_case DB fields to camelCase', () => {
+    const row = {
+      id: 'mem-001',
+      session_group_id: VALID_GROUP_ID,
+      summary_markdown: '## Current task\nFix auth',
+      file_refs: [{ path: '/Users/alice/auth.ts', lastTouchedAt: '2026-04-22T12:00:00Z', relevance: 0.9 }],
+      recent_messages: [{ role: 'user', preview: 'Fix auth' }],
+      token_budget: 3000,
+      version: 2,
+      created_at: '2026-04-22T10:00:00Z',
+      updated_at: '2026-04-22T12:00:00Z',
+    };
+
+    const mem = dbRowToContextMemory(row);
+    expect(mem.id).toBe('mem-001');
+    expect(mem.sessionGroupId).toBe(VALID_GROUP_ID);
+    expect(mem.summaryMarkdown).toBe('## Current task\nFix auth');
+    expect(mem.fileRefs).toHaveLength(1);
+    expect(mem.recentMessages).toHaveLength(1);
+    expect(mem.tokenBudget).toBe(3000);
+    expect(mem.version).toBe(2);
+    expect(mem.createdAt).toBe('2026-04-22T10:00:00Z');
+    expect(mem.updatedAt).toBe('2026-04-22T12:00:00Z');
+  });
+
+  it('uses TOKEN_BUDGET_DEFAULT when token_budget is missing', () => {
+    const row = {
+      id: 'mem-002',
+      session_group_id: VALID_GROUP_ID,
+      summary_markdown: '',
+      file_refs: null,
+      recent_messages: null,
+      version: 1,
+      created_at: '2026-04-22T10:00:00Z',
+      updated_at: '2026-04-22T10:00:00Z',
+    };
+
+    const mem = dbRowToContextMemory(row);
+    expect(mem.tokenBudget).toBe(TOKEN_BUDGET_DEFAULT);
+  });
+
+  it('defaults fileRefs and recentMessages to empty arrays when null', () => {
+    const row = {
+      id: 'mem-003',
+      session_group_id: VALID_GROUP_ID,
+      summary_markdown: '',
+      file_refs: null,
+      recent_messages: null,
+      token_budget: 4000,
+      version: 1,
+      created_at: '2026-04-22T10:00:00Z',
+      updated_at: '2026-04-22T10:00:00Z',
+    };
+
+    const mem = dbRowToContextMemory(row);
+    expect(mem.fileRefs).toEqual([]);
+    expect(mem.recentMessages).toEqual([]);
+  });
+});
+
+// ============================================================================
+// handleContextCommand — dispatcher
+// ============================================================================
+
+describe('handleContextCommand', () => {
+  it('exits non-zero for unknown subcommand', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    await expect(handleContextCommand(['unknownsub'])).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('exits non-zero when no subcommand given', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    await expect(handleContextCommand([])).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('exits non-zero for "show" with missing --group', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    await expect(handleContextCommand(['show'])).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('exits non-zero for "sync" with missing --group', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    await expect(handleContextCommand(['sync'])).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('exits non-zero for "export" with missing --session', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    await expect(handleContextCommand(['export'])).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('exits non-zero for "import" with missing --from', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    await expect(
+      handleContextCommand(['import', '--session', VALID_SESSION_ID])
+    ).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+});

--- a/packages/styrby-cli/src/commands/context.ts
+++ b/packages/styrby-cli/src/commands/context.ts
@@ -1,0 +1,855 @@
+/**
+ * Context Command Handler (Phase 3.5)
+ *
+ * Implements `styrby context` subcommands for cross-agent context sync:
+ *
+ * ```
+ * styrby context show --group <groupId>       Dump memory as markdown + file_refs JSON
+ * styrby context sync --group <groupId>       Recompute memory from recent session messages
+ * styrby context export --session <sessionId> Extract memory from a single session
+ * styrby context import --session <target> --from <source>  Inject another session's memory
+ * ```
+ *
+ * ## WHY
+ *
+ * When a user switches from Claude Code to Codex mid-task, Codex starts cold —
+ * no knowledge of what was being worked on, which files were touched, or what
+ * the last conversation was about. `styrby context` commands let users inspect,
+ * refresh, and transplant context memory so the new agent hits the ground running.
+ *
+ * The "magic" happens automatically on focus change (POST /api/sessions/groups/[id]/focus),
+ * but these CLI commands give power users fine-grained control and visibility.
+ *
+ * ## Security
+ *
+ * - All context is scrubbed by the Phase 3.3 scrub engine before storing or printing.
+ * - Session group membership is verified server-side (RLS + explicit user_id check).
+ * - Optimistic locking prevents concurrent sync races from silently clobbering each other.
+ * - The `--from` source session must belong to the same authenticated user (server enforces).
+ *
+ * ## Token budget
+ *
+ * The `--budget` flag on `sync` is passed to the server but capped at 8000 server-side.
+ * Passing a value above 8000 is silently clamped, not rejected, to avoid breaking
+ * scripts that set a large budget assuming "unlimited".
+ *
+ * @module commands/context
+ */
+
+import chalk from 'chalk';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { logger } from '@/ui/logger';
+import { loadPersistedData } from '@/persistence';
+import { config as envConfig } from '@/env';
+import {
+  summarize,
+  buildInjectionPrompt,
+  TOKEN_BUDGET_DEFAULT,
+  TOKEN_BUDGET_MAX,
+  TOKEN_BUDGET_MIN,
+} from '@styrby/shared/context-sync';
+import type {
+  AgentContextMemory,
+  SummarizerInputMessage,
+  ContextShowOptions,
+  ContextSyncOptions,
+  ContextExportOptions,
+  ContextImportOptions,
+} from '@styrby/shared/context-sync';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * UUID v4 validation regex for group and session IDs.
+ *
+ * WHY (SEC-PATH-003): IDs are used in Supabase `.eq('id', id)` queries.
+ * Restricting to UUID format prevents unexpected query shapes from user input
+ * that might contain SQL special characters.
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Maximum number of recent messages fetched from the DB for sync.
+ *
+ * WHY 40 not 20: We fetch 40 so the summarizer has a larger pool to extract
+ * file refs from. The summarizer itself caps the output at CONTEXT_MESSAGE_LIMIT (20).
+ * More input → better file ref signal → better context quality.
+ */
+const SYNC_FETCH_MESSAGE_LIMIT = 40;
+
+// ============================================================================
+// Arg parsing
+// ============================================================================
+
+/**
+ * Parses `styrby context show` arguments.
+ *
+ * ```
+ * styrby context show --group <groupId> [--json]
+ * ```
+ *
+ * @param args - Arguments after `context show`.
+ * @returns Parsed options, or null if --group is missing/invalid.
+ */
+export function parseContextShowArgs(args: string[]): ContextShowOptions | null {
+  const groupIndex = args.indexOf('--group');
+  if (groupIndex === -1 || !args[groupIndex + 1]) {
+    logger.error('Usage: styrby context show --group <groupId>');
+    return null;
+  }
+
+  const groupId = args[groupIndex + 1]!;
+  if (!UUID_REGEX.test(groupId)) {
+    logger.error('Error: --group must be a valid UUID');
+    return null;
+  }
+
+  return {
+    groupId,
+    json: args.includes('--json'),
+  };
+}
+
+/**
+ * Parses `styrby context sync` arguments.
+ *
+ * ```
+ * styrby context sync --group <groupId> [--budget <number>]
+ * ```
+ *
+ * @param args - Arguments after `context sync`.
+ * @returns Parsed options, or null if --group is missing/invalid.
+ */
+export function parseContextSyncArgs(args: string[]): ContextSyncOptions | null {
+  const groupIndex = args.indexOf('--group');
+  if (groupIndex === -1 || !args[groupIndex + 1]) {
+    logger.error('Usage: styrby context sync --group <groupId> [--budget <number>]');
+    return null;
+  }
+
+  const groupId = args[groupIndex + 1]!;
+  if (!UUID_REGEX.test(groupId)) {
+    logger.error('Error: --group must be a valid UUID');
+    return null;
+  }
+
+  let tokenBudget: number | undefined;
+  const budgetIndex = args.indexOf('--budget');
+  if (budgetIndex !== -1 && args[budgetIndex + 1]) {
+    const parsed = parseInt(args[budgetIndex + 1]!, 10);
+    if (!isNaN(parsed)) {
+      // Clamp to valid range (server does this too, but clamp early for UX)
+      tokenBudget = Math.min(TOKEN_BUDGET_MAX, Math.max(TOKEN_BUDGET_MIN, parsed));
+    }
+  }
+
+  return { groupId, tokenBudget };
+}
+
+/**
+ * Parses `styrby context export` arguments.
+ *
+ * ```
+ * styrby context export --session <sessionId> [--json]
+ * ```
+ *
+ * @param args - Arguments after `context export`.
+ * @returns Parsed options, or null if --session is missing/invalid.
+ */
+export function parseContextExportArgs(args: string[]): ContextExportOptions | null {
+  const sessionIndex = args.indexOf('--session');
+  if (sessionIndex === -1 || !args[sessionIndex + 1]) {
+    logger.error('Usage: styrby context export --session <sessionId>');
+    return null;
+  }
+
+  const sessionId = args[sessionIndex + 1]!;
+  if (!UUID_REGEX.test(sessionId)) {
+    logger.error('Error: --session must be a valid UUID');
+    return null;
+  }
+
+  return {
+    sessionId,
+    json: args.includes('--json'),
+  };
+}
+
+/**
+ * Parses `styrby context import` arguments.
+ *
+ * ```
+ * styrby context import --session <target> --from <source> [--task "description"]
+ * ```
+ *
+ * @param args - Arguments after `context import`.
+ * @returns Parsed options, or null if required flags are missing/invalid.
+ */
+export function parseContextImportArgs(args: string[]): ContextImportOptions | null {
+  const sessionIndex = args.indexOf('--session');
+  if (sessionIndex === -1 || !args[sessionIndex + 1]) {
+    logger.error('Usage: styrby context import --session <target> --from <source>');
+    return null;
+  }
+
+  const fromIndex = args.indexOf('--from');
+  if (fromIndex === -1 || !args[fromIndex + 1]) {
+    logger.error('Usage: styrby context import --session <target> --from <source>');
+    return null;
+  }
+
+  const sessionId = args[sessionIndex + 1]!;
+  const fromSessionId = args[fromIndex + 1]!;
+
+  if (!UUID_REGEX.test(sessionId)) {
+    logger.error('Error: --session must be a valid UUID');
+    return null;
+  }
+
+  if (!UUID_REGEX.test(fromSessionId)) {
+    logger.error('Error: --from must be a valid UUID');
+    return null;
+  }
+
+  let task: string | undefined;
+  const taskIndex = args.indexOf('--task');
+  if (taskIndex !== -1 && args[taskIndex + 1]) {
+    task = args[taskIndex + 1];
+  }
+
+  return { sessionId, fromSessionId, task };
+}
+
+// ============================================================================
+// Supabase client factory
+// ============================================================================
+
+/**
+ * Creates an authenticated Supabase client using the stored user token.
+ *
+ * WHY inline not imported from a shared helper:
+ *   The CLI's Supabase client is constructed differently from the web's
+ *   server-side client (cookie-based auth vs. stored token). Reusing the
+ *   web helper would introduce a server-only import into the CLI bundle.
+ *
+ * @returns Authenticated SupabaseClient.
+ * @throws {Error} When the user is not authenticated.
+ */
+function createAuthenticatedClient(): SupabaseClient {
+  const persisted = loadPersistedData();
+  if (!persisted?.accessToken) {
+    throw new Error('Not authenticated. Run `styrby auth` first.');
+  }
+
+  const client = createClient(envConfig.supabaseUrl, envConfig.supabaseAnonKey, {
+    global: {
+      headers: { Authorization: `Bearer ${persisted.accessToken}` },
+    },
+    auth: { persistSession: false },
+  });
+
+  return client;
+}
+
+// ============================================================================
+// DB helpers
+// ============================================================================
+
+/**
+ * Fetches the context memory record for a session group.
+ *
+ * @param supabase - Authenticated Supabase client.
+ * @param groupId - UUID of the session group.
+ * @returns The memory record, or null if none exists yet.
+ * @throws When the Supabase query itself errors (network, RLS denial, etc.)
+ */
+async function fetchContextMemory(
+  supabase: SupabaseClient,
+  groupId: string
+): Promise<AgentContextMemory | null> {
+  const { data, error } = await supabase
+    .from('agent_context_memory')
+    .select('*')
+    .eq('session_group_id', groupId)
+    .order('version', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      // PostgREST: no rows returned — memory doesn't exist yet
+      return null;
+    }
+    throw new Error(`Failed to fetch context memory: ${error.message}`);
+  }
+
+  // Map snake_case DB columns to camelCase TS interface
+  return dbRowToContextMemory(data as Record<string, unknown>);
+}
+
+/**
+ * Maps a DB row from agent_context_memory to the AgentContextMemory interface.
+ *
+ * WHY explicit mapping: Supabase returns snake_case column names. Using a
+ * mapper keeps the interface clean (camelCase) and makes renames auditable.
+ *
+ * @param row - Raw DB row from agent_context_memory.
+ * @returns Typed AgentContextMemory record.
+ */
+export function dbRowToContextMemory(row: Record<string, unknown>): AgentContextMemory {
+  return {
+    id: String(row['id'] ?? ''),
+    sessionGroupId: String(row['session_group_id'] ?? ''),
+    summaryMarkdown: String(row['summary_markdown'] ?? ''),
+    fileRefs: (row['file_refs'] as AgentContextMemory['fileRefs']) ?? [],
+    recentMessages: (row['recent_messages'] as AgentContextMemory['recentMessages']) ?? [],
+    tokenBudget: Number(row['token_budget'] ?? TOKEN_BUDGET_DEFAULT),
+    version: Number(row['version'] ?? 1),
+    createdAt: String(row['created_at'] ?? new Date().toISOString()),
+    updatedAt: String(row['updated_at'] ?? new Date().toISOString()),
+  };
+}
+
+/**
+ * Fetches recent session messages for a group's active session.
+ *
+ * Fetches up to SYNC_FETCH_MESSAGE_LIMIT messages from the most recent
+ * session in the group. These are used as input to the summarizer.
+ *
+ * WHY only the active session's messages:
+ *   Multi-agent groups can have N concurrent sessions. On sync, we want to
+ *   capture what the CURRENTLY ACTIVE agent was doing — not blend all agents'
+ *   messages together, which would create a confusing context mix.
+ *
+ * @param supabase - Authenticated Supabase client.
+ * @param groupId - UUID of the session group.
+ * @returns Array of summarizer input messages, or empty array if no sessions.
+ */
+async function fetchGroupMessages(
+  supabase: SupabaseClient,
+  groupId: string
+): Promise<SummarizerInputMessage[]> {
+  // Step 1: get the active session for this group
+  const { data: group, error: groupError } = await supabase
+    .from('agent_session_groups')
+    .select('active_agent_session_id')
+    .eq('id', groupId)
+    .single();
+
+  if (groupError || !group || !group.active_agent_session_id) {
+    return [];
+  }
+
+  // Step 2: fetch recent messages from the active session
+  // WHY decrypted_content doesn't exist: session_messages stores E2E-encrypted
+  // content. For sync purposes, we use the token counts + metadata available
+  // in plaintext columns. Full decryption requires the session private key,
+  // which the CLI has in memory but the sync command doesn't re-derive here.
+  //
+  // PRAGMATIC CHOICE (Phase 3.5): We use the message_summary column (if present)
+  // or fall back to the role + token_count as a proxy for message content.
+  // Full decryption-based sync is a Phase 3.6 enhancement.
+  const { data: messages, error: messagesError } = await supabase
+    .from('session_messages')
+    .select('role, message_summary, token_count, created_at')
+    .eq('session_id', group.active_agent_session_id)
+    .order('created_at', { ascending: false })
+    .limit(SYNC_FETCH_MESSAGE_LIMIT);
+
+  if (messagesError || !messages) {
+    return [];
+  }
+
+  // Convert to SummarizerInputMessage (oldest first)
+  return [...messages].reverse().map((row) => ({
+    role: (row.role as string) ?? 'user',
+    content: (row.message_summary as string) ?? `[${row.token_count ?? 0} tokens]`,
+  }));
+}
+
+/**
+ * Upserts a context memory record using optimistic locking.
+ *
+ * WHY optimistic locking:
+ *   CLI workers can race on sync (e.g. two terminals sharing the same session
+ *   group). The optimistic lock ensures the writer with stale data loses
+ *   gracefully rather than silently clobbering a newer sync.
+ *
+ * @param supabase - Authenticated Supabase client.
+ * @param groupId - UUID of the session group.
+ * @param memory - The memory to write (current version for conflict detection).
+ * @param summaryMarkdown - New summary markdown from the summarizer.
+ * @param fileRefs - New file refs from the summarizer.
+ * @param recentMessages - New message previews from the summarizer.
+ * @param tokenBudget - Token budget to store.
+ * @returns true if the write succeeded, false if the optimistic lock was violated.
+ * @throws On Supabase errors unrelated to optimistic locking.
+ */
+async function upsertContextMemory(
+  supabase: SupabaseClient,
+  groupId: string,
+  existing: AgentContextMemory | null,
+  summaryMarkdown: string,
+  fileRefs: AgentContextMemory['fileRefs'],
+  recentMessages: AgentContextMemory['recentMessages'],
+  tokenBudget: number
+): Promise<boolean> {
+  if (!existing) {
+    // INSERT — no existing record, no version conflict possible
+    const { error } = await supabase.from('agent_context_memory').insert({
+      session_group_id: groupId,
+      summary_markdown: summaryMarkdown,
+      file_refs: fileRefs,
+      recent_messages: recentMessages,
+      token_budget: Math.min(TOKEN_BUDGET_MAX, Math.max(TOKEN_BUDGET_MIN, tokenBudget)),
+      version: 1,
+    });
+
+    if (error) {
+      if (error.code === '23505') {
+        // Unique constraint violation — concurrent insert; re-fetch and retry
+        return false;
+      }
+      throw new Error(`Failed to insert context memory: ${error.message}`);
+    }
+    return true;
+  }
+
+  // UPDATE with optimistic lock: WHERE version = existing.version
+  const { data: updated, error } = await supabase
+    .from('agent_context_memory')
+    .update({
+      summary_markdown: summaryMarkdown,
+      file_refs: fileRefs,
+      recent_messages: recentMessages,
+      token_budget: Math.min(TOKEN_BUDGET_MAX, Math.max(TOKEN_BUDGET_MIN, tokenBudget)),
+      version: existing.version + 1,
+    })
+    .eq('session_group_id', groupId)
+    .eq('version', existing.version) // Optimistic lock condition
+    .select('id')
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to update context memory: ${error.message}`);
+  }
+
+  // If updated is null, the WHERE version = <expected> matched 0 rows →
+  // optimistic lock violated (concurrent write won).
+  return updated !== null;
+}
+
+// ============================================================================
+// Command implementations
+// ============================================================================
+
+/**
+ * Handles `styrby context show --group <groupId> [--json]`.
+ *
+ * Fetches and displays the current context memory for a session group.
+ * In default mode, pretty-prints the summary markdown and file refs.
+ * In --json mode, outputs raw JSON for scripting.
+ *
+ * @param args - Command arguments.
+ */
+async function handleContextShow(args: string[]): Promise<void> {
+  const options = parseContextShowArgs(args);
+  if (!options) {
+    process.exit(1);
+  }
+
+  let supabase: SupabaseClient;
+  try {
+    supabase = createAuthenticatedClient();
+  } catch (err) {
+    logger.error((err as Error).message);
+    process.exit(1);
+  }
+
+  const memory = await fetchContextMemory(supabase, options.groupId);
+
+  if (!memory) {
+    logger.info(
+      chalk.yellow('No context memory found for this group. Run `styrby context sync` to create one.')
+    );
+    return;
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(memory, null, 2));
+    return;
+  }
+
+  // Pretty-print
+  console.log(chalk.bold.cyan('\n── Context Memory ──────────────────────────────────────'));
+  console.log(chalk.dim(`Group: ${memory.sessionGroupId}  |  Version: ${memory.version}  |  Budget: ${memory.tokenBudget} tokens`));
+  console.log(chalk.dim(`Last synced: ${new Date(memory.updatedAt).toLocaleString()}`));
+  console.log('');
+  console.log(memory.summaryMarkdown);
+
+  if (memory.fileRefs.length > 0) {
+    console.log('');
+    console.log(chalk.bold('\nFile references:'));
+    for (const ref of memory.fileRefs) {
+      const bar = '█'.repeat(Math.round(ref.relevance * 10));
+      const empty = '░'.repeat(10 - bar.length);
+      console.log(
+        chalk.cyan(`  ${bar}${empty}`) +
+        chalk.dim(` ${ref.relevance.toFixed(2)}`) +
+        `  ${ref.path}`
+      );
+    }
+  }
+
+  console.log(chalk.bold.cyan('────────────────────────────────────────────────────────\n'));
+}
+
+/**
+ * Handles `styrby context sync --group <groupId> [--budget <n>]`.
+ *
+ * Recomputes the context memory from the group's recent session messages
+ * and writes it back to agent_context_memory. Uses optimistic locking;
+ * retries once on conflict.
+ *
+ * @param args - Command arguments.
+ */
+async function handleContextSync(args: string[]): Promise<void> {
+  const options = parseContextSyncArgs(args);
+  if (!options) {
+    process.exit(1);
+  }
+
+  let supabase: SupabaseClient;
+  try {
+    supabase = createAuthenticatedClient();
+  } catch (err) {
+    logger.error((err as Error).message);
+    process.exit(1);
+  }
+
+  logger.info(chalk.dim('Fetching session messages…'));
+
+  const messages = await fetchGroupMessages(supabase, options.groupId);
+
+  if (messages.length === 0) {
+    logger.info(
+      chalk.yellow('No messages found. The session group may have no active session yet.')
+    );
+    return;
+  }
+
+  logger.info(chalk.dim(`Summarizing ${messages.length} messages…`));
+
+  const summarizerOutput = summarize({
+    messages,
+    tokenBudget: options.tokenBudget,
+  });
+
+  // Fetch existing memory for optimistic locking
+  const existing = await fetchContextMemory(supabase, options.groupId);
+
+  // Retry once on optimistic lock violation
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const existingForWrite = attempt === 0 ? existing : await fetchContextMemory(supabase, options.groupId);
+
+    const success = await upsertContextMemory(
+      supabase,
+      options.groupId,
+      existingForWrite,
+      summarizerOutput.summaryMarkdown,
+      summarizerOutput.fileRefs,
+      summarizerOutput.recentMessages,
+      options.tokenBudget ?? TOKEN_BUDGET_DEFAULT
+    );
+
+    if (success) {
+      logger.info(
+        chalk.green('✓') +
+        ` Context memory synced — ${summarizerOutput.estimatedTokens} tokens, ` +
+        `${summarizerOutput.fileRefs.length} file refs, ` +
+        `${summarizerOutput.recentMessages.length} messages`
+      );
+
+      // Audit log (non-fatal)
+      await supabase.from('audit_log').insert({
+        action: 'context_memory_synced',
+        metadata: {
+          group_id: options.groupId,
+          estimated_tokens: summarizerOutput.estimatedTokens,
+          file_ref_count: summarizerOutput.fileRefs.length,
+          message_count: summarizerOutput.recentMessages.length,
+        },
+      }).then(({ error }) => {
+        if (error) {
+          // WHY non-fatal: audit log failure must not block user operations.
+          logger.warn(`[context sync] Audit log failed: ${error.message}`);
+        }
+      });
+
+      return;
+    }
+
+    if (attempt === 0) {
+      logger.info(chalk.dim('Concurrent write detected — retrying with fresh version…'));
+    }
+  }
+
+  logger.error('Failed to sync context memory after retry. Please try again.');
+  process.exit(1);
+}
+
+/**
+ * Handles `styrby context export --session <sessionId> [--json]`.
+ *
+ * Finds the session's group, fetches the context memory, and prints it.
+ * If the session has no group or no memory, prints an informative message.
+ *
+ * @param args - Command arguments.
+ */
+async function handleContextExport(args: string[]): Promise<void> {
+  const options = parseContextExportArgs(args);
+  if (!options) {
+    process.exit(1);
+  }
+
+  let supabase: SupabaseClient;
+  try {
+    supabase = createAuthenticatedClient();
+  } catch (err) {
+    logger.error((err as Error).message);
+    process.exit(1);
+  }
+
+  // Resolve session → group
+  const { data: session, error: sessionError } = await supabase
+    .from('sessions')
+    .select('id, session_group_id')
+    .eq('id', options.sessionId)
+    .single();
+
+  if (sessionError || !session) {
+    logger.error(`Session not found: ${options.sessionId}`);
+    process.exit(1);
+  }
+
+  if (!session.session_group_id) {
+    logger.info(
+      chalk.yellow(
+        'This session is not part of a session group. ' +
+        'Context sync is available for multi-agent groups started with `styrby multi`.'
+      )
+    );
+    return;
+  }
+
+  const memory = await fetchContextMemory(supabase, session.session_group_id as string);
+
+  if (!memory) {
+    logger.info(
+      chalk.yellow(
+        'No context memory found for this session\'s group. ' +
+        `Run \`styrby context sync --group ${session.session_group_id as string}\` to create one.`
+      )
+    );
+    return;
+  }
+
+  // Audit log
+  await supabase.from('audit_log').insert({
+    action: 'context_memory_exported',
+    metadata: { session_id: options.sessionId, group_id: session.session_group_id },
+  }).then(({ error }) => {
+    if (error) logger.warn(`[context export] Audit log failed: ${error.message}`);
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(memory, null, 2));
+    return;
+  }
+
+  // Pretty-print (same as `show`)
+  const payload = buildInjectionPrompt(memory);
+  console.log(chalk.bold.cyan('\n── Exported Context (Injection Preview) ────────────────'));
+  console.log(chalk.dim(`~${payload.estimatedTokens} tokens  |  ${payload.messageCount} messages  |  ${payload.includedFileRefs.length} file refs`));
+  console.log('');
+  console.log(payload.systemPrompt);
+  console.log(chalk.bold.cyan('────────────────────────────────────────────────────────\n'));
+}
+
+/**
+ * Handles `styrby context import --session <target> --from <source> [--task "..."]`.
+ *
+ * Copies the context memory from the source session's group to the target
+ * session's group. Useful when you want to continue work from one session
+ * in a different agent or project context.
+ *
+ * Security:
+ *   Both source and target sessions must belong to the authenticated user.
+ *   Server-side RLS enforces this; the CLI checks up front for a better error UX.
+ *
+ * @param args - Command arguments.
+ */
+async function handleContextImport(args: string[]): Promise<void> {
+  const options = parseContextImportArgs(args);
+  if (!options) {
+    process.exit(1);
+  }
+
+  let supabase: SupabaseClient;
+  try {
+    supabase = createAuthenticatedClient();
+  } catch (err) {
+    logger.error((err as Error).message);
+    process.exit(1);
+  }
+
+  // Resolve source session → group
+  const { data: sourceSession, error: sourceError } = await supabase
+    .from('sessions')
+    .select('id, session_group_id')
+    .eq('id', options.fromSessionId)
+    .single();
+
+  if (sourceError || !sourceSession || !sourceSession.session_group_id) {
+    logger.error(
+      `Source session not found or not in a group: ${options.fromSessionId}`
+    );
+    process.exit(1);
+  }
+
+  // Resolve target session → group
+  const { data: targetSession, error: targetError } = await supabase
+    .from('sessions')
+    .select('id, session_group_id')
+    .eq('id', options.sessionId)
+    .single();
+
+  if (targetError || !targetSession || !targetSession.session_group_id) {
+    logger.error(
+      `Target session not found or not in a group: ${options.sessionId}. ` +
+      'The target session must be part of a multi-agent group.'
+    );
+    process.exit(1);
+  }
+
+  // Fetch source memory
+  const sourceMemory = await fetchContextMemory(supabase, sourceSession.session_group_id as string);
+
+  if (!sourceMemory) {
+    logger.error(
+      `No context memory found for source session's group. ` +
+      `Run \`styrby context sync --group ${sourceSession.session_group_id as string}\` first.`
+    );
+    process.exit(1);
+  }
+
+  // Re-summarize with optional task override
+  const importedSummary = summarize({
+    messages: sourceMemory.recentMessages.map((m) => ({
+      role: m.role,
+      content: m.preview,
+    })),
+    tokenBudget: sourceMemory.tokenBudget,
+    taskOverride: options.task,
+  });
+
+  // Fetch existing target memory for optimistic locking
+  const existingTarget = await fetchContextMemory(supabase, targetSession.session_group_id as string);
+
+  const success = await upsertContextMemory(
+    supabase,
+    targetSession.session_group_id as string,
+    existingTarget,
+    importedSummary.summaryMarkdown,
+    importedSummary.fileRefs,
+    importedSummary.recentMessages,
+    sourceMemory.tokenBudget
+  );
+
+  if (!success) {
+    logger.error(
+      'Concurrent write to target group memory detected. Please retry.'
+    );
+    process.exit(1);
+  }
+
+  // Audit log
+  await supabase.from('audit_log').insert({
+    action: 'context_memory_imported',
+    metadata: {
+      source_session_id: options.fromSessionId,
+      target_session_id: options.sessionId,
+      source_group_id: sourceSession.session_group_id,
+      target_group_id: targetSession.session_group_id,
+      task_override: options.task ?? null,
+    },
+  }).then(({ error }) => {
+    if (error) logger.warn(`[context import] Audit log failed: ${error.message}`);
+  });
+
+  logger.info(
+    chalk.green('✓') +
+    ` Context imported from session ${options.fromSessionId} → ${options.sessionId}. ` +
+    chalk.dim(
+      `~${importedSummary.estimatedTokens} tokens, ` +
+      `${importedSummary.fileRefs.length} file refs`
+    )
+  );
+
+  if (options.task) {
+    logger.info(chalk.dim(`Task override applied: "${options.task}"`));
+  }
+}
+
+// ============================================================================
+// Main dispatcher
+// ============================================================================
+
+/**
+ * Dispatches `styrby context <subcommand>` to the correct handler.
+ *
+ * Subcommands:
+ *   show    — Display current context memory for a group
+ *   sync    — Recompute and write context memory from recent messages
+ *   export  — Print context memory for a session (as markdown or JSON)
+ *   import  — Copy context memory from one session's group to another
+ *
+ * @param args - Arguments after `styrby context`.
+ */
+export async function handleContextCommand(args: string[]): Promise<void> {
+  const subcommand = args[0];
+  const subArgs = args.slice(1);
+
+  switch (subcommand) {
+    case 'show':
+      await handleContextShow(subArgs);
+      break;
+
+    case 'sync':
+      await handleContextSync(subArgs);
+      break;
+
+    case 'export':
+      await handleContextExport(subArgs);
+      break;
+
+    case 'import':
+      await handleContextImport(subArgs);
+      break;
+
+    default:
+      logger.error(subcommand ? `Unknown context subcommand: ${subcommand}` : 'Usage: styrby context <subcommand>');
+      console.error('');
+      console.error('Subcommands:');
+      console.error('  show    --group <groupId>                          Show current context memory');
+      console.error('  sync    --group <groupId> [--budget <n>]           Recompute from recent messages');
+      console.error('  export  --session <sessionId> [--json]             Export memory for a session');
+      console.error('  import  --session <target> --from <source>         Copy memory between sessions');
+      console.error('');
+      process.exit(1);
+  }
+}
+
+export default { handleContextCommand };

--- a/packages/styrby-cli/tsconfig.json
+++ b/packages/styrby-cli/tsconfig.json
@@ -28,7 +28,8 @@
       "@styrby/shared/pricing": ["../../styrby-shared/dist/pricing/index"],
       "@styrby/shared/cost": ["../../styrby-shared/dist/cost/index"],
       "@styrby/shared/logging": ["../../styrby-shared/dist/logging/index"],
-      "@styrby/shared/session-handoff": ["../../styrby-shared/dist/session-handoff/index"]
+      "@styrby/shared/session-handoff": ["../../styrby-shared/dist/session-handoff/index"],
+      "@styrby/shared/context-sync": ["../../styrby-shared/dist/context-sync/index"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/styrby-cli/vitest.config.ts
+++ b/packages/styrby-cli/vitest.config.ts
@@ -38,6 +38,12 @@ export default defineConfig({
       // points to dist/session-handoff/index.js, but vitest's Vite resolver
       // needs an explicit alias since it doesn't traverse package.json exports.
       '@styrby/shared/session-handoff': resolve(__dirname, '../styrby-shared/dist/session-handoff/index.js'),
+      // WHY (Phase 3.5): Mirror the tsconfig path for the context-sync subpath
+      // so vitest can resolve `import ... from '@styrby/shared/context-sync'`
+      // during test runs. The subpath export in styrby-shared's package.json
+      // points to dist/context-sync/index.js, but vitest's Vite resolver
+      // needs an explicit alias since it doesn't traverse package.json exports.
+      '@styrby/shared/context-sync': resolve(__dirname, '../styrby-shared/dist/context-sync/index.js'),
     },
   },
 });

--- a/packages/styrby-shared/package.json
+++ b/packages/styrby-shared/package.json
@@ -68,6 +68,10 @@
     "./session-replay": {
       "types": "./dist/session-replay/index.d.ts",
       "import": "./dist/session-replay/index.js"
+    },
+    "./context-sync": {
+      "types": "./dist/context-sync/index.d.ts",
+      "import": "./dist/context-sync/index.js"
     }
   },
   "scripts": {

--- a/packages/styrby-shared/src/context-sync/index.ts
+++ b/packages/styrby-shared/src/context-sync/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Context Sync — Public API (Phase 3.5)
+ *
+ * Re-exports all public symbols from the context-sync sub-module.
+ *
+ * WHY NOT re-exported from the main barrel:
+ *   The summarizer imports the scrub engine regex patterns. Consumers who
+ *   only need the types can import from '@styrby/shared/context-sync'
+ *   without pulling in the scrub regex runtime.
+ *
+ *   Import the full summarizer:
+ *   `import { summarize, buildInjectionPrompt } from '@styrby/shared/context-sync'`
+ *
+ *   Import types only:
+ *   `import type { AgentContextMemory, ... } from '@styrby/shared/context-sync'`
+ *
+ * @module context-sync
+ */
+
+// Types and constants
+export type {
+  ContextFileRef,
+  ContextMessage,
+  AgentContextMemory,
+  SummarizerInput,
+  SummarizerInputMessage,
+  SummarizerOutput,
+  ContextShowOptions,
+  ContextSyncOptions,
+  ContextExportOptions,
+  ContextImportOptions,
+  ContextInjectionPayload,
+} from './types.js';
+
+export {
+  CONTEXT_MESSAGE_LIMIT,
+  TOKEN_BUDGET_DEFAULT,
+  TOKEN_BUDGET_MAX,
+  TOKEN_BUDGET_MIN,
+  MESSAGE_PREVIEW_MAX_CHARS,
+  FILE_REF_RELEVANCE_MAX,
+} from './types.js';
+
+// Summarizer functions (pure, deterministic)
+export {
+  summarize,
+  buildInjectionPrompt,
+  estimateTokens,
+  extractPathsFromString,
+  extractPathsFromToolCall,
+  computeRelevance,
+  normaliseRole,
+  buildMessagePreview,
+  detectCurrentTask,
+  detectOpenQuestion,
+  buildSummaryMarkdown,
+  buildFileRefs,
+} from './summarizer.js';

--- a/packages/styrby-shared/src/context-sync/summarizer.ts
+++ b/packages/styrby-shared/src/context-sync/summarizer.ts
@@ -1,0 +1,708 @@
+/**
+ * Context Sync — Deterministic Summarizer (Phase 3.5)
+ *
+ * Pure-function summarizer that builds a structured context memory from a
+ * session message array and an optional token budget.
+ *
+ * WHY pure functions:
+ *   Pure functions are trivially testable (no mocks needed), deterministic
+ *   (same input → same output on every CI run), and safe to call in hot paths
+ *   (no side effects). All 15+ tests exercise this module directly.
+ *
+ * WHY NOT an LLM call:
+ *   An LLM-based summarizer introduces latency (300-2000ms), network failure
+ *   risk, and nondeterminism. The deterministic string-processing approach
+ *   runs in <5ms, never fails due to network, and produces auditable output.
+ *   The tradeoff is slightly lower semantic quality — acceptable given that
+ *   the output supplements the agent's context window, not replaces it.
+ *
+ * Security:
+ *   - EVERY message is passed through the Phase 3.3 scrub engine before
+ *     any content appears in the output. Secrets, file paths, and shell
+ *     commands are redacted.
+ *   - The summarizer NEVER logs message content.
+ *   - Raw content never appears in returned types (only scrubbed previews).
+ *
+ * GDPR Art. 5(1)(c) data minimisation:
+ *   Only the first MESSAGE_PREVIEW_MAX_CHARS chars of each message are
+ *   retained. Tool calls are collapsed to a single 'tool' role entry.
+ *
+ * SOC2 CC6.1:
+ *   Token budget is enforced at the output layer — the summary is truncated
+ *   to fit within TOKEN_BUDGET_MAX even if the caller supplies a larger value.
+ *
+ * @module context-sync/summarizer
+ */
+
+import { scrubMessage } from '../session-replay/scrub.js';
+import type { ScrubMask } from '../session-replay/scrub.js';
+import {
+  CONTEXT_MESSAGE_LIMIT,
+  TOKEN_BUDGET_DEFAULT,
+  TOKEN_BUDGET_MAX,
+  TOKEN_BUDGET_MIN,
+  MESSAGE_PREVIEW_MAX_CHARS,
+  FILE_REF_RELEVANCE_MAX,
+} from './types.js';
+import type {
+  SummarizerInput,
+  SummarizerOutput,
+  SummarizerInputMessage,
+  ContextFileRef,
+  ContextMessage,
+  ContextInjectionPayload,
+  AgentContextMemory,
+} from './types.js';
+
+// ============================================================================
+// Internal constants
+// ============================================================================
+
+/**
+ * Scrub mask applied to EVERY message before preview extraction.
+ *
+ * WHY all three categories enabled:
+ *   - secrets: Agents frequently debug .env files and API calls; key leakage
+ *     in context memory would persist secrets across agent lifetimes.
+ *   - file_paths: Absolute paths expose system layout; basenames are preserved
+ *     for context. Matches the Phase 3.3 scrub engine behavior.
+ *   - commands: Shell command arguments often carry sensitive flags (tokens,
+ *     passwords) passed via --token=... or MYKEY=... prefix.
+ *
+ * This mask is intentionally more aggressive than the user-configurable replay
+ * mask, because context memory is automatically propagated to agents that may
+ * not be owned by the same person.
+ */
+const FULL_SCRUB_MASK: ScrubMask = {
+  secrets: true,
+  file_paths: true,
+  commands: true,
+};
+
+/**
+ * Words-per-token heuristic used for token estimation.
+ *
+ * WHY 1.3: This is the same constant used by styrby-shared/tokenizers as its
+ * fallback when neither the Anthropic nor OpenAI tokenizer is available. Using
+ * the same constant ensures budget checks are consistent across the codebase.
+ *
+ * Over-estimate is intentional: better to inject less context than to overflow
+ * the agent's context window.
+ */
+const WORDS_PER_TOKEN_DIVISOR = 1.3;
+
+/**
+ * Minimum relevance score for a file ref to be included in the injection prompt.
+ * Used by buildInjectionPrompt to filter out low-signal refs.
+ */
+const INJECTION_MIN_RELEVANCE = 0.5;
+
+/**
+ * Recency half-life in milliseconds for the relevance decay function.
+ *
+ * WHY 30 minutes: AI coding sessions are fast-paced. A file touched 30 minutes
+ * ago is roughly half as relevant as one touched just now. Files touched >2h
+ * ago get relevance < 0.25, which typically falls below INJECTION_MIN_RELEVANCE.
+ */
+const RECENCY_HALF_LIFE_MS = 30 * 60 * 1000;
+
+/**
+ * Tool names whose arguments are expected to contain file paths.
+ *
+ * WHY an allowlist not a denylist: Unknown tools may have arguments with
+ * arbitrary structure. Scanning unknown tools risks false-positive file refs
+ * from strings that look like paths (e.g. CSS color '#aabbcc').
+ */
+const FILE_TOOL_NAMES = new Set([
+  'str_replace_editor',
+  'str_replace_based_edit_tool',
+  'read_file',
+  'write_file',
+  'create_file',
+  'patch_file',
+  'bash', // bash commands often include file paths as arguments
+  'execute_bash',
+  'computer', // Claude's computer use tool can reference files
+  'edit_file',
+  'view_file',
+  'list_directory',
+  'glob',
+  'grep',
+]);
+
+/**
+ * Argument keys that typically hold a file path value.
+ *
+ * WHY multiple keys: Different tools use different field names. Covering
+ * common variants extracts more file refs without requiring tool-specific logic.
+ */
+const PATH_ARG_KEYS = new Set([
+  'path',
+  'file_path',
+  'filepath',
+  'filename',
+  'target_file',
+  'command', // bash commands — we extract paths from the command string
+]);
+
+// ============================================================================
+// Token estimation
+// ============================================================================
+
+/**
+ * Estimates the token count of a string using the words×DIVISOR heuristic.
+ *
+ * This is the same heuristic as styrby-shared/tokenizers/index.ts. The result
+ * is an OVER-estimate (conservative), which is the correct bias for budget enforcement.
+ *
+ * @param text - The string to estimate.
+ * @returns Estimated token count (ceiling).
+ *
+ * @example
+ * ```ts
+ * estimateTokens('Hello world') // → 2 (2 words / 1.3, ceiling = 2)
+ * ```
+ */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return 0;
+  // WHY filter empty strings: '   '.trim().split(/\s+/) yields [''] (one empty
+  // string element), not an empty array. Filtering ensures whitespace-only
+  // input returns 0 instead of 1.
+  const wordCount = trimmed.split(/\s+/).filter((w) => w.length > 0).length;
+  if (wordCount === 0) return 0;
+  return Math.ceil(wordCount / WORDS_PER_TOKEN_DIVISOR);
+}
+
+// ============================================================================
+// File reference extraction
+// ============================================================================
+
+/**
+ * Extracts absolute filesystem paths from a string.
+ *
+ * Looks for Unix absolute paths (/Users/..., /home/..., /root/...,
+ * /var/..., /tmp/..., /etc/..., /opt/..., /usr/..., /srv/...).
+ *
+ * WHY same regex as scrub engine ABSOLUTE_PATH_PATTERN but without the capture
+ * group — here we want the FULL path, not just the basename.
+ *
+ * @param text - The string to scan for paths.
+ * @returns Array of unique absolute paths found.
+ *
+ * @example
+ * ```ts
+ * extractPathsFromString('/Users/alice/projects/app/src/auth.ts is broken')
+ * // → ['/Users/alice/projects/app/src/auth.ts']
+ * ```
+ */
+export function extractPathsFromString(text: string): string[] {
+  const PATH_PATTERN = /(?:\/(?:Users|home|root|var|tmp|etc|opt|usr|srv)[^\s"'`]*)/g;
+  const matches = text.match(PATH_PATTERN) ?? [];
+  // Deduplicate preserving first-occurrence order
+  return [...new Set(matches)];
+}
+
+/**
+ * Extracts file paths from a tool_call arguments object.
+ *
+ * Checks PATH_ARG_KEYS first (direct string values), then falls back to
+ * scanning all string values in the arguments object for path patterns.
+ *
+ * @param toolName - The name of the tool (used to gate extraction).
+ * @param args - Parsed tool call arguments.
+ * @returns Array of unique absolute paths found in the arguments.
+ */
+export function extractPathsFromToolCall(
+  toolName: string,
+  args: Record<string, unknown>
+): string[] {
+  const paths: string[] = [];
+
+  if (!FILE_TOOL_NAMES.has(toolName)) {
+    // Skip tools whose arguments are unlikely to contain file paths
+    return paths;
+  }
+
+  // First pass: check well-known path argument keys
+  for (const key of PATH_ARG_KEYS) {
+    const value = args[key];
+    if (typeof value === 'string') {
+      paths.push(...extractPathsFromString(value));
+    }
+  }
+
+  // Second pass: scan all string values (catches non-standard arg keys)
+  for (const [key, value] of Object.entries(args)) {
+    if (PATH_ARG_KEYS.has(key)) continue; // already processed above
+    if (typeof value === 'string' && value.length > 0) {
+      paths.push(...extractPathsFromString(value));
+    }
+  }
+
+  return [...new Set(paths)];
+}
+
+// ============================================================================
+// Relevance scoring
+// ============================================================================
+
+/**
+ * Computes the relevance score for a file path given recency and mention frequency.
+ *
+ * Score = 0.7 × recencyScore + 0.3 × frequencyScore
+ *
+ * WHY 70/30 weighting:
+ *   Recency is the stronger signal — if a file was just modified, it's almost
+ *   certainly relevant. Frequency matters because files touched once at session
+ *   start may be peripheral, while files mentioned repeatedly are central to
+ *   the task. The 70/30 split reflects this hierarchy.
+ *
+ * @param lastTouchedAt - ISO 8601 timestamp of the last touch.
+ * @param mentionCount - Number of messages that reference this file.
+ * @param totalMentions - Maximum mention count across all files (for normalisation).
+ * @param now - Reference timestamp (defaults to Date.now()); injectable for tests.
+ * @returns Normalised relevance score in [0, FILE_REF_RELEVANCE_MAX].
+ *
+ * @example
+ * ```ts
+ * // File touched 5 minutes ago, mentioned twice (max mentions = 5)
+ * computeRelevance('2026-04-22T10:55:00Z', 2, 5, new Date('2026-04-22T11:00:00Z').getTime())
+ * // → approximately 0.84
+ * ```
+ */
+export function computeRelevance(
+  lastTouchedAt: string,
+  mentionCount: number,
+  totalMentions: number,
+  now: number = Date.now()
+): number {
+  const ageMs = Math.max(0, now - new Date(lastTouchedAt).getTime());
+
+  // Exponential decay: score = e^(-age / half_life × ln(2))
+  // At age = half_life: score = 0.5. At age = 0: score = 1.0.
+  const recencyScore = Math.exp((-ageMs / RECENCY_HALF_LIFE_MS) * Math.LN2);
+
+  // Frequency score: normalised to [0, 1]. If totalMentions is 0, frequency = 0.
+  const frequencyScore = totalMentions > 0 ? mentionCount / totalMentions : 0;
+
+  const combined = 0.7 * recencyScore + 0.3 * frequencyScore;
+
+  // Clamp to [0, FILE_REF_RELEVANCE_MAX] and round to 2 decimal places
+  return Math.round(Math.min(FILE_REF_RELEVANCE_MAX, Math.max(0, combined)) * 100) / 100;
+}
+
+// ============================================================================
+// Message processing
+// ============================================================================
+
+/**
+ * Normalises a message role to one of the three context summary roles.
+ *
+ * The session DB can contain 'tool_result', 'system', and other roles.
+ * For context injection, we collapse these to the three roles the receiving
+ * agent cares about: user, assistant, tool.
+ *
+ * @param role - The raw message role from the DB.
+ * @returns Normalised role.
+ */
+export function normaliseRole(role: string): ContextMessage['role'] {
+  if (role === 'user') return 'user';
+  if (role === 'assistant') return 'assistant';
+  return 'tool';
+}
+
+/**
+ * Converts a raw input message to a scrubbed ContextMessage preview.
+ *
+ * The scrub engine is always applied (FULL_SCRUB_MASK). After scrubbing,
+ * the content is truncated to MESSAGE_PREVIEW_MAX_CHARS.
+ *
+ * @param message - Raw input message.
+ * @returns Scrubbed ContextMessage preview.
+ */
+export function buildMessagePreview(message: SummarizerInputMessage): ContextMessage {
+  // Apply full scrub mask (secrets + file_paths + commands)
+  const scrubbed = scrubMessage(
+    { role: message.role, content: message.content ?? '' },
+    FULL_SCRUB_MASK
+  );
+
+  const preview = scrubbed.content.slice(0, MESSAGE_PREVIEW_MAX_CHARS).trim();
+
+  return {
+    role: normaliseRole(message.role),
+    preview,
+  };
+}
+
+// ============================================================================
+// Task detection
+// ============================================================================
+
+/**
+ * Detects the "current task" from the message array.
+ *
+ * Heuristic (in priority order):
+ *   1. taskOverride from SummarizerInput (caller explicitly sets the task)
+ *   2. The goal from the first tool_call in the session (what was the agent
+ *      initially asked to do?)
+ *   3. The last user message (what is the user asking right now?)
+ *   4. Fallback: "Session in progress"
+ *
+ * WHY first tool_call goal: The very first tool call captures the initial
+ * task description more reliably than any single message. Users often write
+ * one-line messages, but the first tool call's description is typically the
+ * most complete statement of the task.
+ *
+ * @param messages - Input messages in chronological order.
+ * @param taskOverride - Optional caller-supplied task description.
+ * @returns Scrubbed, truncated task description.
+ */
+export function detectCurrentTask(
+  messages: SummarizerInputMessage[],
+  taskOverride?: string
+): string {
+  if (taskOverride && taskOverride.trim().length > 0) {
+    return taskOverride.trim().slice(0, MESSAGE_PREVIEW_MAX_CHARS);
+  }
+
+  // Look for the first user message (initial task statement)
+  const firstUserMessage = messages.find((m) => m.role === 'user');
+  if (firstUserMessage) {
+    const scrubbed = scrubMessage(
+      { role: 'user', content: firstUserMessage.content ?? '' },
+      FULL_SCRUB_MASK
+    );
+    const preview = scrubbed.content.trim().slice(0, MESSAGE_PREVIEW_MAX_CHARS);
+    if (preview.length > 0) return preview;
+  }
+
+  // Last user message (if different from first)
+  const lastUserMessage = [...messages].reverse().find((m) => m.role === 'user');
+  if (lastUserMessage && lastUserMessage !== firstUserMessage) {
+    const scrubbed = scrubMessage(
+      { role: 'user', content: lastUserMessage.content ?? '' },
+      FULL_SCRUB_MASK
+    );
+    const preview = scrubbed.content.trim().slice(0, MESSAGE_PREVIEW_MAX_CHARS);
+    if (preview.length > 0) return preview;
+  }
+
+  return 'Session in progress';
+}
+
+/**
+ * Detects open questions from the last user message.
+ *
+ * A message qualifies as an "open question" if it ends with '?' after trimming.
+ * This is a simple heuristic — false positives (non-questions ending in ?) are
+ * acceptable; the section will simply contain a statement rather than a question.
+ *
+ * @param messages - Input messages in chronological order.
+ * @returns Scrubbed question preview, or empty string if none found.
+ */
+export function detectOpenQuestion(messages: SummarizerInputMessage[]): string {
+  const lastUserMessage = [...messages].reverse().find((m) => m.role === 'user');
+  if (!lastUserMessage) return '';
+
+  const scrubbed = scrubMessage(
+    { role: 'user', content: lastUserMessage.content ?? '' },
+    FULL_SCRUB_MASK
+  );
+
+  const trimmed = scrubbed.content.trim();
+  if (trimmed.endsWith('?')) {
+    return trimmed.slice(0, MESSAGE_PREVIEW_MAX_CHARS);
+  }
+
+  return '';
+}
+
+// ============================================================================
+// Summary markdown builder
+// ============================================================================
+
+/**
+ * Builds the fixed-template summary markdown from task, file refs, and open question.
+ *
+ * Template:
+ * ```markdown
+ * ## Current task
+ * <task>
+ *
+ * ## Recently touched
+ * - <path1> (relevance 0.95)
+ * - <path2> (relevance 0.72)
+ *
+ * ## Open questions
+ * <question or "(none)">
+ * ```
+ *
+ * WHY a fixed template:
+ *   Fixed templates are predictable for all 11 agents (which have different
+ *   system prompt parsing styles). A consistent structure means the agent
+ *   injection system can be tested and verified once and works everywhere.
+ *
+ * @param task - Current task description (scrubbed).
+ * @param fileRefs - File refs sorted descending by relevance.
+ * @param openQuestion - Open question from the last user message, or empty.
+ * @returns Assembled markdown string.
+ */
+export function buildSummaryMarkdown(
+  task: string,
+  fileRefs: ContextFileRef[],
+  openQuestion: string
+): string {
+  const lines: string[] = [];
+
+  lines.push('## Current task');
+  lines.push(task);
+  lines.push('');
+
+  lines.push('## Recently touched');
+  if (fileRefs.length === 0) {
+    lines.push('(no files tracked yet)');
+  } else {
+    for (const ref of fileRefs) {
+      lines.push(`- ${ref.path} (relevance ${ref.relevance.toFixed(2)})`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Open questions');
+  lines.push(openQuestion.length > 0 ? openQuestion : '(none)');
+
+  return lines.join('\n');
+}
+
+// ============================================================================
+// File ref builder
+// ============================================================================
+
+/**
+ * Builds a deduplicated, relevance-sorted file ref array from the input messages.
+ *
+ * Steps:
+ *   1. Scan each message with a toolCall for file paths (using extractPathsFromToolCall).
+ *   2. Track per-path: last touch timestamp + mention count.
+ *   3. Compute relevance for each path using computeRelevance().
+ *   4. Sort descending by relevance.
+ *   5. Return deduplicated result.
+ *
+ * @param messages - Input messages in chronological order.
+ * @param now - Reference timestamp for recency computation (injectable for tests).
+ * @returns Deduplicated file refs sorted descending by relevance.
+ */
+export function buildFileRefs(
+  messages: SummarizerInputMessage[],
+  now: number = Date.now()
+): ContextFileRef[] {
+  // Accumulate per-path data: lastTouchedAt + mentionCount
+  const pathData = new Map<string, { lastTouchedAt: string; mentionCount: number }>();
+
+  for (const message of messages) {
+    if (!message.toolCall) continue;
+
+    // Parse args if string
+    let args: Record<string, unknown>;
+    if (typeof message.toolCall.arguments === 'string') {
+      try {
+        args = JSON.parse(message.toolCall.arguments) as Record<string, unknown>;
+      } catch {
+        // Invalid JSON arguments — skip this tool call
+        continue;
+      }
+    } else {
+      args = message.toolCall.arguments;
+    }
+
+    const paths = extractPathsFromToolCall(message.toolCall.name, args);
+    const touchedAt = new Date(now).toISOString(); // Use now as the touch time for summarizer
+
+    for (const path of paths) {
+      const existing = pathData.get(path);
+      if (existing) {
+        existing.mentionCount += 1;
+        // Keep the most recent touch time
+        existing.lastTouchedAt = touchedAt;
+      } else {
+        pathData.set(path, { lastTouchedAt: touchedAt, mentionCount: 1 });
+      }
+    }
+  }
+
+  if (pathData.size === 0) return [];
+
+  const maxMentions = Math.max(...[...pathData.values()].map((d) => d.mentionCount));
+
+  const refs: ContextFileRef[] = [...pathData.entries()].map(([path, data]) => ({
+    path,
+    lastTouchedAt: data.lastTouchedAt,
+    relevance: computeRelevance(data.lastTouchedAt, data.mentionCount, maxMentions, now),
+  }));
+
+  // Sort descending by relevance, then alphabetically by path for determinism
+  refs.sort((a, b) => {
+    const relDiff = b.relevance - a.relevance;
+    return relDiff !== 0 ? relDiff : a.path.localeCompare(b.path);
+  });
+
+  return refs;
+}
+
+// ============================================================================
+// Main summarizer
+// ============================================================================
+
+/**
+ * Builds a structured context memory summary from a session message array.
+ *
+ * This is the main entry point. It is:
+ *   - PURE: no I/O, no mutations, no network calls.
+ *   - DETERMINISTIC: same input → same output (modulo `now` parameter).
+ *   - SAFE: all message content is scrubbed before appearing in the output.
+ *
+ * @param input - The summarizer input containing messages and budget.
+ * @param now - Reference timestamp for recency computation (injectable for tests).
+ * @returns A SummarizerOutput ready to write to agent_context_memory.
+ *
+ * @throws {RangeError} When tokenBudget is outside [TOKEN_BUDGET_MIN, TOKEN_BUDGET_MAX].
+ *
+ * @example
+ * ```ts
+ * const output = summarize({
+ *   messages: sessionMessages,
+ *   tokenBudget: 3000,
+ * });
+ * // output.summaryMarkdown — markdown injected into new agent
+ * // output.fileRefs — top-relevance files to mention
+ * // output.recentMessages — last 20 scrubbed previews
+ * ```
+ */
+export function summarize(input: SummarizerInput, now: number = Date.now()): SummarizerOutput {
+  const tokenBudget = Math.min(
+    TOKEN_BUDGET_MAX,
+    Math.max(TOKEN_BUDGET_MIN, input.tokenBudget ?? TOKEN_BUDGET_DEFAULT)
+  );
+
+  // Step 1: Build file refs from tool calls across ALL messages (full history gives better signal)
+  const fileRefs = buildFileRefs(input.messages, now);
+
+  // Step 2: Take last CONTEXT_MESSAGE_LIMIT messages for preview (most recent first, then reverse)
+  const recentRaw = input.messages.slice(-CONTEXT_MESSAGE_LIMIT);
+  const recentMessages: ContextMessage[] = recentRaw.map(buildMessagePreview);
+
+  // Step 3: Detect task + open question from the full message array
+  const task = detectCurrentTask(input.messages, input.taskOverride);
+  const openQuestion = detectOpenQuestion(input.messages);
+
+  // Step 4: Build summary markdown
+  let summaryMarkdown = buildSummaryMarkdown(task, fileRefs, openQuestion);
+
+  // Step 5: Enforce token budget — truncate summaryMarkdown if it overflows.
+  // WHY only truncate summaryMarkdown, not fileRefs/recentMessages:
+  //   fileRefs and recentMessages are stored separately in the DB and injected
+  //   independently by buildInjectionPrompt(). The budget enforcement here applies
+  //   only to the summaryMarkdown column.
+  const estimatedTokens = estimateTokens(summaryMarkdown);
+  if (estimatedTokens > tokenBudget) {
+    // Truncate to approximate character count that fits the budget.
+    // Heuristic: chars per token ≈ 4 (conservative for code-heavy content).
+    const maxChars = tokenBudget * 4;
+    summaryMarkdown = summaryMarkdown.slice(0, maxChars).trimEnd();
+    // Append truncation notice so the receiving agent knows the summary is cut
+    summaryMarkdown += '\n\n*(summary truncated to fit token budget)*';
+  }
+
+  return {
+    summaryMarkdown,
+    fileRefs,
+    recentMessages,
+    estimatedTokens: estimateTokens(summaryMarkdown),
+  };
+}
+
+// ============================================================================
+// Injection prompt builder
+// ============================================================================
+
+/**
+ * Builds the system-role injection prompt from an AgentContextMemory record.
+ *
+ * This is what the agent factory injects as the system-role startup message
+ * when the user switches focus to a new agent in the group.
+ *
+ * Structure:
+ * ```
+ * [Styrby Context Sync — cross-agent handoff]
+ *
+ * <summaryMarkdown>
+ *
+ * ## Files you may need
+ * - /path/to/file.ts
+ * - /path/to/other.ts
+ *
+ * ## Recent conversation (last N messages)
+ * **user**: <preview>
+ * **assistant**: <preview>
+ * ...
+ * ```
+ *
+ * WHY a preamble header:
+ *   All 11 supported agents are instructed to treat `[...]` headers as
+ *   Styrby system metadata (this is documented in their startup prompts).
+ *   The header makes it unambiguous that this section is injected context,
+ *   not part of the user's actual task description.
+ *
+ * @param memory - The context memory record to inject.
+ * @returns A ContextInjectionPayload ready to send to the agent factory.
+ *
+ * @example
+ * ```ts
+ * const payload = buildInjectionPrompt(memory);
+ * agentFactory.setSystemContext(payload.systemPrompt);
+ * ```
+ */
+export function buildInjectionPrompt(memory: AgentContextMemory): ContextInjectionPayload {
+  const lines: string[] = [];
+
+  // Preamble
+  lines.push('[Styrby Context Sync — cross-agent handoff]');
+  lines.push('');
+
+  // Summary markdown (already scrubbed and budget-enforced)
+  lines.push(memory.summaryMarkdown);
+  lines.push('');
+
+  // File refs — filter to relevance ≥ INJECTION_MIN_RELEVANCE
+  const includedFileRefs = memory.fileRefs.filter(
+    (ref) => ref.relevance >= INJECTION_MIN_RELEVANCE
+  );
+  if (includedFileRefs.length > 0) {
+    lines.push('## Files you may need');
+    for (const ref of includedFileRefs) {
+      lines.push(`- ${ref.path}`);
+    }
+    lines.push('');
+  }
+
+  // Recent messages
+  if (memory.recentMessages.length > 0) {
+    lines.push(`## Recent conversation (last ${memory.recentMessages.length} messages)`);
+    for (const msg of memory.recentMessages) {
+      const roleLabel = msg.role === 'tool' ? 'tool' : msg.role;
+      lines.push(`**${roleLabel}**: ${msg.preview}`);
+    }
+  }
+
+  const systemPrompt = lines.join('\n');
+
+  return {
+    systemPrompt,
+    includedFileRefs,
+    messageCount: memory.recentMessages.length,
+    estimatedTokens: estimateTokens(systemPrompt),
+  };
+}

--- a/packages/styrby-shared/src/context-sync/types.ts
+++ b/packages/styrby-shared/src/context-sync/types.ts
@@ -1,0 +1,409 @@
+/**
+ * Context Sync — Shared Types (Phase 3.5)
+ *
+ * Type definitions for cross-agent context synchronization. These types are
+ * consumed by styrby-cli (context commands), styrby-web (focus API extension),
+ * and future styrby-mobile surfaces.
+ *
+ * WHY a separate sub-module:
+ *   Context sync involves scrubbing (Phase 3.3 engine), session groups (Phase 3.1),
+ *   and its own DB table (migration 039). Keeping types in a dedicated module
+ *   prevents circular imports and keeps the barrel index lean.
+ *
+ * GDPR Art. 5(1)(c) data minimisation:
+ *   All types that carry message content (ContextMessage) carry SCRUBBED previews
+ *   only. Raw content is never surfaced through these types.
+ *
+ * SOC2 CC6.1:
+ *   The token_budget field is enforced server-side (max 8000). Client-side
+ *   types mirror this via the TOKEN_BUDGET_MAX constant.
+ *
+ * @module context-sync/types
+ */
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Default number of recent messages captured in context memory.
+ *
+ * WHY 20: Covers approximately one task cycle for all 11 supported agents.
+ * Beyond 20, token budget limits become the binding constraint.
+ */
+export const CONTEXT_MESSAGE_LIMIT = 20 as const;
+
+/**
+ * Default token budget for memory injection into a new agent.
+ *
+ * WHY 4000: ~3× the average message size. Fits comfortably in the context
+ * window of all supported agents without dominating available tokens.
+ */
+export const TOKEN_BUDGET_DEFAULT = 4000 as const;
+
+/**
+ * Server-side maximum token budget (enforced in API and summarizer).
+ *
+ * WHY 8000: Above this, memory injection consumes a meaningful fraction of
+ * Claude Haiku's 8192-token context window, leaving no room for the actual
+ * task. Cap prevents denial-of-service via oversized memories.
+ */
+export const TOKEN_BUDGET_MAX = 8000 as const;
+
+/**
+ * Minimum allowed token budget.
+ *
+ * WHY 100: Below 100 tokens the summary_markdown header alone may be truncated,
+ * making the injected context useless. The summarizer rejects budgets below this.
+ */
+export const TOKEN_BUDGET_MIN = 100 as const;
+
+/**
+ * Maximum characters captured per message preview.
+ *
+ * WHY 200: Long enough for the receiver to understand what was being asked/answered;
+ * short enough to stay well under the token budget even for 20 messages.
+ */
+export const MESSAGE_PREVIEW_MAX_CHARS = 200 as const;
+
+/**
+ * Maximum relevance score for a file reference.
+ * Scores are normalised to [0, 1.0].
+ */
+export const FILE_REF_RELEVANCE_MAX = 1.0 as const;
+
+// ============================================================================
+// File reference
+// ============================================================================
+
+/**
+ * A file touched during the session, with relevance metadata.
+ *
+ * Relevance is a normalised [0, 1.0] score combining:
+ *   - Recency (exponential decay from lastTouchedAt to now)
+ *   - Mention frequency (how many messages reference this path)
+ *
+ * WHY combined score: Recency alone over-weights files touched once at session
+ * start. Frequency alone over-weights noisy output files written on every
+ * build. The combined score surfaces files that were recently AND repeatedly
+ * touched — which are the files the next agent needs to know about.
+ */
+export interface ContextFileRef {
+  /** Absolute filesystem path (scrubbed: /Users/alice → [PATH]/file.ts not stored). */
+  path: string;
+
+  /** ISO 8601 timestamp of the last tool_call that touched this file. */
+  lastTouchedAt: string;
+
+  /**
+   * Normalised relevance score in [0, 1.0].
+   * Higher = more relevant to the current task; injected first.
+   */
+  relevance: number;
+}
+
+// ============================================================================
+// Message preview
+// ============================================================================
+
+/**
+ * A scrubbed preview of a single session message.
+ *
+ * SECURITY: The `preview` field MUST contain only scrubbed content.
+ * The summarizer calls the Phase 3.3 scrub engine before populating
+ * this field. Raw content must never appear here.
+ *
+ * GDPR Art. 5(1)(c): Only the first MESSAGE_PREVIEW_MAX_CHARS characters
+ * of each message are stored — minimising personal data retention.
+ */
+export interface ContextMessage {
+  /**
+   * Message role — determines which agent or user produced the message.
+   * 'tool' covers tool_call + tool_result pairs (collapsed for brevity).
+   */
+  role: 'user' | 'assistant' | 'tool';
+
+  /**
+   * First MESSAGE_PREVIEW_MAX_CHARS characters of the message content,
+   * after secrets / file-paths / commands have been scrubbed.
+   */
+  preview: string;
+}
+
+// ============================================================================
+// Context memory record (mirrors agent_context_memory table)
+// ============================================================================
+
+/**
+ * A context memory record as stored in `agent_context_memory`.
+ *
+ * This is the full DB-mirror shape — all fields present. The API may
+ * omit or transform fields before surfacing to CLI callers; see
+ * ContextMemorySummary for the read-optimised view.
+ */
+export interface AgentContextMemory {
+  /** UUID primary key. */
+  id: string;
+
+  /** UUID of the session group this memory belongs to. */
+  sessionGroupId: string;
+
+  /**
+   * Condensed project state in Markdown.
+   *
+   * Fixed template:
+   * ```markdown
+   * ## Current task
+   * <derived from first tool_call goal + last user message>
+   *
+   * ## Recently touched
+   * - path/to/file.ts (relevance 0.95)
+   * - path/to/other.ts (relevance 0.72)
+   *
+   * ## Open questions
+   * <last user message if it ends with '?', else empty>
+   * ```
+   */
+  summaryMarkdown: string;
+
+  /**
+   * File references sorted descending by relevance.
+   * Injected after the summary to give the new agent immediate file context.
+   */
+  fileRefs: ContextFileRef[];
+
+  /**
+   * Last N message previews (scrubbed) in chronological order.
+   * N ≤ CONTEXT_MESSAGE_LIMIT.
+   */
+  recentMessages: ContextMessage[];
+
+  /**
+   * Maximum tokens this memory may consume when injected.
+   * Enforced at write time (100 ≤ tokenBudget ≤ TOKEN_BUDGET_MAX).
+   */
+  tokenBudget: number;
+
+  /**
+   * Optimistic locking counter.
+   * Incremented by 1 on every successful sync write.
+   */
+  version: number;
+
+  /** ISO 8601 timestamp when the record was created. */
+  createdAt: string;
+
+  /** ISO 8601 timestamp of the last successful sync. */
+  updatedAt: string;
+}
+
+// ============================================================================
+// Summarizer input / output
+// ============================================================================
+
+/**
+ * Raw message as fed into the summarizer.
+ *
+ * This is a superset of ContextMessage — it includes the full content string
+ * (which the summarizer scrubs before truncating to a preview) and optional
+ * tool_call data for file-ref extraction.
+ *
+ * WHY not SessionMessage from @styrby/shared types.ts:
+ *   The summarizer is a pure function with no Supabase dependency.
+ *   Accepting a narrow interface keeps it decoupled from the DB model.
+ */
+export interface SummarizerInputMessage {
+  /** Message role. */
+  role: 'user' | 'assistant' | 'tool' | 'tool_result' | string;
+
+  /** Full raw message content. Secrets/paths/commands will be scrubbed. */
+  content: string;
+
+  /**
+   * Optional tool call data. When present, the summarizer scans `arguments`
+   * for file path strings to populate file_refs.
+   *
+   * WHY optional: not all messages are tool calls; scanning is skipped for
+   * user/assistant messages.
+   */
+  toolCall?: {
+    /** Tool name, e.g. 'str_replace_editor', 'bash', 'read_file'. */
+    name: string;
+
+    /**
+     * Tool arguments as a JSON string or already-parsed object.
+     * The summarizer parses it if it's a string.
+     */
+    arguments: string | Record<string, unknown>;
+  };
+}
+
+/**
+ * Input to the deterministic context summarizer.
+ *
+ * WHY not accepting the DB record directly:
+ *   The summarizer is called both on fresh messages (CLI auto-sync) and when
+ *   building an injection prompt (focus-change handler). Accepting a plain
+ *   input struct keeps it decoupled from whether the caller has a DB record.
+ */
+export interface SummarizerInput {
+  /**
+   * Messages to summarize — typically the last CONTEXT_MESSAGE_LIMIT×2 messages
+   * from the current session to give the summarizer enough signal. The output
+   * is capped to CONTEXT_MESSAGE_LIMIT.
+   */
+  messages: SummarizerInputMessage[];
+
+  /**
+   * Maximum tokens the output may occupy when injected.
+   * Must be within [TOKEN_BUDGET_MIN, TOKEN_BUDGET_MAX].
+   */
+  tokenBudget?: number;
+
+  /**
+   * Optional seed for the "current task" heading.
+   * When provided, overrides the task-detection heuristic.
+   * Used by `styrby context import --task "..."`.
+   */
+  taskOverride?: string;
+}
+
+/**
+ * Output from the deterministic context summarizer.
+ *
+ * All fields are safe to write directly to agent_context_memory without
+ * additional scrubbing (the summarizer applies the scrub engine internally).
+ */
+export interface SummarizerOutput {
+  /** Assembled Markdown summary within token_budget. */
+  summaryMarkdown: string;
+
+  /**
+   * Deduplicated file refs sorted descending by relevance.
+   * Empty array if no tool_call file references were found.
+   */
+  fileRefs: ContextFileRef[];
+
+  /**
+   * Scrubbed message previews (chronological, length ≤ CONTEXT_MESSAGE_LIMIT).
+   */
+  recentMessages: ContextMessage[];
+
+  /**
+   * Estimated token count of summaryMarkdown.
+   * Uses the words×1.3 heuristic (same as styrby-shared tokenizers fallback).
+   */
+  estimatedTokens: number;
+}
+
+// ============================================================================
+// CLI command types
+// ============================================================================
+
+/**
+ * Options for `styrby context show --group <groupId>`.
+ *
+ * Dumps the current context memory as markdown + file_refs JSON to stdout.
+ */
+export interface ContextShowOptions {
+  /** UUID of the session group. */
+  groupId: string;
+
+  /** When true, output raw JSON instead of pretty-printed markdown. */
+  json?: boolean;
+}
+
+/**
+ * Options for `styrby context sync --group <groupId>`.
+ *
+ * Recomputes the context memory from recent session messages and writes it back.
+ */
+export interface ContextSyncOptions {
+  /** UUID of the session group. */
+  groupId: string;
+
+  /**
+   * Maximum token budget for the output memory.
+   * Capped at TOKEN_BUDGET_MAX server-side.
+   */
+  tokenBudget?: number;
+}
+
+/**
+ * Options for `styrby context export --session <sessionId>`.
+ *
+ * Extracts the context memory from a single session and writes to stdout.
+ */
+export interface ContextExportOptions {
+  /** UUID of the session to export from. */
+  sessionId: string;
+
+  /** When true, output raw JSON instead of pretty-printed markdown. */
+  json?: boolean;
+}
+
+/**
+ * Options for `styrby context import --session <target> --from <source>`.
+ *
+ * Injects another session's memory into the target session's group.
+ */
+export interface ContextImportOptions {
+  /** UUID of the target session (receives the injected memory). */
+  sessionId: string;
+
+  /** UUID of the source session (memory is copied from here). */
+  fromSessionId: string;
+
+  /**
+   * Optional task description to override the imported memory's "Current task"
+   * heading. Useful when importing across different task contexts.
+   */
+  task?: string;
+}
+
+// ============================================================================
+// Injection payload
+// ============================================================================
+
+/**
+ * The structured prompt injected into the new agent on focus change.
+ *
+ * This is what the agent factory receives as its system-role startup context.
+ * It is built by buildInjectionPrompt() from an AgentContextMemory record.
+ */
+export interface ContextInjectionPayload {
+  /**
+   * System-role prompt content ready to send to the agent.
+   *
+   * Format:
+   * ```
+   * [Styrby Context Sync — cross-agent handoff]
+   *
+   * <summaryMarkdown>
+   *
+   * ## Files you may need
+   * - /path/to/file.ts
+   * - /path/to/other.ts
+   *
+   * ## Recent conversation (last N messages)
+   * **user**: <preview>
+   * **assistant**: <preview>
+   * ```
+   */
+  systemPrompt: string;
+
+  /**
+   * The file refs included in the injection (for logging / audit).
+   * Subset of AgentContextMemory.fileRefs filtered to relevance ≥ 0.5.
+   */
+  includedFileRefs: ContextFileRef[];
+
+  /**
+   * Number of recent messages included in the injection.
+   * Always ≤ CONTEXT_MESSAGE_LIMIT.
+   */
+  messageCount: number;
+
+  /** Estimated token count of systemPrompt. */
+  estimatedTokens: number;
+}

--- a/packages/styrby-shared/src/index.ts
+++ b/packages/styrby-shared/src/index.ts
@@ -97,3 +97,31 @@ export * from './feedback/index.js';
 // mobile consumers — which use moduleResolution: "node" and can't follow
 // package.json exports subpaths — can import them directly from the root.)
 export type * from './session-replay/types.js';
+
+// Phase 3.5 — Cross-agent context sync types (runtime summarizer stays at
+// subpath '@styrby/shared/context-sync' for tree-shaking — it imports the
+// scrub engine regex patterns which add bundle weight). Types re-exported here
+// so mobile consumers can import them from the root.
+// Constants also re-exported: TOKEN_BUDGET_DEFAULT etc. are pure number literals
+// with zero bundle weight.
+export type {
+  ContextFileRef,
+  ContextMessage,
+  AgentContextMemory,
+  SummarizerInput,
+  SummarizerInputMessage,
+  SummarizerOutput,
+  ContextShowOptions,
+  ContextSyncOptions,
+  ContextExportOptions,
+  ContextImportOptions,
+  ContextInjectionPayload,
+} from './context-sync/types.js';
+export {
+  CONTEXT_MESSAGE_LIMIT,
+  TOKEN_BUDGET_DEFAULT,
+  TOKEN_BUDGET_MAX,
+  TOKEN_BUDGET_MIN,
+  MESSAGE_PREVIEW_MAX_CHARS,
+  FILE_REF_RELEVANCE_MAX,
+} from './context-sync/types.js';

--- a/packages/styrby-shared/src/session-replay/scrub.ts
+++ b/packages/styrby-shared/src/session-replay/scrub.ts
@@ -178,7 +178,13 @@ const ABSOLUTE_PATH_PATTERN = /(?:\/(?:Users|home|root|var|tmp|etc|opt|usr|srv)[
  * WHY capture the $: Stripping the prompt entirely would remove context that
  * tells the viewer "this was a shell command invocation".
  */
-const SHELL_COMMAND_PATTERN = /^(\s*\$\s+).+$/gm;
+// WHY [ \t] instead of \s: Using \s here would create a ReDoS vulnerability
+// (CWE-1333). The \s class matches newlines, so in multiline (/m) mode the
+// engine can explore exponentially many ways to split horizontal-whitespace
+// sequences across alternations. Restricting to [ \t] (horizontal whitespace
+// only) eliminates the catastrophic-backtracking vector while still matching
+// every realistic shell-prompt format. (CodeQL: js/redos)
+const SHELL_COMMAND_PATTERN = /^([ \t]*\$[ \t]+).+$/gm;
 
 // ============================================================================
 // Core scrub function

--- a/packages/styrby-shared/tests/context-sync/summarizer.test.ts
+++ b/packages/styrby-shared/tests/context-sync/summarizer.test.ts
@@ -1,0 +1,805 @@
+/**
+ * Context Sync — Summarizer Tests (Phase 3.5)
+ *
+ * Comprehensive test suite covering all exported functions from
+ * packages/styrby-shared/src/context-sync/summarizer.ts.
+ *
+ * Test strategy:
+ *   - estimateTokens: empty string, single word, multi-word, code-heavy string
+ *   - extractPathsFromString: Unix paths detected, non-paths ignored, dedup
+ *   - extractPathsFromToolCall: allowlisted tools, non-allowlisted tools, arg key priority
+ *   - computeRelevance: age-decay, frequency normalisation, clamp [0, 1]
+ *   - normaliseRole: all five DB roles → three output roles
+ *   - buildMessagePreview: scrubbing applied, truncation at 200 chars, scrub removes secrets
+ *   - detectCurrentTask: taskOverride wins, first user message used, fallback
+ *   - detectOpenQuestion: question mark detection, non-question returns empty, last user message
+ *   - buildSummaryMarkdown: template structure, empty fileRefs, empty openQuestion
+ *   - buildFileRefs: path extraction from tool calls, dedup, sorted by relevance
+ *   - summarize: full integration (deterministic output, token budget enforcement,
+ *                scrub integration, empty input, budget clamp)
+ *   - buildInjectionPrompt: preamble present, low-relevance refs filtered,
+ *                           message count correct, estimatedTokens > 0
+ *
+ * WHY: The summarizer is the core of Phase 3.5. Bugs here leak secrets into
+ * agent context windows across user agents, or produce malformed injection
+ * prompts that confuse the receiving agent. Every branch must be exercised.
+ *
+ * @module tests/context-sync/summarizer.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  estimateTokens,
+  extractPathsFromString,
+  extractPathsFromToolCall,
+  computeRelevance,
+  normaliseRole,
+  buildMessagePreview,
+  detectCurrentTask,
+  detectOpenQuestion,
+  buildSummaryMarkdown,
+  buildFileRefs,
+  summarize,
+  buildInjectionPrompt,
+} from '../../src/context-sync/summarizer';
+import {
+  TOKEN_BUDGET_DEFAULT,
+  TOKEN_BUDGET_MAX,
+  TOKEN_BUDGET_MIN,
+  CONTEXT_MESSAGE_LIMIT,
+  MESSAGE_PREVIEW_MAX_CHARS,
+} from '../../src/context-sync/types';
+import type {
+  SummarizerInputMessage,
+  AgentContextMemory,
+} from '../../src/context-sync/types';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build a minimal SummarizerInputMessage for test purposes.
+ */
+function userMsg(content: string): SummarizerInputMessage {
+  return { role: 'user', content };
+}
+
+function assistantMsg(content: string): SummarizerInputMessage {
+  return { role: 'assistant', content };
+}
+
+function toolMsg(
+  content: string,
+  toolName: string,
+  args: Record<string, unknown>
+): SummarizerInputMessage {
+  return {
+    role: 'tool',
+    content,
+    toolCall: { name: toolName, arguments: args },
+  };
+}
+
+/**
+ * Fixed timestamp used to make recency-based tests deterministic.
+ * All "now" references in the test suite use this value.
+ */
+const FIXED_NOW = new Date('2026-04-22T12:00:00.000Z').getTime();
+
+/**
+ * Build a minimal AgentContextMemory record for injection prompt tests.
+ */
+function buildMemory(overrides: Partial<AgentContextMemory> = {}): AgentContextMemory {
+  return {
+    id: 'mem-001',
+    sessionGroupId: 'group-001',
+    summaryMarkdown:
+      '## Current task\nRefactor auth middleware\n\n## Recently touched\n- [PATH]/auth.ts (relevance 0.95)\n\n## Open questions\n(none)',
+    fileRefs: [
+      { path: '/Users/alice/project/src/auth.ts', lastTouchedAt: new Date(FIXED_NOW - 60_000).toISOString(), relevance: 0.95 },
+      { path: '/Users/alice/project/src/middleware.ts', lastTouchedAt: new Date(FIXED_NOW - 120_000).toISOString(), relevance: 0.72 },
+      { path: '/Users/alice/project/src/legacy.ts', lastTouchedAt: new Date(FIXED_NOW - 7_200_000).toISOString(), relevance: 0.18 },
+    ],
+    recentMessages: [
+      { role: 'user', preview: 'Refactor auth middleware to use the new token format' },
+      { role: 'assistant', preview: 'Sure, I will start with the middleware file.' },
+    ],
+    tokenBudget: TOKEN_BUDGET_DEFAULT,
+    version: 1,
+    createdAt: new Date(FIXED_NOW).toISOString(),
+    updatedAt: new Date(FIXED_NOW).toISOString(),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// estimateTokens
+// ============================================================================
+
+describe('estimateTokens', () => {
+  it('returns 0 for empty string', () => {
+    expect(estimateTokens('')).toBe(0);
+  });
+
+  it('returns 0 for whitespace-only string', () => {
+    expect(estimateTokens('   ')).toBe(0);
+  });
+
+  it('estimates single word', () => {
+    // 1 word / 1.3 = 0.77 → ceil = 1
+    expect(estimateTokens('hello')).toBe(1);
+  });
+
+  it('estimates multi-word string', () => {
+    // "Hello world foo bar" = 4 words / 1.3 = 3.08 → ceil = 4
+    expect(estimateTokens('Hello world foo bar')).toBe(4);
+  });
+
+  it('returns ceiling not floor', () => {
+    // 2 words / 1.3 = 1.54 → ceil = 2
+    expect(estimateTokens('hello world')).toBe(2);
+  });
+
+  it('handles code-heavy string with multiple tokens per word', () => {
+    const code = 'const x = require("path"); const y = require("fs"); x.join(y);';
+    expect(estimateTokens(code)).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================================
+// extractPathsFromString
+// ============================================================================
+
+describe('extractPathsFromString', () => {
+  it('detects /Users/ paths', () => {
+    const paths = extractPathsFromString('Error in /Users/alice/projects/app/src/auth.ts line 42');
+    expect(paths).toContain('/Users/alice/projects/app/src/auth.ts');
+  });
+
+  it('detects /home/ paths', () => {
+    const paths = extractPathsFromString('Reading /home/bob/projects/api/index.ts');
+    expect(paths).toContain('/home/bob/projects/api/index.ts');
+  });
+
+  it('detects /tmp/ paths', () => {
+    const paths = extractPathsFromString('Wrote /tmp/styrby-session-output.json');
+    expect(paths).toContain('/tmp/styrby-session-output.json');
+  });
+
+  it('ignores relative paths', () => {
+    const paths = extractPathsFromString('See ./src/auth.ts for details');
+    expect(paths).toHaveLength(0);
+  });
+
+  it('ignores API URL paths', () => {
+    // /api/sessions/123 is an URL path, not a file path
+    // (It doesn't start with /Users|home|root|var|tmp|etc|opt|usr|srv)
+    const paths = extractPathsFromString('POST /api/sessions/123 returned 200');
+    expect(paths).toHaveLength(0);
+  });
+
+  it('deduplicates identical paths', () => {
+    const paths = extractPathsFromString(
+      '/Users/alice/app/auth.ts was read and /Users/alice/app/auth.ts was written'
+    );
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toBe('/Users/alice/app/auth.ts');
+  });
+
+  it('returns multiple distinct paths', () => {
+    const paths = extractPathsFromString(
+      'Read /Users/alice/app/auth.ts and /Users/alice/app/middleware.ts'
+    );
+    expect(paths).toHaveLength(2);
+  });
+
+  it('returns empty array for string with no paths', () => {
+    expect(extractPathsFromString('No file paths here')).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// extractPathsFromToolCall
+// ============================================================================
+
+describe('extractPathsFromToolCall', () => {
+  it('extracts path from well-known arg key "path"', () => {
+    const paths = extractPathsFromToolCall('read_file', {
+      path: '/Users/alice/src/auth.ts',
+    });
+    expect(paths).toContain('/Users/alice/src/auth.ts');
+  });
+
+  it('extracts path from "file_path" arg key', () => {
+    const paths = extractPathsFromToolCall('write_file', {
+      file_path: '/Users/alice/src/index.ts',
+      content: 'export default 42;',
+    });
+    expect(paths).toContain('/Users/alice/src/index.ts');
+  });
+
+  it('extracts path from "command" arg for bash', () => {
+    const paths = extractPathsFromToolCall('bash', {
+      command: 'cat /Users/alice/src/main.ts | head -10',
+    });
+    expect(paths).toContain('/Users/alice/src/main.ts');
+  });
+
+  it('returns empty for non-allowlisted tool', () => {
+    const paths = extractPathsFromToolCall('unknown_tool_xyz', {
+      path: '/Users/alice/src/auth.ts',
+    });
+    expect(paths).toHaveLength(0);
+  });
+
+  it('handles JSON string arguments', () => {
+    // When toolCall.arguments is a JSON string, it should be parsed
+    // Note: this test exercises the summarizer's JSON.parse path
+    const paths = extractPathsFromToolCall('str_replace_editor', {
+      path: '/Users/alice/src/editor.ts',
+    });
+    expect(paths).toContain('/Users/alice/src/editor.ts');
+  });
+
+  it('deduplicates paths across multiple arg keys', () => {
+    const paths = extractPathsFromToolCall('edit_file', {
+      path: '/Users/alice/src/auth.ts',
+      file_path: '/Users/alice/src/auth.ts',
+    });
+    expect(paths).toHaveLength(1);
+  });
+
+  it('returns empty array when no paths in arguments', () => {
+    const paths = extractPathsFromToolCall('bash', {
+      command: 'echo hello world',
+    });
+    expect(paths).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// computeRelevance
+// ============================================================================
+
+describe('computeRelevance', () => {
+  it('returns 1.0 for a file touched right now with max mentions', () => {
+    const touchedAt = new Date(FIXED_NOW).toISOString();
+    const score = computeRelevance(touchedAt, 5, 5, FIXED_NOW);
+    // Recency = e^0 = 1.0, Frequency = 1.0 → combined = 1.0
+    expect(score).toBe(1.0);
+  });
+
+  it('returns lower score for file touched 30 minutes ago', () => {
+    const thirtyMinAgo = new Date(FIXED_NOW - 30 * 60 * 1000).toISOString();
+    const score = computeRelevance(thirtyMinAgo, 1, 1, FIXED_NOW);
+    // At half-life: recency ≈ 0.5, frequency = 1.0 → combined ≈ 0.65
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(1.0);
+    expect(score).toBeCloseTo(0.65, 1);
+  });
+
+  it('gives lower score for file with low mention frequency', () => {
+    const recentAt = new Date(FIXED_NOW).toISOString();
+    const highFreq = computeRelevance(recentAt, 5, 5, FIXED_NOW);
+    const lowFreq = computeRelevance(recentAt, 1, 5, FIXED_NOW);
+    expect(highFreq).toBeGreaterThan(lowFreq);
+  });
+
+  it('clamps result to [0, 1]', () => {
+    const veryOldAt = new Date(FIXED_NOW - 48 * 60 * 60 * 1000).toISOString();
+    const score = computeRelevance(veryOldAt, 0, 0, FIXED_NOW);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1.0);
+  });
+
+  it('handles zero totalMentions without division-by-zero', () => {
+    const touchedAt = new Date(FIXED_NOW).toISOString();
+    expect(() => computeRelevance(touchedAt, 0, 0, FIXED_NOW)).not.toThrow();
+  });
+
+  it('rounds to 2 decimal places', () => {
+    const touchedAt = new Date(FIXED_NOW - 15 * 60 * 1000).toISOString();
+    const score = computeRelevance(touchedAt, 2, 5, FIXED_NOW);
+    const decimal = score.toString().split('.')[1] ?? '';
+    expect(decimal.length).toBeLessThanOrEqual(2);
+  });
+});
+
+// ============================================================================
+// normaliseRole
+// ============================================================================
+
+describe('normaliseRole', () => {
+  it('maps "user" to "user"', () => {
+    expect(normaliseRole('user')).toBe('user');
+  });
+
+  it('maps "assistant" to "assistant"', () => {
+    expect(normaliseRole('assistant')).toBe('assistant');
+  });
+
+  it('maps "tool" to "tool"', () => {
+    expect(normaliseRole('tool')).toBe('tool');
+  });
+
+  it('maps "tool_result" to "tool"', () => {
+    expect(normaliseRole('tool_result')).toBe('tool');
+  });
+
+  it('maps "system" to "tool"', () => {
+    expect(normaliseRole('system')).toBe('tool');
+  });
+
+  it('maps unknown role to "tool"', () => {
+    expect(normaliseRole('function_call')).toBe('tool');
+  });
+});
+
+// ============================================================================
+// buildMessagePreview
+// ============================================================================
+
+describe('buildMessagePreview', () => {
+  it('scrubs secrets from message content', () => {
+    const msg: SummarizerInputMessage = {
+      role: 'assistant',
+      // WHY split across concat: GitHub push protection scans for literal sk_live_ strings.
+      // Using concat prevents false-positive secret detection on a clearly fake test value.
+      content: 'Found API key: ' + 'sk_li' + 've_ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    };
+    const preview = buildMessagePreview(msg);
+    expect(preview.preview).not.toContain('sk_live_');
+    expect(preview.preview).toContain('[REDACTED_SECRET]');
+  });
+
+  it('truncates to MESSAGE_PREVIEW_MAX_CHARS', () => {
+    const longContent = 'a'.repeat(MESSAGE_PREVIEW_MAX_CHARS + 100);
+    const msg: SummarizerInputMessage = { role: 'user', content: longContent };
+    const preview = buildMessagePreview(msg);
+    expect(preview.preview.length).toBeLessThanOrEqual(MESSAGE_PREVIEW_MAX_CHARS);
+  });
+
+  it('normalises role correctly', () => {
+    const msg: SummarizerInputMessage = { role: 'tool_result', content: 'File contents here' };
+    const preview = buildMessagePreview(msg);
+    expect(preview.role).toBe('tool');
+  });
+
+  it('handles empty content without throwing', () => {
+    const msg: SummarizerInputMessage = { role: 'user', content: '' };
+    expect(() => buildMessagePreview(msg)).not.toThrow();
+    expect(buildMessagePreview(msg).preview).toBe('');
+  });
+
+  it('preserves content under the character limit', () => {
+    const content = 'Short message here';
+    const msg: SummarizerInputMessage = { role: 'user', content };
+    const preview = buildMessagePreview(msg);
+    // Scrubbed but not truncated (no secrets, short content)
+    expect(preview.preview).toBe(content);
+  });
+});
+
+// ============================================================================
+// detectCurrentTask
+// ============================================================================
+
+describe('detectCurrentTask', () => {
+  it('returns taskOverride when provided', () => {
+    const msgs = [userMsg('Refactor auth'), assistantMsg('OK')];
+    const task = detectCurrentTask(msgs, 'Custom task override');
+    expect(task).toBe('Custom task override');
+  });
+
+  it('uses first user message when no override', () => {
+    const msgs = [
+      userMsg('Refactor the auth middleware to use JWT'),
+      assistantMsg('Starting now...'),
+      userMsg('Also fix the CORS headers'),
+    ];
+    const task = detectCurrentTask(msgs);
+    expect(task).toBe('Refactor the auth middleware to use JWT');
+  });
+
+  it('returns fallback when no user messages', () => {
+    const msgs = [assistantMsg('Ready.')];
+    const task = detectCurrentTask(msgs);
+    expect(task).toBe('Session in progress');
+  });
+
+  it('scrubs secrets from the task description', () => {
+    // WHY concat: prevents false-positive secret scanning on clearly fake test value.
+    const fakeKey = 'sk_li' + 've_ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const msgs = [userMsg(`Use token ${fakeKey} for auth`)];
+    const task = detectCurrentTask(msgs);
+    expect(task).not.toContain('sk_live_');
+  });
+
+  it('truncates taskOverride to MESSAGE_PREVIEW_MAX_CHARS', () => {
+    const longOverride = 'x'.repeat(MESSAGE_PREVIEW_MAX_CHARS + 50);
+    const task = detectCurrentTask([], longOverride);
+    expect(task.length).toBeLessThanOrEqual(MESSAGE_PREVIEW_MAX_CHARS);
+  });
+
+  it('ignores empty string taskOverride and falls through', () => {
+    const msgs = [userMsg('My actual task')];
+    const task = detectCurrentTask(msgs, '   ');
+    expect(task).toBe('My actual task');
+  });
+});
+
+// ============================================================================
+// detectOpenQuestion
+// ============================================================================
+
+describe('detectOpenQuestion', () => {
+  it('returns question from last user message ending with ?', () => {
+    const msgs = [
+      userMsg('Refactor auth'),
+      assistantMsg('Done'),
+      userMsg('Should I also update the tests?'),
+    ];
+    const q = detectOpenQuestion(msgs);
+    expect(q).toBe('Should I also update the tests?');
+  });
+
+  it('returns empty string when last user message does not end with ?', () => {
+    const msgs = [userMsg('Refactor auth'), assistantMsg('Done')];
+    const q = detectOpenQuestion(msgs);
+    expect(q).toBe('');
+  });
+
+  it('returns empty string when no user messages', () => {
+    const msgs = [assistantMsg('Ready')];
+    const q = detectOpenQuestion(msgs);
+    expect(q).toBe('');
+  });
+
+  it('scrubs secrets from the question', () => {
+    // WHY concat: prevents false-positive secret scanning on clearly fake test value.
+    const fakeKey = 'sk_li' + 've_ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const msgs = [userMsg(`Is ${fakeKey} correct?`)];
+    const q = detectOpenQuestion(msgs);
+    expect(q).not.toContain('sk_live_');
+    expect(q.endsWith('?')).toBe(true);
+  });
+
+  it('uses the LAST user message, not the first', () => {
+    const msgs = [
+      userMsg('First message?'),
+      assistantMsg('Answer'),
+      userMsg('Last message without question mark'),
+    ];
+    const q = detectOpenQuestion(msgs);
+    expect(q).toBe(''); // Last user msg doesn't end with ?
+  });
+});
+
+// ============================================================================
+// buildSummaryMarkdown
+// ============================================================================
+
+describe('buildSummaryMarkdown', () => {
+  it('includes ## Current task heading', () => {
+    const md = buildSummaryMarkdown('Fix auth', [], '');
+    expect(md).toContain('## Current task');
+    expect(md).toContain('Fix auth');
+  });
+
+  it('includes ## Recently touched heading', () => {
+    const md = buildSummaryMarkdown('task', [], '');
+    expect(md).toContain('## Recently touched');
+  });
+
+  it('includes ## Open questions heading', () => {
+    const md = buildSummaryMarkdown('task', [], '');
+    expect(md).toContain('## Open questions');
+  });
+
+  it('shows (no files tracked yet) when fileRefs is empty', () => {
+    const md = buildSummaryMarkdown('task', [], '');
+    expect(md).toContain('(no files tracked yet)');
+  });
+
+  it('lists file refs with relevance scores', () => {
+    const refs = [
+      { path: '/Users/alice/auth.ts', lastTouchedAt: new Date().toISOString(), relevance: 0.95 },
+    ];
+    const md = buildSummaryMarkdown('task', refs, '');
+    expect(md).toContain('/Users/alice/auth.ts');
+    expect(md).toContain('0.95');
+  });
+
+  it('shows (none) when openQuestion is empty', () => {
+    const md = buildSummaryMarkdown('task', [], '');
+    expect(md).toContain('(none)');
+  });
+
+  it('shows the open question when provided', () => {
+    const md = buildSummaryMarkdown('task', [], 'Should I refactor this?');
+    expect(md).toContain('Should I refactor this?');
+    expect(md).not.toContain('(none)');
+  });
+});
+
+// ============================================================================
+// buildFileRefs
+// ============================================================================
+
+describe('buildFileRefs', () => {
+  it('returns empty array when no tool calls', () => {
+    const msgs = [userMsg('Hello'), assistantMsg('Hi')];
+    expect(buildFileRefs(msgs, FIXED_NOW)).toHaveLength(0);
+  });
+
+  it('extracts paths from tool calls', () => {
+    const msgs = [
+      toolMsg('Read file', 'read_file', { path: '/Users/alice/src/auth.ts' }),
+    ];
+    const refs = buildFileRefs(msgs, FIXED_NOW);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]!.path).toBe('/Users/alice/src/auth.ts');
+  });
+
+  it('deduplicates identical paths across multiple tool calls', () => {
+    const msgs = [
+      toolMsg('Read', 'read_file', { path: '/Users/alice/auth.ts' }),
+      toolMsg('Write', 'write_file', { file_path: '/Users/alice/auth.ts' }),
+    ];
+    const refs = buildFileRefs(msgs, FIXED_NOW);
+    expect(refs).toHaveLength(1);
+  });
+
+  it('sorts refs descending by relevance', () => {
+    const msgs = [
+      toolMsg('Read old', 'read_file', { path: '/Users/alice/old.ts' }),
+      toolMsg('Read new', 'read_file', { path: '/Users/alice/new.ts' }),
+      toolMsg('Read new again', 'read_file', { path: '/Users/alice/new.ts' }),
+    ];
+    const refs = buildFileRefs(msgs, FIXED_NOW);
+    // new.ts is mentioned twice → higher frequency → higher relevance
+    expect(refs[0]!.path).toBe('/Users/alice/new.ts');
+  });
+
+  it('ignores tool calls for non-allowlisted tools', () => {
+    const msgs = [
+      toolMsg('Custom tool', 'unknown_custom_tool', { path: '/Users/alice/secret.ts' }),
+    ];
+    const refs = buildFileRefs(msgs, FIXED_NOW);
+    expect(refs).toHaveLength(0);
+  });
+
+  it('handles JSON string arguments', () => {
+    const msgs: SummarizerInputMessage[] = [
+      {
+        role: 'tool',
+        content: '',
+        toolCall: {
+          name: 'read_file',
+          arguments: JSON.stringify({ path: '/Users/alice/json-arg.ts' }),
+        },
+      },
+    ];
+    const refs = buildFileRefs(msgs, FIXED_NOW);
+    expect(refs.some((r) => r.path === '/Users/alice/json-arg.ts')).toBe(true);
+  });
+
+  it('skips tool calls with invalid JSON string arguments', () => {
+    const msgs: SummarizerInputMessage[] = [
+      {
+        role: 'tool',
+        content: '',
+        toolCall: { name: 'read_file', arguments: 'NOT_VALID_JSON' },
+      },
+    ];
+    expect(() => buildFileRefs(msgs, FIXED_NOW)).not.toThrow();
+    const refs = buildFileRefs(msgs, FIXED_NOW);
+    expect(refs).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// summarize — integration tests
+// ============================================================================
+
+describe('summarize', () => {
+  it('returns deterministic output for same input', () => {
+    const messages = [
+      userMsg('Refactor auth'),
+      toolMsg('Reading', 'read_file', { path: '/Users/alice/src/auth.ts' }),
+      assistantMsg('Done with auth.ts'),
+    ];
+    const out1 = summarize({ messages }, FIXED_NOW);
+    const out2 = summarize({ messages }, FIXED_NOW);
+    expect(out1.summaryMarkdown).toBe(out2.summaryMarkdown);
+    expect(out1.fileRefs).toEqual(out2.fileRefs);
+    expect(out1.recentMessages).toEqual(out2.recentMessages);
+  });
+
+  it('detects task from first user message', () => {
+    const messages = [userMsg('Add rate limiting to the API'), assistantMsg('OK')];
+    const out = summarize({ messages }, FIXED_NOW);
+    expect(out.summaryMarkdown).toContain('Add rate limiting to the API');
+  });
+
+  it('applies scrub to message content in recentMessages', () => {
+    // WHY concat: prevents false-positive secret scanning on clearly fake test value.
+    const fakeKey = 'sk_li' + 've_ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const messages = [
+      userMsg(`My key is ${fakeKey} — use it`),
+    ];
+    const out = summarize({ messages }, FIXED_NOW);
+    for (const msg of out.recentMessages) {
+      expect(msg.preview).not.toContain('sk_live_');
+    }
+  });
+
+  it('caps recentMessages at CONTEXT_MESSAGE_LIMIT', () => {
+    const messages: SummarizerInputMessage[] = Array.from(
+      { length: CONTEXT_MESSAGE_LIMIT + 10 },
+      (_, i) => userMsg(`Message ${i}`)
+    );
+    const out = summarize({ messages }, FIXED_NOW);
+    expect(out.recentMessages.length).toBeLessThanOrEqual(CONTEXT_MESSAGE_LIMIT);
+  });
+
+  it('enforces token budget by truncating summaryMarkdown', () => {
+    // Create a scenario where the summary would be very long
+    const refs = Array.from({ length: 50 }, (_, i) => ({
+      path: `/Users/alice/src/very-long-file-name-for-testing-${i}.ts`,
+      lastTouchedAt: new Date(FIXED_NOW - i * 1000).toISOString(),
+      relevance: (50 - i) / 50,
+    }));
+
+    // Build input with many file-touching tool calls to generate large summary
+    const messages: SummarizerInputMessage[] = [
+      userMsg('Big task'),
+      ...refs.slice(0, 10).map((ref) =>
+        toolMsg('', 'read_file', { path: ref.path })
+      ),
+    ];
+
+    const minBudget = TOKEN_BUDGET_MIN;
+    const out = summarize({ messages, tokenBudget: minBudget }, FIXED_NOW);
+    // The summary should be truncated — estimatedTokens may exceed minBudget slightly
+    // due to the truncation notice, but summaryMarkdown should be significantly shorter
+    // than an unbounded summary
+    expect(out.summaryMarkdown.length).toBeLessThan(10_000);
+  });
+
+  it('clamps tokenBudget below TOKEN_BUDGET_MIN to TOKEN_BUDGET_MIN', () => {
+    const messages = [userMsg('Task')];
+    expect(() => summarize({ messages, tokenBudget: 0 }, FIXED_NOW)).not.toThrow();
+  });
+
+  it('clamps tokenBudget above TOKEN_BUDGET_MAX to TOKEN_BUDGET_MAX', () => {
+    const messages = [userMsg('Task')];
+    expect(() => summarize({ messages, tokenBudget: TOKEN_BUDGET_MAX + 10_000 }, FIXED_NOW)).not.toThrow();
+  });
+
+  it('handles empty message array', () => {
+    const out = summarize({ messages: [] }, FIXED_NOW);
+    expect(out.summaryMarkdown).toContain('## Current task');
+    expect(out.fileRefs).toHaveLength(0);
+    expect(out.recentMessages).toHaveLength(0);
+  });
+
+  it('uses taskOverride when provided', () => {
+    const messages = [userMsg('Original task')];
+    const out = summarize({ messages, taskOverride: 'Override task description' }, FIXED_NOW);
+    expect(out.summaryMarkdown).toContain('Override task description');
+    expect(out.summaryMarkdown).not.toContain('Original task');
+  });
+
+  it('returns positive estimatedTokens for non-empty summary', () => {
+    const messages = [userMsg('Hello, start working on auth')];
+    const out = summarize({ messages }, FIXED_NOW);
+    expect(out.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  it('includes detected open question in summary', () => {
+    const messages = [
+      userMsg('Refactor auth'),
+      assistantMsg('Done'),
+      userMsg('Should I also add unit tests?'),
+    ];
+    const out = summarize({ messages }, FIXED_NOW);
+    expect(out.summaryMarkdown).toContain('Should I also add unit tests?');
+  });
+
+  it('populates fileRefs from tool calls across messages', () => {
+    const messages = [
+      toolMsg('Read', 'read_file', { path: '/Users/alice/auth.ts' }),
+      toolMsg('Write', 'write_file', { file_path: '/Users/alice/middleware.ts' }),
+    ];
+    const out = summarize({ messages }, FIXED_NOW);
+    expect(out.fileRefs.length).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================================
+// buildInjectionPrompt
+// ============================================================================
+
+describe('buildInjectionPrompt', () => {
+  it('includes the Styrby Context Sync preamble header', () => {
+    const memory = buildMemory();
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.systemPrompt).toContain('[Styrby Context Sync — cross-agent handoff]');
+  });
+
+  it('includes the summary markdown', () => {
+    const memory = buildMemory({ summaryMarkdown: '## Current task\nRefactor auth middleware' });
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.systemPrompt).toContain('Refactor auth middleware');
+  });
+
+  it('filters out low-relevance file refs (< 0.5)', () => {
+    const memory = buildMemory(); // legacy.ts has relevance 0.18
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.systemPrompt).not.toContain('legacy.ts');
+    expect(payload.includedFileRefs.every((r) => r.relevance >= 0.5)).toBe(true);
+  });
+
+  it('includes high-relevance file refs', () => {
+    const memory = buildMemory();
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.systemPrompt).toContain('auth.ts');
+    expect(payload.systemPrompt).toContain('middleware.ts');
+  });
+
+  it('includes ## Files you may need section when refs present', () => {
+    const memory = buildMemory();
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.systemPrompt).toContain('## Files you may need');
+  });
+
+  it('omits ## Files you may need when all refs below threshold', () => {
+    const memory = buildMemory({
+      fileRefs: [
+        {
+          path: '/Users/alice/old.ts',
+          lastTouchedAt: new Date(FIXED_NOW - 86_400_000).toISOString(),
+          relevance: 0.1,
+        },
+      ],
+    });
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.systemPrompt).not.toContain('## Files you may need');
+  });
+
+  it('includes recent conversation section', () => {
+    const memory = buildMemory();
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.systemPrompt).toContain('## Recent conversation');
+    expect(payload.systemPrompt).toContain('**user**:');
+    expect(payload.systemPrompt).toContain('**assistant**:');
+  });
+
+  it('sets messageCount to length of recentMessages', () => {
+    const memory = buildMemory();
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.messageCount).toBe(memory.recentMessages.length);
+  });
+
+  it('returns positive estimatedTokens', () => {
+    const memory = buildMemory();
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  it('handles empty recentMessages gracefully', () => {
+    const memory = buildMemory({ recentMessages: [] });
+    expect(() => buildInjectionPrompt(memory)).not.toThrow();
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.messageCount).toBe(0);
+  });
+
+  it('handles empty fileRefs gracefully', () => {
+    const memory = buildMemory({ fileRefs: [] });
+    expect(() => buildInjectionPrompt(memory)).not.toThrow();
+    const payload = buildInjectionPrompt(memory);
+    expect(payload.includedFileRefs).toHaveLength(0);
+  });
+});

--- a/packages/styrby-web/src/__tests__/focus-with-context-injection.test.ts
+++ b/packages/styrby-web/src/__tests__/focus-with-context-injection.test.ts
@@ -102,8 +102,6 @@ function buildMockClient(state: MockState) {
     let _limit = false;
     const builder: Record<string, unknown> = {};
 
-    const chain = () => builder;
-
     // Fluent methods that return the chain
     ['select', 'eq', 'update', 'insert'].forEach((method) => {
       builder[method] = vi.fn().mockReturnValue(builder);

--- a/packages/styrby-web/src/__tests__/focus-with-context-injection.test.ts
+++ b/packages/styrby-web/src/__tests__/focus-with-context-injection.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for POST /api/sessions/groups/[groupId]/focus — Phase 3.5 Extension
+ *
+ * Covers the Phase 3.5 additions to the focus route:
+ *   1. contextInjection: null when no memory record exists
+ *   2. contextInjection populated when memory record exists
+ *   3. Focus update still succeeds when memory fetch throws (non-fatal path)
+ *   4. contextInjection respects file ref relevance threshold (low-relevance refs filtered)
+ *   5. contextInjection.estimatedTokens > 0 for non-empty memory
+ *   6. Idempotent sync: calling focus twice returns the same contextInjection
+ *
+ * Pre-Phase-3.5 behavior (auth, validation, group membership, session membership)
+ * is tested in the original focus route tests (not duplicated here).
+ *
+ * WHY separate test file:
+ *   Keeping Phase 3.5 additions in a dedicated file avoids merge conflicts with
+ *   any existing focus route tests and makes the Phase 3.5 surface explicit for
+ *   code review.
+ *
+ * @module __tests__/focus-with-context-injection
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const VALID_GROUP_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+const VALID_SESSION_ID = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff';
+const VALID_USER_ID = 'user-0001-0000-0000-000000000000';
+
+/**
+ * A minimal agent_context_memory DB row for testing injection.
+ */
+function buildMemoryRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'mem-0001-0000-0000-000000000000',
+    session_group_id: VALID_GROUP_ID,
+    summary_markdown:
+      '## Current task\nRefactor auth middleware\n\n## Recently touched\n- [PATH]/auth.ts (relevance 0.92)\n\n## Open questions\n(none)',
+    file_refs: [
+      { path: '/Users/alice/src/auth.ts', lastTouchedAt: new Date().toISOString(), relevance: 0.92 },
+      { path: '/Users/alice/src/legacy.ts', lastTouchedAt: new Date(Date.now() - 3_600_000).toISOString(), relevance: 0.15 },
+    ],
+    recent_messages: [
+      { role: 'user', preview: 'Refactor the auth middleware to use JWT' },
+      { role: 'assistant', preview: 'Starting with the middleware file.' },
+    ],
+    token_budget: 4000,
+    version: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Supabase mock factory
+// ============================================================================
+
+interface MockState {
+  authed: boolean;
+  groupExists: boolean;
+  sessionInGroup: boolean;
+  focusUpdateSucceeds: boolean;
+  memoryRow: Record<string, unknown> | null;
+  memoryFetchError: boolean;
+  auditInsertError: boolean;
+}
+
+function createMockState(overrides: Partial<MockState> = {}): MockState {
+  return {
+    authed: true,
+    groupExists: true,
+    sessionInGroup: true,
+    focusUpdateSucceeds: true,
+    memoryRow: buildMemoryRow(),
+    memoryFetchError: false,
+    auditInsertError: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a mock Supabase client driven by the provided state.
+ *
+ * WHY a state object: Using a mutable state object lets tests override
+ * individual behaviors without re-wiring the entire mock.
+ */
+function buildMockClient(state: MockState) {
+  const updatedGroupRow = {
+    id: VALID_GROUP_ID,
+    active_agent_session_id: VALID_SESSION_ID,
+    updated_at: new Date().toISOString(),
+  };
+
+  // Each .from() call returns a chainable builder that resolves to the right data
+  const buildQuery = (table: string) => {
+    let _order = false;
+    let _limit = false;
+    const builder: Record<string, unknown> = {};
+
+    const chain = () => builder;
+
+    // Fluent methods that return the chain
+    ['select', 'eq', 'update', 'insert'].forEach((method) => {
+      builder[method] = vi.fn().mockReturnValue(builder);
+    });
+
+    builder['order'] = vi.fn().mockImplementation(() => {
+      _order = true;
+      return builder;
+    });
+
+    builder['limit'] = vi.fn().mockImplementation(() => {
+      _limit = true;
+      return builder;
+    });
+
+    builder['then'] = vi.fn().mockImplementation((cb) => {
+      if (state.auditInsertError) {
+        return Promise.resolve(cb({ error: { message: 'audit write failed' } }));
+      }
+      return Promise.resolve(cb({ error: null }));
+    });
+
+    builder['single'] = vi.fn().mockImplementation(() => {
+      if (table === 'agent_session_groups' && !state.groupExists) {
+        return Promise.resolve({ data: null, error: { code: '42P01', message: 'not found' } });
+      }
+
+      if (table === 'sessions' && !state.sessionInGroup) {
+        return Promise.resolve({ data: null, error: { code: 'PGRST116' } });
+      }
+
+      if (table === 'agent_session_groups' && state.focusUpdateSucceeds && _order === false) {
+        // This is the update call
+        return Promise.resolve({ data: updatedGroupRow, error: null });
+      }
+
+      if (table === 'agent_context_memory') {
+        if (state.memoryFetchError) {
+          return Promise.resolve({ data: null, error: { code: '500', message: 'DB error' } });
+        }
+        if (!state.memoryRow) {
+          return Promise.resolve({ data: null, error: { code: 'PGRST116' } });
+        }
+        return Promise.resolve({ data: state.memoryRow, error: null });
+      }
+
+      // Default: group ownership check
+      return Promise.resolve({
+        data: { id: VALID_GROUP_ID, user_id: VALID_USER_ID },
+        error: null,
+      });
+    });
+
+    return builder;
+  };
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: state.authed ? { id: VALID_USER_ID } : null },
+        error: state.authed ? null : { message: 'Unauthorized' },
+      }),
+    },
+    from: vi.fn().mockImplementation((table: string) => buildQuery(table)),
+  };
+}
+
+// ============================================================================
+// Module mocking
+// ============================================================================
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn().mockResolvedValue({ allowed: true, retryAfter: null }),
+  rateLimitResponse: vi.fn().mockReturnValue(new NextResponse(null, { status: 429 })),
+  RATE_LIMITS: { budgetAlerts: { windowMs: 60000, maxRequests: 30 } },
+}));
+
+// ============================================================================
+// Import after mocking
+// ============================================================================
+
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * Import the route handler dynamically after mocks are set up.
+ * WHY dynamic: Next.js API routes use `createClient` at module scope in some
+ * patterns. Dynamic import ensures the mock is in place before the module runs.
+ */
+async function importRoute() {
+  const { POST } = await import(
+    '../app/api/sessions/groups/[groupId]/focus/route'
+  );
+  return { POST };
+}
+
+/**
+ * Creates a minimal NextRequest for the focus endpoint.
+ */
+function buildRequest(body: Record<string, unknown> = { sessionId: VALID_SESSION_ID }) {
+  return new Request('http://localhost/api/sessions/groups/test/focus', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Creates the route context with a resolved params promise.
+ */
+function buildContext(groupId: string = VALID_GROUP_ID) {
+  return { params: Promise.resolve({ groupId }) };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('POST /api/sessions/groups/[groupId]/focus — Phase 3.5 context injection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns contextInjection: null when no memory record exists', async () => {
+    const state = createMockState({ memoryRow: null });
+    vi.mocked(createClient).mockResolvedValue(buildMockClient(state) as never);
+
+    const { POST } = await importRoute();
+    const res = await POST(buildRequest() as never, buildContext() as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.contextInjection).toBeNull();
+  });
+
+  it('returns contextInjection payload when memory record exists', async () => {
+    const state = createMockState();
+    vi.mocked(createClient).mockResolvedValue(buildMockClient(state) as never);
+
+    const { POST } = await importRoute();
+    const res = await POST(buildRequest() as never, buildContext() as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.contextInjection).not.toBeNull();
+    expect(typeof body.contextInjection.systemPrompt).toBe('string');
+    expect(body.contextInjection.systemPrompt).toContain('[Styrby Context Sync');
+  });
+
+  it('focus update still succeeds (200) when memory fetch throws', async () => {
+    const state = createMockState({ memoryFetchError: true });
+    vi.mocked(createClient).mockResolvedValue(buildMockClient(state) as never);
+
+    const { POST } = await importRoute();
+    const res = await POST(buildRequest() as never, buildContext() as never);
+    const body = await res.json();
+
+    // The focus update must succeed even when context fetch fails
+    expect(res.status).toBe(200);
+    expect(body.activeSessionId).toBe(VALID_SESSION_ID);
+    // contextInjection should be null (graceful degradation)
+    expect(body.contextInjection).toBeNull();
+  });
+
+  it('filters low-relevance file refs in contextInjection (< 0.5 excluded)', async () => {
+    const state = createMockState({
+      memoryRow: buildMemoryRow({
+        file_refs: [
+          { path: '/Users/alice/src/high.ts', lastTouchedAt: new Date().toISOString(), relevance: 0.85 },
+          { path: '/Users/alice/src/low.ts', lastTouchedAt: new Date().toISOString(), relevance: 0.20 },
+        ],
+      }),
+    });
+    vi.mocked(createClient).mockResolvedValue(buildMockClient(state) as never);
+
+    const { POST } = await importRoute();
+    const res = await POST(buildRequest() as never, buildContext() as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.contextInjection).not.toBeNull();
+    expect(body.contextInjection.systemPrompt).toContain('high.ts');
+    expect(body.contextInjection.systemPrompt).not.toContain('low.ts');
+  });
+
+  it('contextInjection.estimatedTokens > 0 for non-empty memory', async () => {
+    const state = createMockState();
+    vi.mocked(createClient).mockResolvedValue(buildMockClient(state) as never);
+
+    const { POST } = await importRoute();
+    const res = await POST(buildRequest() as never, buildContext() as never);
+    const body = await res.json();
+
+    expect(body.contextInjection.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  it('contextInjection.messageCount equals number of recentMessages in memory', async () => {
+    const recentMessages = [
+      { role: 'user', preview: 'Fix the bug' },
+      { role: 'assistant', preview: 'Looking at it now.' },
+      { role: 'tool', preview: 'Read /Users/alice/src/auth.ts' },
+    ];
+    const state = createMockState({
+      memoryRow: buildMemoryRow({ recent_messages: recentMessages }),
+    });
+    vi.mocked(createClient).mockResolvedValue(buildMockClient(state) as never);
+
+    const { POST } = await importRoute();
+    const res = await POST(buildRequest() as never, buildContext() as never);
+    const body = await res.json();
+
+    expect(body.contextInjection.messageCount).toBe(3);
+  });
+});

--- a/packages/styrby-web/src/__tests__/migration-039.test.ts
+++ b/packages/styrby-web/src/__tests__/migration-039.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Migration 039 structural tests — agent_context_memory (Phase 3.5)
+ *
+ * Validates that migration 039 contains all required DDL for:
+ *   - `agent_context_memory` table with all spec-required columns
+ *   - RLS enabled + ownership policy via agent_session_groups join
+ *   - UNIQUE index on session_group_id (one memory record per group)
+ *   - Version ordering index
+ *   - updated_at trigger
+ *   - CHECK constraints on token_budget and version
+ *   - ON DELETE CASCADE FK to agent_session_groups
+ *   - audit_action enum extensions (4 new values)
+ *
+ * WHY migration regression tests:
+ *   - Missing RLS exposes context memory to unauthorized readers (cross-user leak)
+ *   - Missing UNIQUE index on session_group_id would allow duplicate memory records
+ *     that corrupt the upsert-on-sync pattern
+ *   - Missing token_budget CHECK constraints would allow client-supplied budgets
+ *     above 8000 to bypass the server-side cap in the DB layer
+ *   - These file-content tests catch all three regressions in milliseconds
+ *
+ * @module __tests__/migration-039
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const MIGRATIONS_DIR = resolve(__dirname, '../../../..', 'supabase/migrations');
+
+function readMigration(filename: string): string {
+  return readFileSync(resolve(MIGRATIONS_DIR, filename), 'utf-8');
+}
+
+describe('Migration 039: agent_context_memory', () => {
+  const sql = readMigration('039_agent_context_memory.sql');
+
+  // ── Table creation ──────────────────────────────────────────────────────────
+
+  it('creates agent_context_memory with IF NOT EXISTS guard', () => {
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS public.agent_context_memory');
+  });
+
+  // ── Required columns ────────────────────────────────────────────────────────
+
+  it('has id UUID PRIMARY KEY with gen_random_uuid()', () => {
+    expect(sql).toContain('id                  UUID PRIMARY KEY DEFAULT gen_random_uuid()');
+  });
+
+  it('has session_group_id UUID NOT NULL with FK to agent_session_groups(id)', () => {
+    expect(sql).toContain('session_group_id    UUID NOT NULL REFERENCES public.agent_session_groups(id)');
+  });
+
+  it('has ON DELETE CASCADE on session_group_id FK', () => {
+    expect(sql).toContain('ON DELETE CASCADE');
+  });
+
+  it('has summary_markdown TEXT NOT NULL', () => {
+    expect(sql).toContain('summary_markdown    TEXT NOT NULL');
+  });
+
+  it('has file_refs JSONB with empty array default', () => {
+    expect(sql).toContain("file_refs           JSONB NOT NULL DEFAULT '[]'::jsonb");
+  });
+
+  it('has recent_messages JSONB with empty array default', () => {
+    expect(sql).toContain("recent_messages     JSONB NOT NULL DEFAULT '[]'::jsonb");
+  });
+
+  it('has token_budget INTEGER with DEFAULT 4000', () => {
+    expect(sql).toContain('token_budget        INTEGER NOT NULL DEFAULT 4000');
+  });
+
+  it('has version INTEGER with DEFAULT 1', () => {
+    expect(sql).toContain('version             INTEGER NOT NULL DEFAULT 1');
+  });
+
+  it('has created_at TIMESTAMPTZ', () => {
+    expect(sql).toContain('created_at          TIMESTAMPTZ NOT NULL DEFAULT now()');
+  });
+
+  it('has updated_at TIMESTAMPTZ', () => {
+    expect(sql).toContain('updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()');
+  });
+
+  // ── CHECK constraints ───────────────────────────────────────────────────────
+
+  it('enforces token_budget minimum (100)', () => {
+    expect(sql).toContain('token_budget >= 100');
+  });
+
+  it('enforces token_budget maximum (8000)', () => {
+    expect(sql).toContain('token_budget <= 8000');
+  });
+
+  it('enforces version positive (>= 1)', () => {
+    expect(sql).toContain('version >= 1');
+  });
+
+  // ── Indexes ─────────────────────────────────────────────────────────────────
+
+  it('creates UNIQUE index on session_group_id', () => {
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_context_memory_group_id_unique');
+  });
+
+  it('creates version ordering index', () => {
+    expect(sql).toContain('CREATE INDEX IF NOT EXISTS idx_agent_context_memory_version');
+  });
+
+  // ── updated_at trigger ──────────────────────────────────────────────────────
+
+  it('creates set_agent_context_memory_updated_at function', () => {
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.set_agent_context_memory_updated_at()');
+  });
+
+  it('creates updated_at trigger on agent_context_memory', () => {
+    expect(sql).toContain('CREATE TRIGGER trg_agent_context_memory_updated_at');
+  });
+
+  it('trigger fires BEFORE UPDATE', () => {
+    expect(sql).toContain('BEFORE UPDATE ON public.agent_context_memory');
+  });
+
+  // ── RLS ─────────────────────────────────────────────────────────────────────
+
+  it('enables RLS on agent_context_memory', () => {
+    expect(sql).toContain('ALTER TABLE public.agent_context_memory ENABLE ROW LEVEL SECURITY');
+  });
+
+  it('creates RLS policy via agent_session_groups join', () => {
+    expect(sql).toContain('CREATE POLICY');
+    expect(sql).toContain('agent_session_groups');
+  });
+
+  it('RLS policy uses (SELECT auth.uid()) for query-plan caching', () => {
+    expect(sql).toContain('(SELECT auth.uid())');
+  });
+
+  it('RLS policy has both USING and WITH CHECK clauses', () => {
+    expect(sql).toContain('USING (');
+    expect(sql).toContain('WITH CHECK (');
+  });
+
+  // ── audit_action enum extensions ────────────────────────────────────────────
+
+  it('adds context_memory_synced to audit_action', () => {
+    expect(sql).toContain("ADD VALUE IF NOT EXISTS 'context_memory_synced'");
+  });
+
+  it('adds context_memory_injected to audit_action', () => {
+    expect(sql).toContain("ADD VALUE IF NOT EXISTS 'context_memory_injected'");
+  });
+
+  it('adds context_memory_exported to audit_action', () => {
+    expect(sql).toContain("ADD VALUE IF NOT EXISTS 'context_memory_exported'");
+  });
+
+  it('adds context_memory_imported to audit_action', () => {
+    expect(sql).toContain("ADD VALUE IF NOT EXISTS 'context_memory_imported'");
+  });
+
+  // ── Security rationale in comments ─────────────────────────────────────────
+
+  it('references GDPR Art. 5(1)(c) data minimisation in comments', () => {
+    expect(sql).toContain('GDPR Art. 5(1)(c)');
+  });
+
+  it('references SOC2 CC6.1 in comments', () => {
+    expect(sql).toContain('SOC2 CC6.1');
+  });
+});

--- a/packages/styrby-web/src/app/api/sessions/groups/[groupId]/focus/route.ts
+++ b/packages/styrby-web/src/app/api/sessions/groups/[groupId]/focus/route.ts
@@ -8,16 +8,33 @@
  * SessionGroupStrip on mobile, the app calls this endpoint to persist which
  * session is the current focus.
  *
- * WHY a dedicated endpoint instead of a general group PATCH:
- *   Focus changes are frequent, high-frequency operations (user swipes
- *   between agents). A narrow endpoint with focused validation is faster,
- *   easier to rate-limit correctly, and produces a clean audit trail
- *   (session_group_focus_changed action) without general PATCH noise.
+ * Phase 3.5 extension:
+ *   On successful focus change, this endpoint additionally reads the group's
+ *   agent_context_memory record (if one exists) and builds a ContextInjectionPayload.
+ *   The payload is included in the response as `contextInjection`. The CLI
+ *   daemon receives this payload via the Realtime channel and injects it as a
+ *   system-role message to the newly-focused agent before its first user prompt.
+ *
+ *   WHY inject via focus endpoint response rather than a separate fetch:
+ *     The focus change and context fetch are a single atomic operation from
+ *     the user's perspective ("I tapped a card — now that agent knows what I
+ *     was doing"). Bundling them in one response eliminates a round trip and
+ *     avoids a race where the CLI fetches context before the focus update is
+ *     committed.
+ *
+ *   WHY nullable contextInjection:
+ *     A group may have no memory record yet (user hasn't run `styrby context sync`
+ *     or the group was just created). Returning null lets the CLI detect this
+ *     and proceed without injection (cold start — same behavior as pre-Phase-3.5).
  *
  * Security model:
  *   - User must own the group (RLS enforces via user_id = auth.uid())
  *   - sessionId must belong to the group (explicit membership check)
  *   - No cross-user group focus (cannot focus another user's sessions)
+ *   - contextInjection contains only SCRUBBED content (Phase 3.3 scrub engine
+ *     was applied when the memory record was written by `styrby context sync`)
+ *   - token_budget is server-side enforced (capped at 8000); client cannot
+ *     request a larger injection payload
  *
  * @auth Required - Supabase Auth JWT via cookie
  * @rateLimit 60 requests per minute per user (mobile swipe UX)
@@ -31,7 +48,8 @@
  * @returns 200 {
  *   groupId: string,
  *   activeSessionId: string,
- *   updatedAt: string  (ISO 8601)
+ *   updatedAt: string  (ISO 8601),
+ *   contextInjection: ContextInjectionPayload | null  (Phase 3.5)
  * }
  *
  * @error 400 { error: 'VALIDATION_FAILED', message: string }
@@ -47,6 +65,8 @@ import { createClient } from '@/lib/supabase/server';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { z } from 'zod';
 import { apiError } from '@styrby/shared';
+import { buildInjectionPrompt } from '@styrby/shared/context-sync';
+import type { AgentContextMemory, ContextInjectionPayload } from '@styrby/shared/context-sync';
 
 // ---------------------------------------------------------------------------
 // Request Schema
@@ -215,10 +235,82 @@ export async function POST(request: NextRequest, context: RouteContext) {
       }
     });
 
+    // ── 5. Phase 3.5: Fetch context memory and build injection payload ─────
+    // WHY after the focus update (not before): The focus update is the critical
+    // path. Context injection is a best-effort enhancement — if memory fetch
+    // fails, we still return 200 with contextInjection: null. The new agent
+    // starts cold (same as pre-Phase-3.5) rather than the entire focus change
+    // failing because of a secondary lookup.
+    //
+    // WHY server-side injection payload: The CLI daemon receives this payload
+    // in the response and injects it as a system-role message before the first
+    // user prompt. Building the payload here (rather than returning raw memory)
+    // means the daemon only needs to pass it through — no summarizer code needed
+    // in the daemon process.
+    //
+    // SECURITY: contextInjection is built from agent_context_memory, which
+    // was written by `styrby context sync` after applying the Phase 3.3 scrub
+    // engine. No raw message content is in the memory record.
+    let contextInjection: ContextInjectionPayload | null = null;
+
+    try {
+      const { data: memoryRow } = await supabase
+        .from('agent_context_memory')
+        .select('*')
+        .eq('session_group_id', groupId)
+        .order('version', { ascending: false })
+        .limit(1)
+        .single();
+
+      if (memoryRow) {
+        // Map DB columns → AgentContextMemory interface
+        const memory: AgentContextMemory = {
+          id: String(memoryRow.id),
+          sessionGroupId: String(memoryRow.session_group_id),
+          summaryMarkdown: String(memoryRow.summary_markdown),
+          fileRefs: (memoryRow.file_refs as AgentContextMemory['fileRefs']) ?? [],
+          recentMessages: (memoryRow.recent_messages as AgentContextMemory['recentMessages']) ?? [],
+          tokenBudget: Number(memoryRow.token_budget),
+          version: Number(memoryRow.version),
+          createdAt: String(memoryRow.created_at),
+          updatedAt: String(memoryRow.updated_at),
+        };
+
+        contextInjection = buildInjectionPrompt(memory);
+
+        // Audit the injection (non-fatal)
+        await supabase.from('audit_log').insert({
+          user_id: user.id,
+          action: 'context_memory_injected',
+          metadata: {
+            group_id: groupId,
+            focused_session_id: sessionId,
+            estimated_tokens: contextInjection.estimatedTokens,
+            file_ref_count: contextInjection.includedFileRefs.length,
+            message_count: contextInjection.messageCount,
+          },
+        }).then(({ error: injAuditError }) => {
+          if (injAuditError) {
+            console.warn('[sessions/groups/focus] Context injection audit failed:', injAuditError.message);
+          }
+        });
+      }
+    } catch (memoryError) {
+      // WHY catch-all: context fetch errors must never block the focus change.
+      // Log in dev; silence in production to avoid log noise from groups
+      // that have no memory record yet.
+      if (process.env.NODE_ENV === 'development') {
+        console.warn('[sessions/groups/focus] Context memory fetch error:', memoryError);
+      }
+      // contextInjection remains null — cold start for the new agent
+    }
+
     return NextResponse.json({
       groupId: updated.id,
       activeSessionId: updated.active_agent_session_id,
       updatedAt: updated.updated_at,
+      // Phase 3.5: null when no memory record exists yet — agent starts cold
+      contextInjection,
     });
   } catch (error) {
     const isDev = process.env.NODE_ENV === 'development';

--- a/supabase/migrations/039_agent_context_memory.sql
+++ b/supabase/migrations/039_agent_context_memory.sql
@@ -1,0 +1,211 @@
+-- ============================================================================
+-- Migration 039: Agent Context Memory — Cross-Agent Context Sync (Phase 3.5)
+--
+-- Adds:
+--   1. agent_context_memory table — structured memory record per session group
+--   2. Indexes for group lookup and version ordering
+--   3. RLS: user can only access their own groups' memory
+--   4. updated_at trigger (consistent with prior table patterns)
+--   5. Extend audit_action enum with context-sync values
+--
+-- Design rationale:
+--   When a user switches the active agent in a session group, the new agent
+--   starts cold with no knowledge of what the previous agent was doing.
+--   agent_context_memory closes this gap: it holds a structured summary of
+--   the project state (markdown), relevant file references (JSONB), and the
+--   last 20 message summaries (JSONB — no raw content; scrub engine applied).
+--
+--   The token_budget column lets the injection system truncate the memory
+--   to fit the target agent's context window. The version column enables
+--   optimistic-locking writes from concurrent CLI workers without clobbering
+--   each other.
+--
+--   One record per session group (upsert on session_group_id). Older versions
+--   are preserved in the version history by bumping the version counter;
+--   but the "live" record is always the one with the highest version for
+--   that group.
+--
+-- Security model:
+--   - RLS: membership derived via agent_session_groups.user_id = auth.uid()
+--   - recent_messages stores SCRUBBED summaries only (Phase 3.3 scrub engine)
+--   - Raw message content never stored in this table (GDPR Art. 5(1)(c))
+--   - token_budget is server-side enforced (capped at 8000) to prevent DoS
+--
+-- References:
+--   Phase 3.1: agent_session_groups (migration 035)
+--   Phase 3.3: scrub engine — packages/styrby-shared/src/session-replay/scrub.ts
+--
+-- GDPR Art. 5(1)(c) data minimisation — only scrubbed summaries stored.
+-- SOC2 CC6.1 — no cached plaintext; scrub applied before every write.
+-- ============================================================================
+
+-- ============================================================================
+-- 1. agent_context_memory table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.agent_context_memory (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- FK to the session group this memory record belongs to.
+  -- ON DELETE CASCADE: deleting a group wipes its memory — no orphaned data.
+  -- WHY CASCADE not SET NULL: orphaned memory records with no group have no
+  -- owner context and can never be accessed (RLS blocks them). They would
+  -- accumulate as storage waste.
+  session_group_id    UUID NOT NULL REFERENCES public.agent_session_groups(id) ON DELETE CASCADE,
+
+  -- Condensed project state in Markdown. Built by the summarizer using the
+  -- fixed template: "## Current task / ## Recently touched / ## Open questions".
+  -- Length bounded by token_budget at write time; typically 400-2000 chars.
+  --
+  -- WHY Markdown: All 11 supported agents accept system-role prompts in Markdown.
+  -- Markdown headings make the structure machine-parseable for injection.
+  summary_markdown    TEXT NOT NULL,
+
+  -- Array of file references extracted from tool_call arguments in recent messages.
+  -- Schema: [{ "path": "/abs/path/file.ts", "lastTouchedAt": "ISO8601", "relevance": 0.0-1.0 }]
+  --
+  -- WHY JSONB not a separate table: file refs are ephemeral; they change every
+  -- sync cycle. A separate table would require DELETE + INSERT on every sync,
+  -- creating churn on a hot path. JSONB with a full replacement update is
+  -- simpler and matches the "replace-on-sync" semantic.
+  file_refs           JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Last 20 message summaries (scrubbed). NEVER raw message content.
+  -- Schema: [{ "role": "user"|"assistant"|"tool", "preview": "first 200 chars" }]
+  --
+  -- WHY 20 messages: Matches the spec. Empirically, 20 messages cover ~1 task
+  -- cycle for all supported agents. Going beyond 20 hits token budget limits.
+  --
+  -- SECURITY: Secrets, file paths, and shell commands are stripped by the
+  -- Phase 3.3 scrub engine before this column is written. The application
+  -- layer is responsible for scrubbing; no DB trigger can enforce content rules.
+  recent_messages     JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Maximum tokens this memory may consume when injected into a new agent.
+  -- The summarizer truncates content to this budget. Server-side cap: 8000.
+  --
+  -- WHY 4000 default: balances context richness against not consuming a large
+  -- fraction of a model's context window on memory injection alone.
+  token_budget        INTEGER NOT NULL DEFAULT 4000
+    CONSTRAINT token_budget_min CHECK (token_budget >= 100)
+    CONSTRAINT token_budget_max CHECK (token_budget <= 8000),
+
+  -- Optimistic locking counter. Incremented by 1 on every sync write.
+  -- WHY: CLI workers can race on sync (e.g. two terminals sharing the same
+  -- session group). The writer reads current version, increments, then uses
+  -- WHERE version = <expected> in the UPDATE. If the row was concurrently
+  -- updated, the write fails and the writer re-reads before retrying.
+  version             INTEGER NOT NULL DEFAULT 1
+    CONSTRAINT version_positive CHECK (version >= 1),
+
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.agent_context_memory IS
+  'Structured memory record for a session group enabling cross-agent context sync. '
+  'Holds a scrubbed markdown summary, file references, and last-20 message previews. '
+  'Injected as a system-role prompt when focus switches to a new agent. Phase 3.5.';
+
+COMMENT ON COLUMN public.agent_context_memory.summary_markdown IS
+  'Condensed project state in Markdown. Scrubbed via Phase 3.3 scrub engine. '
+  'Injected verbatim as a system-role message to the newly-focused agent.';
+
+COMMENT ON COLUMN public.agent_context_memory.file_refs IS
+  'JSONB array of file references extracted from tool_call arguments. '
+  'Schema: [{ path: string, lastTouchedAt: string, relevance: number }]. '
+  'Sorted descending by relevance when injected.';
+
+COMMENT ON COLUMN public.agent_context_memory.recent_messages IS
+  'JSONB array of last-20 message summaries. SCRUBBED — no raw content. '
+  'Schema: [{ role: string, preview: string (≤200 chars) }]. '
+  'GDPR Art. 5(1)(c): only the minimum necessary preview is stored.';
+
+COMMENT ON COLUMN public.agent_context_memory.token_budget IS
+  'Maximum tokens this memory may consume when injected. '
+  'Server-side cap: 8000. Client-supplied budgets above 8000 are rejected.';
+
+COMMENT ON COLUMN public.agent_context_memory.version IS
+  'Optimistic locking counter. Write pattern: UPDATE ... WHERE version = $expected '
+  'AND SET version = $expected + 1. Retry on 0-rows-affected.';
+
+-- ============================================================================
+-- 2. Indexes
+-- ============================================================================
+
+-- Primary lookup: get the memory record for a group.
+-- WHY UNIQUE: one memory record per group (latest state wins via upsert).
+-- The application performs INSERT ... ON CONFLICT (session_group_id) DO UPDATE.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_context_memory_group_id_unique
+  ON public.agent_context_memory(session_group_id);
+
+-- Version ordering index: supports "get highest version for group" queries.
+-- Partial index on non-null groups (all rows qualify, so this is a full index).
+CREATE INDEX IF NOT EXISTS idx_agent_context_memory_version
+  ON public.agent_context_memory(session_group_id, version DESC);
+
+-- ============================================================================
+-- 3. updated_at trigger (reuses pattern from agent_session_groups)
+-- ============================================================================
+
+-- WHY: Consistent trigger pattern — application code never needs to manually
+-- set updated_at. The trigger fires on every UPDATE row.
+CREATE OR REPLACE FUNCTION public.set_agent_context_memory_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_agent_context_memory_updated_at
+  BEFORE UPDATE ON public.agent_context_memory
+  FOR EACH ROW EXECUTE FUNCTION public.set_agent_context_memory_updated_at();
+
+-- ============================================================================
+-- 4. RLS
+-- ============================================================================
+
+ALTER TABLE public.agent_context_memory ENABLE ROW LEVEL SECURITY;
+
+-- WHY join to agent_session_groups: agent_context_memory has no direct user_id
+-- column (denormalizing it would drift from the source of truth). The group
+-- record is the ownership anchor.
+--
+-- WHY (SELECT auth.uid()): query-plan caching per CLAUDE.md "Query Optimization
+-- Patterns". Prevents re-evaluating auth.uid() per row.
+--
+-- WHY subquery with EXISTS: Using a lateral EXISTS is faster than a JOIN
+-- for single-row ownership checks because it short-circuits on the first match.
+CREATE POLICY "Users can manage their own group context memory"
+  ON public.agent_context_memory
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.agent_session_groups g
+      WHERE g.id = session_group_id
+        AND g.user_id = (SELECT auth.uid())
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.agent_session_groups g
+      WHERE g.id = session_group_id
+        AND g.user_id = (SELECT auth.uid())
+    )
+  );
+
+-- ============================================================================
+-- 5. Extend audit_action enum with context-sync values
+-- ============================================================================
+
+-- WHY IF NOT EXISTS guard: ALTER TYPE ADD VALUE is non-transactional.
+-- Safe to re-run if migration is retried.
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'context_memory_synced';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'context_memory_injected';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'context_memory_exported';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'context_memory_imported';


### PR DESCRIPTION
## Summary

- **Migration 039** — `agent_context_memory` table: stores scrubbed markdown summary, file refs (JSONB), and last-20 message previews per session group; UNIQUE index on `session_group_id`; CHECK constraints (100 ≤ `token_budget` ≤ 8000); optimistic locking via `version` column; RLS via `agent_session_groups` join (no direct `user_id` column); 4 new `audit_action` enum values
- **`packages/styrby-shared/src/context-sync/`** — pure deterministic summarizer (no LLM calls, <5ms, 100% deterministic): extracts file refs from tool_call arguments, computes recency+frequency relevance scores, builds fixed-template markdown; Phase 3.3 scrub engine applied to all content before storage; `buildInjectionPrompt()` assembles the system-role handoff prompt; subpath export `@styrby/shared/context-sync` added
- **CLI `styrby context {show,sync,export,import}`** — full arg parsing with UUID validation, `--budget` clamping, optimistic-lock retry on sync, audit logging on all writes; wired into `commandRouter.ts` + `helpScreen.ts`
- **`POST /api/sessions/groups/[groupId]/focus`** — Phase 3.5 extension: fetches `agent_context_memory` for the group and builds `ContextInjectionPayload` in the same response as the focus update; graceful `contextInjection: null` fallback when no memory exists (agent starts cold - same as pre-Phase-3.5); injection errors are non-fatal and logged

## Security

- All message content is scrubbed by the Phase 3.3 scrub engine before any field in `agent_context_memory` is written (secrets + file_paths + commands)
- `token_budget` server-side cap at 8000 enforced at DB layer (CHECK constraint) and application layer
- RLS policy uses EXISTS subquery to agent_session_groups for group ownership — no cross-user context access possible
- `(SELECT auth.uid())` pattern used in RLS for query-plan caching (CLAUDE.md Query Optimization Patterns)
- GDPR Art. 5(1)(c) data minimisation: only first 200 chars of each message stored as preview
- SOC2 CC6.1: no cached plaintext; scrub applied before every write

## Test plan

- [x] `packages/styrby-shared`: 86 summarizer unit tests (deterministic output, scrub integration, file-ref extraction, token-budget truncation, injection prompt builder) — all passing
- [x] `packages/styrby-cli`: 36 context command arg parser tests + dispatcher exit tests — all passing
- [x] `packages/styrby-web`: 6 focus route Phase 3.5 injection tests (null when no memory, payload populated, non-fatal memory fetch error, relevance threshold filtering, estimatedTokens > 0, messageCount correct) — all passing
- [x] `packages/styrby-web`: 29 migration-039 structural tests (table creation, all columns, CHECK constraints, UNIQUE index, updated_at trigger, RLS policy, audit_action enum values, GDPR/SOC2 references) — all passing
- [x] Pre-existing: 2 startup timing test failures on `main` before this PR — unchanged

**Total new tests: 157 (86 + 36 + 6 + 29)**

## Concurrent phase isolation

Phase 3.4 agent was running in parallel. This PR intentionally avoids:
- Migration 038 (Phase 3.4 surface)
- `packages/styrby-shared/src/cost-forecast/**`
- `/api/costs/forecast`
- Cost dashboard components

🤖 Generated with [Claude Code](https://claude.com/claude-code)