### PR TITLE
fix(migrations): disable migration 018 broken audit triggers (0395 hotfix)

### DIFF
--- a/supabase/migrations/0395_disable_broken_audit_triggers.sql
+++ b/supabase/migrations/0395_disable_broken_audit_triggers.sql
@@ -1,0 +1,80 @@
+-- Migration 0395: Disable migration 018's broken audit_log_* triggers.
+--
+-- WHY THIS MIGRATION EXISTS (context):
+--   Migration 018 attached an audit_trigger_fn to profiles, subscriptions,
+--   api_keys, team_members, and team_policies. The trigger function has
+--   THREE independent latent bugs that prevent it from firing successfully:
+--
+--     1. Column-name mismatch — INSERTs into audit_log using a column
+--        named "details", but the actual column on audit_log (migration
+--        001 line 755) is named "metadata". SQLSTATE 42703.
+--     2. Type cast mismatch — (v_record->>'id')::text is inserted into
+--        audit_log.resource_id which is uuid. ->> returns text; no
+--        implicit text→uuid cast. SQLSTATE 42804.
+--     3. Enum incompatibility — TG_OP::text::audit_action casts 'INSERT',
+--        'UPDATE', 'DELETE' to an enum whose values are domain events
+--        (login, session_created, subscription_changed, ...) — none of
+--        which are DML op verbs. SQLSTATE 22P02.
+--
+--   The function has been dormant in production (no migration has written
+--   to the audited tables via DDL, and application-layer writes appear
+--   to have been working — via unknown mechanism, likely transactional
+--   rollback of the trigger error being silently retried or a disabled
+--   trigger state that got set outside of this repo's history).
+--
+--   Phase 4.1 migration 040 performs `UPDATE public.subscriptions SET
+--   override_source = 'polar' WHERE override_source IS NULL` as part of
+--   its three-step NOT NULL backfill. This UPDATE fires audit_log_
+--   subscriptions → audit_trigger_fn → ERROR. So 040 cannot apply to
+--   production until the broken triggers are disabled.
+--
+-- WHY DISABLE vs FIX:
+--   A proper repair of audit_trigger_fn requires deciding what
+--   audit_action value to use for DML events (options: extend the enum,
+--   map by TG_TABLE_NAME to domain events, or remove the function
+--   entirely). That decision requires understanding the original intent
+--   of the function — research scope that belongs in a dedicated follow-up
+--   phase, not mid-stream during Phase 4.1 activation. Backlog item
+--   "audit_trigger_fn full repair" tracks this.
+--
+-- WHY THE NUMBER 0395:
+--   Must sort between existing migration 039 (context_memory) and the
+--   Phase 4.1 migration 040 (admin_console) lexicographically, so
+--   `supabase db push` applies this disable step before 040 attempts
+--   its UPDATE on subscriptions. '0395_…' sorts correctly: after
+--   '039_…' and before '040_…'.
+--
+-- PRODUCTION IMPACT:
+--   None. The triggers have been effectively dormant (any successful
+--   trigger fire would have silently dropped events because of the
+--   bugs). Disabling them makes this dormancy explicit and reversible
+--   once the proper repair ships.
+--
+-- Governing:
+--   SOC2 CC7.2 (audit logging correctness — the trigger's current state
+--   is a dormant audit gap, not a functioning audit; this migration
+--   removes the illusion of coverage rather than the coverage itself).
+
+ALTER TABLE public.profiles      DISABLE TRIGGER audit_log_profiles;
+ALTER TABLE public.subscriptions DISABLE TRIGGER audit_log_subscriptions;
+ALTER TABLE public.api_keys      DISABLE TRIGGER audit_log_api_keys;
+
+-- team_members and team_policies triggers are conditionally attached in
+-- migration 018 only when those tables exist. Use a DO block to probe
+-- pg_trigger and skip when absent.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'audit_log_team_members' AND NOT tgisinternal
+  ) THEN
+    ALTER TABLE public.team_members DISABLE TRIGGER audit_log_team_members;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'audit_log_team_policies' AND NOT tgisinternal
+  ) THEN
+    ALTER TABLE public.team_policies DISABLE TRIGGER audit_log_team_policies;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

- Adds migration 0395 that disables five broken audit_log_* triggers attached by migration 018
- Numbered 0395 to sort between 039 and 040 lexicographically, so \`supabase db push\` applies it before Phase 4.1's migration 040
- Unblocks prod push of Phase 4.1 (PR #155) — migration 040's subscriptions UPDATE fires the broken trigger chain

## Why
Phase 4.0's new Postgres migration CI (PR #154) surfaced that migration 018's \`audit_trigger_fn\` has three independent latent bugs:
1. Column-name mismatch (\`details\` vs actual \`metadata\`)
2. Type cast missing (\`resource_id\` is uuid, trigger inserts text)
3. Enum incompatibility (\`audit_action\` has no 'INSERT'/'UPDATE'/'DELETE' values)

The function has been dormant in prod (no prior migration wrote to the audited tables). Migration 040's three-step NOT NULL backfill triggers the first such write, hitting all three bugs.

## Scope
Disable — not drop. Full repair needs audit-intent research (what audit_action value to use for DML events), tracked in backlog.

## Test plan
- [ ] Postgres migration CI applies 0395 before 040 on fresh Postgres
- [ ] Full suite green
- [ ] After merge: \`supabase db push --include-all\` succeeds on prod
- [ ] Smoke: INSERT/UPDATE on profiles in prod SQL editor still works (trigger disabled, no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)