### PR TITLE
fix(security): remove broken approval-link + add no-store for /support/access/*

### DIFF
--- a/packages/styrby-web/next.config.ts
+++ b/packages/styrby-web/next.config.ts
@@ -261,11 +261,30 @@ const nextConfig: NextConfig = {
         // WHY: CDN caching authenticated pages is a critical data-leakage risk.
         // private prevents CDN storage; no-cache forces revalidation with the
         // origin on every request; no-store disallows any intermediate storage.
+        // must-revalidate ensures HTTP/1.1 proxies also skip stale serving.
         source: '/dashboard/:path*',
         headers: [
           {
             key: 'Cache-Control',
-            value: 'private, no-cache, no-store',
+            value: 'private, no-cache, no-store, must-revalidate',
+          },
+        ],
+      },
+      {
+        // Support access pages: never cache — authenticated user approval flow
+        // WHY: /support/access/[grantId] renders per-user grant approval state.
+        // Any CDN or browser cache storing this page could expose one user's
+        // grant to another user on a shared device or after session rotation.
+        // private, no-cache, no-store, must-revalidate matches the dashboard
+        // policy and satisfies OWASP A01:2021 / SOC2 CC6.1 / GDPR Art. 5(1)(f).
+        // NOTE: This next.config.ts rule is the authoritative source of the
+        // no-store guarantee — NOT middleware. The admin session page comment
+        // previously stated middleware was responsible; that was inaccurate.
+        source: '/support/access/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'private, no-cache, no-store, must-revalidate',
           },
         ],
       },

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/success/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/success/page.tsx
@@ -206,21 +206,59 @@ export default function RequestAccessSuccessPage() {
               </p>
             )}
 
-            {/* User-facing approval link */}
-            <div className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3">
-              <p className="mb-1 text-xs font-medium text-zinc-400">
-                User approval link
-              </p>
-              <p className="break-all font-mono text-xs text-zinc-300" data-testid="approval-link">
-                {typeof window !== 'undefined'
-                  ? `${window.location.origin}/api/support-access/${grantId ?? ''}/approve?token=${rawToken}`
-                  : `/api/support-access/${grantId ?? ''}/approve?token=${rawToken}`}
-              </p>
-              <p className="mt-1 text-xs text-zinc-500">
-                Share this link with the user or include it in the support reply.
-                It expires when the grant expires.
-              </p>
-            </div>
+            {/* User-facing approval link
+                WHY this URL requires NO token in the query string:
+                  - The user must be authenticated via their own session cookie.
+                  - RLS on support_access_grants enforces ownership — a logged-in
+                    user can only see grants that belong to them.
+                  - The grantId in the URL is already persisted in the DB; the page
+                    reads it via RLS-protected SELECT, not via a query-param token.
+                  - Embedding rawToken in the URL was removed because:
+                    (a) /api/support-access/[grantId]/approve does not exist and
+                        would produce a broken link for the admin,
+                    (b) GDPR Art. 7 forbids query-param auto-approval (no affirmative
+                        POST action), and
+                    (c) exposing the token in the DOM extends the blast radius beyond
+                        the short-lived non-HttpOnly cookie.
+                  SOC2 CC6.1 / OWASP A01:2021 / GDPR Art. 7. */}
+            {grantId && (
+              <div className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3">
+                <p className="mb-1 text-xs font-medium text-zinc-400">
+                  User approval link
+                </p>
+                <p
+                  className="break-all font-mono text-xs text-zinc-300"
+                  data-testid="approval-link"
+                >
+                  {typeof window !== 'undefined'
+                    ? `${window.location.origin}/support/access/${grantId}`
+                    : `/support/access/${grantId}`}
+                </p>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    const origin =
+                      typeof window !== 'undefined' ? window.location.origin : '';
+                    try {
+                      await navigator.clipboard.writeText(
+                        `${origin}/support/access/${grantId}`,
+                      );
+                    } catch {
+                      // Clipboard API may be denied — fail silently.
+                    }
+                  }}
+                  className="mt-2 inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+                  data-testid="copy-approval-link-button"
+                >
+                  <Copy className="h-3 w-3" />
+                  Copy link
+                </button>
+                <p className="mt-1 text-xs text-zinc-500">
+                  Share this link with the user via the ticket reply form. The user
+                  must be signed in to approve - no token is embedded in the URL.
+                </p>
+              </div>
+            )}
           </div>
         ) : (
           /* Fallback when cookie is gone (reload / expired) */

--- a/packages/styrby-web/src/app/dashboard/admin/support/session/[sessionId]/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/session/[sessionId]/page.tsx
@@ -717,10 +717,12 @@ export default async function AdminSupportSessionPage({
   void headerStore; // headers() is called above; Next.js does not expose set() on this API
   // Note: In Next.js App Router Server Components, response headers are set via
   // the generateMetadata export or the special `headers` export. For no-store, we
-  // rely on the middleware adding Cache-Control: no-store to /dashboard/admin/* routes.
+  // rely on next.config.ts headers rules which apply Cache-Control:
+  //   private, no-cache, no-store, must-revalidate
+  // to both /dashboard/:path* and /support/access/:path* at the CDN/proxy layer.
+  // That config is the authoritative guarantee — NOT middleware.
   // Additional belt-and-suspenders could be added via a route.ts Response wrapper,
   // but Server Component pages cannot directly set response headers in Next.js 15.
-  // The admin middleware (Phase 4.1) should enforce no-store on the admin segment.
 
   // ── Step 13: Render ────────────────────────────────────────────────────────
   return (


### PR DESCRIPTION
## Summary

- **F1 (HIGH 9/10)**: Removed the broken approval-link block from `packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/success/page.tsx`. The old block rendered `/api/support-access/[grantId]/approve?token=<rawToken>` — an endpoint that does not exist (broken link) and also violated GDPR Art. 7 (no query-param auto-approval) and extended the token blast radius into the DOM. Replaced with a safe, token-free link: `${origin}/support/access/${grantId}`. RLS on `support_access_grants` enforces ownership when the logged-in user visits that URL — no token channel needed. Copy-link button updated accordingly.
- **F2 (MEDIUM 8/10)**: Added `Cache-Control: private, no-cache, no-store, must-revalidate` header rule for `/support/access/:path*` in `next.config.ts`. Also added `must-revalidate` to the existing `/dashboard/:path*` rule for belt-and-suspenders. Fixed a misleading comment in the admin session page that claimed middleware was the authoritative source of no-store — that guarantee comes from `next.config.ts`.

## Files changed

| File | Change |
|------|--------|
| `packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/success/page.tsx` | Replace broken token-in-URL approval link with safe `${origin}/support/access/${grantId}` |
| `packages/styrby-web/next.config.ts` | Add `/support/access/:path*` no-store rule; add `must-revalidate` to dashboard rule |
| `packages/styrby-web/src/app/dashboard/admin/support/session/[sessionId]/page.tsx` | Fix misleading comment about no-store source of truth |

## Test plan

- [x] `pnpm --filter @styrby/shared build` - PASS
- [x] `pnpm --filter styrby-web typecheck` - PASS (0 errors)
- [x] `pnpm --filter styrby-web lint` - PASS (0 errors, 74 pre-existing warnings)
- [x] `pnpm --filter styrby-web test` - PASS (172/172 test files, 2805/2805 tests)
- [x] No `rawToken` leaked into DOM or URL anywhere on the success page
- [x] `data-testid="approval-link"` now renders `${origin}/support/access/${grantId}` - no token

🤖 Generated with [Claude Code](https://claude.com/claude-code)