### PR TITLE
fix(security): webhook consistency + cookie + housekeeping bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,12 @@ ARCHITECTURE.md
 !README.md
 !SECURITY.md
 !.github/pull_request_template.md
+# Operational runbooks — committed so on-call has them in the repo (SEC-ADV-006).
+# Lives at packages/styrby-web/runbooks/ (NOT under /docs/, which is fully
+# ignored above). The recursive *.md rule would otherwise hide every runbook,
+# so we explicitly un-ignore that subtree.
+!packages/styrby-web/runbooks/
+!packages/styrby-web/runbooks/**/*.md
 .cleancode-reports/
 .perf/
 .a11y/

--- a/packages/styrby-web/.env.example
+++ b/packages/styrby-web/.env.example
@@ -49,6 +49,15 @@ SENTRY_PROJECT=
 # Generate at: sentry.io > Settings > Auth Tokens
 # Leave empty in local dev — build works without it, source maps just won't upload
 SENTRY_AUTH_TOKEN=
+# Emergency Sentry kill switch (browser bundle). Set to "true" to silence ALL
+# client-side Sentry traffic without redeploying — useful during incidents
+# where Sentry itself is the cause of user-visible errors. Mirrors the
+# server-side STYRBY_SENTRY_MUTED.
+NEXT_PUBLIC_STYRBY_SENTRY_MUTED=
+# Cal.com / Calendly booking URL surfaced from the Enterprise tier card on the
+# pricing page. Falls back to a hard-coded default when unset; set this in
+# production so prospects book directly into the founder calendar.
+NEXT_PUBLIC_ENTERPRISE_CALENDAR_URL=
 
 # Email (Resend)
 # Get your API key from: resend.com > API Keys

--- a/packages/styrby-web/runbooks/admin-runbook.md
+++ b/packages/styrby-web/runbooks/admin-runbook.md
@@ -1,0 +1,63 @@
+# Admin Operations Runbook
+
+This runbook covers operator procedures for the Styrby site-admin surface area.
+Each section maps to a security or operational finding tracked in
+`styrby-backlog.md` so the rationale is auditable.
+
+---
+
+## Removing a `site_admin` (SEC-ADV-006)
+
+**Finding:** when a row in the `site_admins` table is deleted (or the user's
+`is_site_admin` flag is otherwise revoked), any JWT issued to that user **before**
+the revocation remains valid until it expires. Supabase Auth issues access
+tokens with a default TTL of ~1 hour. During that window the revoked admin can
+still call admin RPCs that gate on the JWT's `aud` / role claim, even though
+the database row that authorizes them is gone.
+
+This matches Supabase Auth's own session model — JWT validity is independent
+of any application-level authorization table — and is consistent with how
+every JWT-based system behaves (no central revocation list at the auth layer).
+
+### Operational expectation
+
+When removing a site admin you have **two acceptable paths**:
+
+1. **Force-revoke within the JWT TTL window (preferred for high-trust roles).**
+   - Open the Supabase dashboard → Authentication → Users.
+   - Locate the user being demoted.
+   - Click "Sign out" / "Revoke sessions" on their record.
+   - This invalidates the refresh token and forces re-auth on the next access
+     token rotation. Within ~1 hour the access token will expire and cannot be
+     refreshed.
+   - Verify by tailing `admin_audit_log` for the next hour to confirm no admin
+     actions are recorded under that `granted_by` UUID.
+
+2. **Treat the TTL window as accepted residual risk (acceptable for low-risk
+   demotions, e.g., role rotation between trusted staff).**
+   - Delete the `site_admins` row.
+   - Do NOT force-revoke.
+   - Document the demotion timestamp in the team's ops log so any actions
+     within the next hour can be reviewed retroactively.
+   - This is the path used for routine staff rotations where the demoted user
+     is not adversarial.
+
+### Why we do not auto-revoke
+
+Auto-revoking on every demotion would require either:
+
+- Polling Supabase Auth's admin API on every admin RPC call (latency cost,
+  rate-limit risk), or
+- Maintaining a server-side allowlist of valid JWTs (complex, error-prone,
+  defeats the stateless nature of JWT auth).
+
+The 1-hour residual window is the same tradeoff Supabase Auth itself makes
+for every authenticated user across the platform. Documenting it explicitly
+here turns a hidden assumption into an operational expectation.
+
+### Related
+
+- See `supabase/migrations/040_*` for the `admin_audit_log` table schema.
+- See `packages/styrby-web/src/lib/admin/guard.ts` for the JWT-side admin
+  gate.
+- Backlog item: SEC-ADV-006.

--- a/packages/styrby-web/src/app/api/webhooks/polar/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/route.ts
@@ -391,19 +391,33 @@ async function handleTeamSubscriptionEvent(
     )
     .select('event_id');
 
+  // SEC-WEBHOOK-001: Mirror the individual-path posture on dedup table errors.
+  //
+  // WHY non-fatal on DB error (not 500): the team-tier downstream UPDATE on the
+  // teams table is also idempotent — the same final billing_tier / seat_cap /
+  // billing_status state results regardless of how many times we apply it for
+  // a given Polar payload. Returning 500 here would cause Polar to retry
+  // indefinitely if the polar_webhook_events table itself has a transient
+  // issue (lock contention, brief unavailability), creating a retry storm.
+  // Falling through and letting the downstream UPDATE provide correctness
+  // matches the individual path's tradeoff. The dedup failure is captured in
+  // logs (and Sentry via console.error wrapping) for ops visibility.
+  // SOC2 CC9.2: idempotency is still enforced in aggregate by the deterministic
+  // state writes; the dedup table is an optimization, not the only guarantor.
+  let dedupRecorded = true;
   if (insertError) {
-    // A DB error here (not a conflict) means we cannot safely enforce idempotency.
-    // Return 500 so Polar retries — the retry will either succeed or hit the
-    // duplicate key (if the first attempt actually committed before the error).
-    console.error('polar/route: failed to record team webhook event:', insertError.message);
-    return NextResponse.json({ error: 'Processing failed' }, { status: 500 });
-  }
-
-  if (!insertedRows || insertedRows.length === 0) {
+    console.error(
+      'polar/route: team path — failed to record event in polar_webhook_events (non-fatal):',
+      insertError.message,
+    );
+    dedupRecorded = false;
+  } else if (!insertedRows || insertedRows.length === 0) {
     // Conflict — this event was already processed. Acknowledge and return.
     if (isDev) console.log(`polar/route: duplicate team event ${eventId}, skipping`);
     return NextResponse.json({ received: true });
   }
+  // dedupRecorded is informational only; the function continues either way.
+  void dedupRecorded;
 
   // --------------------------------------------------------------------------
   // 2. Product ID resolution (subscription.updated only)

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/actions.ts
@@ -252,15 +252,27 @@ export async function requestSupportAccessAction(
   if (error) return mapRpcError(error, 'request_support_access');
 
   // ── 5. Flash raw token via short-lived cookie ──────────────────────────────
-  // WHY non-HttpOnly: the success page JS needs to clear this cookie after
-  // displaying the token. HttpOnly cookies cannot be cleared by client-side JS.
-  // WHY maxAge: 60 (1 minute): tight window ensures the token self-destructs
+  // SEC-COOKIE-001: Hardened from sameSite='lax' to 'strict'.
+  //
+  // WHY 'strict' is correct here (correcting the prior 'lax' rationale):
+  // The redirect target (/dashboard/admin/support/[id]/request-access/success)
+  // is same-site as the form-submission origin. SameSite=Strict ONLY drops
+  // cookies on cross-site navigations — same-site server-action redirects
+  // preserve the cookie. The previous comment claimed Strict would drop the
+  // cookie on the redirect; that was factually incorrect for this flow. Strict
+  // gives maximum CSRF protection for a 60-second read-once token without
+  // breaking the redirect.
+  //
+  // WHY non-HttpOnly: the success page JS reads + clears this cookie after
+  // displaying the raw token. HttpOnly cookies cannot be cleared from JS, and
+  // we want the token gone the instant the admin sees it (defense-in-depth
+  // against shoulder-surfing or stale tabs).
+  //
+  // WHY maxAge=60 (1 minute): tight window ensures the token self-destructs
   // even if the admin doesn't navigate to the success page immediately. We do
   // NOT use sessionStorage here because the redirect creates a new navigation
   // which would clear sessionStorage in some browsers.
-  // WHY sameSite: 'lax': prevents CSRF while allowing the redirect to carry
-  // the cookie. 'strict' would drop the cookie on the redirect from the form
-  // submission response.
+  //
   // SECURITY: the raw token is the ONLY sensitive value in this cookie. The
   // grant ID in the redirect URL is not sensitive (it's a bigint primary key
   // visible only to admins).
@@ -268,7 +280,7 @@ export async function requestSupportAccessAction(
   cookieStore.set('support_grant_token_once', raw, {
     httpOnly: false,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
+    sameSite: 'strict',
     maxAge: 60,
     path: '/',
   });

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
@@ -263,11 +263,20 @@ export async function issueRefundAction(
   let polarResponseJson: unknown;
 
   try {
+    // SEC-REFUND-001 (TODO): Polar's refund API requires an actual order ID,
+    // not a subscription ID. Verified against the SDK type at
+    // `@polar-sh/sdk/src/models/components/refundcreate.ts` — `orderId` is
+    // required and is NOT aliased to subscription_id. Passing subscription_id
+    // here will cause Polar to return HTTPValidationError (mapped to
+    // RefundError code='invalid' inside createPolarRefund). The correct fix
+    // is to call `polar.orders.list({ subscriptionId })` to find the most
+    // recent paid order for this subscription (or accept an orderId from the
+    // admin form) BEFORE calling createPolarRefund. This bundle leaves the
+    // existing fallback in place because production has not yet exercised
+    // the refund path; switching to a Polar-orders lookup is a separate PR
+    // (PR-D in the backlog) so the change is reviewable in isolation.
     const refundResult = await createPolarRefund({
       subscriptionId: subscription_id,
-      // WHY subscriptionId as orderId: the admin UI references subscriptions, not
-      // individual orders. The spec accepts subscriptionId here; when Polar exposes
-      // a dedicated orderId lookup endpoint, this should be updated accordingly.
       orderId: subscription_id,
       amountCents: amount_cents,
       reason,

--- a/packages/styrby-web/src/lib/admin/resolveEmails.ts
+++ b/packages/styrby-web/src/lib/admin/resolveEmails.ts
@@ -39,10 +39,64 @@ interface ResolveEmailRow {
   email: string | null;
 }
 
+/**
+ * SEC-ADV-007: Typed error thrown when resolveAdminEmails is invoked with a
+ * non-service-role client. Distinct class so callers can catch this specifically
+ * (e.g. to render a forensic-degraded UI) without swallowing other RPC errors.
+ *
+ * WHY a typed error (not a generic Error): the previous behavior silently
+ * returned `{}` when called with a user-scoped client, causing the admin
+ * forensic UI to show UUIDs everywhere with no log signal that anything was
+ * wrong. A typed throw makes the failure loud and traceable.
+ */
+export class AdminEmailResolverMisuseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AdminEmailResolverMisuseError';
+  }
+}
+
+/**
+ * SEC-ADV-007: Asserts the supplied Supabase client carries the service-role
+ * key. The `resolve_user_emails_for_admin` RPC is GRANT EXECUTE TO service_role
+ * only; calling with a user-scoped client returns permission-denied that this
+ * helper used to swallow into an empty map. Throwing at the boundary surfaces
+ * the misuse loudly during dev/test, before it manifests as a degraded admin UI
+ * in production. SOC 2 CC6.1 (logical access control assertions).
+ *
+ * WHY runtime check (not just types): SupabaseClient is the same TypeScript
+ * type for both user and service-role clients. The only runtime distinguisher
+ * is `client.supabaseKey === process.env.SUPABASE_SERVICE_ROLE_KEY`.
+ *
+ * WHY skip the check when the env var is unset: in test environments (vitest)
+ * the service-role key may be absent. We only enforce when both sides exist;
+ * when either is missing we fall back to letting the RPC's own permission
+ * check decide. This avoids breaking tests that mock the client without
+ * setting env vars.
+ */
+function assertServiceRoleClient(supabase: SupabaseClient): void {
+  const expected = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  // Accessing the private supabaseKey field via a typed cast — the property
+  // exists at runtime on every supabase-js v2 client (verified in
+  // node_modules/@supabase/supabase-js dist).
+  const actual = (supabase as unknown as { supabaseKey?: string }).supabaseKey;
+  if (!expected || !actual) return;
+  if (actual !== expected) {
+    throw new AdminEmailResolverMisuseError(
+      'resolveAdminEmails requires a service-role client (createAdminClient()). ' +
+        'Got a client with a different supabaseKey — likely a user-scoped client. ' +
+        'See SEC-ADV-007 in styrby-backlog.md.',
+    );
+  }
+}
+
 export async function resolveAdminEmails(
   supabase: SupabaseClient,
   userIds: string[],
 ): Promise<Record<string, string>> {
+  // SEC-ADV-007: Loud misuse detection — see assertServiceRoleClient above.
+  assertServiceRoleClient(supabase);
+
   // Short-circuit: avoid an unnecessary DB round-trip for empty input.
   if (userIds.length === 0) return {};
 

--- a/packages/styrby-web/src/lib/billing/polar-refund.ts
+++ b/packages/styrby-web/src/lib/billing/polar-refund.ts
@@ -24,18 +24,17 @@
  * WHY orderId is the refund target (not subscriptionId):
  * Polar's refund API operates on *orders* (individual charges), not subscriptions
  * (recurring billing agreements). A subscription generates one or more orders
- * (one per billing cycle). The admin UI passes the Polar subscription ID as a
- * human-readable reference, but the actual refund must target a specific order
- * ID. The `subscriptionId` param here is stored as metadata on the refund for
- * the audit trail; callers must separately resolve the orderId from Polar's
- * order list before calling this function. The param is named `subscriptionId`
- * (not `orderId`) to match the admin panel's data model where admins look up
- * by subscription, not by charge.
+ * (one per billing cycle). Verified against the SDK type definition at
+ * `node_modules/@polar-sh/sdk/src/models/components/refundcreate.ts`:
+ * `RefundCreate` has a required `orderId: string` field and NO `subscriptionId`
+ * field. The two identifiers are NOT aliased by the SDK — passing a
+ * subscription ID where the SDK expects an order ID will produce a 4xx from
+ * Polar (HTTPValidationError → mapped to RefundError code='invalid' below).
  *
- * NOTE: If the admin panel stores both orderId and subscriptionId, replace the
- * subscriptionId param with orderId and adjust callers accordingly. The function
- * signature uses `subscriptionId` to match the T3 spec contract; the orderId
- * passed to Polar's SDK is provided separately via `params.orderId`.
+ * The `subscriptionId` param on this function exists only as metadata for the
+ * audit trail and dashboard cross-reference. Callers MUST resolve the actual
+ * Polar order ID separately (e.g., via `polar.orders.list({ subscriptionId })`)
+ * before calling this function. SEC-REFUND-001 tracks the upstream caller fix.
  *
  * SOC2 CC7.2: All external service interactions that affect customer billing are
  * logged with full request metadata (idempotencyKey, refundId, rawResponse) so


### PR DESCRIPTION
## Summary

Bundles 6 small security/operational findings from /sec-ship into one PR:

- **SEC-WEBHOOK-001** — Polar webhook team-path now falls through (structured log) on `polar_webhook_events` insert errors instead of returning 500. Mirrors the individual-path posture; avoids retry storms when the dedup table has transient issues. The downstream teams-table UPDATE is idempotent on its own.
- **SEC-REFUND-001** — Verified Polar SDK `refunds.create()` signature: `orderId` is **required** and **not** aliased to `subscription_id`. Updated module comment in `polar-refund.ts` to cite the SDK type location. Added an explicit `SEC-REFUND-001` TODO at the caller (`admin/users/[userId]/billing/actions.ts`) flagging that the current `orderId: subscription_id` will produce 4xx until a `polar.orders.list({ subscriptionId })` lookup is added (deferred to PR-D).
- **SEC-COOKIE-001** — `support_grant_token_once` cookie hardened from `sameSite='lax'` to `sameSite='strict'`. The redirect target is same-site so Strict preserves the cookie; the prior 'lax' rationale was factually incorrect. Strict = max CSRF protection for the 60-second read-once token.
- **SEC-ENV-001** — Added `NEXT_PUBLIC_STYRBY_SENTRY_MUTED` and `NEXT_PUBLIC_ENTERPRISE_CALENDAR_URL` to `.env.example` (both are used in code but were missing from the example).
- **SEC-ADV-007** — `resolveAdminEmails` now throws a typed `AdminEmailResolverMisuseError` if invoked with a non-service-role client. Compares `client.supabaseKey` against `SUPABASE_SERVICE_ROLE_KEY`. Skips the check when the env var is unset (test environments) so existing mocks keep working.
- **SEC-ADV-006** — Added `packages/styrby-web/runbooks/admin-runbook.md` documenting the `site_admin` removal procedure. JWT validity persists ~1hr after the row is deleted (matches Supabase Auth's session model). Operators choose: force-revoke via dashboard within the window, or accept the residual risk for low-trust rotations. Required a `.gitignore` exception so the runbook isn't hidden by the recursive `*.md` ignore.

## Test plan

- [x] `pnpm lint` — 0 errors, pre-existing warnings only
- [x] `pnpm test` — 3082 / 3082 pass across 189 test files (incl. `polar-refund.test.ts`, `guard.test.ts`, `rls-audit.test.ts`)
- [x] `pnpm build` — pass
- [ ] Manual: trigger team-tier Polar webhook with simulated dedup-table error and confirm 200 + Sentry log (deferred to staging)
- [ ] Manual: support-grant cookie flow end-to-end (request access → success page reads + clears cookie) on staging to confirm Strict does not drop it

🤖 Generated with [Claude Code](https://claude.com/claude-code)