### PR TITLE
fix(billing): tier resolution reads max(personal, team) tier (SEC-ADV-004)

### DIFF
--- a/packages/styrby-shared/src/constants.ts
+++ b/packages/styrby-shared/src/constants.ts
@@ -106,4 +106,29 @@ export const TIER_LIMITS = {
     apiAccess: true,
     teamFeatures: true,
   },
+  // WHY business / enterprise mirror team caps for enforcement (SEC-ADV-004):
+  // Migration 055 extended `subscriptions.tier` enum to include the team-family
+  // values (team / business / enterprise). The cross-read tier resolver in
+  // `tier-enforcement.ts` may now legitimately resolve a user to any of these
+  // values when their team's `teams.billing_tier` outranks their personal sub.
+  // Without entries here, `TIER_LIMITS[tier]` would be undefined and the
+  // enforcement check would crash. We give them the same enforcement caps as
+  // 'team' (most permissive existing entry); separate marketing/feature caps
+  // still live in `tiers/utils.ts` `TIER_NUMERIC_LIMITS` for the broader matrix.
+  business: {
+    maxAgents: 3,
+    maxSessionsPerDay: Infinity,
+    costDashboard: 'full',
+    budgetAlerts: true,
+    apiAccess: true,
+    teamFeatures: true,
+  },
+  enterprise: {
+    maxAgents: 3,
+    maxSessionsPerDay: Infinity,
+    costDashboard: 'full',
+    budgetAlerts: true,
+    apiAccess: true,
+    teamFeatures: true,
+  },
 } as const;

--- a/packages/styrby-web/src/app/api/bookmarks/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/bookmarks/__tests__/route.test.ts
@@ -134,6 +134,7 @@ describe('Bookmarks API', () => {
       fromCallQueue.push({ data: [{ id: 'bm-1', session_id: VALID_SESSION_ID, note: null, created_at: '2026-01-01T00:00:00Z' }], error: null });
       // 2. subscriptions lookup (getUserTier)
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       const res = await GET();
       expect(res.status).toBe(200);
@@ -148,6 +149,7 @@ describe('Bookmarks API', () => {
       mockAuthenticated();
       fromCallQueue.push({ data: [], error: null });
       fromCallQueue.push({ data: null, error: null }); // no subscription → free
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       const res = await GET();
       expect(res.status).toBe(200);
@@ -195,6 +197,7 @@ describe('Bookmarks API', () => {
       mockAuthenticated();
       // getUserTier → free
       fromCallQueue.push({ data: null, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       // count → 5 (at limit)
       fromCallQueue.push({ count: 5, error: null });
 
@@ -207,6 +210,7 @@ describe('Bookmarks API', () => {
     it('returns 403 when pro user is at bookmark limit (50/50)', async () => {
       mockAuthenticated();
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       fromCallQueue.push({ count: 50, error: null });
 
       const res = await POST(makeRequest('POST', { session_id: VALID_SESSION_ID }));
@@ -216,6 +220,7 @@ describe('Bookmarks API', () => {
     it('allows power user to exceed 50 bookmarks (unlimited)', async () => {
       mockAuthenticated();
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       fromCallQueue.push({ count: 999, error: null }); // -1 = unlimited
       fromCallQueue.push({ data: { id: 'bm-new', session_id: VALID_SESSION_ID }, error: null });
 
@@ -228,6 +233,7 @@ describe('Bookmarks API', () => {
     it('creates bookmark and returns 201', async () => {
       mockAuthenticated();
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       fromCallQueue.push({ count: 1, error: null });
       fromCallQueue.push({ data: { id: 'bm-created', session_id: VALID_SESSION_ID, note: 'key session' }, error: null });
 
@@ -240,6 +246,7 @@ describe('Bookmarks API', () => {
     it('returns 409 when session is already bookmarked', async () => {
       mockAuthenticated();
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       fromCallQueue.push({ count: 1, error: null });
       fromCallQueue.push({ data: null, error: { code: '23505', message: 'unique violation' } });
 

--- a/packages/styrby-web/src/app/api/bookmarks/route.ts
+++ b/packages/styrby-web/src/app/api/bookmarks/route.ts
@@ -14,6 +14,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { TIERS, type TierId } from '@/lib/polar';
+import { resolveEffectiveTier, toLegacyTierId } from '@/lib/tier-enforcement';
 import { z } from 'zod';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 
@@ -43,24 +44,25 @@ const DeleteBookmarkSchema = z.object({
 // ---------------------------------------------------------------------------
 
 /**
- * Resolves the user's subscription tier from Supabase.
+ * Resolves the user's EFFECTIVE subscription tier — the higher of personal
+ * `subscriptions.tier` and the maximum `teams.billing_tier` across all of
+ * their active team memberships (SEC-ADV-004).
  *
- * @param supabase - Authenticated Supabase client
- * @param userId - The authenticated user's ID
- * @returns The user's tier ID (defaults to 'free' if no subscription found)
+ * The legacy `TIERS` table only knows `'free' | 'pro' | 'power'`, so any
+ * team-family effective tier (`team` / `business` / `enterprise`) is
+ * collapsed to `'power'` via {@link toLegacyTierId} — those tiers grant
+ * at least power-level privileges for the bookmark cap.
+ *
+ * @param supabase - Authenticated Supabase client.
+ * @param userId - The authenticated user's ID.
+ * @returns The user's tier ID for `TIERS[...]` lookup (defaults to 'free').
  */
 async function getUserTier(
   supabase: Awaited<ReturnType<typeof createClient>>,
   userId: string
 ): Promise<TierId> {
-  const { data: subscription } = await supabase
-    .from('subscriptions')
-    .select('tier')
-    .eq('user_id', userId)
-    .eq('status', 'active')
-    .single();
-
-  return (subscription?.tier as TierId) || 'free';
+  const effective = await resolveEffectiveTier(supabase, userId);
+  return toLegacyTierId(effective) as TierId;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/styrby-web/src/app/api/budget-alerts/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/budget-alerts/__tests__/route.test.ts
@@ -165,6 +165,7 @@ describe('Budget Alerts API', () => {
       });
       // 2. subscriptions.select().eq().eq().single() — getUserTier
       fromCallQueue.push({ data: null, error: null }); // free tier
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       // 3. cost_records.select().eq().gte().limit() — spend calc
       fromCallQueue.push({ data: [{ cost_usd: 3.5 }, { cost_usd: 1.2 }], error: null });
 
@@ -248,6 +249,7 @@ describe('Budget Alerts API', () => {
       // POST calls Promise.all with 2 parallel queries:
       // 1. getUserTier → subscriptions.select().eq().eq().single()
       fromCallQueue.push({ data: null, error: null }); // free tier
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       // 2. count query → budget_alerts.select('id', { count: 'exact', head: true }).eq()
       // Free tier limit is 1, so having count=1 puts user at their limit.
       fromCallQueue.push({ count: 1, error: null });
@@ -265,6 +267,7 @@ describe('Budget Alerts API', () => {
 
       // 1. getUserTier → pro
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       // 2. count → 3 (at limit)
       fromCallQueue.push({ count: 3, error: null });
 
@@ -281,6 +284,7 @@ describe('Budget Alerts API', () => {
 
       // 1. getUserTier → pro
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       // 2. count → 1 (under limit of 3)
       fromCallQueue.push({ count: 1, error: null });
       // 3. insert().select().single()

--- a/packages/styrby-web/src/app/api/budget-alerts/route.ts
+++ b/packages/styrby-web/src/app/api/budget-alerts/route.ts
@@ -16,6 +16,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { TIERS, type TierId } from '@/lib/polar';
+import { resolveEffectiveTier, toLegacyTierId } from '@/lib/tier-enforcement';
 import { z } from 'zod';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 
@@ -234,14 +235,11 @@ async function getUserTier(
   supabase: Awaited<ReturnType<typeof createClient>>,
   userId: string
 ): Promise<TierId> {
-  const { data: subscription } = await supabase
-    .from('subscriptions')
-    .select('tier')
-    .eq('user_id', userId)
-    .eq('status', 'active')
-    .single();
-
-  return (subscription?.tier as TierId) || 'free';
+  // SEC-ADV-004: cross-read personal subscription + team memberships and
+  // pick the higher-ranked tier. team-family results are collapsed to
+  // 'power' for compatibility with the legacy TIERS table.
+  const effective = await resolveEffectiveTier(supabase, userId);
+  return toLegacyTierId(effective) as TierId;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/styrby-web/src/app/api/keys/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/keys/__tests__/route.test.ts
@@ -141,6 +141,7 @@ describe('GET /api/keys', () => {
 
     // Second query: getUserTier → subscriptions.select('tier').eq().eq().single()
     fromCallQueue.push({ data: { tier: 'power' }, error: null });
+    fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
     const response = await GET(new Request('http://localhost/api/keys'));
     const data = await response.json();
@@ -198,6 +199,7 @@ describe('GET /api/keys', () => {
 
     // Second query: getUserTier
     fromCallQueue.push({ data: { tier: 'power' }, error: null });
+    fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
     const response = await GET(new Request('http://localhost/api/keys'));
     const data = await response.json();
@@ -338,6 +340,7 @@ describe('POST /api/keys', () => {
 
     // getUserTier → power tier
     fromCallQueue.push({ data: { tier: 'power' }, error: null });
+    fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
     // Count query returns at/over limit (999 exceeds any tier limit)
     fromCallQueue.push({ count: 999, error: null });
@@ -367,6 +370,7 @@ describe('POST /api/keys', () => {
 
     // getUserTier → power tier
     fromCallQueue.push({ data: { tier: 'power' }, error: null });
+    fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
     // Count query → under limit
     fromCallQueue.push({ count: 2, error: null });
@@ -416,6 +420,7 @@ describe('POST /api/keys', () => {
 
     // getUserTier → power tier
     fromCallQueue.push({ data: { tier: 'power' }, error: null });
+    fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
     // Count query
     fromCallQueue.push({ count: 2, error: null });

--- a/packages/styrby-web/src/app/api/keys/route.ts
+++ b/packages/styrby-web/src/app/api/keys/route.ts
@@ -20,6 +20,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { TIERS, type TierId } from '@/lib/polar';
+import { resolveEffectiveTier, toLegacyTierId } from '@/lib/tier-enforcement';
 import { hashApiKey } from '@/lib/api-keys';
 import { generateApiKey } from '@styrby/shared';
 import { z } from 'zod';
@@ -73,14 +74,11 @@ async function getUserTier(
   supabase: Awaited<ReturnType<typeof createClient>>,
   userId: string
 ): Promise<TierId> {
-  const { data: subscription } = await supabase
-    .from('subscriptions')
-    .select('tier')
-    .eq('user_id', userId)
-    .eq('status', 'active')
-    .single();
-
-  return (subscription?.tier as TierId) || 'free';
+  // SEC-ADV-004: cross-read personal subscription + team memberships and
+  // pick the higher-ranked tier. team-family results are collapsed to
+  // 'power' for compatibility with the legacy TIERS table.
+  const effective = await resolveEffectiveTier(supabase, userId);
+  return toLegacyTierId(effective) as TierId;
 }
 
 /**

--- a/packages/styrby-web/src/app/api/teams/[id]/members/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/members/__tests__/route.test.ts
@@ -270,6 +270,7 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
 
       // 3. getUserTier => power (limit: 3)
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // 4. member count => 2 existing members
       fromCallQueue.push({ count: 2, error: null });
@@ -302,6 +303,7 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
 
       // 3. getUserTier => power
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // 4. member count => 2
       fromCallQueue.push({ count: 2, error: null });
@@ -340,6 +342,7 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
 
       // 3. getUserTier => power
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // 4. member count => 1
       fromCallQueue.push({ count: 1, error: null });
@@ -381,6 +384,7 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
 
       // 3. getUserTier => power
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // 4. member count => 2
       fromCallQueue.push({ count: 2, error: null });
@@ -443,6 +447,7 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
 
       // 3. getUserTier => power (uses team owner's tier)
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // 4. member count => 2
       fromCallQueue.push({ count: 2, error: null });
@@ -505,6 +510,7 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
 
       // 3. getUserTier => power
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // 4. member count => 1
       fromCallQueue.push({ count: 1, error: null });
@@ -558,6 +564,7 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
 
       // 3. getUserTier => power
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // 4. member count => 1
       fromCallQueue.push({ count: 1, error: null });
@@ -606,6 +613,7 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
 
       // 3. power tier
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // 4. member count => 2
       fromCallQueue.push({ count: 2, error: null });

--- a/packages/styrby-web/src/app/api/teams/[id]/members/route.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/members/route.ts
@@ -13,6 +13,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { TIERS, type TierId } from '@/lib/polar';
+import { resolveEffectiveTier, toLegacyTierId } from '@/lib/tier-enforcement';
 import { z } from 'zod';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { randomBytes } from 'crypto';
@@ -60,14 +61,11 @@ async function getUserTier(
   supabase: Awaited<ReturnType<typeof createClient>>,
   userId: string
 ): Promise<TierId> {
-  const { data: subscription } = await supabase
-    .from('subscriptions')
-    .select('tier')
-    .eq('user_id', userId)
-    .eq('status', 'active')
-    .single();
-
-  return (subscription?.tier as TierId) || 'free';
+  // SEC-ADV-004: cross-read personal subscription + team memberships and
+  // pick the higher-ranked tier. team-family results are collapsed to
+  // 'power' for compatibility with the legacy TIERS table.
+  const effective = await resolveEffectiveTier(supabase, userId);
+  return toLegacyTierId(effective) as TierId;
 }
 
 /**

--- a/packages/styrby-web/src/app/api/teams/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/teams/__tests__/route.test.ts
@@ -166,6 +166,7 @@ describe('Teams API — /api/teams', () => {
 
       // getUserTier: subscriptions.select().eq().eq().single()
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // teams.select('id, created_at').in('id', teamIds)
       fromCallQueue.push({
@@ -214,6 +215,7 @@ describe('Teams API — /api/teams', () => {
 
       // getUserTier: pro tier
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       const response = await GET();
       expect(response.status).toBe(200);
@@ -300,6 +302,7 @@ describe('Teams API — /api/teams', () => {
 
       // WHY: Pro is single-user — team management is Power-only.
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       const req = createNextRequest({ name: 'My Team' });
       const response = await POST(req);
@@ -314,6 +317,7 @@ describe('Teams API — /api/teams', () => {
 
       // getUserTier: power tier
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // insert().select().single()
       fromCallQueue.push({
@@ -345,6 +349,7 @@ describe('Teams API — /api/teams', () => {
 
       // getUserTier: power tier
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // insert().select().single()
       fromCallQueue.push({
@@ -371,6 +376,7 @@ describe('Teams API — /api/teams', () => {
 
       // getUserTier: power tier
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       // insert fails
       fromCallQueue.push({

--- a/packages/styrby-web/src/app/api/teams/route.ts
+++ b/packages/styrby-web/src/app/api/teams/route.ts
@@ -14,6 +14,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { TIERS, type TierId } from '@/lib/polar';
+import { resolveEffectiveTier, toLegacyTierId } from '@/lib/tier-enforcement';
 import { z } from 'zod';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 
@@ -56,14 +57,11 @@ async function getUserTier(
   supabase: Awaited<ReturnType<typeof createClient>>,
   userId: string
 ): Promise<TierId> {
-  const { data: subscription } = await supabase
-    .from('subscriptions')
-    .select('tier')
-    .eq('user_id', userId)
-    .eq('status', 'active')
-    .single();
-
-  return (subscription?.tier as TierId) || 'free';
+  // SEC-ADV-004: cross-read personal subscription + team memberships and
+  // pick the higher-ranked tier. team-family results are collapsed to
+  // 'power' for compatibility with the legacy TIERS table.
+  const effective = await resolveEffectiveTier(supabase, userId);
+  return toLegacyTierId(effective) as TierId;
 }
 
 /**

--- a/packages/styrby-web/src/app/api/templates/route.ts
+++ b/packages/styrby-web/src/app/api/templates/route.ts
@@ -18,6 +18,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { TIERS, type TierId } from '@/lib/polar';
+import { resolveEffectiveTier, toLegacyTierId } from '@/lib/tier-enforcement';
 import { z } from 'zod';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 
@@ -62,14 +63,11 @@ async function getUserTier(
   supabase: Awaited<ReturnType<typeof createClient>>,
   userId: string
 ): Promise<TierId> {
-  const { data: subscription } = await supabase
-    .from('subscriptions')
-    .select('tier')
-    .eq('user_id', userId)
-    .eq('status', 'active')
-    .single();
-
-  return (subscription?.tier as TierId) || 'free';
+  // SEC-ADV-004: cross-read personal subscription + team memberships and
+  // pick the higher-ranked tier. team-family results are collapsed to
+  // 'power' for compatibility with the legacy TIERS table.
+  const effective = await resolveEffectiveTier(supabase, userId);
+  return toLegacyTierId(effective) as TierId;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/styrby-web/src/app/api/webhooks/user/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/webhooks/user/__tests__/route.test.ts
@@ -160,6 +160,7 @@ describe('User Webhooks API', () => {
       });
       // 2. subscriptions.select().eq().eq().single() — getUserTier → pro
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       const response = await GET();
       expect(response.status).toBe(200);
@@ -205,6 +206,7 @@ describe('User Webhooks API', () => {
 
       fromCallQueue.push({ data: [], error: null });
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
       const response = await GET();
       const body = await response.json();
@@ -409,6 +411,7 @@ describe('User Webhooks API', () => {
       // POST calls Promise.all with 2 parallel queries:
       // 1. getUserTier → subscriptions.select().eq().eq().single()
       fromCallQueue.push({ data: null, error: null }); // free tier
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       // 2. count query → webhooks.select('id', { count: 'exact', head: true }).eq().is()
       fromCallQueue.push({ count: 0, error: null });
 
@@ -425,6 +428,7 @@ describe('User Webhooks API', () => {
 
       // 1. getUserTier → pro
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       // 2. count → 3 (at limit)
       fromCallQueue.push({ count: 3, error: null });
 
@@ -442,6 +446,7 @@ describe('User Webhooks API', () => {
 
       // 1. getUserTier → pro
       fromCallQueue.push({ data: { tier: 'pro' }, error: null });
+      fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
       // 2. count → 1 (under limit of 3)
       fromCallQueue.push({ count: 1, error: null });
       // 3. insert().select().single()

--- a/packages/styrby-web/src/app/api/webhooks/user/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/user/route.ts
@@ -16,6 +16,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { TIERS, type TierId } from '@/lib/polar';
+import { resolveEffectiveTier, toLegacyTierId } from '@/lib/tier-enforcement';
 import { z } from 'zod';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 
@@ -228,14 +229,11 @@ async function getUserTier(
   supabase: Awaited<ReturnType<typeof createClient>>,
   userId: string
 ): Promise<TierId> {
-  const { data: subscription } = await supabase
-    .from('subscriptions')
-    .select('tier')
-    .eq('user_id', userId)
-    .eq('status', 'active')
-    .single();
-
-  return (subscription?.tier as TierId) || 'free';
+  // SEC-ADV-004: cross-read personal subscription + team memberships and
+  // pick the higher-ranked tier. team-family results are collapsed to
+  // 'power' for compatibility with the legacy TIERS table.
+  const effective = await resolveEffectiveTier(supabase, userId);
+  return toLegacyTierId(effective) as TierId;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/styrby-web/src/lib/__tests__/tier-enforcement.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/tier-enforcement.test.ts
@@ -15,8 +15,19 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { checkTierLimit } from '../tier-enforcement';
-import type { TierLimitResult, TierLimitAllowed, TierLimitBlocked } from '../tier-enforcement';
+import {
+  checkTierLimit,
+  resolveEffectiveTier,
+  rankTier,
+  maxTier,
+  normalizeEffectiveTier,
+} from '../tier-enforcement';
+import type {
+  TierLimitResult,
+  TierLimitAllowed,
+  TierLimitBlocked,
+  EffectiveTierId,
+} from '../tier-enforcement';
 import { TIER_LIMITS } from '@styrby/shared';
 
 // ---------------------------------------------------------------------------
@@ -38,10 +49,20 @@ function buildSupabaseMock({
   tier,
   sessionCount = 0,
   agentCount = 0,
+  teamBillingTiers = [],
+  teamMembersError = false,
 }: {
   tier: string | null | Error;
   sessionCount?: number | Error;
   agentCount?: number | Error;
+  /**
+   * Active team memberships for the user. Each entry yields one row from
+   * `team_members` with a joined `teams.billing_tier` value. Default empty
+   * (user is on no team).
+   */
+  teamBillingTiers?: Array<string | null>;
+  /** When true, the team_members query resolves with an error. */
+  teamMembersError?: boolean;
 }) {
   const subscriptionResult =
     tier instanceof Error
@@ -50,14 +71,27 @@ function buildSupabaseMock({
       ? { data: null, error: { message: 'No rows found' } }
       : { data: { tier }, error: null };
 
-  // We need to support two different .from() calls: 'subscriptions' and either
-  // 'sessions' or 'agent_configs'. We track the table name via the mock.
+  // We need to support multiple .from() calls: 'subscriptions', 'team_members',
+  // 'sessions', 'agent_configs'. We track the table name via the mock.
   const fromMock = vi.fn((table: string) => {
     if (table === 'subscriptions') {
       return {
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
         single: vi.fn().mockResolvedValue(subscriptionResult),
+      };
+    }
+    if (table === 'team_members') {
+      // The resolver runs `.from('team_members').select('teams!inner(billing_tier)').eq('user_id', userId)`
+      // which terminates on the .eq() call.
+      const teamRows = teamBillingTiers.map((bt) => ({ teams: { billing_tier: bt } }));
+      const res = teamMembersError
+        ? { data: null, error: { message: 'team_members unavailable' } }
+        : { data: teamRows, error: null };
+      const eqMock = vi.fn().mockResolvedValue(res);
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: eqMock,
       };
     }
     if (table === 'sessions') {
@@ -381,14 +415,13 @@ describe('checkTierLimit — fail-closed: Supabase tier lookup failure', () => {
 // ---------------------------------------------------------------------------
 
 describe('checkTierLimit — fail-closed: unknown or malformed tier', () => {
-  it('defaults to free when tier is an unknown string', async () => {
-    // Future DB tier values or typos should not grant unexpected access
-    // WHY: We build an "allowed" mock (sessionCount: 0) first only to verify that
-    // the unknown tier doesn't crash — the real assertion is on `blockedResult`.
-    // enterprise is unknown → falls back to free
+  it('defaults to free when tier is a typo / unknown string', async () => {
+    // Post SEC-ADV-004 the resolver recognises all 6 canonical tier ids
+    // (free / pro / power / team / business / enterprise) — anything else
+    // (typos, future values, escalation attempts) MUST fall back to free.
     const freeLimit = TIER_LIMITS.free.maxSessionsPerDay as number;
     const blockedSupabase = buildSupabaseMock({
-      tier: 'enterprise',
+      tier: 'super-admin',
       sessionCount: freeLimit,
     });
     const blockedResult = await checkTierLimit(USER_ID, 'maxSessionsPerDay', blockedSupabase);
@@ -655,5 +688,210 @@ describe('TIER_LIMITS constants — shape validation', () => {
 
   it('pro maxAgents is less than power maxAgents', () => {
     expect(TIER_LIMITS.pro.maxAgents).toBeLessThan(TIER_LIMITS.power.maxAgents);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SEC-ADV-004 — Tier ordering helpers
+// ---------------------------------------------------------------------------
+
+describe('rankTier — canonical tier ordering', () => {
+  it('ranks all 6 known tiers monotonically', () => {
+    expect(rankTier('free')).toBe(0);
+    expect(rankTier('pro')).toBe(1);
+    expect(rankTier('power')).toBe(2);
+    expect(rankTier('team')).toBe(3);
+    expect(rankTier('business')).toBe(4);
+    expect(rankTier('enterprise')).toBe(5);
+  });
+
+  it('returns 0 (free) for an unknown tier — fail-closed', () => {
+    // @ts-expect-error — feeding an invalid string on purpose to exercise
+    // the fail-closed branch. Production callers always pass a typed value.
+    expect(rankTier('hacker-tier')).toBe(0);
+  });
+});
+
+describe('maxTier — picks the higher-ranked tier', () => {
+  it('returns the higher of two tiers', () => {
+    expect(maxTier('free', 'business')).toBe('business');
+    expect(maxTier('power', 'team')).toBe('team');
+    expect(maxTier('enterprise', 'free')).toBe('enterprise');
+  });
+
+  it('returns either when tiers are equal', () => {
+    expect(maxTier('team', 'team')).toBe('team');
+  });
+
+  it('handles power vs pro correctly (power > pro)', () => {
+    expect(maxTier('pro', 'power')).toBe('power');
+  });
+});
+
+describe('normalizeEffectiveTier — input sanitisation', () => {
+  it('preserves known tier ids', () => {
+    const all: EffectiveTierId[] = ['free', 'pro', 'power', 'team', 'business', 'enterprise'];
+    for (const t of all) {
+      expect(normalizeEffectiveTier(t)).toBe(t);
+    }
+  });
+
+  it('falls back to free for null / undefined / unknown', () => {
+    expect(normalizeEffectiveTier(null)).toBe('free');
+    expect(normalizeEffectiveTier(undefined)).toBe('free');
+    expect(normalizeEffectiveTier('')).toBe('free');
+    expect(normalizeEffectiveTier('admin')).toBe('free');
+    expect(normalizeEffectiveTier("'; DROP TABLE --")).toBe('free');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SEC-ADV-004 — resolveEffectiveTier cross-read
+// ---------------------------------------------------------------------------
+
+describe('resolveEffectiveTier — personal vs team cross-read', () => {
+  it('user with no team and free personal sub → free', async () => {
+    const supabase = buildSupabaseMock({ tier: 'free', teamBillingTiers: [] });
+    expect(await resolveEffectiveTier(supabase, USER_ID)).toBe('free');
+  });
+
+  it('user with no team but power personal sub → power (preserves current behaviour)', async () => {
+    const supabase = buildSupabaseMock({ tier: 'power', teamBillingTiers: [] });
+    expect(await resolveEffectiveTier(supabase, USER_ID)).toBe('power');
+  });
+
+  it('user with personal=free + team=business → business (THE BUG FIX)', async () => {
+    // SEC-ADV-004 happy path: a team admin whose team pays for business but
+    // who has no personal subscription must receive business-tier access.
+    const supabase = buildSupabaseMock({
+      tier: null,
+      teamBillingTiers: ['business'],
+    });
+    expect(await resolveEffectiveTier(supabase, USER_ID)).toBe('business');
+  });
+
+  it('user with personal=enterprise (admin override) + team=team → enterprise (personal outranks team)', async () => {
+    // Admin-overridden personal tier must be honored when above the team tier.
+    // Canonical TIER_ORDER: free < pro < power < team < business < enterprise.
+    const supabase = buildSupabaseMock({
+      tier: 'enterprise',
+      teamBillingTiers: ['team'],
+    });
+    expect(await resolveEffectiveTier(supabase, USER_ID)).toBe('enterprise');
+  });
+
+  it('user with personal=power + team=team → team (team outranks power per canonical order)', async () => {
+    // Pins the documented ordering: team-family always >= solo tiers.
+    const supabase = buildSupabaseMock({
+      tier: 'power',
+      teamBillingTiers: ['team'],
+    });
+    expect(await resolveEffectiveTier(supabase, USER_ID)).toBe('team');
+  });
+
+  it('user on multiple teams → max team tier wins', async () => {
+    const supabase = buildSupabaseMock({
+      tier: 'free',
+      teamBillingTiers: ['team', 'enterprise', 'business'],
+    });
+    expect(await resolveEffectiveTier(supabase, USER_ID)).toBe('enterprise');
+  });
+
+  it('team_members query error → falls back to personal tier (fail-closed for team component)', async () => {
+    const supabase = buildSupabaseMock({
+      tier: 'power',
+      teamMembersError: true,
+    });
+    expect(await resolveEffectiveTier(supabase, USER_ID)).toBe('power');
+  });
+
+  it('both reads fail → free (fail-closed end-to-end)', async () => {
+    const supabase = buildSupabaseMock({
+      tier: new Error('subs down'),
+      teamMembersError: true,
+    });
+    expect(await resolveEffectiveTier(supabase, USER_ID)).toBe('free');
+  });
+
+  it('team billing_tier with unknown value is normalised to free, does not poison max', async () => {
+    const supabase = buildSupabaseMock({
+      tier: 'pro',
+      teamBillingTiers: ['??? rogue value', null],
+    });
+    // pro outranks normalised free → effective is pro
+    expect(await resolveEffectiveTier(supabase, USER_ID)).toBe('pro');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SEC-ADV-004 — checkTierLimit honors team billing
+// ---------------------------------------------------------------------------
+
+describe('checkTierLimit — team-tier elevation via teams.billing_tier', () => {
+  it('free personal + business team → maxSessionsPerDay is unlimited', async () => {
+    // Without the cross-read, this user would be blocked at the free 5/day cap.
+    // With the fix, business has Infinity sessions so they pass without a count.
+    const supabase = buildSupabaseMock({
+      tier: null,
+      teamBillingTiers: ['business'],
+      sessionCount: 9999,
+    });
+    const result = await checkTierLimit(USER_ID, 'maxSessionsPerDay', supabase);
+    expect(isAllowed(result)).toBe(true);
+  });
+
+  it('free personal + enterprise team → maxAgents follows enterprise caps', async () => {
+    const enterpriseAgents = TIER_LIMITS.enterprise.maxAgents as number;
+    const supabase = buildSupabaseMock({
+      tier: null,
+      teamBillingTiers: ['enterprise'],
+      agentCount: enterpriseAgents - 1,
+    });
+    const result = await checkTierLimit(USER_ID, 'maxAgents', supabase);
+    expect(isAllowed(result)).toBe(true);
+  });
+
+  it('free personal + enterprise team at agent cap → blocked, tier="enterprise"', async () => {
+    const enterpriseAgents = TIER_LIMITS.enterprise.maxAgents as number;
+    const supabase = buildSupabaseMock({
+      tier: null,
+      teamBillingTiers: ['enterprise'],
+      agentCount: enterpriseAgents,
+    });
+    const result = await checkTierLimit(USER_ID, 'maxAgents', supabase);
+    expect(isBlocked(result)).toBe(true);
+    if (isBlocked(result)) {
+      expect(result.tier).toBe('enterprise');
+      expect(result.limit).toBe(enterpriseAgents);
+    }
+  });
+
+  it('admin override (personal=power) above team=team is honored', async () => {
+    // Admin set personal to power; team is on the team plan. Power outranks
+    // team in the canonical ordering only if personal is the max — but here
+    // team (rank 3) > power (rank 2), so team wins. This test pins the
+    // ordering documented in TIER_ORDER.
+    const supabase = buildSupabaseMock({
+      tier: 'power',
+      teamBillingTiers: ['team'],
+      sessionCount: 0,
+    });
+    const result = await checkTierLimit(USER_ID, 'maxSessionsPerDay', supabase);
+    // Both power and team have Infinity sessions → allowed without a count query.
+    expect(isAllowed(result)).toBe(true);
+  });
+
+  it('user on no team behaves identically to pre-SEC-ADV-004 (regression guard)', async () => {
+    const freeLimit = TIER_LIMITS.free.maxSessionsPerDay as number;
+    const supabase = buildSupabaseMock({
+      tier: 'free',
+      teamBillingTiers: [],
+      sessionCount: freeLimit,
+    });
+    const result = await checkTierLimit(USER_ID, 'maxSessionsPerDay', supabase);
+    expect(isBlocked(result)).toBe(true);
+    if (isBlocked(result)) {
+      expect(result.tier).toBe('free');
+    }
   });
 });

--- a/packages/styrby-web/src/lib/tier-enforcement.ts
+++ b/packages/styrby-web/src/lib/tier-enforcement.ts
@@ -11,18 +11,117 @@
  * This module enforces the same caps on the server side, regardless of how
  * the request was initiated.
  *
+ * WHY the resolver cross-reads `subscriptions.tier` AND `teams.billing_tier`
+ * (SEC-ADV-004): A team admin whose team is on `teams.billing_tier='business'`
+ * but who has no personal `subscriptions` row (or an outdated one with
+ * `tier='free'`) was previously receiving free-tier limits despite their team
+ * paying. We now compute the EFFECTIVE tier as
+ *   max(personal_subscription_tier, max(team_billing_tier_for_active_memberships))
+ * over the canonical tier ordering free < pro < power < team < business <
+ * enterprise. This:
+ *   - avoids a backfill migration (no risk of inconsistent state during deploy)
+ *   - avoids tying tier sync to team membership change triggers
+ *   - honors admin overrides that elevate a personal tier above the team tier
+ *   - correctly handles users on multiple teams (max across team memberships)
+ *
  * Design principles:
  * - Fail-closed: if tier lookup fails, defaults to 'free' (most restrictive)
- * - Infinity limits (pro/power) always pass without a DB count query
+ * - Infinity limits (pro/power/team/business/enterprise for sessions) skip DB count
  * - Returns structured errors so callers can surface actionable messages
+ *
+ * Compliance: SOC2 CC6.1 (logical access enforcement) + OWASP ASVS V11.
  */
 
-import { TIER_LIMITS, normalizeTier } from '@styrby/shared';
+import { TIER_LIMITS } from '@styrby/shared';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { TierId } from '@/lib/polar';
 
 // ---------------------------------------------------------------------------
-// Types
+// Tier identifier + ordering
+// ---------------------------------------------------------------------------
+
+/**
+ * The full set of tier identifiers that may resolve from this module.
+ *
+ * 'pro' is a legacy alias retained because some `subscriptions.tier` rows in
+ * production may still hold the literal value (the enum predates the rename).
+ * Marketing surfaces no longer offer 'pro' but enforcement must still honor
+ * it (it currently maps to a stricter cap than 'power').
+ *
+ * Order in {@link TIER_ORDER} is the canonical upgrade path used by
+ * {@link rankTier} and {@link resolveEffectiveTier}.
+ */
+export type EffectiveTierId =
+  | 'free'
+  | 'pro'
+  | 'power'
+  | 'team'
+  | 'business'
+  | 'enterprise';
+
+/**
+ * Canonical upgrade-path ordering. Index 0 = most restrictive (`free`),
+ * last = most permissive (`enterprise`). Used by {@link rankTier} so that
+ * cross-reading `max(personal, team)` always picks the higher tier.
+ */
+const TIER_ORDER: readonly EffectiveTierId[] = [
+  'free',
+  'pro',
+  'power',
+  'team',
+  'business',
+  'enterprise',
+] as const;
+
+/**
+ * Returns the canonical numeric rank for a tier within {@link TIER_ORDER}.
+ * Unknown values rank as `0` (free) — fail-closed.
+ *
+ * @param tier - The tier identifier.
+ * @returns The numeric rank (0 = free, higher = more permissive).
+ */
+export function rankTier(tier: EffectiveTierId): number {
+  const idx = TIER_ORDER.indexOf(tier);
+  return idx === -1 ? 0 : idx;
+}
+
+/**
+ * Normalises an arbitrary string to a known {@link EffectiveTierId},
+ * defaulting to `'free'` for any unknown value.
+ *
+ * WHY fail-closed to 'free' (SOC2 CC6.1): an unrecognised tier must never
+ * accidentally grant paid features. Mapping it to the most-restrictive tier
+ * is the safe default.
+ *
+ * @param raw - Raw tier string from DB / API.
+ * @returns A validated {@link EffectiveTierId}.
+ */
+export function normalizeEffectiveTier(raw: string | null | undefined): EffectiveTierId {
+  switch (raw) {
+    case 'pro':
+    case 'power':
+    case 'team':
+    case 'business':
+    case 'enterprise':
+      return raw;
+    default:
+      return 'free';
+  }
+}
+
+/**
+ * Picks the higher-ranked tier of two. Used to fold personal and team tier
+ * candidates into a single effective tier.
+ *
+ * @param a - First tier.
+ * @param b - Second tier.
+ * @returns Whichever of `a` / `b` ranks higher in {@link TIER_ORDER}.
+ */
+export function maxTier(a: EffectiveTierId, b: EffectiveTierId): EffectiveTierId {
+  return rankTier(a) >= rankTier(b) ? a : b;
+}
+
+// ---------------------------------------------------------------------------
+// Public types
 // ---------------------------------------------------------------------------
 
 /**
@@ -49,8 +148,8 @@ export interface TierLimitBlocked {
   limit: number;
   /** The current usage count. */
   current: number;
-  /** The user's resolved tier. */
-  tier: TierId;
+  /** The user's resolved effective tier. */
+  tier: EffectiveTierId;
   /** URL to upgrade the plan. */
   upgradeUrl: '/pricing';
 }
@@ -59,38 +158,151 @@ export interface TierLimitBlocked {
 export type TierLimitResult = TierLimitAllowed | TierLimitBlocked;
 
 // ---------------------------------------------------------------------------
-// Internal helpers
+// Internal helpers — DB reads
 // ---------------------------------------------------------------------------
 
 /**
- * Resolves the authenticated user's subscription tier from Supabase.
+ * Reads the user's personal subscription tier.
  *
  * WHY fail-closed default: if the subscriptions table returns an error or no
- * active row, we treat the user as 'free'. This prevents a DB hiccup from
- * granting unlimited access, while only causing a minor UX inconvenience for
- * paid users during a transient failure.
+ * active row, we treat the personal tier as 'free'. This prevents a DB
+ * hiccup from granting unlimited access. The team-tier read below may still
+ * elevate the user above 'free' if their team is paying.
  *
- * @param supabase - An authenticated Supabase client (anon or service role)
- * @param userId - The authenticated user's UUID
- * @returns The user's tier ID — 'free' | 'pro' | 'power' — defaulting to 'free'
+ * @param supabase - An authenticated Supabase client.
+ * @param userId - The authenticated user's UUID.
+ * @returns The user's personal tier — defaulting to 'free' on any miss.
  */
-async function resolveUserTier(supabase: SupabaseClient, userId: string): Promise<TierId> {
-  const { data: subscription, error } = await supabase
+async function readPersonalTier(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<EffectiveTierId> {
+  const { data, error } = await supabase
     .from('subscriptions')
     .select('tier')
     .eq('user_id', userId)
     .eq('status', 'active')
     .single();
 
-  if (error || !subscription?.tier) {
-    // WHY: Fail-closed. Any lookup failure → treat as free tier.
+  if (error || !data?.tier) {
+    return 'free';
+  }
+  return normalizeEffectiveTier(data.tier as string);
+}
+
+/**
+ * Reads the maximum `billing_tier` across all active team memberships for
+ * the user.
+ *
+ * WHY join via team_members: each row in team_members represents an ACTIVE
+ * membership (rows are deleted on leave; pending invitations live in a
+ * separate table). Joining to `teams.billing_tier` gives us the per-team
+ * paid tier without needing a denormalised column on the user.
+ *
+ * WHY fail-closed: any error or empty result yields 'free' — the personal
+ * tier is then the sole source of truth for that resolution.
+ *
+ * @param supabase - An authenticated Supabase client.
+ * @param userId - The authenticated user's UUID.
+ * @returns The highest-ranking team billing tier across all of the user's
+ *   active memberships, or 'free' when the user is on no team.
+ */
+async function readMaxTeamTier(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<EffectiveTierId> {
+  // PostgREST nested-select: pull billing_tier from the related teams row.
+  // The CHECK constraint on teams.billing_tier guarantees one of
+  // 'free' | 'team' | 'business' | 'enterprise' (migration 031), so values
+  // here are already constrained — we still pass them through the normaliser
+  // for defence-in-depth.
+  const { data, error } = await supabase
+    .from('team_members')
+    .select('teams!inner(billing_tier)')
+    .eq('user_id', userId);
+
+  if (error || !data || data.length === 0) {
     return 'free';
   }
 
-  // Phase 0.10 — delegate to the shared normalizeTier helper so web and
-  // mobile agree on the fail-closed default. Any unknown value falls back
-  // to 'free' so future tiers in the DB don't accidentally grant full access.
-  return normalizeTier(subscription.tier as string) as TierId;
+  let best: EffectiveTierId = 'free';
+  for (const row of data) {
+    // PostgREST may return `teams` as either an object (one-to-one inferred)
+    // or an array (one-to-many) depending on schema introspection. Handle both.
+    const teamsRel = (row as { teams?: unknown }).teams;
+    const candidates = Array.isArray(teamsRel) ? teamsRel : [teamsRel];
+    for (const t of candidates) {
+      const raw = (t as { billing_tier?: string } | null | undefined)?.billing_tier;
+      best = maxTier(best, normalizeEffectiveTier(raw));
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolves the EFFECTIVE tier for a user by cross-reading their personal
+ * subscription AND every team they belong to, returning the higher-ranking
+ * value (SEC-ADV-004).
+ *
+ * Use this anywhere you previously read `subscriptions.tier` directly for
+ * gating purposes. Direct reads are now a footgun because they miss the
+ * team-billing path.
+ *
+ * @param supabase - An authenticated Supabase client.
+ * @param userId - The authenticated user's UUID.
+ * @returns The user's effective tier id.
+ *
+ * @example
+ * ```ts
+ * const tier = await resolveEffectiveTier(supabase, user.id);
+ * if (tier === 'free') { return upgradePrompt(); }
+ * ```
+ */
+export async function resolveEffectiveTier(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<EffectiveTierId> {
+  // Run both reads in parallel — they are independent and the resolver is
+  // hit on every gated request, so latency matters.
+  const [personal, team] = await Promise.all([
+    readPersonalTier(supabase, userId),
+    readMaxTeamTier(supabase, userId),
+  ]);
+  return maxTier(personal, team);
+}
+
+/**
+ * Collapses an {@link EffectiveTierId} to the narrower
+ * `'free' | 'pro' | 'power'` set used by the legacy `TIERS` table in
+ * `lib/polar.ts` (and re-exported as the `TierId` type there).
+ *
+ * WHY this bridge exists: many API route handlers were written before the
+ * team-family tiers were enforceable on a per-user basis. They consume
+ * `TIERS[tier].limits.<x>` to gate features. Until those callers are fully
+ * refactored to consume `TIER_LIMITS` directly, this collapse maps the
+ * team-family tiers down to `'power'` (the most permissive solo tier in the
+ * legacy table) so a team-paying user is never accidentally downgraded.
+ *
+ * - free → free
+ * - pro → pro
+ * - power → power
+ * - team / business / enterprise → power (≥ power privileges)
+ *
+ * @param tier - The full effective tier.
+ * @returns A legacy-compatible tier id.
+ */
+export function toLegacyTierId(tier: EffectiveTierId): 'free' | 'pro' | 'power' {
+  switch (tier) {
+    case 'free':
+      return 'free';
+    case 'pro':
+      return 'pro';
+    case 'power':
+    case 'team':
+    case 'business':
+    case 'enterprise':
+      return 'power';
+  }
 }
 
 /**
@@ -99,9 +311,9 @@ async function resolveUserTier(supabase: SupabaseClient, userId: string): Promis
  * WHY interval '1 day': Rolling window rather than midnight-reset so a user
  * who starts 5 sessions at 11 PM cannot immediately start 5 more at midnight.
  *
- * @param supabase - An authenticated Supabase client
- * @param userId - The authenticated user's UUID
- * @returns Session count over the last 24 hours, or 0 on error
+ * @param supabase - An authenticated Supabase client.
+ * @param userId - The authenticated user's UUID.
+ * @returns Session count over the last 24 hours, or 0 on error.
  */
 async function countDailySessions(supabase: SupabaseClient, userId: string): Promise<number> {
   const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
@@ -125,12 +337,13 @@ async function countDailySessions(supabase: SupabaseClient, userId: string): Pro
 /**
  * Counts the number of distinct configured agents for the user.
  *
- * WHY COUNT(*): Each row in agent_configs represents one configured agent type.
- * The unique constraint on (user_id, agent_type) ensures no double-counting.
+ * WHY COUNT(*): Each row in agent_configs represents one configured agent
+ * type. The unique constraint on (user_id, agent_type) ensures no
+ * double-counting.
  *
- * @param supabase - An authenticated Supabase client
- * @param userId - The authenticated user's UUID
- * @returns Number of configured agents, or 0 on error
+ * @param supabase - An authenticated Supabase client.
+ * @param userId - The authenticated user's UUID.
+ * @returns Number of configured agents, or 0 on error.
  */
 async function countAgentConfigs(supabase: SupabaseClient, userId: string): Promise<number> {
   const { count, error } = await supabase
@@ -151,21 +364,24 @@ async function countAgentConfigs(supabase: SupabaseClient, userId: string): Prom
 // ---------------------------------------------------------------------------
 
 /**
- * Checks whether a user has exceeded their tier's limit for a given resource.
+ * Checks whether a user has exceeded their EFFECTIVE tier's limit for a
+ * given resource. Effective tier is `max(personal_subscription, team_billing)`
+ * — see {@link resolveEffectiveTier} (SEC-ADV-004).
  *
  * This is the single authoritative enforcement point for SEC-LOGIC-002. Call
  * it at the start of any API handler that creates a session or agent config
  * before performing any DB writes.
  *
  * Edge cases handled:
- * - `Infinity` limits (pro/power for sessions) → always allowed, no DB query
+ * - `Infinity` limits (pro/power/team/business/enterprise for sessions) →
+ *   always allowed, no DB count query
  * - Tier lookup failure → defaults to 'free' (fail-closed)
  * - Count query failure → returns 0 (fail-open for counting, fail-closed on tier)
  *
- * @param userId - The authenticated user's UUID
- * @param limitType - Which resource limit to check
- * @param supabase - An authenticated Supabase client instance
- * @returns `{ allowed: true }` or `{ allowed: false, limit, current, tier, upgradeUrl }`
+ * @param userId - The authenticated user's UUID.
+ * @param limitType - Which resource limit to check.
+ * @param supabase - An authenticated Supabase client instance.
+ * @returns `{ allowed: true }` or `{ allowed: false, limit, current, tier, upgradeUrl }`.
  *
  * @example
  * const result = await checkTierLimit(user.id, 'maxSessionsPerDay', supabase);
@@ -181,16 +397,17 @@ export async function checkTierLimit(
   limitType: TierLimitType,
   supabase: SupabaseClient
 ): Promise<TierLimitResult> {
-  // Resolve tier first — needed to determine the limit and whether to even count.
-  const tier = await resolveUserTier(supabase, userId);
+  // Cross-read personal sub + team memberships → effective tier.
+  const tier = await resolveEffectiveTier(supabase, userId);
 
-  // Look up the limit for this tier. TIER_LIMITS covers 'free' | 'pro' | 'power' | 'team'.
-  // We resolved tier to one of 'free' | 'pro' | 'power' above, all of which are present.
+  // Look up the limit for this tier. TIER_LIMITS now covers all 6 effective
+  // tier ids (free / pro / power / team / business / enterprise) — see
+  // packages/styrby-shared/src/constants.ts.
   const tierLimits = TIER_LIMITS[tier as keyof typeof TIER_LIMITS];
   const limit = tierLimits[limitType] as number;
 
-  // WHY early return: Infinity means unlimited (pro/power for sessions).
-  // Skip the DB count entirely to save a round-trip.
+  // WHY early return: Infinity means unlimited. Skip the DB count entirely
+  // to save a round-trip on every gated request.
   if (!isFinite(limit)) {
     return { allowed: true };
   }


### PR DESCRIPTION
## The bug (SEC-ADV-004)

`/sec-ship --comprehensive 2026-04-24` flagged that every tier-enforcement code path read only `subscriptions.tier`. After migration 031 introduced `teams.billing_tier` (TEXT + CHECK over `free/team/business/enterprise`) and migration 055 extended `subscription_tier` enum to all 6 values, the **read side never reconciled the two**.

Concrete impact: a team admin whose team is on `teams.billing_tier='business'` but who has no personal `subscriptions` row (or an outdated row with `tier='free'`) was silently receiving free-tier session/agent limits despite their team paying. Every gated API (bookmarks, budget-alerts, keys, templates, webhooks, team-create, team-invite, agent-configs) would block them at the free cap.

## The fix

Cross-read at enforcement time. New `resolveEffectiveTier(supabase, userId)` returns
`max(personal_subscription_tier, max(team_billing_tier_for_active_memberships))`
over the canonical ordering `free < pro < power < team < business < enterprise`.

`checkTierLimit` (the SEC-LOGIC-002 enforcement helper) now consumes the resolver. The 7 route handlers that had a private `getUserTier` helper duplicating the old direct read have been refactored to use the resolver via `toLegacyTierId` (which collapses team-family results to `'power'` for compatibility with the legacy `TIERS` table in `lib/polar.ts`).

## Alternatives considered (and rejected)

- **Backfill migration**: would create transient inconsistent state during deploy and lock us into a single-tier-per-user model that admin overrides legitimately violate.
- **Trigger-sync on team membership / billing change**: trigger failure modes are nasty (partial sync on multi-team users, late propagation during seat transfers) and SEC-ADV-002 just burned us on triggers a few PRs ago.
- **Server-side RPC `get_effective_tier`**: kept the resolution in TypeScript because the join is cheap, mocking is easier, and an RPC-level definition would require a migration plus rpc-contract-sync coverage for one fairly trivial query. If a future caller needs the same logic from PL/pgSQL we can add the RPC then.

## Files changed (16)

- `packages/styrby-shared/src/constants.ts` — TIER_LIMITS now has `business` + `enterprise` entries (mirror `team`).
- `packages/styrby-web/src/lib/tier-enforcement.ts` — new resolver + helpers + full JSDoc rewrite.
- `packages/styrby-web/src/lib/__tests__/tier-enforcement.test.ts` — +21 new cases (67 total).
- 7 API route handlers refactored to use the resolver: `bookmarks`, `budget-alerts`, `keys`, `teams`, `teams/[id]/members`, `templates`, `webhooks/user`.
- 6 route-handler test files updated to enqueue empty `team_members` mock results so the parallel `Promise.all` cross-read matches.

## Test plan

- [x] `pnpm vitest run` (styrby-web): 3103/3103 passing
- [x] `pnpm vitest run` (styrby-shared): 1441/1441 passing
- [x] `pnpm lint` (styrby-web): 0 errors (85 pre-existing warnings untouched)
- [x] `pnpm build` (styrby-web): clean
- [x] New unit tests cover all 6 tier values + ordering helper edge cases (unknown / null / SQL-injection / empty)
- [x] New integration tests cover: free+business team → business; power+team → team (canonical order); enterprise admin override + team=team → enterprise; multi-team max; team_members error → falls back to personal; both reads fail → free
- [x] Regression guard: user on no team behaves identically to pre-fix
- [x] Compatibility shim (`toLegacyTierId`) prevents downstream `TIERS[tier]` lookups in the 7 route handlers from blowing up on team-family values

## Compliance

SOC2 CC6.1 (logical access enforcement is consistent across the system) + OWASP ASVS V11 (business logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)