### PR TITLE
fix(security): /sec-ship comprehensive r2 cleanup bundle (7 fixes)

### DIFF
--- a/packages/styrby-web/src/__tests__/billing-ops/refund-flow.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/refund-flow.integration.test.ts
@@ -244,11 +244,19 @@ describe('issueRefundAction — end-to-end refund flow', () => {
 
     // WHY not throw: 'invalid' is a user-recoverable condition — action returns { ok: false }.
     expect(result.ok).toBe(false);
-    expect(result.error).toContain('Polar rejected');
+    // SEC-R2-S2-002: error message is now static; assert the stable prefix and
+    // verify the SDK error message is NOT leaked to the user-facing response.
+    expect(result.error).toContain('Polar rejected the refund request');
+    expect(result.error).not.toMatch(/amount exceeds/i);
     // RPC must NOT be called — no audit row for a failed refund.
     expect(mockRpc).not.toHaveBeenCalled();
-    // WHY no Sentry: 'invalid' is a 4xx (expected failure) — not an ops alert.
-    expect(mockSentryCapture).not.toHaveBeenCalled();
+    // SEC-R2-S2-002 changed posture: 'invalid' now captures Sentry at 'info'
+    // level so ops can correlate Polar API rejections without surfacing the
+    // SDK message to admins. Was previously asserted absent.
+    expect(mockSentryCapture).toHaveBeenCalledOnce();
+    const [, ctx] = mockSentryCapture.mock.calls[0];
+    expect(ctx.level).toBe('info');
+    expect(ctx.tags.refund_error_code).toBe('invalid');
   });
 
   // ── (3) Polar 'idempotent-replay' (409 from Polar) → success, RPC proceeds ─

--- a/packages/styrby-web/src/app/api/account/delete/route.ts
+++ b/packages/styrby-web/src/app/api/account/delete/route.ts
@@ -306,7 +306,11 @@ export async function DELETE(request: Request) {
       user_id: user.id,
       action: 'settings_updated',
       resource_type: 'account_deletion',
-      ip_address: request.headers.get('x-forwarded-for') || 'unknown',
+      // SEC-R2-S2-004: take only the first hop. x-forwarded-for is a comma-
+      // separated chain; a malicious client can append arbitrary text after
+      // the first comma to pollute the audit_log's ip_address column. The
+      // export route already does this split; the delete route was inconsistent.
+      ip_address: (request.headers.get('x-forwarded-for') || 'unknown').split(',')[0].trim(),
       metadata: {
         soft_delete: true,
         reason: validation.data.reason || 'Not provided',

--- a/packages/styrby-web/src/app/api/webhooks/polar/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/route.ts
@@ -1167,6 +1167,54 @@ export async function POST(request: Request) {
         const { data } = event;
         const isDev = process.env.NODE_ENV === 'development';
 
+        // SEC-R2-S2-003 — event_id dedup parity with subscription.created /
+        // subscription.updated. Without this guard, a Polar retry of a cancel
+        // event (e.g., after a transient 5xx response from us) re-runs the
+        // .update() and overwrites canceled_at on each replay. More
+        // dangerously, if Polar ever delivers a corrective re-activation
+        // followed by a delayed-replay of the cancel, the subscription would
+        // be silently re-canceled. Mirror the dedup pattern from the
+        // created/updated cases above (lines ~894–942).
+        {
+          const rawEventId = (rawParsed as Record<string, unknown>).id as string | undefined;
+          if (!rawEventId) {
+            console.error(
+              'polar/route: subscription.canceled event missing top-level id field — cannot enforce event-id dedup'
+            );
+          } else {
+            const cancelPayloadHash = sha256Hex(payload);
+            const { data: dedupRows, error: dedupErr } = await supabase
+              .from('polar_webhook_events')
+              .upsert(
+                {
+                  event_id: rawEventId,
+                  event_type: event.type,
+                  subscription_id: data.id,
+                  payload_hash: cancelPayloadHash,
+                },
+                { onConflict: 'event_id', ignoreDuplicates: true }
+              )
+              .select('event_id');
+
+            if (dedupErr) {
+              // Non-fatal — same rationale as created/updated. State-based
+              // idempotency below (the .update() is naturally idempotent for
+              // already-canceled rows) provides the correctness floor.
+              console.error(
+                'polar/route: subscription.canceled — failed to record event in polar_webhook_events (non-fatal):',
+                dedupErr.message
+              );
+            } else if (!dedupRows || dedupRows.length === 0) {
+              if (isDev) {
+                console.log(
+                  `polar/route: duplicate canceled event ${rawEventId}, skipping`
+                );
+              }
+              return NextResponse.json({ received: true });
+            }
+          }
+        }
+
         // WHY: When a subscription is canceled, access should continue until the
         // end of the paid billing period - not cut off immediately. We record
         // current_period_end (or ended_at as a fallback) so the scheduled cron

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/__tests__/actions.test.ts
@@ -429,9 +429,11 @@ describe('issueRefundAction', () => {
 
   // ── (r2) Polar invalid ────────────────────────────────────────────────────
 
-  it('(r2) Polar invalid: returns { ok: false, error: Polar rejected: ... }, no Sentry', async () => {
-    // WHY no Sentry: 'invalid' is a 4xx — the request was malformed. Expected
-    // failure condition, not an infrastructure issue.
+  it('(r2) Polar invalid: returns static error + captures Sentry at info level (SEC-R2-S2-002)', async () => {
+    // SEC-R2-S2-002: 'invalid' previously surfaced `Polar rejected: ${err.message}`
+    // verbatim, leaking Polar SDK internal field names and validation context.
+    // The fix replaces the dynamic message with a static one and captures the
+    // full error in Sentry at 'info' level (expected-failure, not server error).
     mockCreatePolarRefund.mockRejectedValueOnce(
       new RefundError('invalid', 'Amount exceeds original charge'),
     );
@@ -449,9 +451,17 @@ describe('issueRefundAction', () => {
     );
 
     expect(result).toMatchObject({ ok: false });
-    expect((result as { ok: false; error: string }).error).toMatch(/Polar rejected/);
+    expect((result as { ok: false; error: string }).error).toBe(
+      'Polar rejected the refund request. Verify the order, amount, and subscription status.',
+    );
+    // Should NOT leak the SDK error message:
+    expect((result as { ok: false; error: string }).error).not.toMatch(/Amount exceeds/);
     expect(mockRpc).not.toHaveBeenCalled();
-    expect(mockSentryCapture).not.toHaveBeenCalled();
+    // Now expects ONE Sentry call at 'info' severity (was previously asserted absent).
+    expect(mockSentryCapture).toHaveBeenCalledOnce();
+    const [, ctx] = mockSentryCapture.mock.calls[0];
+    expect(ctx.level).toBe('info');
+    expect(ctx.tags.refund_error_code).toBe('invalid');
   });
 
   // ── (r3) Polar polar-error ────────────────────────────────────────────────
@@ -702,9 +712,12 @@ describe('issueRefundAction', () => {
         }),
       );
 
+      // SEC-R2-S2-002: error message is now static, not dynamic. Just assert
+      // it contains the stable prefix, since "Polar rejected" appears at the
+      // start of the static message.
       expect(result).toEqual({
         ok: false,
-        error: expect.stringContaining('Polar rejected'),
+        error: expect.stringContaining('Polar rejected the refund request'),
       });
       expect(mockCreatePolarRefund).not.toHaveBeenCalled();
       expect(mockRpc).not.toHaveBeenCalled();

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
@@ -312,6 +312,21 @@ export async function issueRefundAction(
     return { ok: false, error: 'Subscription does not belong to this user.' };
   }
 
+  // SEC-R2-S2-001: Null polar_customer_id guard. The subscriptions table
+  // declares polar_customer_id as NOT NULL but historical / migrated rows
+  // may have it set to '' or — more dangerously — TypeScript types it as
+  // `string` while the runtime value can be null on data anomalies. Without
+  // this guard, findRefundableOrderForSubscription's customerId.trim() throws
+  // a non-RefundError TypeError, which falls through to the generic
+  // "Internal error" branch with no actionable signal to the admin.
+  if (!subRow.polar_customer_id || !subRow.polar_customer_id.trim()) {
+    return {
+      ok: false,
+      error: 'No Polar customer ID linked to this subscription — cannot resolve order.',
+      field: 'subscription_id',
+    };
+  }
+
   // ── 4. Issue refund via Polar SDK ──────────────────────────────────────────
   // WHY createPolarRefund before RPC: Polar is the authoritative money-moving
   // system. We write to Supabase only after Polar confirms. SOC 2 CC7.2.
@@ -362,9 +377,25 @@ export async function issueRefundAction(
           break;
 
         case 'invalid':
-          // WHY not Sentry: 'invalid' means Polar rejected a bad request (4xx).
-          // This is an expected failure condition — no server error to track.
-          return { ok: false, error: `Polar rejected: ${err.message}` };
+          // WHY static message (SEC-R2-S2-002): Polar SDK error strings can
+          // include internal field names, raw schema validation context, and
+          // upstream order/charge identifiers — useful for an attacker who
+          // wants to map Polar's API surface or correlate internal IDs with
+          // user accounts. We capture the full err to Sentry for ops triage
+          // and surface a stable user-facing message to the admin UI.
+          Sentry.captureException(err, {
+            level: 'info', // expected failure, not a server error — info severity
+            tags: {
+              admin_action: 'issue_refund',
+              target_user_id: targetUserId,
+              refund_error_code: err.code,
+            },
+          });
+          return {
+            ok: false,
+            error:
+              'Polar rejected the refund request. Verify the order, amount, and subscription status.',
+          };
 
         case 'polar-error':
           // WHY Sentry: Polar 5xx indicates a transient platform issue.

--- a/packages/styrby-web/src/lib/billing/polar-refund.ts
+++ b/packages/styrby-web/src/lib/billing/polar-refund.ts
@@ -518,10 +518,18 @@ export async function findRefundableOrderForSubscription(
     );
   }
 
-  // The SDK returns an async iterable of pages. We walk pages until we find
-  // the first refundable order for this subscription.
-  for await (const page of pages) {
-    for (const raw of page.result.items) {
+  // SEC-ADV-R2-006 — cap iteration at the first page (50 most-recent orders).
+  // The SDK's async iterator auto-paginates by default; for a high-volume
+  // customer with all-refunded older orders this can fan out to many sequential
+  // Polar API calls and breach Vercel's serverless function timeout. The
+  // 50-most-recent window covers the realistic admin-refund use case (the
+  // intended target is almost always within recent billing cycles); on the
+  // rare older-order edge case the helper throws 'invalid' and the admin
+  // currently has no override path. A future enhancement is an explicit
+  // orderIdOverride parameter; for now, fail-fast on the bounded scan.
+  const firstPage = await pages[Symbol.asyncIterator]().next();
+  if (firstPage.value) {
+    for (const raw of firstPage.value.result.items) {
       // The Order shape (per @polar-sh/sdk components/order.ts):
       //   { id, status, amount, refundedAmount, subscriptionId, createdAt, ... }
       // subscription_id may be camel- or snake-cased depending on SDK serializer.
@@ -546,6 +554,6 @@ export async function findRefundableOrderForSubscription(
 
   throw new RefundError(
     'invalid',
-    `No refundable orders found for subscription ${subscriptionId}. The subscription may have no paid charges, or all charges may already be fully refunded.`,
+    `No refundable orders found for subscription ${subscriptionId} in the most-recent 50 orders. The subscription may have no paid charges, or all charges may already be fully refunded.`,
   );
 }

--- a/supabase/migrations/059_audit_scrub_and_event_id_required.sql
+++ b/supabase/migrations/059_audit_scrub_and_event_id_required.sql
@@ -1,0 +1,182 @@
+-- Migration 059: audit metadata PII scrub + idempotency event-id contract enforcement
+--
+-- Closes two findings from /sec-ship --comprehensive run #2 (2026-04-25):
+--   * SEC-ADV-R2-003 (MEDIUM 5/10) — audit_trigger_fn on churn_save_offers
+--     stores polar_discount_code into user-readable audit_log; user can
+--     exfiltrate the coupon via GDPR export.
+--   * SEC-ADV-R2-004 (LOW-MEDIUM 4/10) — admin_idempotency_check_with_event
+--     silently degrades to minute-bucket dedup when p_event_id is NULL,
+--     re-exposing the audit-row collapse bug it was specifically built to
+--     prevent.
+--
+-- ────────────────────────────────────────────────────────────────────────────
+-- PART 1 — audit_trigger_fn: per-table sensitive-key scrub
+-- ────────────────────────────────────────────────────────────────────────────
+-- WHAT: replace audit_trigger_fn (last set in migration 058 with bigserial
+--   compatibility). Add a final step before the audit_log INSERT that strips
+--   sensitive columns from metadata.record on a per-table allowlist basis.
+--
+-- WHY THIS APPROACH (table-keyed scrub vs. column-level RLS or denormalised
+-- metadata):
+--   - Table-keyed scrub is the smallest behaviour change. The audit_log row
+--     keeps existing semantics; only the offending sub-key disappears.
+--   - Column-level RLS would require splitting metadata into multiple jsonb
+--     paths and gating each — heavier surgery.
+--   - Denormalising to a separate audit_record_metadata table would change
+--     query patterns across every existing audit consumer.
+--
+--   The scrub pattern is extensible: future tables that want to track
+--   mutations but avoid leaking secrets can be added to the same case.
+--
+-- TABLES SCRUBBED:
+--   churn_save_offers — strip polar_discount_code (Polar coupon string).
+--     Audit retains the offer kind / discount_pct / duration / accepted_at
+--     so SOC2 CC7.2 reconstruction works; only the raw coupon code is gone.
+--
+-- COMPATIBILITY: idempotent (CREATE OR REPLACE). Bigserial-PK handling from
+--   migration 058 is preserved verbatim.
+
+CREATE OR REPLACE FUNCTION public.audit_trigger_fn()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_record jsonb;
+  v_user_id uuid;
+  v_resource_id uuid;
+BEGIN
+  IF (TG_OP = 'DELETE') THEN
+    v_record := to_jsonb(OLD);
+  ELSIF (TG_OP = 'UPDATE') THEN
+    v_record := to_jsonb(NEW);
+  ELSIF (TG_OP = 'INSERT') THEN
+    v_record := to_jsonb(NEW);
+  END IF;
+
+  IF v_record ? 'user_id' THEN
+    BEGIN
+      v_user_id := (v_record->>'user_id')::uuid;
+    EXCEPTION WHEN invalid_text_representation THEN
+      v_user_id := NULL;
+    END;
+  ELSE
+    v_user_id := NULL;
+  END IF;
+
+  -- bigserial-PK compatibility (migration 058) — preserved unchanged.
+  BEGIN
+    v_resource_id := (v_record->>'id')::uuid;
+  EXCEPTION WHEN invalid_text_representation THEN
+    v_resource_id := NULL;
+  END;
+
+  -- SEC-ADV-R2-003 scrub: drop sensitive columns from per-table allowlist
+  -- BEFORE the metadata.record INSERT so the user-accessible audit_log path
+  -- (and the GDPR export path that reads audit_log) cannot leak them.
+  --
+  -- Currently scrubbed:
+  --   * churn_save_offers.polar_discount_code — Polar coupon code; the user
+  --     would otherwise receive the raw code via GET /api/account/export.
+  IF TG_TABLE_NAME = 'churn_save_offers' THEN
+    v_record := v_record - 'polar_discount_code';
+  END IF;
+
+  INSERT INTO public.audit_log (
+    user_id,
+    action,
+    resource_type,
+    resource_id,
+    metadata,
+    created_at
+  ) VALUES (
+    COALESCE(v_user_id, auth.uid()),
+    'record_mutated'::audit_action,
+    TG_TABLE_NAME,
+    v_resource_id,
+    jsonb_build_object(
+      'operation', TG_OP,
+      'table', TG_TABLE_NAME,
+      'record', v_record,
+      'control_ref', 'SOC2 CC7.2'
+    ),
+    now()
+  );
+
+  RETURN NULL;
+END;
+$$;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- PART 2 — admin_idempotency_check_with_event: require non-NULL event_id
+-- ────────────────────────────────────────────────────────────────────────────
+-- WHAT: replace the helper from migration 056. Drop the silent fallback that
+--   collapsed NULL p_event_id to '' and degraded to minute-bucket dedup
+--   (which is the very bug R2-IDEM was meant to fix).
+--
+-- WHY THROW INSTEAD OF FALLBACK:
+--   The helper exists specifically because the older minute-bucket dedup
+--   collapsed two distinct billing events into one audit row. Falling back
+--   to that same behaviour for NULL inputs re-creates the original bug class
+--   silently. Failing loud forces the caller to either: (a) supply a real
+--   event id (the contract), or (b) explicitly call the OLDER helper if
+--   they want minute-bucket semantics.
+--
+-- CALLER IMPACT: admin_issue_refund (migration 056) is the sole caller. Its
+--   Polar webhook event-id is sourced from refund.id, which Polar's SDK
+--   guarantees is non-null on success. The idempotent-replay path (set in
+--   actions.ts) supplies the literal string 'idempotent-replay' — also
+--   non-null. So no legitimate caller passes NULL today; the throw is
+--   strictly defensive.
+
+CREATE OR REPLACE FUNCTION public.admin_idempotency_check_with_event(
+  p_actor_user_id uuid,
+  p_action_name text,
+  p_target_user_id uuid,
+  p_reason text,
+  p_event_id text
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_lock_key bigint;
+  v_existing bigint;
+BEGIN
+  -- SEC-ADV-R2-004 — fail-loud on NULL or empty event id. The caller MUST
+  -- supply a real correlation token; without it we'd silently collapse
+  -- distinct billing events into a single audit row.
+  IF p_event_id IS NULL OR btrim(p_event_id) = '' THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '22023',
+      MESSAGE = 'admin_idempotency_check_with_event: p_event_id must be non-null and non-empty (use admin_idempotency_check for minute-bucket semantics)';
+  END IF;
+
+  v_lock_key := hashtextextended(
+    p_actor_user_id::text || '|' || p_action_name || '|' ||
+    COALESCE(p_target_user_id::text, '') || '|' ||
+    COALESCE(btrim(p_reason), '') || '|' || btrim(p_event_id),
+    0
+  );
+
+  PERFORM pg_advisory_xact_lock(v_lock_key);
+
+  SELECT id INTO v_existing
+  FROM admin_audit_log
+  WHERE actor_user_id = p_actor_user_id
+    AND action = p_action_name
+    AND COALESCE(target_user_id, '00000000-0000-0000-0000-000000000000'::uuid)
+        = COALESCE(p_target_user_id, '00000000-0000-0000-0000-000000000000'::uuid)
+    AND after_json->>'polar_event_id' = btrim(p_event_id)
+  ORDER BY id ASC
+  LIMIT 1;
+
+  RETURN v_existing;
+END;
+$$;
+
+-- Preserve EXECUTE grant (matches the original from migration 056).
+GRANT EXECUTE ON FUNCTION public.admin_idempotency_check_with_event(uuid, text, uuid, text, text) TO authenticated;

--- a/supabase/migrations/059_audit_scrub_and_event_id_required.sql
+++ b/supabase/migrations/059_audit_scrub_and_event_id_required.sql
@@ -130,12 +130,15 @@ $$;
 --   non-null. So no legitimate caller passes NULL today; the throw is
 --   strictly defensive.
 
+-- WHY parameter names match migration 056 verbatim: Postgres CREATE OR REPLACE
+-- FUNCTION allows changing the body but NOT parameter names (SQLSTATE 42P13).
+-- Names below mirror 056's signature exactly; only the body changes.
 CREATE OR REPLACE FUNCTION public.admin_idempotency_check_with_event(
-  p_actor_user_id uuid,
-  p_action_name text,
-  p_target_user_id uuid,
-  p_reason text,
-  p_event_id text
+  p_actor_id        uuid,
+  p_action          text,
+  p_target_user_id  uuid,
+  p_reason          text,
+  p_event_id        text
 )
 RETURNS bigint
 LANGUAGE plpgsql
@@ -156,7 +159,7 @@ BEGIN
   END IF;
 
   v_lock_key := hashtextextended(
-    p_actor_user_id::text || '|' || p_action_name || '|' ||
+    p_actor_id::text || '|' || p_action || '|' ||
     COALESCE(p_target_user_id::text, '') || '|' ||
     COALESCE(btrim(p_reason), '') || '|' || btrim(p_event_id),
     0
@@ -166,8 +169,8 @@ BEGIN
 
   SELECT id INTO v_existing
   FROM admin_audit_log
-  WHERE actor_user_id = p_actor_user_id
-    AND action = p_action_name
+  WHERE actor_user_id = p_actor_id
+    AND action = p_action
     AND COALESCE(target_user_id, '00000000-0000-0000-0000-000000000000'::uuid)
         = COALESCE(p_target_user_id, '00000000-0000-0000-0000-000000000000'::uuid)
     AND after_json->>'polar_event_id' = btrim(p_event_id)


### PR DESCRIPTION
## Summary

7-finding consolidated cleanup from `/sec-ship --comprehensive` run #2 (2026-04-25), following the migration-058 hotfix in #171. Four fixes closed CRITICAL/HIGH severity, three closed MEDIUM/LOW.

| # | ID | Severity | What |
|---|----|----------|------|
| 1 | S2-001 | CRITICAL 9/10 | Null `polar_customer_id` guard in `issueRefundAction` (was: TypeError → generic "Internal error") |
| 2 | S2-002 | HIGH 9/10 | Replace `Polar rejected: ${err.message}` with static msg + Sentry info-level capture (was: leaked SDK validation context to admin) |
| 3 | S2-003 | HIGH 8/10 | Add event-id dedup to `subscription.canceled` individual webhook path (regression vs created/updated siblings) |
| 4 | S2-004 | HIGH 8/10 | Split `x-forwarded-for` in delete-route audit_log (was: arbitrary multi-IP strings polluted SOC2 forensics) |
| 5 | R2-003 | MEDIUM 5/10 | Migration 059 §1: audit_trigger_fn scrubs `polar_discount_code` from churn_save_offers metadata (was: users exfiltrated coupons via GDPR export) |
| 6 | R2-004 | LOW-MED 4/10 | Migration 059 §2: `admin_idempotency_check_with_event` throws on NULL p_event_id (was: silent minute-bucket fallback re-created the bug it was built to prevent) |
| 7 | R2-006 | LOW 3/10 | Cap `findRefundableOrderForSubscription` to single Polar page (was: unbounded auto-pagination → Vercel function timeout for high-volume customers) |

## Deferred (documented residual risks)

- **R2-001** RSC payload serializes rawToken — threat-overlap with prior cookie design; substantial refactor; revisit on enterprise threat-model trigger.
- **R2-002** Idempotency on `admin_request_support_access` — rogue admin already has UI power; user sees all pending grants.
- **MIG-R2-002** GRANT/doc cosmetic mismatch.
- **R2-005** Tighten GRANT to service_role — defense-in-depth only.
- **R2-007** GDPR delete + stash race — 60s edge case, non-exploitable.

## Test plan

- [x] `pnpm test` — 3140/3140 pass
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — clean
- [ ] CI: full suite + Phase 4.0 db-reset-twice migration check
- [ ] After merge: apply migration 059 to prod via Supabase Management API

## Governing controls

SOC2 CC7.2 (audit-trail integrity), CC6.1 (admin auth), GDPR Art. 5 (data minimization — coupon code scrub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)