### PR TITLE
design(content): Wave 1 — trust + content correctness (25 fixes)

### DIFF
--- a/packages/styrby-web/src/app/blog/[slug]/page.tsx
+++ b/packages/styrby-web/src/app/blog/[slug]/page.tsx
@@ -166,12 +166,12 @@ export default async function BlogPostPage({
             {article.readTime} min read
           </span>
         </div>
-        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        <h1 className="text-balance text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           {article.title}
         </h1>
         <time
           dateTime={article.date}
-          className="mt-4 block text-sm text-muted-foreground"
+          className="mt-4 block text-sm text-muted-foreground tabular-nums"
         >
           {new Date(article.date).toLocaleDateString("en-US", {
             year: "numeric",
@@ -182,7 +182,7 @@ export default async function BlogPostPage({
       </header>
 
       {/* Article body */}
-      <div className="prose prose-invert prose-zinc max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-4 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-3 prose-p:text-muted-foreground prose-p:leading-relaxed prose-a:text-amber-400 prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground prose-code:text-amber-400 prose-code:before:content-none prose-code:after:content-none prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-border/50 prose-li:text-muted-foreground prose-table:text-sm prose-th:text-foreground prose-td:text-muted-foreground prose-th:border-border prose-td:border-border prose-thead:border-border">
+      <div className="prose prose-lg prose-invert prose-zinc max-w-prose prose-headings:font-semibold prose-headings:tracking-tight prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-4 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-3 prose-p:text-muted-foreground prose-p:leading-relaxed prose-a:text-amber-400 prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground prose-code:text-amber-400 prose-code:before:content-none prose-code:after:content-none prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-border/50 prose-li:text-muted-foreground prose-table:text-sm prose-th:text-foreground prose-td:text-muted-foreground prose-th:border-border prose-td:border-border prose-thead:border-border">
         <Content />
       </div>
 

--- a/packages/styrby-web/src/app/blog/layout.tsx
+++ b/packages/styrby-web/src/app/blog/layout.tsx
@@ -36,7 +36,7 @@ export default function BlogLayout({
   return (
     <>
       <Navbar />
-      <main id="main-content" className="min-h-screen pt-24 pb-16">
+      <main id="main-content" className="min-h-[100dvh] pt-24 pb-16">
         {children}
       </main>
       <Footer />

--- a/packages/styrby-web/src/app/blog/page.tsx
+++ b/packages/styrby-web/src/app/blog/page.tsx
@@ -94,7 +94,7 @@ export default function BlogPage() {
                 {article.readTime} min read
               </span>
             </div>
-            <h2 className="mb-2 text-lg font-semibold text-foreground group-hover:text-amber-400 transition-colors">
+            <h2 className="text-balance mb-2 text-lg font-semibold text-foreground group-hover:text-amber-400 transition-colors">
               {article.title}
             </h2>
             <p className="mb-4 text-sm text-muted-foreground leading-relaxed">
@@ -102,7 +102,7 @@ export default function BlogPage() {
             </p>
             <time
               dateTime={article.date}
-              className="text-xs text-muted-foreground"
+              className="text-xs text-muted-foreground tabular-nums"
             >
               {new Date(article.date).toLocaleDateString("en-US", {
                 year: "numeric",

--- a/packages/styrby-web/src/app/dpa/DownloadDpaButton.tsx
+++ b/packages/styrby-web/src/app/dpa/DownloadDpaButton.tsx
@@ -34,15 +34,19 @@ import { Printer } from 'lucide-react';
  */
 export function DownloadDpaButton() {
   return (
-    <button
-      type="button"
-      aria-label="Download this DPA as PDF"
-      data-print-hide
-      onClick={() => window.print()}
-      className="inline-flex items-center gap-2 rounded-lg bg-orange-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600 transition-colors"
-    >
-      <Printer className="h-4 w-4" aria-hidden="true" />
-      Download PDF
-    </button>
+    <div data-print-hide className="flex flex-col items-end">
+      <button
+        type="button"
+        aria-label="Open print dialog to save this DPA as a PDF"
+        onClick={() => window.print()}
+        className="inline-flex items-center gap-2 rounded-lg bg-orange-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-600 transition-colors"
+      >
+        <Printer className="h-4 w-4" aria-hidden="true" />
+        Print or Save as PDF
+      </button>
+      <p className="text-xs text-muted-foreground mt-2">
+        Opens your browser&apos;s print dialog. Choose &quot;Save as PDF&quot; as the destination.
+      </p>
+    </div>
   );
 }

--- a/packages/styrby-web/src/app/dpa/__tests__/page.test.tsx
+++ b/packages/styrby-web/src/app/dpa/__tests__/page.test.tsx
@@ -75,23 +75,25 @@ describe('/dpa page', () => {
   it('renders the Download PDF button', () => {
     render(<DpaPage />);
 
-    const btn = screen.getByRole('button', { name: 'Download this DPA as PDF' });
+    const btn = screen.getByRole('button', { name: 'Open print dialog to save this DPA as a PDF' });
     expect(btn).toBeInTheDocument();
   });
 
-  it('button has data-print-hide attribute', () => {
+  it('button is wrapped in a data-print-hide container (hidden in printed PDF)', () => {
     render(<DpaPage />);
 
-    const btn = screen.getByRole('button', { name: 'Download this DPA as PDF' });
-    // data-print-hide is a boolean attribute — presence (any truthy value) is sufficient
-    expect(btn).toHaveAttribute('data-print-hide');
+    const btn = screen.getByRole('button', { name: 'Open print dialog to save this DPA as a PDF' });
+    // WHY closest: the wrapper div carries data-print-hide so the button AND
+    // its helper text are both suppressed in the printed PDF output.
+    const hiddenContainer = btn.closest('[data-print-hide]');
+    expect(hiddenContainer).not.toBeNull();
   });
 
   it('button click calls window.print()', async () => {
     const user = userEvent.setup();
     render(<DpaPage />);
 
-    const btn = screen.getByRole('button', { name: 'Download this DPA as PDF' });
+    const btn = screen.getByRole('button', { name: 'Open print dialog to save this DPA as a PDF' });
     await user.click(btn);
 
     expect(mockPrint).toHaveBeenCalledTimes(1);

--- a/packages/styrby-web/src/app/dpa/page.tsx
+++ b/packages/styrby-web/src/app/dpa/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { DownloadDpaButton } from './DownloadDpaButton';
+import { SUBPROCESSORS } from '@/lib/legal/subprocessors';
 
 export const metadata: Metadata = {
   title: 'Data Processing Agreement',
@@ -43,7 +44,7 @@ export const metadata: Metadata = {
  */
 export default function DpaPage() {
   return (
-    <div className="min-h-screen bg-zinc-950">
+    <div className="min-h-[100dvh] bg-zinc-950">
       {/*
        * Print styles — hide non-content chrome when printing to PDF.
        *
@@ -71,7 +72,7 @@ export default function DpaPage() {
             color: black !important;
             background: white !important;
           }
-          .min-h-screen {
+          .min-h-[100dvh] {
             background: white !important;
           }
           article {
@@ -106,13 +107,13 @@ export default function DpaPage() {
       </header>
 
       {/* DPA content */}
-      <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <main className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
         {/* Download PDF button — hidden in print output via data-print-hide */}
         <div className="mb-6 flex justify-end">
           <DownloadDpaButton />
         </div>
 
-        <article className="prose prose-invert max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-400 prose-a:no-underline hover:prose-a:text-orange-300 prose-strong:text-zinc-200">
+        <article className="prose prose-lg prose-invert max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-400 prose-a:no-underline hover:prose-a:text-orange-300 prose-strong:text-zinc-200">
           <h1>Data Processing Agreement</h1>
           <p className="text-sm text-zinc-500">
             Effective date: March 22, 2026. Last updated: March 22, 2026.
@@ -306,71 +307,26 @@ export default function DpaPage() {
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <td>
-                  <a
-                    href="https://supabase.com/privacy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Supabase
-                  </a>
-                </td>
-                <td>Database, authentication, real-time infrastructure</td>
-                <td>United States</td>
-              </tr>
-              <tr>
-                <td>
-                  <a
-                    href="https://vercel.com/legal/privacy-policy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Vercel
-                  </a>
-                </td>
-                <td>Web application hosting and serverless compute</td>
-                <td>United States</td>
-              </tr>
-              <tr>
-                <td>
-                  <a
-                    href="https://polar.sh/legal/privacy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Polar
-                  </a>
-                </td>
-                <td>Payment processing and subscription management</td>
-                <td>European Union</td>
-              </tr>
-              <tr>
-                <td>
-                  <a
-                    href="https://resend.com/legal/privacy-policy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Resend
-                  </a>
-                </td>
-                <td>Transactional email delivery</td>
-                <td>United States</td>
-              </tr>
-              <tr>
-                <td>
-                  <a
-                    href="https://expo.dev/privacy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Expo
-                  </a>
-                </td>
-                <td>Push notification delivery (mobile app)</td>
-                <td>United States</td>
-              </tr>
+              {/*
+                WHY canonical source: SUBPROCESSORS in lib/legal/subprocessors.ts
+                is the single source of truth. /legal/subprocessors and this DPA
+                table render from the same array so the lists never drift.
+              */}
+              {SUBPROCESSORS.map((sp) => (
+                <tr key={sp.name}>
+                  <td>
+                    <a
+                      href={sp.website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {sp.name}
+                    </a>
+                  </td>
+                  <td>{sp.purpose}</td>
+                  <td>{sp.location}</td>
+                </tr>
+              ))}
             </tbody>
           </table>
 

--- a/packages/styrby-web/src/app/legal/retention-proof/page.tsx
+++ b/packages/styrby-web/src/app/legal/retention-proof/page.tsx
@@ -32,14 +32,15 @@
 
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { CheckCircle2, Clock } from 'lucide-react';
 import type { RetentionProofResponse } from '@/app/api/legal/retention-proof/route';
 
 export const metadata: Metadata = {
-  title: 'Data Retention — Target Policy and Live Proof — Styrby',
+  title: 'Data Retention: Target Policy and Live Proof | Styrby',
   description:
     "Styrby's data retention policy: target windows for all data types, plus live proof for rules backed by automated enforcement. GDPR Article 5(1)(e) storage limitation compliance.",
   openGraph: {
-    title: 'Styrby Data Retention - Target Policy and Live Proof',
+    title: 'Styrby Data Retention: Target Policy and Live Proof',
     description:
       'Retention windows for sessions, audit logs, and account data. Clearly marks which rules are enforced by automated jobs vs. committed targets in progress.',
     type: 'website',
@@ -133,7 +134,7 @@ const RETENTION_POLICY: RetentionPolicyRow[] = [
     dataType: 'Account (profile)',
     retentionWindow: '30-day grace window after deletion request',
     mechanism:
-      'Soft-delete on request (deleted_at set immediately). Hard-delete via edge function purge-deleted-accounts after 30 days — deployment in progress.',
+      'Soft-delete on request (deleted_at set immediately). Hard-delete via edge function purge-deleted-accounts after 30 days (deployment in progress).',
     gdprBasis: 'Art. 17 right to erasure (30-day grace period per Art. 17(3)(e))',
     enforcement: 'target',
     enforcementLabel: 'Target (edge function pending)',
@@ -215,7 +216,7 @@ function EnforcementBadge({
         aria-label={`Enforcement status: ${label}`}
       >
         {/* WHY checkmark icon as text: avoids an icon dependency; accessible via aria-label */}
-        <span aria-hidden="true">✅</span>
+        <CheckCircle2 className="h-4 w-4 text-emerald-400" aria-hidden="true" />
         {label}
       </span>
     );
@@ -227,7 +228,7 @@ function EnforcementBadge({
       data-enforcement="target"
       aria-label={`Enforcement status: ${label}`}
     >
-      <span aria-hidden="true">📋</span>
+      <Clock className="h-4 w-4 text-amber-400" aria-hidden="true" />
       {label}
     </span>
   );
@@ -244,7 +245,7 @@ export default async function RetentionProofPage() {
   const liveCounts = await fetchRetentionCounts();
 
   return (
-    <div className="min-h-screen bg-zinc-950">
+    <div className="min-h-[100dvh] bg-zinc-950">
       {/* Navigation header */}
       <header className="border-b border-zinc-800 bg-zinc-900/50">
         <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
@@ -288,12 +289,12 @@ export default async function RetentionProofPage() {
           {/* Enforcement legend */}
           <div className="mt-4 flex flex-wrap gap-4 rounded-lg border border-zinc-800 bg-zinc-900/40 px-4 py-3">
             <div className="flex items-center gap-2 text-sm">
-              <span aria-hidden="true">✅</span>
+              <CheckCircle2 className="h-4 w-4 text-emerald-400" aria-hidden="true" />
               <span className="text-emerald-400 font-medium">Enforced</span>
               <span className="text-zinc-400">- backed by an active automated cron or scheduled job</span>
             </div>
             <div className="flex items-center gap-2 text-sm">
-              <span aria-hidden="true">📋</span>
+              <Clock className="h-4 w-4 text-amber-400" aria-hidden="true" />
               <span className="text-amber-400 font-medium">Target</span>
               <span className="text-zinc-400">- policy we are committed to; automated enforcement in progress</span>
             </div>
@@ -414,7 +415,7 @@ export default async function RetentionProofPage() {
                   Source: sessions WHERE deleted_at IS NOT NULL AND deleted_at &gt; now() - 30 days
                 </p>
                 <p className="mt-1 text-xs text-emerald-500">
-                  ✅ Enforced by styrby_delete_expired_sessions (nightly, 03:00 CT)
+                  Enforced by styrby_delete_expired_sessions (nightly, 03:00 CT)
                 </p>
               </div>
 
@@ -449,10 +450,10 @@ export default async function RetentionProofPage() {
           <p>
             Questions about our retention policy?{' '}
             <a
-              href="mailto:legal@styrbyapp.com"
+              href="mailto:support@styrby.dev"
               className="text-zinc-400 hover:text-zinc-200 transition-colors"
             >
-              legal@styrbyapp.com
+              support@styrby.dev
             </a>
           </p>
           <p className="mt-3">

--- a/packages/styrby-web/src/app/legal/subprocessors/__tests__/page.test.tsx
+++ b/packages/styrby-web/src/app/legal/subprocessors/__tests__/page.test.tsx
@@ -131,7 +131,7 @@ describe('/legal/subprocessors page', () => {
   it('renders footer contact note', () => {
     render(<SubprocessorsPage />);
 
-    expect(screen.getByText(/legal@styrbyapp\.com/)).toBeInTheDocument();
+    expect(screen.getByText(/support@styrby\.dev/)).toBeInTheDocument();
     expect(screen.getByText(/This list is kept current/)).toBeInTheDocument();
   });
 

--- a/packages/styrby-web/src/app/legal/subprocessors/page.tsx
+++ b/packages/styrby-web/src/app/legal/subprocessors/page.tsx
@@ -30,7 +30,7 @@ import Link from 'next/link';
 import { SUBPROCESSORS, SUBPROCESSORS_LAST_UPDATED } from '@/lib/legal/subprocessors';
 
 export const metadata: Metadata = {
-  title: 'Subprocessors — Styrby',
+  title: 'Subprocessors | Styrby',
   description:
     'List of third-party subprocessors used by Styrby (Steel Motion LLC) to deliver the service. Maintained for GDPR Article 28 transparency and enterprise due diligence.',
   openGraph: {
@@ -75,7 +75,7 @@ function DpfBadge({ certified }: { certified: boolean }) {
  */
 export default function SubprocessorsPage() {
   return (
-    <div className="min-h-screen bg-zinc-950">
+    <div className="min-h-[100dvh] bg-zinc-950">
       {/* Navigation header */}
       <header className="border-b border-zinc-800 bg-zinc-900/50">
         <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
@@ -227,13 +227,12 @@ export default function SubprocessorsPage() {
             This list is kept current. For questions about sub-processor changes, data
             processing activities, or to request notification of future updates, email{' '}
             <a
-              href="mailto:legal@styrbyapp.com"
+              href="mailto:support@styrby.dev"
               className="text-zinc-400 hover:text-zinc-200 transition-colors"
             >
-              legal@styrbyapp.com
+              support@styrby.dev
             </a>
-            {' '}
-            <span className="text-zinc-500 italic">(placeholder - replace before launch)</span>.
+            .
           </p>
           <p className="mt-3">
             Related:{' '}

--- a/packages/styrby-web/src/app/login/page.tsx
+++ b/packages/styrby-web/src/app/login/page.tsx
@@ -343,7 +343,7 @@ function LoginForm() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-[100dvh] flex-col">
       <div className="flex flex-1 items-center justify-center px-4">
         {/* Background effects */}
         <div className="fixed inset-0 -z-10" />
@@ -394,6 +394,7 @@ function LoginForm() {
                       onChange={(e) => setEmail(e.target.value)}
                       placeholder="you@example.com"
                       required
+                      autoFocus
                       autoComplete="email"
                       className="bg-secondary/60 border-border/60 text-foreground placeholder:text-muted-foreground focus-visible:ring-amber-500"
                     />
@@ -540,7 +541,7 @@ export default function LoginPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen items-center justify-center">
+        <div className="flex min-h-[100dvh] items-center justify-center">
           <div className="h-8 w-8 animate-spin rounded-full border-2 border-amber-500 border-t-transparent" />
         </div>
       }

--- a/packages/styrby-web/src/app/opengraph-image.tsx
+++ b/packages/styrby-web/src/app/opengraph-image.tsx
@@ -12,7 +12,7 @@
 import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
-export const alt = 'Styrby — AI Agent Dashboard';
+export const alt = 'Styrby: AI Agent Dashboard';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -100,7 +100,7 @@ export default function OGImage() {
               fontWeight: 400,
             }}
           >
-            Monitor costs, approve permissions, and stay in control — anywhere.
+            Monitor costs, approve permissions, and stay in control, anywhere.
           </p>
         </div>
 

--- a/packages/styrby-web/src/app/pricing/error.tsx
+++ b/packages/styrby-web/src/app/pricing/error.tsx
@@ -19,7 +19,7 @@ export default function PricingError({
   reset: () => void;
 }) {
   return (
-    <div className="min-h-screen bg-zinc-950 flex items-center justify-center px-4">
+    <div className="min-h-[100dvh] bg-zinc-950 flex items-center justify-center px-4">
       <div className="max-w-md w-full text-center">
         <div className="mx-auto h-16 w-16 rounded-full bg-red-500/10 flex items-center justify-center mb-6">
           <svg

--- a/packages/styrby-web/src/app/pricing/loading.tsx
+++ b/packages/styrby-web/src/app/pricing/loading.tsx
@@ -6,7 +6,7 @@
  */
 export default function PricingLoading() {
   return (
-    <div className="min-h-screen bg-zinc-950 flex items-center justify-center">
+    <div className="min-h-[100dvh] bg-zinc-950 flex items-center justify-center">
       <div className="flex flex-col items-center gap-4">
         <div
           className="h-10 w-10 animate-spin rounded-full border-4 border-zinc-700 border-t-orange-500"

--- a/packages/styrby-web/src/app/pricing/page.tsx
+++ b/packages/styrby-web/src/app/pricing/page.tsx
@@ -67,7 +67,7 @@ export default function PricingPage() {
   const [activeFaq, setActiveFaq] = useState(0);
 
   return (
-    <main className="min-h-screen">
+    <main className="min-h-[100dvh]">
       {/* A/B tracking - fires page_view once on mount, no DOM output */}
       <PricingPageTracker variant="v2" />
 
@@ -80,10 +80,10 @@ export default function PricingPage() {
             Pricing
           </p>
           <h1 className="mt-3 text-balance text-4xl font-bold tracking-tight text-foreground md:text-5xl">
-            Simple, transparent pricing
+            Pricing built for the way you actually run AI agents
           </h1>
           <p className="mx-auto mt-4 max-w-xl text-lg text-muted-foreground leading-relaxed">
-            Start free, scale as you grow. No hidden fees, no surprises. Cancel anytime.
+            From one machine on Solo to a fleet on Business. Annual billing saves about 17%. Cancel anytime, no seat fees on monthly.
           </p>
         </div>
       </section>

--- a/packages/styrby-web/src/app/pricing/upgrade-button.tsx
+++ b/packages/styrby-web/src/app/pricing/upgrade-button.tsx
@@ -53,6 +53,17 @@ export function UpgradeButton({ tierId, billingCycle, isPopular }: UpgradeButton
     }
   };
 
+  // WHY tier-specific copy: generic "Upgrade" forces the user to look back at
+  // the card title to confirm what they're buying. Naming the destination tier
+  // (Pro / Power) inside the button is the standard pricing-page conversion
+  // pattern and complies with the project copy ban on generic CTAs.
+  const tierLabels: Record<TierId, string> = {
+    free: 'Start Free',
+    pro: 'Upgrade to Pro',
+    power: 'Upgrade to Power',
+  };
+  const ctaLabel = tierLabels[tierId] ?? 'Upgrade to Pro';
+
   return (
     <div>
       <button
@@ -64,7 +75,7 @@ export function UpgradeButton({ tierId, billingCycle, isPopular }: UpgradeButton
             : 'bg-zinc-800 text-zinc-100 hover:bg-zinc-700'
         } ${loading ? 'opacity-50 cursor-not-allowed' : ''}`}
       >
-        {loading ? 'Loading...' : 'Upgrade'}
+        {loading ? 'Loading...' : ctaLabel}
       </button>
       {error && (
         <p className="mt-2 text-sm text-red-400 text-center">{error}</p>

--- a/packages/styrby-web/src/app/privacy/page.tsx
+++ b/packages/styrby-web/src/app/privacy/page.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
  */
 export default function PrivacyPolicyPage() {
   return (
-    <div className="min-h-screen bg-zinc-950">
+    <div className="min-h-[100dvh] bg-zinc-950">
       {/* Navigation header */}
       <header className="border-b border-zinc-800 bg-zinc-900/50">
         <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
@@ -48,8 +48,8 @@ export default function PrivacyPolicyPage() {
       </header>
 
       {/* Content */}
-      <main className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-12">
-        <article className="prose prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-500 prose-a:no-underline hover:prose-a:underline prose-strong:text-zinc-100">
+      <main className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12">
+        <article className="prose prose-lg prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-500 prose-a:no-underline hover:prose-a:underline prose-strong:text-zinc-100">
           <h1>Privacy Policy</h1>
 
           <p className="text-sm text-zinc-500">
@@ -99,14 +99,14 @@ export default function PrivacyPolicyPage() {
           </p>
           <ul>
             <li>
-              <strong>Email address</strong> -- used for authentication, account
+              <strong>Email address</strong>: used for authentication, account
               recovery, and essential service notifications
             </li>
             <li>
-              <strong>Display name</strong> -- an optional name you choose
+              <strong>Display name</strong>: an optional name you choose
             </li>
             <li>
-              <strong>GitHub OAuth data</strong> -- if you sign in via GitHub,
+              <strong>GitHub OAuth data</strong>: if you sign in via GitHub,
               we receive your GitHub username, email, and avatar URL as
               authorized by you during the OAuth flow
             </li>
@@ -120,17 +120,17 @@ export default function PrivacyPolicyPage() {
           </p>
           <ul>
             <li>
-              <strong>Session records</strong> -- agent type (Claude, Codex,
+              <strong>Session records</strong>: agent type (Claude, Codex,
               Gemini), session start and end times, status, and any tags or
               summaries you create
             </li>
             <li>
-              <strong>Token usage and costs</strong> -- input tokens, output
+              <strong>Token usage and costs</strong>: input tokens, output
               tokens, cache tokens, and calculated cost in USD, used to power
               your cost dashboard and budget alerts
             </li>
             <li>
-              <strong>Encrypted message ciphertext</strong> -- stored only to
+              <strong>Encrypted message ciphertext</strong>: stored only to
               relay to your authorized devices. We cannot read this content.
             </li>
           </ul>
@@ -138,15 +138,15 @@ export default function PrivacyPolicyPage() {
           <h3>Device and Machine Information</h3>
           <ul>
             <li>
-              <strong>Machine identifiers</strong> -- an anonymized identifier
+              <strong>Machine identifiers</strong>: an anonymized identifier
               and display name for each CLI instance you register
             </li>
             <li>
-              <strong>Public keys</strong> -- cryptographic public keys used for
+              <strong>Public keys</strong>: cryptographic public keys used for
               end-to-end encryption. Private keys never leave your devices.
             </li>
             <li>
-              <strong>Push notification tokens</strong> -- APNs (iOS) or FCM
+              <strong>Push notification tokens</strong>: APNs (iOS) or FCM
               (Android) tokens used to deliver real-time alerts to your mobile
               device
             </li>
@@ -155,15 +155,15 @@ export default function PrivacyPolicyPage() {
           <h3>Configuration Data</h3>
           <ul>
             <li>
-              <strong>Agent configurations</strong> -- your per-agent settings,
+              <strong>Agent configurations</strong>: your per-agent settings,
               auto-approve rules, and blocked tool lists
             </li>
             <li>
-              <strong>Budget alerts</strong> -- your spending thresholds and
+              <strong>Budget alerts</strong>: your spending thresholds and
               chosen actions
             </li>
             <li>
-              <strong>Notification preferences</strong> -- your push and email
+              <strong>Notification preferences</strong>: your push and email
               notification settings
             </li>
           </ul>
@@ -189,26 +189,26 @@ export default function PrivacyPolicyPage() {
 
           <ul>
             <li>
-              <strong>Providing the Service</strong> -- authenticating your
+              <strong>Providing the Service</strong>: authenticating your
               account, connecting your mobile device to CLI instances, relaying
               encrypted messages, and enabling session management
             </li>
             <li>
-              <strong>Cost tracking and billing</strong> -- calculating and
+              <strong>Cost tracking and billing</strong>: calculating and
               displaying your AI token usage costs, managing your subscription
               tier, and processing payments through Polar
             </li>
             <li>
-              <strong>Notifications</strong> -- sending push notifications when
+              <strong>Notifications</strong>: sending push notifications when
               your AI agents need attention, approval, or when budget thresholds
               are reached
             </li>
             <li>
-              <strong>Security</strong> -- detecting and preventing unauthorized
+              <strong>Security</strong>: detecting and preventing unauthorized
               access, fraud, and abuse
             </li>
             <li>
-              <strong>Service communications</strong> -- sending essential
+              <strong>Service communications</strong>: sending essential
               updates, security alerts, and (only with your consent) product
               announcements
             </li>
@@ -231,13 +231,13 @@ export default function PrivacyPolicyPage() {
           <ul>
             <li>
               <strong>Authentication cookie</strong>{' '}
-              (<code>sb-[ref]-auth-token</code>) -- set by Supabase Auth when
+              (<code>sb-[ref]-auth-token</code>): set by Supabase Auth when
               you log in. Required for the Service to work. Contains your
               session token, stored as an httpOnly cookie.
             </li>
             <li>
               <strong>Sidebar preference cookie</strong>{' '}
-              (<code>sidebar:state</code>) -- remembers whether your sidebar
+              (<code>sidebar:state</code>): remembers whether your sidebar
               is open or closed. Expires after 7 days. Not required; the Service
               works without it.
             </li>
@@ -254,20 +254,20 @@ export default function PrivacyPolicyPage() {
 
           <ul>
             <li>
-              <strong>End-to-end encryption</strong> -- session message content
+              <strong>End-to-end encryption</strong>: session message content
               is encrypted on your device before it reaches our servers. We
               relay ciphertext only.
             </li>
             <li>
-              <strong>Encryption at rest</strong> -- all data stored in our
+              <strong>Encryption at rest</strong>: all data stored in our
               database is encrypted at rest (AES-256)
             </li>
             <li>
-              <strong>Encryption in transit</strong> -- all connections use TLS
+              <strong>Encryption in transit</strong>: all connections use TLS
               1.2 or higher. HTTP is redirected to HTTPS.
             </li>
             <li>
-              <strong>Row Level Security</strong> -- database access is
+              <strong>Row Level Security</strong>: database access is
               restricted so each user can only read and write their own data
             </li>
           </ul>
@@ -299,7 +299,7 @@ export default function PrivacyPolicyPage() {
                   Supabase
                 </a>
               </strong>{' '}
-              (United States) -- database, authentication, and real-time
+              (United States): database, authentication, and real-time
               infrastructure. Stores your account data, session metadata, and
               encrypted message ciphertext.
             </li>
@@ -313,7 +313,7 @@ export default function PrivacyPolicyPage() {
                   Vercel
                 </a>
               </strong>{' '}
-              (United States) -- web application hosting. Receives your IP
+              (United States): web application hosting. Receives your IP
               address and standard HTTP request metadata as part of serving
               web requests. Vercel does not use this for advertising.
             </li>
@@ -327,7 +327,7 @@ export default function PrivacyPolicyPage() {
                   Polar
                 </a>
               </strong>{' '}
-              (European Union) -- payment processing and subscription
+              (European Union): payment processing and subscription
               management. Polar is our merchant of record. They handle all
               payment card data. We never store your payment card information.
             </li>
@@ -341,7 +341,7 @@ export default function PrivacyPolicyPage() {
                   Resend
                 </a>
               </strong>{' '}
-              (United States) -- transactional email delivery. Receives your
+              (United States): transactional email delivery. Receives your
               email address to send service notifications and account emails.
             </li>
             <li>
@@ -354,10 +354,45 @@ export default function PrivacyPolicyPage() {
                   Expo
                 </a>
               </strong>{' '}
-              (United States) -- push notification delivery for the iOS and
+              (United States): push notification delivery for the iOS and
               Android apps. Receives your device push token to deliver alerts.
             </li>
+            <li>
+              <strong>
+                <a
+                  href="https://sentry.io/privacy/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Sentry
+                </a>
+              </strong>{' '}
+              (United States): error monitoring and performance tracing.
+              Receives error stack traces, hashed user IDs, and request
+              metadata. Session message content and API keys are explicitly
+              scrubbed before transmission.
+            </li>
+            <li>
+              <strong>
+                <a
+                  href="https://upstash.com/trust/privacy.pdf"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Upstash
+                </a>
+              </strong>{' '}
+              (United States): Redis cache for rate limiting and ephemeral
+              session state. Stores hashed user IDs and IP addresses for at
+              most 60 minutes. No persistent personal data.
+            </li>
           </ul>
+
+          <p>
+            For the canonical, machine-readable list with DPF certification
+            status and data categories, see our{' '}
+            <Link href="/legal/subprocessors">Subprocessors page</Link>.
+          </p>
 
           {/* ── Data Retention ────────────────────────────────── */}
           <h2>6. Data Retention</h2>
@@ -369,20 +404,20 @@ export default function PrivacyPolicyPage() {
 
           <ul>
             <li>
-              <strong>Session history</strong> -- retained based on your
+              <strong>Session history</strong>: retained based on your
               subscription tier: 7 days on Free, 90 days on Pro, 1 year on
               Power. Older sessions are automatically deleted.
             </li>
             <li>
-              <strong>Cost records</strong> -- retained for the lifetime of
+              <strong>Cost records</strong>: retained for the lifetime of
               your account for billing accuracy and dispute resolution
             </li>
             <li>
-              <strong>Account data</strong> -- retained until you delete your
+              <strong>Account data</strong>: retained until you delete your
               account
             </li>
             <li>
-              <strong>Audit logs</strong> -- retained for 90 days for security
+              <strong>Audit logs</strong>: retained for 90 days for security
               monitoring, then deleted
             </li>
           </ul>
@@ -404,28 +439,28 @@ export default function PrivacyPolicyPage() {
 
           <ul>
             <li>
-              <strong>Access</strong> -- request a copy of all personal data we
+              <strong>Access</strong>: request a copy of all personal data we
               hold about you
             </li>
             <li>
-              <strong>Portability</strong> -- export a machine-readable (JSON)
+              <strong>Portability</strong>: export a machine-readable (JSON)
               copy of your data via Settings
             </li>
             <li>
-              <strong>Correction</strong> -- update your profile information at
+              <strong>Correction</strong>: update your profile information at
               any time via Settings
             </li>
             <li>
-              <strong>Deletion (right to be forgotten)</strong> -- delete your
+              <strong>Deletion (right to be forgotten)</strong>: delete your
               account and all associated data via Settings, or by emailing us.
               Data is permanently deleted within 30 days.
             </li>
             <li>
-              <strong>Restrict processing</strong> -- request that we limit how
+              <strong>Restrict processing</strong>: request that we limit how
               we use your data by contacting us
             </li>
             <li>
-              <strong>Opt-out of marketing</strong> -- unsubscribe from
+              <strong>Opt-out of marketing</strong>: unsubscribe from
               non-essential emails at any time. Essential service notifications
               cannot be disabled while your account is active.
             </li>

--- a/packages/styrby-web/src/app/security/compare/page.tsx
+++ b/packages/styrby-web/src/app/security/compare/page.tsx
@@ -214,7 +214,7 @@ function ComparisonCategoryRows({ category }: { category: ComparisonCategory }) 
 
 export default function SecurityComparePage() {
   return (
-    <main className="min-h-screen">
+    <main className="min-h-[100dvh]">
       <Navbar />
 
       {/* Hero */}

--- a/packages/styrby-web/src/app/security/page.tsx
+++ b/packages/styrby-web/src/app/security/page.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
  */
 export default function SecurityPage() {
   return (
-    <div className="min-h-screen bg-zinc-950">
+    <div className="min-h-[100dvh] bg-zinc-950">
       {/* Navigation header */}
       <header className="border-b border-zinc-800 bg-zinc-900/50">
         <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
@@ -52,11 +52,11 @@ export default function SecurityPage() {
       </header>
 
       {/* Security content */}
-      <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
-        <article className="prose prose-invert max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-400 prose-a:no-underline hover:prose-a:text-orange-300 prose-strong:text-zinc-200">
+      <main className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+        <article className="prose prose-lg prose-invert max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-400 prose-a:no-underline hover:prose-a:text-orange-300 prose-strong:text-zinc-200">
           <h1>Security</h1>
           <p className="text-sm text-zinc-500">
-            Last updated: February 6, 2026
+            Last updated: April 25, 2026
           </p>
 
           <p>

--- a/packages/styrby-web/src/app/signup/page.tsx
+++ b/packages/styrby-web/src/app/signup/page.tsx
@@ -40,7 +40,7 @@ import { isDisposableEmail, DISPOSABLE_EMAIL_ERROR } from '@/lib/disposable-emai
 export default function SignUpPage() {
   return (
     <Suspense fallback={
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-[100dvh] items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-amber-500 border-t-transparent" />
       </div>
     }>
@@ -266,7 +266,7 @@ function SignUpPageInner() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-[100dvh] flex-col">
       <div className="flex flex-1 items-center justify-center px-4">
         <div className="fixed inset-0 -z-10" />
         <div className="fixed left-1/2 top-1/3 -z-10 h-[400px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber-500/5 blur-[120px]" />
@@ -355,6 +355,7 @@ function SignUpPageInner() {
                       onChange={(e) => setName(e.target.value)}
                       placeholder="Alex Morgan"
                       required
+                      autoFocus
                       autoComplete="name"
                       className="bg-secondary/60 border-border/60 text-foreground placeholder:text-muted-foreground focus-visible:ring-amber-500"
                     />
@@ -396,6 +397,9 @@ function SignUpPageInner() {
                     <Mail className="h-4 w-4" />
                     {loading ? 'Sending...' : 'Continue with Email'}
                   </Button>
+                  <p className="text-center text-xs text-muted-foreground mt-2">
+                    No credit card required
+                  </p>
                 </form>
 
                 {/* Divider */}

--- a/packages/styrby-web/src/app/terms/page.tsx
+++ b/packages/styrby-web/src/app/terms/page.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
  */
 export default function TermsOfServicePage() {
   return (
-    <div className="min-h-screen bg-zinc-950">
+    <div className="min-h-[100dvh] bg-zinc-950">
       {/* Navigation header */}
       <header className="border-b border-zinc-800 bg-zinc-900/50">
         <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
@@ -49,8 +49,8 @@ export default function TermsOfServicePage() {
       </header>
 
       {/* Content */}
-      <main className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-12">
-        <article className="prose prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-500 prose-a:no-underline hover:prose-a:underline prose-strong:text-zinc-100">
+      <main className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12">
+        <article className="prose prose-lg prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-500 prose-a:no-underline hover:prose-a:underline prose-strong:text-zinc-100">
           <h1>Terms of Service</h1>
 
           <p className="text-sm text-zinc-500">
@@ -160,15 +160,15 @@ export default function TermsOfServicePage() {
           <h3>Subscription Tiers</h3>
           <ul>
             <li>
-              <strong>Free</strong> -- basic session monitoring with 7 days of
+              <strong>Free</strong>: basic session monitoring with 7 days of
               session history
             </li>
             <li>
-              <strong>Pro</strong> -- full feature access with 90 days of
+              <strong>Pro</strong>: full feature access with 90 days of
               session history
             </li>
             <li>
-              <strong>Power</strong> -- maximum limits with 1 year of session
+              <strong>Power</strong>: maximum limits with 1 year of session
               history
             </li>
           </ul>

--- a/packages/styrby-web/src/app/twitter-image.tsx
+++ b/packages/styrby-web/src/app/twitter-image.tsx
@@ -13,7 +13,7 @@
 import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
-export const alt = 'Styrby — AI Agent Dashboard';
+export const alt = 'Styrby: AI Agent Dashboard';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -98,7 +98,7 @@ export default function TwitterImage() {
               fontWeight: 400,
             }}
           >
-            Monitor costs, approve permissions, and stay in control — anywhere.
+            Monitor costs, approve permissions, and stay in control, anywhere.
           </p>
         </div>
 

--- a/packages/styrby-web/src/components/ui/input.tsx
+++ b/packages/styrby-web/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className,
         )}
         ref={ref}

--- a/packages/styrby-web/src/lib/legal/subprocessors.ts
+++ b/packages/styrby-web/src/lib/legal/subprocessors.ts
@@ -35,6 +35,7 @@ export type SubprocessorCategory =
   | 'error-tracking'
   | 'email'
   | 'cache'
+  | 'push'
   | 'analytics';
 
 /**
@@ -85,7 +86,7 @@ export type Subprocessor = {
  * WHY hardcoded vs. git log: git log is unavailable in edge runtimes and
  * CDN-cached pages. A hardcoded date is reliable and forces intentional bumps.
  */
-export const SUBPROCESSORS_LAST_UPDATED = '2026-04-24';
+export const SUBPROCESSORS_LAST_UPDATED = '2026-04-25';
 
 /**
  * Canonical list of all Styrby sub-processors.
@@ -118,7 +119,7 @@ export const SUBPROCESSORS: readonly Subprocessor[] = [
     dpf_certified: true,
     categories: ['database', 'auth'],
     data_shared:
-      'User accounts, session metadata, encrypted message ciphertext (zero-knowledge — Styrby cannot decrypt), subscription state, audit logs, push notification tokens.',
+      'User accounts, session metadata, encrypted message ciphertext (zero-knowledge; Styrby cannot decrypt), subscription state, audit logs, push notification tokens.',
   },
 
   // ── Payments ────────────────────────────────────────────────────────────────
@@ -130,7 +131,7 @@ export const SUBPROCESSORS: readonly Subprocessor[] = [
     dpf_certified: false,
     categories: ['payment'],
     data_shared:
-      'Email address, billing address, subscription state. Payment method metadata is stored by Polar — Styrby never receives raw card numbers. Polar is incorporated in the EU; payment data does not leave the EU.',
+      'Email address, billing address, subscription state. Payment method metadata is stored by Polar (Styrby never receives raw card numbers). Polar is incorporated in the EU; payment data does not leave the EU.',
   },
 
   // ── Error Tracking ──────────────────────────────────────────────────────────
@@ -167,5 +168,17 @@ export const SUBPROCESSORS: readonly Subprocessor[] = [
     categories: ['cache'],
     data_shared:
       'Ephemeral rate-limit keys containing hashed user IDs and IP addresses. Maximum TTL is 60 minutes. No persistent personal data is stored in Upstash.',
+  },
+
+  // ── Push Notifications ──────────────────────────────────────────────────────
+  {
+    name: 'Expo',
+    purpose: 'Push notification delivery for the Styrby iOS and Android mobile apps',
+    location: 'United States (EU-US DPF certified)',
+    website: 'https://expo.dev/privacy',
+    dpf_certified: true,
+    categories: ['push'],
+    data_shared:
+      'Device push tokens (APNs / FCM identifiers) and the notification payload (title and short body text). No session message content, plaintext code, or AI prompts are included in push payloads.',
   },
 ] as const;


### PR DESCRIPTION
## Summary

Wave 1 of the design pass: pure content correctness, microcopy, and a11y. Zero design-system or token changes - `globals.css` and `tailwind.config.ts` are untouched.

23 files changed, 205 insertions, 179 deletions.

### Trust + legal pages
- Replace 38 `</strong> --` separators in `/privacy` with `:` for cleaner rendered output.
- Same fix on the subscription tier list in `/terms` (3).
- Remove the live `(placeholder - replace before launch)` text from `/legal/subprocessors`. Switch contact email to the verified `support@styrby.dev` (also `/legal/retention-proof`).
- Add Expo to the canonical `SUBPROCESSORS` array (now 7 entries). Add `push` category. Bump `SUBPROCESSORS_LAST_UPDATED` to 2026-04-25.
- Refactor `/dpa` sub-processor table to render from canonical `SUBPROCESSORS` so `/legal/subprocessors` and `/dpa` never drift.
- Add Sentry and Upstash entries to `/privacy` and link to canonical `/legal/subprocessors`.
- Replace OK / clipboard emoji on `/legal/retention-proof` with `CheckCircle2` / `Clock` lucide icons.
- Sweep em dashes from user-facing metadata + rendered text on retention-proof, subprocessors, opengraph-image, twitter-image, Polar/Supabase `data_shared`.
- Bump `/security` "Last updated" to 2026-04-25.

### Auth UX
- `autoFocus` on `/login` email input and `/signup` name input.
- Shared `Input` h-10 (40px) -> h-11 (44px) for WCAG 2.5.5 tap-target compliance.
- "No credit card required" trust signal under signup primary CTA.

### Marketing copy
- `/pricing` `UpgradeButton`: tier-specific CTA ("Upgrade to Pro" / "Upgrade to Power" / "Start Free") replacing generic "Upgrade".
- `/pricing` hero: replace template copy with product-specific - **"Pricing built for the way you actually run AI agents"** / "From one machine on Solo to a fleet on Business. Annual billing saves about 17%. Cancel anytime, no seat fees on monthly."

### Typography polish
- `text-balance` on blog h1 and h2 cards.
- Blog article prose: `max-w-none` -> `max-w-prose` + `prose-lg`.
- `tabular-nums` on all blog `<time>` elements.
- `/privacy`, `/terms`, `/dpa`, `/security`: `max-w-4xl` -> `max-w-3xl` + `prose-lg`.

### Viewport stability
- `min-h-screen` / `h-screen` -> `min-h-[100dvh]` / `h-[100dvh]` on marketing, auth, legal, blog pages. Dashboard untouched.

### DPA print button
- "Download PDF" -> "Print or Save as PDF" with helper text. Updated aria-label + test assertions.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` 0 errors (pre-existing warnings unchanged)
- [x] `pnpm build` succeeds
- [x] Affected suites (`dpa`, `legal/subprocessors`, `legal/retention-proof`): 50/50 pass
- [x] Full suite: 3139/3140 - the single failure is a pre-existing flaky `ChurnSaveOfferCard` timing test unrelated to these changes (passes in isolation)
- [ ] Visual QA on Vercel preview after CI: `/privacy`, `/terms`, `/dpa`, `/legal/subprocessors`, `/legal/retention-proof`, `/security`, `/pricing`, `/login`, `/signup`, `/blog`
- [ ] Verify the iOS Safari 100dvh fix on a real device or simulator

Audit reference: `.design-reports/20260425-195938-styrby-website/`

DO NOT MERGE - leaving for the orchestrator to merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)