### PR TITLE
design(system): Wave 3 - OKLCH token system + Industrial Dark identity

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -152,6 +152,12 @@ module.exports = [
     // IntersectionObserver-driven section highlighting on docs pages) + CopyButton
     // (per-CodeBlock copy-to-clipboard). Shiki itself is build-time, zero runtime
     // JS. Measured 775.51 KB gzip — 0.51 KB over. Smallest ratchet to date.
+    //
+    // /design Wave 3 (no ratchet): OKLCH token system rework adds ZERO new JS.
+    // Tailwind's color utilities are CSS only and the new ramps (steel-*, amber-*)
+    // are JIT-purged based on usage — components reference semantic tokens
+    // (bg-background, text-foreground, bg-primary) which existed before. Measured
+    // 775.64 KB gzip — within budget without bumping the limit.
     limit: '776 KB',
     gzip: true,
     // WHY import is omitted: We cannot import directly from Next.js output —

--- a/packages/styrby-web/src/app/globals.css
+++ b/packages/styrby-web/src/app/globals.css
@@ -2,42 +2,174 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ── shadcn/ui CSS variable design tokens ── */
+/*
+ * ==========================================================================
+ *  Styrby OKLCH Token System (Wave 3)
+ * ==========================================================================
+ *
+ * Three-layer architecture:
+ *   1. PRIMITIVES — named raw OKLCH ramps (steel-blue, amber). Hue-locked
+ *      so every shade in a family shares the same chromatic identity.
+ *   2. SEMANTIC   — meaning-bearing aliases (--background, --primary, etc.)
+ *      that components reference. Dark theme is the default.
+ *   3. LIGHT      — explicit overrides under :root.light / [data-theme=light]
+ *      for printing, accessibility, future toggle.
+ *
+ * WHY OKLCH: perceptually uniform — moving through L (lightness) keeps the
+ * apparent brightness step constant, so a 100/200/300/... ramp actually
+ * reads as evenly-spaced, unlike HSL ramps which clip in saturated regions.
+ *
+ * WHY hue 220 for surfaces: the previous shadcn defaults used 240
+ * (violet-leaning). 220 is steel-blue — cool, technical, "made by people
+ * who ship". Pairs with the amber accent for the Industrial Dark identity.
+ *
+ * WHY hue 60 for amber (vs Tailwind's 30): the default Tailwind orange/amber
+ * scale at hue ~30 is the single most overused brand palette in 2024-2026
+ * SaaS. Shifting to ~60 (slightly cooler, more "burnt amber") gives the
+ * brand a distinct fingerprint — still warm, still amber, but no longer
+ * a literal Tailwind clone.
+ *
+ * Component code references the semantic tokens (bg-background,
+ * text-foreground, bg-primary, border-border, etc.). The primitive
+ * ramps are exposed as Tailwind utilities (bg-steel-900, bg-amber-500)
+ * for the rare cases that need direct ramp access.
+ */
 @layer base {
   :root {
-    --background: 240 6% 3.5%;
-    --foreground: 0 0% 98%;
-    --card: 240 5% 7%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 5% 7%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 38 92% 50%;
-    --primary-foreground: 0 0% 3.9%;
-    --secondary: 240 4% 10%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 4% 10%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 4% 16%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 4% 16%;
-    --input: 240 4% 16%;
-    --ring: 38 92% 50%;
-    --chart-1: 24 95% 53%;
-    --chart-2: 142 71% 45%;
-    --chart-3: 217 91% 60%;
-    --chart-4: 38 92% 50%;
-    --chart-5: 0 84% 60%;
-    --radius: 0.625rem;
-    --sidebar-background: 240 5% 7%;
-    --sidebar-foreground: 0 0% 98%;
-    --sidebar-primary: 38 92% 50%;
-    --sidebar-primary-foreground: 0 0% 3.9%;
-    --sidebar-accent: 240 4% 16%;
-    --sidebar-accent-foreground: 0 0% 98%;
-    --sidebar-border: 240 4% 16%;
-    --sidebar-ring: 38 92% 50%;
+    /* ── Layer 1: Primitives ── */
+
+    /* Steel-blue near-black scale — surfaces & neutrals (hue 220) */
+    --color-steel-50: 0.97 0.005 220;
+    --color-steel-100: 0.94 0.008 220;
+    --color-steel-200: 0.88 0.012 220;
+    --color-steel-300: 0.78 0.015 220;
+    --color-steel-400: 0.65 0.018 220;
+    --color-steel-500: 0.50 0.020 220;
+    --color-steel-600: 0.38 0.018 220;
+    --color-steel-700: 0.27 0.015 220;
+    --color-steel-800: 0.18 0.012 220;
+    --color-steel-900: 0.13 0.010 220;
+    --color-steel-950: 0.09 0.008 220;
+    --color-steel-1000: 0.05 0.005 220;
+
+    /* Amber brand scale — accent (hue ~55-60, distinct from Tailwind orange) */
+    --color-amber-50: 0.98 0.025 60;
+    --color-amber-100: 0.94 0.060 60;
+    --color-amber-200: 0.88 0.110 60;
+    --color-amber-300: 0.82 0.150 60;
+    --color-amber-400: 0.76 0.170 58;
+    --color-amber-500: 0.70 0.180 56;
+    --color-amber-600: 0.62 0.170 54;
+    --color-amber-700: 0.52 0.150 52;
+    --color-amber-800: 0.42 0.120 50;
+    --color-amber-900: 0.32 0.090 48;
+    --color-amber-950: 0.22 0.060 46;
+
+    /* ── Layer 2: Semantic mappings (DARK is default — app is dark-first) ── */
+
+    /* Surface hierarchy — 5 elevation levels */
+    --background: var(--color-steel-950);
+    --surface-1: var(--color-steel-900);
+    --surface-2: var(--color-steel-800);
+    --surface-3: var(--color-steel-700);
+    --surface-4: var(--color-steel-600);
+
+    /* Foreground (text) */
+    --foreground: 0.95 0.005 220;
+    --foreground-secondary: 0.70 0.010 220;
+    --foreground-tertiary: 0.50 0.012 220;
+
+    /* Borders */
+    --border: 0.22 0.010 220;
+    --border-strong: 0.30 0.012 220;
+
+    /* Brand */
+    --primary: var(--color-amber-500);
+    --primary-foreground: var(--color-steel-950);
+    --primary-muted: 0.40 0.060 56;
+
+    /* Status */
+    --destructive: 0.62 0.18 25;
+    --destructive-foreground: var(--color-steel-50);
+    --success: 0.62 0.15 145;
+    --warning: 0.72 0.15 80;
+
+    /* shadcn/ui token aliases — components reference these names directly */
+    --card: var(--surface-1);
+    --card-foreground: var(--foreground);
+    --popover: var(--surface-3);
+    --popover-foreground: var(--foreground);
+    --secondary: var(--surface-2);
+    --secondary-foreground: var(--foreground);
+    --muted: var(--surface-2);
+    --muted-foreground: var(--foreground-secondary);
+    --accent: var(--surface-2);
+    --accent-foreground: var(--foreground);
+    --input: var(--border);
+    --ring: var(--color-amber-500);
+
+    /* Chart palette — derived from token primitives */
+    --chart-1: var(--color-amber-500);
+    --chart-2: 0.62 0.15 145;
+    --chart-3: 0.65 0.18 250;
+    --chart-4: 0.72 0.15 80;
+    --chart-5: 0.62 0.18 25;
+
+    /* Sidebar — same surface hierarchy */
+    --sidebar-background: var(--surface-1);
+    --sidebar-foreground: var(--foreground);
+    --sidebar-primary: var(--color-amber-500);
+    --sidebar-primary-foreground: var(--color-steel-950);
+    --sidebar-accent: var(--surface-2);
+    --sidebar-accent-foreground: var(--foreground);
+    --sidebar-border: var(--border);
+    --sidebar-ring: var(--color-amber-500);
+
+    /* Radius — slightly tighter than the prior 0.625rem for technical feel */
+    --radius: 0.5rem;
+  }
+
+  /* ── Layer 3: Light mode (supplementary — dark stays default) ── */
+  :root.light,
+  :root[data-theme='light'] {
+    --background: var(--color-steel-50);
+    --surface-1: 1.0 0 0;
+    --surface-2: var(--color-steel-100);
+    --surface-3: var(--color-steel-200);
+    --surface-4: 1.0 0 0;
+
+    --foreground: var(--color-steel-950);
+    --foreground-secondary: var(--color-steel-700);
+    --foreground-tertiary: var(--color-steel-500);
+
+    --border: var(--color-steel-200);
+    --border-strong: var(--color-steel-300);
+
+    --primary: var(--color-amber-600);
+    --primary-foreground: var(--color-steel-50);
+    --primary-muted: var(--color-amber-100);
+
+    --destructive: 0.55 0.18 25;
+    --destructive-foreground: var(--color-steel-50);
+
+    --card: var(--surface-1);
+    --popover: var(--surface-1);
+    --secondary: var(--surface-2);
+    --muted: var(--surface-2);
+    --muted-foreground: var(--foreground-secondary);
+    --accent: var(--surface-2);
+    --accent-foreground: var(--foreground);
+    --input: var(--border);
+    --ring: var(--color-amber-600);
+
+    --sidebar-background: var(--surface-1);
+    --sidebar-foreground: var(--foreground);
+    --sidebar-primary: var(--color-amber-600);
+    --sidebar-primary-foreground: var(--color-steel-50);
+    --sidebar-accent: var(--surface-2);
+    --sidebar-accent-foreground: var(--foreground);
+    --sidebar-border: var(--border);
+    --sidebar-ring: var(--color-amber-600);
   }
 }
 
@@ -72,14 +204,14 @@
   background-size: 256px 256px;
 }
 
-/* ── Glass-morphism ── */
+/* ── Glass-morphism — token-derived ── */
 .glass {
-  background: rgba(24, 24, 27, 0.92);
+  background: color-mix(in oklch, oklch(var(--surface-1)) 92%, transparent);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
 }
 
-/* ── Gradient border effect ── */
+/* ── Gradient border effect — token-derived ── */
 .gradient-border {
   position: relative;
 }
@@ -89,17 +221,24 @@
   inset: 0;
   border-radius: inherit;
   padding: 1px;
-  background: linear-gradient(135deg, rgba(245, 158, 11, 0.3), transparent 50%, rgba(39, 39, 42, 0.3));
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklch, oklch(var(--primary)) 30%, transparent),
+    transparent 50%,
+    color-mix(in oklch, oklch(var(--border-strong)) 30%, transparent)
+  );
   -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   pointer-events: none;
 }
 
-/* ── Amber glow ── */
-/* Used on the Pro pricing card and other highlighted elements */
+/* ── Amber glow — token-derived ── */
+/* WHY token-derived: keeps glow tied to brand primary so theming flows through. */
 .amber-glow {
-  box-shadow: 0 0 60px rgba(245, 158, 11, 0.12), 0 0 120px rgba(245, 158, 11, 0.06);
+  box-shadow:
+    0 0 60px color-mix(in oklch, oklch(var(--primary)) 12%, transparent),
+    0 0 120px color-mix(in oklch, oklch(var(--primary)) 6%, transparent);
 }
 
 /* ── Pulse animation for live indicators ── */
@@ -111,24 +250,33 @@
   animation: live-pulse 2s ease-in-out infinite;
 }
 
-/* ── Shimmer loading effect ── */
+/* ── Shimmer loading effect — token-derived ── */
 @keyframes shimmer {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
 }
 .shimmer {
-  background: linear-gradient(90deg, hsl(240 4% 10%) 25%, hsl(240 4% 16%) 50%, hsl(240 4% 10%) 75%);
+  background: linear-gradient(
+    90deg,
+    oklch(var(--surface-2)) 25%,
+    oklch(var(--surface-3)) 50%,
+    oklch(var(--surface-2)) 75%
+  );
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite;
 }
 
-/* ── Dot grid pattern ── */
+/* ── Dot grid pattern — token-derived ── */
 .dot-grid {
-  background-image: radial-gradient(circle, rgba(113, 113, 122, 0.15) 1px, transparent 1px);
+  background-image: radial-gradient(
+    circle,
+    color-mix(in oklch, oklch(var(--foreground-tertiary)) 15%, transparent) 1px,
+    transparent 1px
+  );
   background-size: 24px 24px;
 }
 
-/* ── Smooth scrollbar ── */
+/* ── Smooth scrollbar — token-derived ── */
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
@@ -137,9 +285,9 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(240 4% 16%);
+  background: oklch(var(--border));
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(240 5% 26%);
+  background: oklch(var(--border-strong));
 }

--- a/packages/styrby-web/tailwind.config.ts
+++ b/packages/styrby-web/tailwind.config.ts
@@ -3,6 +3,26 @@ import forms from '@tailwindcss/forms';
 import typography from '@tailwindcss/typography';
 import animate from 'tailwindcss-animate';
 
+/**
+ * Styrby Tailwind config (Wave 3 — OKLCH token system).
+ *
+ * Color sourcing: every color references a CSS custom property whose value
+ * is bare OKLCH parts (L C H — no oklch() wrapper). Tailwind utilities wrap
+ * with `oklch(var(--token) / <alpha-value>)` so opacity modifiers like
+ * `bg-primary/80` continue to work. This mirrors the pattern Tailwind
+ * recommends for HSL but uses OKLCH for perceptual uniformity.
+ *
+ * Three layers (defined in src/app/globals.css):
+ *   1. Primitives — `--color-steel-*`, `--color-amber-*` (named ramps).
+ *   2. Semantic — `--background`, `--foreground`, `--primary`, etc.
+ *      (what components reference 95% of the time).
+ *   3. Light overrides under :root.light (supplementary; dark stays default).
+ *
+ * NO `styrby: { 50: ..., 950: ... }` block: that was a literal copy of
+ * Tailwind's default orange palette and read as template-clone "slop".
+ * Brand color now comes through `primary` (semantic) which resolves to
+ * `--color-amber-500` (a hue-60 OKLCH amber, distinct from Tailwind's hue-30).
+ */
 const config: Config = {
   darkMode: ['class'],
   content: [
@@ -12,75 +32,110 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      screens: {
+        // 2xs handles older / smaller Android devices common in dev demographics
+        '2xs': '320px',
+      },
       colors: {
-        /* ── shadcn/ui CSS variable tokens ── */
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
+        /* ── Semantic tokens (what components should reference) ── */
+        background: 'oklch(var(--background) / <alpha-value>)',
+        foreground: 'oklch(var(--foreground) / <alpha-value>)',
+        'foreground-secondary': 'oklch(var(--foreground-secondary) / <alpha-value>)',
+        'foreground-tertiary': 'oklch(var(--foreground-tertiary) / <alpha-value>)',
+
         card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))',
+          DEFAULT: 'oklch(var(--card) / <alpha-value>)',
+          foreground: 'oklch(var(--card-foreground) / <alpha-value>)',
         },
         popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
+          DEFAULT: 'oklch(var(--popover) / <alpha-value>)',
+          foreground: 'oklch(var(--popover-foreground) / <alpha-value>)',
         },
         primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
+          DEFAULT: 'oklch(var(--primary) / <alpha-value>)',
+          foreground: 'oklch(var(--primary-foreground) / <alpha-value>)',
+          muted: 'oklch(var(--primary-muted) / <alpha-value>)',
         },
         secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
+          DEFAULT: 'oklch(var(--secondary) / <alpha-value>)',
+          foreground: 'oklch(var(--secondary-foreground) / <alpha-value>)',
         },
         muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
+          DEFAULT: 'oklch(var(--muted) / <alpha-value>)',
+          foreground: 'oklch(var(--muted-foreground) / <alpha-value>)',
         },
         accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
+          DEFAULT: 'oklch(var(--accent) / <alpha-value>)',
+          foreground: 'oklch(var(--accent-foreground) / <alpha-value>)',
         },
         destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
+          DEFAULT: 'oklch(var(--destructive) / <alpha-value>)',
+          foreground: 'oklch(var(--destructive-foreground) / <alpha-value>)',
         },
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
+        success: 'oklch(var(--success) / <alpha-value>)',
+        warning: 'oklch(var(--warning) / <alpha-value>)',
+        border: 'oklch(var(--border) / <alpha-value>)',
+        'border-strong': 'oklch(var(--border-strong) / <alpha-value>)',
+        input: 'oklch(var(--input) / <alpha-value>)',
+        ring: 'oklch(var(--ring) / <alpha-value>)',
+
+        surface: {
+          1: 'oklch(var(--surface-1) / <alpha-value>)',
+          2: 'oklch(var(--surface-2) / <alpha-value>)',
+          3: 'oklch(var(--surface-3) / <alpha-value>)',
+          4: 'oklch(var(--surface-4) / <alpha-value>)',
+        },
+
         chart: {
-          '1': 'hsl(var(--chart-1))',
-          '2': 'hsl(var(--chart-2))',
-          '3': 'hsl(var(--chart-3))',
-          '4': 'hsl(var(--chart-4))',
-          '5': 'hsl(var(--chart-5))',
+          '1': 'oklch(var(--chart-1) / <alpha-value>)',
+          '2': 'oklch(var(--chart-2) / <alpha-value>)',
+          '3': 'oklch(var(--chart-3) / <alpha-value>)',
+          '4': 'oklch(var(--chart-4) / <alpha-value>)',
+          '5': 'oklch(var(--chart-5) / <alpha-value>)',
         },
         sidebar: {
-          DEFAULT: 'hsl(var(--sidebar-background))',
-          foreground: 'hsl(var(--sidebar-foreground))',
-          primary: 'hsl(var(--sidebar-primary))',
-          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-          accent: 'hsl(var(--sidebar-accent))',
-          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-          border: 'hsl(var(--sidebar-border))',
-          ring: 'hsl(var(--sidebar-ring))',
+          DEFAULT: 'oklch(var(--sidebar-background) / <alpha-value>)',
+          foreground: 'oklch(var(--sidebar-foreground) / <alpha-value>)',
+          primary: 'oklch(var(--sidebar-primary) / <alpha-value>)',
+          'primary-foreground': 'oklch(var(--sidebar-primary-foreground) / <alpha-value>)',
+          accent: 'oklch(var(--sidebar-accent) / <alpha-value>)',
+          'accent-foreground': 'oklch(var(--sidebar-accent-foreground) / <alpha-value>)',
+          border: 'oklch(var(--sidebar-border) / <alpha-value>)',
+          ring: 'oklch(var(--sidebar-ring) / <alpha-value>)',
         },
 
-        /* ── Styrby brand scale ── */
-        styrby: {
-          50: '#fff7ed',
-          100: '#ffedd5',
-          200: '#fed7aa',
-          300: '#fdba74',
-          400: '#fb923c',
-          500: '#f97316',
-          600: '#ea580c',
-          700: '#c2410c',
-          800: '#9a3412',
-          900: '#7c2d12',
-          950: '#431407',
+        /* ── Primitive ramps (rare direct access — prefer semantic) ── */
+        steel: {
+          50: 'oklch(var(--color-steel-50) / <alpha-value>)',
+          100: 'oklch(var(--color-steel-100) / <alpha-value>)',
+          200: 'oklch(var(--color-steel-200) / <alpha-value>)',
+          300: 'oklch(var(--color-steel-300) / <alpha-value>)',
+          400: 'oklch(var(--color-steel-400) / <alpha-value>)',
+          500: 'oklch(var(--color-steel-500) / <alpha-value>)',
+          600: 'oklch(var(--color-steel-600) / <alpha-value>)',
+          700: 'oklch(var(--color-steel-700) / <alpha-value>)',
+          800: 'oklch(var(--color-steel-800) / <alpha-value>)',
+          900: 'oklch(var(--color-steel-900) / <alpha-value>)',
+          950: 'oklch(var(--color-steel-950) / <alpha-value>)',
+          1000: 'oklch(var(--color-steel-1000) / <alpha-value>)',
+        },
+        amber: {
+          50: 'oklch(var(--color-amber-50) / <alpha-value>)',
+          100: 'oklch(var(--color-amber-100) / <alpha-value>)',
+          200: 'oklch(var(--color-amber-200) / <alpha-value>)',
+          300: 'oklch(var(--color-amber-300) / <alpha-value>)',
+          400: 'oklch(var(--color-amber-400) / <alpha-value>)',
+          500: 'oklch(var(--color-amber-500) / <alpha-value>)',
+          600: 'oklch(var(--color-amber-600) / <alpha-value>)',
+          700: 'oklch(var(--color-amber-700) / <alpha-value>)',
+          800: 'oklch(var(--color-amber-800) / <alpha-value>)',
+          900: 'oklch(var(--color-amber-900) / <alpha-value>)',
+          950: 'oklch(var(--color-amber-950) / <alpha-value>)',
         },
 
-        /* ── Agent brand colors ── */
+        /* ── Agent brand colors (third-party identities — kept as fixed hex
+         *   to match upstream brand guidelines for Claude / Codex / Gemini
+         *   etc; they are not part of Styrby's brand palette) ── */
         claude: {
           DEFAULT: '#f97316',
           light: '#fed7aa',
@@ -99,28 +154,63 @@ const config: Config = {
         opencode: '#06B6D4',
         aider: '#8B5CF6',
 
-        /* ── Explicit amber stops (for v0 landing components) ── */
-        amber: {
-          400: '#FBBF24',
-          500: '#F59E0B',
-          600: '#D97706',
-        },
-
         /* ── Error source colors ── */
         error: {
-          styrby: '#f97316',
+          styrby: 'oklch(var(--primary))',
           agent: '#ef4444',
           build: '#3b82f6',
           network: '#eab308',
         },
       },
       fontFamily: {
-        /* Outfit: geometric display type for headlines and body copy */
         sans: ['var(--font-outfit)', 'system-ui', 'sans-serif'],
-        /* JetBrains Mono: developer-grade monospace for code, costs, agent IDs */
         mono: ['var(--font-jetbrains)', 'ui-monospace', 'monospace'],
       },
+      fontSize: {
+        /* Semantic typography scale — fluid clamp() for headings, fixed for body */
+        'display-xl': [
+          'clamp(3rem, 2rem + 4vw, 5rem)',
+          { lineHeight: '0.95', letterSpacing: '-0.04em', fontWeight: '800' },
+        ],
+        display: [
+          'clamp(2.25rem, 1.5rem + 3vw, 3.75rem)',
+          { lineHeight: '1.0', letterSpacing: '-0.035em', fontWeight: '700' },
+        ],
+        h1: [
+          'clamp(2rem, 1.5rem + 2vw, 3rem)',
+          { lineHeight: '1.1', letterSpacing: '-0.03em', fontWeight: '700' },
+        ],
+        h2: [
+          'clamp(1.5rem, 1.2rem + 1vw, 2rem)',
+          { lineHeight: '1.2', letterSpacing: '-0.02em', fontWeight: '600' },
+        ],
+        h3: [
+          '1.25rem',
+          { lineHeight: '1.4', letterSpacing: '-0.01em', fontWeight: '600' },
+        ],
+        'body-lg': ['1.125rem', { lineHeight: '1.6' }],
+        body: ['1rem', { lineHeight: '1.55' }],
+        'body-sm': ['0.875rem', { lineHeight: '1.5' }],
+        caption: ['0.8125rem', { lineHeight: '1.45' }],
+        /* WHY no textTransform here: Tailwind's fontSize tuple type does not
+         * accept textTransform. Apply `uppercase` as a separate utility class
+         * (e.g. `text-label uppercase`) on labels. */
+        label: [
+          '0.6875rem',
+          {
+            lineHeight: '1.0',
+            letterSpacing: '0.15em',
+            fontWeight: '500',
+          },
+        ],
+      },
       borderRadius: {
+        /* Custom radius hierarchy — semantic intent, not just shorthand */
+        sharp: '0.125rem',
+        base: '0.375rem',
+        card: '0.5rem',
+        hero: '1rem',
+        /* Tailwind's xl/2xl/full retained for compat / decorative use */
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',


### PR DESCRIPTION
## Summary

Architectural foundation rework for the Styrby design system - the highest-risk wave because it touches every page's visual rendering. Three changes land together:

1. **Three-layer OKLCH token system** replacing the prior flat HSL setup. Primitives (steel-blue + amber ramps), semantic aliases, explicit light overrides.
2. **Background undertone shift** from hue 240 (violet-leaning) to 220 (steel-blue). Cool-precision dark surfaces.
3. **Brand-color slop tell eliminated**: the prior \`styrby: { 50..950 }\` block was a literal copy of Tailwind's default orange palette. Replaced with an OKLCH amber ramp at hue ~55-60 (distinct from Tailwind's hue ~30) accessed through the semantic \`primary\` token.

Net effect: distinctive amber accent on cool steel-blue dark surfaces. Industrial Dark identity adapted for Styrby.

## Files Changed

- \`packages/styrby-web/src/app/globals.css\` (244 lines changed) - new three-layer token architecture, glass/gradient-border/amber-glow/shimmer/dot-grid/scrollbar utilities migrated from raw rgba/hsl to \`color-mix(in oklch, ...)\` and \`oklch(var(--token))\`.
- \`packages/styrby-web/tailwind.config.ts\` (204 lines changed) - semantic-token color extension with \`oklch(var(--token) / <alpha-value>)\`, deleted the styrby orange clone, added surface-1..4, foreground-secondary/tertiary, border-strong, primary.muted, semantic typography scale (display-xl..label), custom radius hierarchy (sharp/base/card/hero), 2xs:320px screen, exposed steel-*/amber-* primitives.
- \`.size-limit.js\` - documentation note that Wave 3 added zero JS.

## Decision Log

| Decision | Reasoning |
|---|---|
| Kept amber as brand accent (not full steel-blue swap) | Styrby has established amber identity; the spec asked for fixing the Tailwind-clone slop tell, not replacing amber outright. Hue 60 + OKLCH derivation is distinctive but recognizable. |
| Surface hue 220 vs prior 240 | 220 reads as steel-blue / cool-precision. 240 reads as violet-leaning / template default. |
| Light mode authored even though app is dark-first | Printing, accessibility, future toggle all need it. |
| textTransform omitted from label fontSize tuple | Tailwind's type definition rejects it. Apply \`uppercase\` separately on label elements. |
| Zero new dependencies | No culori, no @radix-ui/colors. All OKLCH values pre-derived in CSS. |

## Component migration: zero work

Pre-flight \`grep\` confirmed no remaining \`bg-styrby\` / \`text-styrby\` / \`border-styrby\` / \`ring-styrby\` class usages anywhere in src/ - Wave 2 had already eliminated them. Components referencing semantic tokens (bg-card, text-foreground, bg-primary, border, etc.) continue to render correctly; only the resolved OKLCH values shift.

## Test plan

- [x] \`pnpm tsc --noEmit\`: clean
- [x] \`pnpm lint\`: 0 errors (85 pre-existing warnings, no new ones)
- [x] \`pnpm test --run\`: 3140/3140 passing across 190 test files
- [x] \`pnpm build\`: clean
- [x] Bundle: 775.64 KB gzip first-load - **under the 776 KB limit, no ratchet needed**. Token rework is CSS-only and Tailwind JIT purges unused utilities, so the new ramps add zero JS.
- [ ] Manual visual QA on representative dark-mode pages (landing, /pricing, /docs, /dashboard, /login) - background should read cooler / steel-blue, amber accent should look slightly burnt vs prior pure orange. Recommend before merge.
- [ ] Manual light-mode spot check - even though app is dark-first, light overrides should resolve cleanly.

## Bundle delta vs 776 KB baseline

**0 KB** (measured 775.64 KB gzip on this branch). No size-limit ratchet required.

## Notes for reviewer

- The agent brand colors (Claude / Codex / Gemini / etc.) were intentionally kept as fixed hex - they match upstream brand identities and are not part of Styrby's palette.
- The chart palette was simplified to derive from token primitives (chart-1 = primary amber, chart-2 = success green, etc.) so theming flows through to data viz.
- 4213 files still reference \`zinc-*\` utilities. Per spec these are utility-neutral and don't need wholesale migration; future polish can convert hot-path marketing/auth surfaces to semantic tokens.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>