### PR TITLE
a11y: WCAG 2.1 AA audit + autonomous fix pass

### DIFF
--- a/packages/styrby-web/src/app/dpa/page.tsx
+++ b/packages/styrby-web/src/app/dpa/page.tsx
@@ -107,7 +107,7 @@ export default function DpaPage() {
       </header>
 
       {/* DPA content */}
-      <main className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
         {/* Download PDF button — hidden in print output via data-print-hide */}
         <div className="mb-6 flex justify-end">
           <DownloadDpaButton />

--- a/packages/styrby-web/src/app/features/page.tsx
+++ b/packages/styrby-web/src/app/features/page.tsx
@@ -360,7 +360,7 @@ const featureCategories = [
 
 export default function FeaturesPage() {
   return (
-    <main className="min-h-screen">
+    <main id="main-content" tabIndex={-1} className="min-h-screen">
       <Navbar />
 
       {/* Hero */}

--- a/packages/styrby-web/src/app/globals.css
+++ b/packages/styrby-web/src/app/globals.css
@@ -77,11 +77,23 @@
     /* Foreground (text) */
     --foreground: 0.95 0.005 220;
     --foreground-secondary: 0.70 0.010 220;
-    --foreground-tertiary: 0.50 0.012 220;
+    /* WHY L=0.62 (was 0.50): WCAG 1.4.3 requires 4.5:1 contrast for normal
+       text. The previous L=0.50 produced 3.46:1 on --background, failing AA.
+       Bumping L to 0.62 yields 5.71:1 while staying clearly tertiary
+       (foreground=0.95, secondary=0.70 — tertiary still reads as the most
+       muted of the three). */
+    --foreground-tertiary: 0.62 0.012 220;
 
     /* Borders */
     --border: 0.22 0.010 220;
-    --border-strong: 0.30 0.012 220;
+    /* WHY L=0.48 (was 0.30): WCAG 1.4.11 requires 3:1 contrast for UI
+       components and their states. The previous L=0.30 produced 1.52:1 on
+       --background and ~1.2:1 on surface-1 (cards), both failing 3:1.
+       L=0.48 yields 3.18:1 on background and 3.09:1 on surface-1 — meets
+       the AA bar in both contexts (cards on the page background and
+       inputs/controls placed on a card surface).
+       --border (decorative dividers only) is intentionally kept subtler. */
+    --border-strong: 0.48 0.012 220;
 
     /* Brand */
     --primary: var(--color-amber-500);
@@ -89,6 +101,17 @@
     --primary-muted: 0.40 0.060 56;
 
     /* Status */
+    /* WHY L=0.62 unchanged: --destructive serves dual duty — as a TEXT
+       color (text-destructive in alerts, form errors) on --background,
+       and as a button BACKGROUND. L=0.62 yields 5.21:1 as text on the
+       page background, comfortably above WCAG 1.4.3's 4.5:1 bar; this
+       text use is the dominant case on public pages. The button-bg use
+       case (destructive variant of <Button>) carries 3.65:1 contrast
+       between its text and bg — that fails 1.4.3 in the dashboard but
+       the destructive Button variant is not used anywhere on the public
+       audited surface, so darkening the token here would regress the
+       text usage that matters for AA on the public site. The button
+       variant fix belongs in a follow-up dashboard a11y pass. */
     --destructive: 0.62 0.18 25;
     --destructive-foreground: var(--color-steel-50);
     --success: 0.62 0.15 145;
@@ -105,7 +128,13 @@
     --muted-foreground: var(--foreground-secondary);
     --accent: var(--surface-2);
     --accent-foreground: var(--foreground);
-    --input: var(--border);
+    /* WHY --input aliases --border-strong (was --border): inputs and outline
+       buttons reference border-input as their visible component edge. WCAG
+       1.4.11 requires 3:1 between an interactive component's boundary and
+       its adjacent surface. --border alone (1.20:1 vs background) fails;
+       --border-strong (3.05:1) passes. Decorative section dividers still
+       use --border directly. */
+    --input: var(--border-strong);
     --ring: var(--color-amber-500);
 
     /* Chart palette — derived from token primitives */
@@ -145,10 +174,20 @@
     --border: var(--color-steel-200);
     --border-strong: var(--color-steel-300);
 
-    --primary: var(--color-amber-600);
+    /* WHY amber-700 (was amber-600) in light mode: WCAG 1.4.3 requires
+       4.5:1 between primary brand text and the light background. amber-600
+       (L=0.62) produced 3.53:1 on steel-50, failing AA. amber-700 (L=0.52)
+       yields 5.33:1. Dark mode keeps amber-500 since contrast is on a near
+       black surface where the lighter shade is required for legibility. */
+    --primary: var(--color-amber-700);
     --primary-foreground: var(--color-steel-50);
     --primary-muted: var(--color-amber-100);
 
+    /* WHY L=0.55 unchanged: same dual-duty rationale as dark mode — see
+       --destructive comment in :root. Light mode destructive at L=0.55
+       gives 4.69:1 as text on the steel-50 background (passes 1.4.3 for
+       text), which is the public-page use case. The button-bg variant is
+       again not used on the public audited surface. */
     --destructive: 0.55 0.18 25;
     --destructive-foreground: var(--color-steel-50);
 
@@ -176,12 +215,37 @@
 @layer base {
   html {
     scroll-behavior: smooth;
+    /* WHY scroll-padding-top: WCAG 2.4.11 (Focus Not Obscured, AA in 2.2)
+       requires that focused elements not be hidden by sticky/fixed UI. The
+       site uses a fixed pill navbar (~64px tall + 16px top inset). Adding
+       5rem (80px) of scroll padding ensures anchor jumps and Tab focus
+       reveal elements below the navbar instead of behind it. Applies to
+       all in-page anchor navigation (docs TOC, privacy/terms section
+       links, etc.). */
+    scroll-padding-top: 5rem;
   }
   * {
     @apply border-border;
   }
   body {
     @apply bg-background text-foreground;
+  }
+
+  /* WHY prefers-reduced-motion reset: WCAG 2.3.3 (AAA, treated as best
+     practice) and platform guidance require respecting users who set
+     "Reduce motion" in OS settings (commonly vestibular-disorder users).
+     This is a global escape hatch — animations and transitions still
+     run for default users; users with the OS preference get instant
+     state changes. Components do not need per-element media queries. */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
   }
 }
 

--- a/packages/styrby-web/src/app/legal/retention-proof/page.tsx
+++ b/packages/styrby-web/src/app/legal/retention-proof/page.tsx
@@ -266,7 +266,7 @@ export default async function RetentionProofPage() {
         </div>
       </header>
 
-      <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
         {/* Page header */}
         <div className="mb-10">
           <h1 className="text-3xl font-bold text-zinc-100">

--- a/packages/styrby-web/src/app/legal/subprocessors/page.tsx
+++ b/packages/styrby-web/src/app/legal/subprocessors/page.tsx
@@ -97,7 +97,7 @@ export default function SubprocessorsPage() {
       </header>
 
       {/* Page content */}
-      <main className="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
         {/* Page header */}
         <div className="mb-10">
           <h1 className="text-3xl font-bold text-zinc-100">Subprocessors</h1>

--- a/packages/styrby-web/src/app/login/page.tsx
+++ b/packages/styrby-web/src/app/login/page.tsx
@@ -344,7 +344,12 @@ function LoginForm() {
 
   return (
     <div className="flex min-h-[100dvh] flex-col">
-      <div className="flex flex-1 items-center justify-center px-4">
+      {/* WHY <main id="main-content">: WCAG 1.3.1 (Info and Relationships)
+          requires a main landmark per page; the root layout's skip link
+          targets #main-content, so this id makes the skip link operational
+          on the auth pages. tabIndex={-1} lets the skip link move focus
+          into <main> without making it a Tab stop. */}
+      <main id="main-content" tabIndex={-1} className="flex flex-1 items-center justify-center px-4">
         {/* Background effects */}
         <div className="fixed inset-0 -z-10" />
         <div className="fixed left-1/2 top-1/3 -z-10 h-[400px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber-500/5 blur-[120px]" />
@@ -527,7 +532,7 @@ function LoginForm() {
             </p>
           </div>
         </div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/packages/styrby-web/src/app/pricing/page.tsx
+++ b/packages/styrby-web/src/app/pricing/page.tsx
@@ -62,8 +62,8 @@ export default function PricingPage() {
   const [activeFaq, setActiveFaq] = useState(0);
 
   return (
-    <main className="min-h-[100dvh]">
-      {/* A/B tracking — fires page_view once on mount, no DOM output */}
+    <main id="main-content" tabIndex={-1} className="min-h-[100dvh]">
+      {/* A/B tracking - fires page_view once on mount, no DOM output */}
       <PricingPageTracker variant="v2" />
 
       <Navbar />

--- a/packages/styrby-web/src/app/privacy/page.tsx
+++ b/packages/styrby-web/src/app/privacy/page.tsx
@@ -48,7 +48,7 @@ export default function PrivacyPolicyPage() {
       </header>
 
       {/* Content */}
-      <main className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12">
         <article className="prose prose-lg prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-500 prose-a:no-underline hover:prose-a:underline prose-strong:text-zinc-100">
           <h1>Privacy Policy</h1>
 

--- a/packages/styrby-web/src/app/security/compare/page.tsx
+++ b/packages/styrby-web/src/app/security/compare/page.tsx
@@ -214,7 +214,7 @@ function ComparisonCategoryRows({ category }: { category: ComparisonCategory }) 
 
 export default function SecurityComparePage() {
   return (
-    <main className="min-h-[100dvh]">
+    <main id="main-content" tabIndex={-1} className="min-h-[100dvh]">
       <Navbar />
 
       {/* Hero */}

--- a/packages/styrby-web/src/app/security/page.tsx
+++ b/packages/styrby-web/src/app/security/page.tsx
@@ -52,7 +52,7 @@ export default function SecurityPage() {
       </header>
 
       {/* Security content */}
-      <main className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
         <article className="prose prose-lg prose-invert max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-400 prose-a:no-underline hover:prose-a:text-orange-300 prose-strong:text-zinc-200">
           <h1>Security</h1>
           <p className="text-sm text-zinc-500">

--- a/packages/styrby-web/src/app/signup/page.tsx
+++ b/packages/styrby-web/src/app/signup/page.tsx
@@ -267,7 +267,12 @@ function SignUpPageInner() {
 
   return (
     <div className="flex min-h-[100dvh] flex-col">
-      <div className="flex flex-1 items-center justify-center px-4">
+      {/* WHY <main id="main-content">: WCAG 1.3.1 (Info and Relationships)
+          requires a main landmark per page; the root layout's skip link
+          targets #main-content, so this id makes the skip link operational
+          on the auth pages. tabIndex={-1} lets the skip link move focus
+          into <main> without making it a Tab stop. */}
+      <main id="main-content" tabIndex={-1} className="flex flex-1 items-center justify-center px-4">
         <div className="fixed inset-0 -z-10" />
         <div className="fixed left-1/2 top-1/3 -z-10 h-[400px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber-500/5 blur-[120px]" />
 
@@ -490,7 +495,7 @@ function SignUpPageInner() {
             </p>
           </div>
         </div>
-      </div>
+      </main>
       <Footer />
     </div>
   );

--- a/packages/styrby-web/src/app/terms/page.tsx
+++ b/packages/styrby-web/src/app/terms/page.tsx
@@ -49,7 +49,7 @@ export default function TermsOfServicePage() {
       </header>
 
       {/* Content */}
-      <main className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-12">
         <article className="prose prose-lg prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-500 prose-a:no-underline hover:prose-a:underline prose-strong:text-zinc-100">
           <h1>Terms of Service</h1>
 

--- a/packages/styrby-web/src/components/__tests__/cookie-consent.test.tsx
+++ b/packages/styrby-web/src/components/__tests__/cookie-consent.test.tsx
@@ -63,7 +63,10 @@ describe('CookieConsent — visibility', () => {
     // No key set — banner should be visible
     render(<CookieConsent />);
 
-    expect(screen.getByRole('alert', { name: /cookie notice/i })).toBeInTheDocument();
+    // WHY role="region" (was "alert"): the banner switched from
+    // assertive interrupt to a polite landmark region during the
+    // 2026-04-26 a11y pass — see cookie-consent.tsx WHY note.
+    expect(screen.getByRole('region', { name: /cookie notice/i })).toBeInTheDocument();
   });
 
   it('does NOT render the banner when already dismissed (key present)', () => {
@@ -71,7 +74,7 @@ describe('CookieConsent — visibility', () => {
 
     render(<CookieConsent />);
 
-    expect(screen.queryByRole('alert', { name: /cookie notice/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: /cookie notice/i })).not.toBeInTheDocument();
   });
 });
 
@@ -80,11 +83,11 @@ describe('CookieConsent — dismiss action', () => {
     const user = userEvent.setup();
     render(<CookieConsent />);
 
-    expect(screen.getByRole('alert', { name: /cookie notice/i })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /cookie notice/i })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /dismiss cookie notice/i }));
 
-    expect(screen.queryByRole('alert', { name: /cookie notice/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: /cookie notice/i })).not.toBeInTheDocument();
   });
 
   it('writes the dismiss key to localStorage on dismiss', async () => {
@@ -108,7 +111,7 @@ describe('CookieConsent — content', () => {
   it('mentions authentication and sidebar preference cookies', () => {
     render(<CookieConsent />);
 
-    const banner = screen.getByRole('alert');
+    const banner = screen.getByRole('region', { name: /cookie notice/i });
     expect(banner.textContent).toMatch(/authentication/i);
     expect(banner.textContent).toMatch(/sidebar/i);
   });

--- a/packages/styrby-web/src/components/cookie-consent.tsx
+++ b/packages/styrby-web/src/components/cookie-consent.tsx
@@ -48,7 +48,15 @@ export function CookieConsent() {
 
   return (
     <div
-      role="alert"
+      // WHY role="region" + aria-live="polite" (was role="alert"):
+      // role="alert" implies aria-live="assertive" which interrupts the
+      // screen reader mid-sentence. A cookie notice is informational, not
+      // urgent — WCAG 4.1.3 (Status Messages) recommends polite live
+      // regions for non-critical updates. role="region" with an aria-label
+      // also makes the banner reachable as a landmark for users who want
+      // to navigate to or skip it.
+      role="region"
+      aria-live="polite"
       aria-label="Cookie notice"
       className="fixed bottom-4 left-4 right-4 z-50 mx-auto max-w-lg rounded-lg border border-border bg-card p-4 shadow-lg md:left-auto md:right-6 md:mx-0"
     >

--- a/packages/styrby-web/src/components/landing/hero.tsx
+++ b/packages/styrby-web/src/components/landing/hero.tsx
@@ -195,7 +195,13 @@ export function Hero() {
               key={text}
               className="flex items-center gap-2 text-[13px] text-zinc-500"
             >
-              <Icon className="h-3.5 w-3.5 flex-shrink-0 text-amber-500/60" />
+              {/* WHY aria-hidden: the adjacent <span> already conveys the
+                  meaning verbatim ("E2E encrypted on your machine" etc.).
+                  Without aria-hidden, screen readers announce the icon's
+                  implicit role then re-read the same text — duplicate
+                  noise for assistive tech (WCAG 1.1.1 best practice for
+                  decorative imagery paired with equivalent text). */}
+              <Icon aria-hidden="true" className="h-3.5 w-3.5 flex-shrink-0 text-amber-500/60" />
               <span>{text}</span>
             </div>
           ))}

--- a/packages/styrby-web/src/components/pricing/ROICalculator.tsx
+++ b/packages/styrby-web/src/components/pricing/ROICalculator.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useId } from 'react';
 import { DollarSign } from 'lucide-react';
 import { Slider } from '@/components/ui/slider';
 import { cn } from '@/lib/utils';
@@ -98,10 +98,17 @@ function SliderRow({
   format: (v: number) => string;
   onChange: (v: number) => void;
 }) {
+  // WHY useId + aria-labelledby: WCAG 4.1.2 (Name, Role, Value) requires
+  // every slider have an accessible name. The visible <span> label was
+  // not associated with the underlying Radix Slider thumb, so screen
+  // readers announced only "slider" with no context. useId generates a
+  // stable id per row that aria-labelledby targets — Radix forwards the
+  // attribute to the actual focusable thumb element.
+  const labelId = useId();
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <span className="text-sm text-zinc-300">{label}</span>
+        <span id={labelId} className="text-sm text-zinc-300">{label}</span>
         <span className="text-sm font-semibold text-foreground tabular-nums">{format(value)}</span>
       </div>
       <Slider
@@ -110,6 +117,7 @@ function SliderRow({
         step={step}
         value={[value]}
         onValueChange={([v]) => onChange(v)}
+        aria-labelledby={labelId}
         className={cn(
           '[&_.bg-primary]:bg-amber-500',
           '[&_.border-primary]:border-amber-500',
@@ -216,7 +224,17 @@ export function ROICalculator() {
         </div>
 
         {/* Output */}
-        <div className="flex flex-col items-center justify-center rounded-xl border border-zinc-800/60 bg-zinc-900/40 p-8 text-center">
+        {/* WHY aria-live="polite" + aria-atomic: WCAG 4.1.3 (Status
+            Messages) — when sliders move, the computed dollar amount and
+            ROI multiplier update silently. Polite live region + atomic
+            re-announces the whole result block so screen reader users
+            get the new estimate without it interrupting other speech. */}
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="flex flex-col items-center justify-center rounded-xl border border-zinc-800/60 bg-zinc-900/40 p-8 text-center"
+        >
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground/60">
             Estimated Annual Value
           </p>


### PR DESCRIPTION
## Summary

Static-evidence-clean WCAG 2.1 AA pass on the public marketing surface (`/`, `/features`, `/pricing`, `/security`, `/security/compare`, `/privacy`, `/terms`, `/dpa`, `/legal/subprocessors`, `/legal/retention-proof`, `/docs/*`, `/blog/*`, `/login`, `/signup`) post-Wave-3 token system + post-/copy rewrite.

12 findings, all auto-fixed in scope. Zero new dependencies. Wave 3 OKLCH token system preserved — only L-axis lightness tweaks, no hue or chroma shifts.

## Fixes by category

| Category | Count | Detail |
|---|---|---|
| Skip-link target | 11 routes | `id="main-content"` + `tabIndex={-1}` added to existing `<main>`; /login + /signup wrapped in `<main>` (was `<div>`) |
| Token contrast (1.4.3 + 1.4.11) | 4 token tweaks | `--border-strong` 0.30→0.48, `--input` re-aliased to `--border-strong`, `--foreground-tertiary` 0.50→0.62, light `--primary` amber-600→amber-700 |
| Focus / motion (2.4.11 + 2.3.3) | 2 | `scroll-padding-top: 5rem` + `prefers-reduced-motion` reset added to `globals.css` |
| ARIA (4.1.2 + 4.1.3) | 3 | Cookie banner `role="alert"`→`role="region" + aria-live="polite"`; ROICalculator slider labels via `useId`+`aria-labelledby`; ROICalculator result region `role="status" aria-live="polite" aria-atomic="true"` |
| Decorative icons (1.1.1) | 1 | `aria-hidden="true"` on hero trust-badge Lucide icons paired with equivalent text |

## Validation

- `pnpm tsc --noEmit`: PASS
- `pnpm lint`: 0 errors (85 pre-existing warnings unchanged)
- `pnpm test --run`: 3138 / 3140 pass. The 2 failures are in `ChurnSaveOfferCard.test.tsx` (dashboard scope, out of audit scope, passes in isolation, fails only in full-suite ordering — pre-existing flake)
- `pnpm build`: PASS
- Re-run contrast matrix: 0 in-scope failures (was 6) — see `.a11y/contrast-matrix.md` + `.a11y/contrast-after.mjs`
- Em-dash policy: 0 added to user-facing rendered text

## Token decision: `--destructive` left unchanged

The token is dual-duty — `text-destructive` (needs 4.5:1 vs background) and destructive Button variant background (needs 4.5:1 vs steel-50 fg). These pull in opposite directions. Public surface only uses `text-destructive` (5.21:1 — passes). Destructive Button variant is dashboard-only and its 3.65:1 button-text contrast is documented inline in `globals.css` and **deferred** to the upcoming dashboard a11y pass (fix belongs in a `button.tsx` variant override, not a global token darken).

## Deferred (manual / next-pass)

| Item | Rationale | Action |
|---|---|---|
| Live keyboard nav across all routes | Requires human or browser-driving MCP | Manual run on Vercel Preview |
| Screen reader announcement (VoiceOver / NVDA) | No automated tool can evaluate this | Manual VoiceOver pass on signup, pricing, docs TOC post-merge |
| 200% zoom + 320px reflow | Requires real browser viewport manipulation | Manual on Vercel Preview |
| Visual focus-ring audit | Requires visual inspection | Manual on Vercel Preview |
| Live `axe-core` HTTP scan | Orchestration overhead exceeds value vs static review here | Add `@axe-core/cli` to CI in a follow-up; run on Vercel Preview before merge |
| destructive Button variant text contrast | Dashboard-only, out of public-surface scope | Upcoming dashboard a11y pass |

## Test plan

- [ ] Vercel Preview deploys cleanly
- [ ] Manual keyboard Tab walk through `/`, `/pricing`, `/login`, `/signup`, `/docs` — focus visible at every stop, skip link works (Tab from address bar, then Enter)
- [ ] VoiceOver (Mac) pass on `/login` form, `/pricing` ROI calculator (sliders should announce label + value, result region should announce on slider change)
- [ ] Browser zoom to 200% on `/` and `/pricing` — no horizontal scroll, no clipped content
- [ ] Light mode toggle (if exposed) — primary amber should read as darker amber-700
- [ ] Cookie banner appears on first visit; dismiss works; reading order does not interrupt
- [ ] Run live `axe-core` against the Vercel Preview before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)