### PR TITLE
fix(billing): expand tierRank guard for Growth + legacy aliases (H5)

### DIFF
--- a/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
@@ -598,6 +598,146 @@ describe('POST /api/webhooks/polar', () => {
       expect(response.status).toBe(200);
       expect(mockUpsert).toHaveBeenCalled();
     });
+
+    // ------------------------------------------------------------------------
+    // Bug #9 (Kaulby hardening) — Growth-tier rank guard cases
+    // ------------------------------------------------------------------------
+    // WHY these tests: Phase H5 introduces Growth as the new highest paid tier
+    // alongside legacy Power/Team/Business/Enterprise rows still present in the
+    // subscription_tier enum (migration 055). The tierRank table maps all of
+    // free=0, pro=1, and {power,team,business,enterprise,growth}=2. The guard
+    // uses strict `<` so equal-rank events PROCEED (renewal / cross-grade),
+    // genuine downgrades (rank-2 → rank-0/1) are rejected.
+
+    it('rejects downgrade from growth to free (Bug #9)', async () => {
+      // WHY: late .active for the deprecated free tier must NOT clobber a paying
+      // growth subscriber. growth=2, free=0, 0 < 2 → guard rejects.
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'growth', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'growth', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { tier: 'growth', status: 'active' },
+        error: null,
+      });
+
+      // WHY product_id 'prod_unknown_thing': there is no Free product in Polar,
+      // so we exercise the unrecognized-product branch which short-circuits
+      // before tierRank — confirming defense-in-depth (no upsert either way).
+      const event = createSubscriptionEvent('subscription.updated', {
+        product_id: 'prod_unknown_thing',
+      });
+      const response = await sendSignedEvent(event);
+
+      expect(response.status).toBe(200);
+      expect(mockUpsert).not.toHaveBeenCalled();
+    });
+
+    it('allows free→growth upgrade event (rank up, Bug #9)', async () => {
+      // WHY: free=0, growth=2 → 2 < 0 is false, guard passes, upsert runs.
+      // Stand-in: 'prod_power_monthly' resolves to tier='power' which shares
+      // rank 2 with growth (defensive aliasing per the new tierRank table).
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'free', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'free', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { tier: 'free', status: 'active' },
+        error: null,
+      });
+
+      const event = createSubscriptionEvent('subscription.updated', {
+        product_id: 'prod_power_monthly',
+      });
+      const response = await sendSignedEvent(event);
+
+      expect(response.status).toBe(200);
+      expect(mockUpsert).toHaveBeenCalled();
+    });
+
+    it('allows renewal at same growth/power rank (Bug #9)', async () => {
+      // WHY: existing tier=growth, incoming tier=power, both rank 2, strict `<`
+      // false → upsert proceeds. This is the renewal / Polar-late-event case
+      // that must NOT be rejected (rejection would block legitimate renewals).
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'growth', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'growth', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { tier: 'growth', status: 'active' },
+        error: null,
+      });
+
+      const event = createSubscriptionEvent('subscription.updated', {
+        product_id: 'prod_power_monthly',
+      });
+      const response = await sendSignedEvent(event);
+
+      expect(response.status).toBe(200);
+      expect(mockUpsert).toHaveBeenCalled();
+    });
+
+    it('allows pro→growth-rank upgrade (Bug #9)', async () => {
+      // WHY: pro=1, power(=growth-rank)=2 → 2 < 1 false → upsert proceeds.
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'pro', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'pro', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { tier: 'pro', status: 'active' },
+        error: null,
+      });
+
+      const event = createSubscriptionEvent('subscription.updated', {
+        product_id: 'prod_power_monthly',
+      });
+      const response = await sendSignedEvent(event);
+
+      expect(response.status).toBe(200);
+      expect(mockUpsert).toHaveBeenCalled();
+    });
+
+    it('rejects downgrade from team-legacy to pro (Bug #9 alias)', async () => {
+      // WHY: team is a legacy alias at rank 2; an inbound Pro event (rank 1)
+      // must be rejected to prevent a stale .active from demoting a team-tier
+      // row still present in the enum per migration 055.
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'team', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'team', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { tier: 'team', status: 'active' },
+        error: null,
+      });
+
+      const event = createSubscriptionEvent('subscription.updated', {
+        product_id: 'prod_pro_monthly',
+      });
+      const response = await sendSignedEvent(event);
+
+      expect(response.status).toBe(200);
+      expect(mockUpsert).not.toHaveBeenCalled();
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/packages/styrby-web/src/app/api/webhooks/polar/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/route.ts
@@ -1105,7 +1105,22 @@ export async function POST(request: Request) {
         // FIX-007: Downgrade protection - don't silently downgrade paid users
         // WHY: If a user is on 'power' and this event says 'pro', it may be
         // a stale webhook or Polar issue. Log a warning and skip the downgrade.
-        const tierRank: Record<string, number> = { free: 0, pro: 1, power: 2 };
+        // BUG #9 (Kaulby hardening taxonomy): Growth replaces Power as the new
+        // highest paid tier. Why the legacy values are kept: defensive aliasing —
+        // the DB's subscription_tier enum still holds free/pro/power/team/business/
+        // enterprise as legacy values per migration 055. A late .active event for
+        // any of those must NOT downgrade a user currently on growth. Map them all
+        // to rank 2 (same as growth) so the guard only fires when the incoming
+        // rank is genuinely lower.
+        const tierRank: Record<string, number> = {
+          free: 0,
+          pro: 1,
+          power: 2,
+          team: 2,
+          business: 2,
+          enterprise: 2,
+          growth: 2,
+        };
         const { data: existingSub } = await supabase
           .from('subscriptions')
           .select('tier, status')


### PR DESCRIPTION
## Summary

- Expands the Polar webhook handler's `tierRank` table from `{ free, pro, power }` to include `growth` (the new highest paid tier) plus defensive aliases for legacy enum values still in `subscription_tier` (`team`, `business`, `enterprise`, `power`) — all mapped to rank 2.
- Strict `<` guard semantics preserved: equal-rank events (renewals, growth↔power cross-grade) PROCEED; only genuine rank decreases (rank-2 → rank-0/1) are rejected.
- Bug #9 from the Kaulby hardening taxonomy. Mirrors the pattern shipped in Kaulby's webhook handler.

## Why the legacy values are kept

Per migration 055, the DB's `subscription_tier` enum still holds `free`/`pro`/`power`/`team`/`business`/`enterprise` as legacy values. A late `subscription.active` event for any of those must NOT downgrade a user currently on `growth`. Mapping them all to rank 2 (same as growth) ensures the guard only fires when the incoming rank is genuinely lower.

## Test plan

- [x] Added 5 new test cases in `src/app/api/webhooks/polar/__tests__/route.test.ts`:
  - rejects downgrade from `growth` to `free` (defense-in-depth via unrecognized-product branch)
  - allows `free`→growth-rank upgrade event
  - allows renewal at same growth/power rank
  - allows `pro`→growth-rank upgrade
  - rejects downgrade from `team`-legacy to `pro`
- [x] All 31 webhook tests pass locally (`pnpm vitest run src/app/api/webhooks/polar/__tests__/route.test.ts`)
- [x] No other handler logic touched — diff scoped to `tierRank` table and inline WHY comment.
- [x] Typecheck clean against this PR's diff (one pre-existing `shiki` module error on `main` is unrelated).

References `.audit/styrby-fulltest.md` Phase H5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)