### PR TITLE
fix(billing): refund subscription-id guard preserves main tier (Bug #8 / H6)

### DIFF
--- a/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
@@ -676,6 +676,211 @@ describe('POST /api/webhooks/polar', () => {
   });
 
   // --------------------------------------------------------------------------
+  // Order Refunded — Bug #8 / Phase H6 subscription-id match guard
+  //
+  // WHY these tests: order.refunded blanket-resets are a billing-state
+  // landmine. The handler MUST differentiate between:
+  //   1. Main subscription refund        → reset to free
+  //   2. Side-purchase refund (seat addon) → preserve main tier
+  //   3. Refund event with missing subscription_id → graceful no-op
+  //
+  // These tests pin the contract so a future refactor cannot regress to the
+  // naive "always reset" behavior. SOC2 CC7.2: every billing decision is
+  // observable via audit_log; we assert the audit row's metadata.event_subtype
+  // discriminator is present in every branch.
+  // --------------------------------------------------------------------------
+
+  describe('order.refunded (Bug #8 subscription-id match guard)', () => {
+    /** Build a signed order.refunded request. */
+    async function sendSignedRefund(body: Record<string, unknown>): Promise<Response> {
+      const payload = JSON.stringify(body);
+      const signature = signPayload(payload);
+      const headersMock = new Headers();
+      headersMock.set('x-polar-signature', signature);
+      vi.mocked(headers).mockResolvedValue(
+        headersMock as unknown as Awaited<ReturnType<typeof headers>>
+      );
+      const request = new Request('http://localhost:3000/api/webhooks/polar', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-forwarded-for': '10.0.0.1',
+        },
+        body: payload,
+      });
+      return POST(request);
+    }
+
+    it('main subscription refund: resets to free, audit metadata event_subtype=order_refunded_main', async () => {
+      // Subscription lookup returns the user's main sub with the SAME id as the
+      // refunded subscription_id below.
+      mockSingle.mockResolvedValueOnce({
+        data: {
+          user_id: 'user-uuid-123',
+          polar_subscription_id: 'sub_main_xyz',
+          tier: 'pro',
+        },
+        error: null,
+      });
+
+      // The flow makes TWO .eq() calls in sequence:
+      //   1. SELECT ... .eq('polar_customer_id', ...).single() — must return the
+      //      chain object so .single() can be called next (mockSingle resolves it).
+      //   2. UPDATE ... .eq('polar_subscription_id', ...) — must resolve to { error: null }.
+      //
+      // Defaults from beforeEach use mockReturnThis() for ALL calls. Adding a
+      // mockResolvedValueOnce would land on call 1 (FIFO), breaking the lookup.
+      // We explicitly chain: first call returns the mock itself (preserving the
+      // chain), second call resolves with success.
+      mockEq.mockReturnValueOnce({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle,
+        upsert: mockUpsert,
+        update: mockUpdate,
+        insert: mockInsert,
+        order: mockOrder,
+        limit: mockLimit,
+      });
+      mockEq.mockResolvedValueOnce({ data: null, error: null });
+
+      const event = {
+        id: 'evt_refund_main_001',
+        type: 'order.refunded',
+        data: {
+          id: 'ord_refund_001',
+          customer_id: 'cust_test_456',
+          subscription_id: 'sub_main_xyz', // === main subscription
+        },
+      };
+
+      const response = await sendSignedRefund(event);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      // WHY no side_purchase_refund key on main-sub branch: the response shape
+      // intentionally differs so callers/observability can distinguish the path.
+      expect(body.side_purchase_refund).toBeUndefined();
+      expect(body.received).toBe(true);
+
+      // Verify update was called to reset tier to free.
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tier: 'free',
+          status: 'canceled',
+        })
+      );
+
+      // Verify audit_log insert with main-branch discriminator.
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'subscription_changed',
+          metadata: expect.objectContaining({
+            event_subtype: 'order_refunded_main',
+            refunded_subscription_id: 'sub_main_xyz',
+            main_subscription_id: 'sub_main_xyz',
+            previous_tier: 'pro',
+            new_tier: 'free',
+          }),
+        })
+      );
+    });
+
+    it('side-purchase refund (subscription_id !== main): preserves main tier, audit event_subtype=order_refunded_side_purchase, response side_purchase_refund=true', async () => {
+      // Subscription lookup returns the user's main sub with a DIFFERENT id
+      // than the refunded subscription_id.
+      mockSingle.mockResolvedValueOnce({
+        data: {
+          user_id: 'user-uuid-123',
+          polar_subscription_id: 'sub_main_xyz',
+          tier: 'pro',
+        },
+        error: null,
+      });
+
+      const event = {
+        id: 'evt_refund_seat_001',
+        type: 'order.refunded',
+        data: {
+          id: 'ord_refund_seat_001',
+          customer_id: 'cust_test_456',
+          subscription_id: 'sub_seat_addon_abc', // !== main
+        },
+      };
+
+      const response = await sendSignedRefund(event);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.received).toBe(true);
+      // WHY this assertion is the headline of Bug #8: side_purchase_refund=true
+      // is the contract that proves the guard fired and the main tier was
+      // preserved. If this flag flips false on a side-purchase refund, the
+      // billing pipeline is back to the naive blanket-reset behavior.
+      expect(body.side_purchase_refund).toBe(true);
+
+      // Verify NO subscription update was called (main tier preserved).
+      expect(mockUpdate).not.toHaveBeenCalled();
+
+      // Verify audit_log insert with side-purchase discriminator.
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'subscription_changed',
+          metadata: expect.objectContaining({
+            event_subtype: 'order_refunded_side_purchase',
+            refunded_subscription_id: 'sub_seat_addon_abc',
+            main_subscription_id: 'sub_main_xyz',
+          }),
+        })
+      );
+    });
+
+    it('refund with missing subscription_id: graceful 200 with side_purchase_refund=true, no main-tier reset', async () => {
+      // Subscription lookup succeeds (so userMainSubscriptionId is non-null),
+      // but the refund event omits subscription_id entirely. The guard MUST
+      // treat this as not-a-main-sub-refund (refundedSubscriptionId === null
+      // fails the equality check) and preserve the main tier.
+      mockSingle.mockResolvedValueOnce({
+        data: {
+          user_id: 'user-uuid-123',
+          polar_subscription_id: 'sub_main_xyz',
+          tier: 'pro',
+        },
+        error: null,
+      });
+
+      const event = {
+        id: 'evt_refund_missing_subid_001',
+        type: 'order.refunded',
+        data: {
+          id: 'ord_refund_missing_001',
+          customer_id: 'cust_test_456',
+          // subscription_id intentionally omitted
+        },
+      };
+
+      const response = await sendSignedRefund(event);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.received).toBe(true);
+      expect(body.side_purchase_refund).toBe(true);
+
+      // No main-tier reset on ambiguous payload.
+      expect(mockUpdate).not.toHaveBeenCalled();
+
+      // Audit row recorded with refunded_subscription_id=null in metadata so
+      // the absence is observable.
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'subscription_changed',
+          metadata: expect.objectContaining({
+            event_subtype: 'order_refunded_side_purchase',
+            refunded_subscription_id: null,
+          }),
+        })
+      );
+    });
+  });
+
+  // --------------------------------------------------------------------------
   // Individual-path event-id dedup (migration 054 hardening)
   //
   // WHY these tests: migration 054 adds event-id dedup to the individual

--- a/packages/styrby-web/src/app/api/webhooks/polar/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/route.ts
@@ -12,6 +12,7 @@
  * - subscription.canceled — individual plan OR team/business plan cancellation
  * - subscription.past_due — team/business payment failure
  * - order.created         — acknowledged, no state change
+ * - order.refunded        — refund: subscription_id-match guarded (Bug #8 / H6)
  *
  * Team-tier events are distinguished by the presence of `subscription.metadata.team_id`
  * in the Polar payload. When team_id is present, the event is routed to the team billing
@@ -144,7 +145,8 @@ type PolarEvent =
   | 'subscription.updated'
   | 'subscription.canceled'
   | 'subscription.past_due'
-  | 'order.created';
+  | 'order.created'
+  | 'order.refunded';
 
 // ============================================================================
 // Team subscription payload schemas
@@ -812,6 +814,7 @@ export async function POST(request: Request) {
       'subscription.canceled',
       'subscription.past_due',
       'order.created',
+      'order.refunded',
     ]);
     if (!knownTypes.has(eventResult.data.type)) {
       console.warn(`Received unrecognized Polar event type: ${eventResult.data.type}`);
@@ -1262,6 +1265,224 @@ export async function POST(request: Request) {
       case 'order.created': {
         const isDev = process.env.NODE_ENV === 'development';
         if (isDev) console.log('Order created event received');
+        break;
+      }
+
+      case 'order.refunded': {
+        // ────────────────────────────────────────────────────────────────────
+        // Bug #8 (Kaulby billing-pipeline-hardening / Phase H6):
+        // subscription-id match guard for order.refunded.
+        //
+        // WHY this guard: order.refunded fires for ANY refunded order, including
+        // side-purchases (e.g., a Growth/team admin refunding ONE seat-addon).
+        // A naive implementation that blanket-resets the user/team to free tier
+        // is wrong — refunding one seat would nuke their entire team subscription.
+        //
+        // The fix: compare the refunded order's subscription_id against the
+        // user's MAIN subscription (the row in `subscriptions` for this customer).
+        // Only the main subscription's refund clears tier state. Side-purchase
+        // refunds preserve the main tier; seat-addon-specific bookkeeping is
+        // handled separately when the corresponding subscription.canceled event
+        // for the seat addon fires.
+        //
+        // STATUS: latent — Styrby's current production tiers (free/pro/power)
+        // do NOT have seat addons, so today every order.refunded is a main-sub
+        // refund. The guard is added proactively so the handler is correct by
+        // construction the moment Growth ships seat-addon SKUs.
+        //
+        // Audit: every branch writes one audit_log row using the existing
+        // `subscription_changed` enum value (no migration required). Branch
+        // discrimination lives in metadata.event_subtype so SOC2 reviewers can
+        // distinguish main-sub refunds from side-purchase refunds without
+        // ambiguity.
+        //
+        // SOC2 CC7.2: every billing state mutation has an audit trail; refund
+        // events that DO NOT mutate state are still audited so the absence of
+        // a reset is itself observable in the trail.
+        // ────────────────────────────────────────────────────────────────────
+
+        const isDev = process.env.NODE_ENV === 'development';
+
+        // WHY rawData (not the narrow `event.data` type): the inline event type
+        // declared at the top of POST is shaped for subscription events and
+        // doesn't carry order.refunded fields (subscription_id, subscription.id,
+        // refunded_amount). We re-use rawData (already parsed for team-routing
+        // above) and read the refund fields explicitly.
+        //
+        // WHY two field-name fallbacks: Polar's order webhook payload nests the
+        // refunded subscription either as `subscription.id` (expanded object) or
+        // `subscription_id` (flat reference) depending on API version. We accept
+        // either to stay forward-compatible without coupling to one shape.
+        const orderRefundData = rawData ?? {};
+        const refundedSubscriptionId =
+          (orderRefundData as { subscription?: { id?: string } }).subscription?.id ??
+          (orderRefundData as { subscription_id?: string }).subscription_id ??
+          null;
+        const refundedCustomerId =
+          (orderRefundData as { customer_id?: string }).customer_id ?? null;
+        const refundedOrderId =
+          (orderRefundData as { id?: string }).id ?? null;
+
+        // WHY we look up by polar_customer_id (not subscription_id): if this is
+        // a side-purchase, refundedSubscriptionId !== mainSubscriptionId by
+        // definition, so a SELECT keyed on it would miss the user entirely.
+        // polar_customer_id is stable across all of a customer's purchases.
+        type MainSubLookup = {
+          user_id: string;
+          polar_subscription_id: string;
+          tier: string;
+        };
+        let mainSubscription: MainSubLookup | null = null;
+
+        if (refundedCustomerId) {
+          const { data: subRow, error: subLookupErr } = await supabase
+            .from('subscriptions')
+            .select('user_id, polar_subscription_id, tier')
+            .eq('polar_customer_id', refundedCustomerId)
+            .single<MainSubLookup>();
+
+          if (subLookupErr) {
+            // Not fatal: customer may have been hard-deleted or this is a refund
+            // for a customer who never had a stored subscription (test order,
+            // pre-Styrby-era purchase). Audit and acknowledge.
+            if (isDev) {
+              console.log(
+                `polar/route: order.refunded — no subscription row for customer ${refundedCustomerId}: ${subLookupErr.message}`
+              );
+            }
+          } else if (subRow) {
+            mainSubscription = subRow;
+          }
+        }
+
+        const userMainSubscriptionId = mainSubscription?.polar_subscription_id ?? null;
+
+        // Match condition: BOTH the refunded subscription id and the user's
+        // main subscription id must be present AND equal. A null on either side
+        // is treated as NOT a main-sub refund — never default to "reset to free"
+        // on ambiguous data (the more conservative choice preserves paid access).
+        const isMainSubRefund =
+          refundedSubscriptionId !== null &&
+          userMainSubscriptionId !== null &&
+          refundedSubscriptionId === userMainSubscriptionId;
+
+        if (!isMainSubRefund) {
+          // Side-purchase refund (or ambiguous payload). Preserve main tier.
+          // The seat-addon-specific bookkeeping (decrement seat count, prorate)
+          // is handled separately when the seat-addon's own subscription.canceled
+          // fires — NOT here.
+          //
+          // WHY no financial details in metadata: PCI/PII hygiene. We log the
+          // subscription_id and order_id (opaque Polar references) but not the
+          // refunded amount or payment-instrument data. The full financial
+          // record lives in Polar's dashboard, not in Styrby's audit_log.
+          const { error: auditErr } = await supabase.from('audit_log').insert({
+            user_id: mainSubscription?.user_id ?? null,
+            action: 'subscription_changed',
+            resource_type: 'subscription',
+            resource_id: null,
+            metadata: {
+              event_subtype: 'order_refunded_side_purchase',
+              refunded_subscription_id: refundedSubscriptionId,
+              main_subscription_id: userMainSubscriptionId,
+              refunded_order_id: refundedOrderId,
+              refunded_customer_id: refundedCustomerId,
+            },
+          });
+          if (auditErr) {
+            // Non-fatal — same posture as other audit writes in this file.
+            console.error(
+              'polar/route: audit_log insert failed on order.refunded side-purchase (non-fatal):',
+              auditErr.message
+            );
+          }
+
+          // TODO(H3 wiring): send refund email here, gated by isMainSubRefund.
+          // Side-purchase refunds should NOT email "your tier was reset" — the
+          // tier was not reset. A separate seat-addon refund email may be wired
+          // later when Growth ships.
+
+          if (isDev) {
+            console.log(
+              `polar/route: order.refunded — side-purchase refund preserved main tier (refunded_sub=${refundedSubscriptionId}, main_sub=${userMainSubscriptionId})`
+            );
+          }
+          return NextResponse.json({ received: true, side_purchase_refund: true });
+        }
+
+        // Main subscription refund — reset to free tier.
+        //
+        // WHY only the columns below: we mirror the subscription.canceled path's
+        // posture (status flip, canceled_at stamp). We additionally clear tier
+        // to 'free' because a refund — unlike a normal cancellation — voids the
+        // paid period. The user does not get a grace period when their money
+        // is returned.
+        //
+        // The .eq() filter pins this to the main subscription row, which we
+        // verified above. mainSubscription is non-null here because
+        // isMainSubRefund implies userMainSubscriptionId is non-null, which
+        // implies mainSubscription is non-null.
+        // TS narrowing: isMainSubRefund === true implies mainSubscription !== null.
+        // Re-assert with a runtime check so the compiler narrows correctly.
+        if (!mainSubscription) {
+          // Defensive — should be unreachable.
+          return NextResponse.json({ received: true });
+        }
+        const mainSub: MainSubLookup = mainSubscription;
+
+        const { error: resetErr } = await supabase
+          .from('subscriptions')
+          .update({
+            tier: 'free',
+            status: 'canceled',
+            canceled_at: new Date().toISOString(),
+            cancel_at_period_end: false,
+            current_period_end: null,
+          })
+          .eq('polar_subscription_id', mainSub.polar_subscription_id);
+
+        if (resetErr) {
+          // Refund processing must not silently fail. Returning 500 lets Polar
+          // retry — the .update() is idempotent (re-applying the same reset
+          // produces the same row state) so retries are safe.
+          console.error(
+            'polar/route: order.refunded — failed to reset main subscription:',
+            resetErr.message
+          );
+          return NextResponse.json({ error: 'Processing failed' }, { status: 500 });
+        }
+
+        const { error: auditErr } = await supabase.from('audit_log').insert({
+          user_id: mainSub.user_id,
+          action: 'subscription_changed',
+          resource_type: 'subscription',
+          resource_id: null,
+          metadata: {
+            event_subtype: 'order_refunded_main',
+            refunded_subscription_id: refundedSubscriptionId,
+            main_subscription_id: userMainSubscriptionId,
+            refunded_order_id: refundedOrderId,
+            refunded_customer_id: refundedCustomerId,
+            previous_tier: mainSub.tier,
+            new_tier: 'free',
+          },
+        });
+        if (auditErr) {
+          console.error(
+            'polar/route: audit_log insert failed on order.refunded main (non-fatal):',
+            auditErr.message
+          );
+        }
+
+        // TODO(H3 wiring): send refund email here, gated by isMainSubRefund.
+        // The email helper (sendRefundEmail) lands with Phase H3; once wired,
+        // call it here ONLY (not in the side-purchase branch above).
+
+        if (isDev) {
+          console.log(
+            `polar/route: order.refunded — main subscription reset to free (sub=${mainSub.polar_subscription_id})`
+          );
+        }
         break;
       }
 


### PR DESCRIPTION
## Summary

Adds a subscription-id match guard to the Polar webhook's `order.refunded` handler. Refunds for side-purchases (e.g., a single seat-addon refund on a future Growth/team plan) no longer blanket-reset the user to free tier — only the user's MAIN subscription's refund clears tier state.

**Bug #8** from the Kaulby billing-pipeline-hardening taxonomy. Reference: `.audit/styrby-fulltest.md` Phase H6.

## Why this is latent today (proactive fix)

Styrby's current production tiers (free / pro / power) do not have seat addons, so every `order.refunded` today is a main-sub refund. The naive "always reset to free" implementation would have happened to be correct. The moment Growth ships seat-addon SKUs, the first seat-addon refund would silently nuke a paying team's subscription. We add the guard now so the handler is correct by construction when Growth lands.

## Implementation

- Adds `'order.refunded'` to the `PolarEvent` union, `knownTypes` set, and module JSDoc.
- Reads refunded subscription id from `event.data.subscription.id` OR `event.data.subscription_id` (Polar API version-tolerant).
- Looks up the user's main subscription by `polar_customer_id` (stable across all of a customer's purchases — keying on subscription_id would miss the user on a side-purchase).
- If `refundedSubscriptionId === userMainSubscriptionId` → reset tier to free, status canceled, clear period.
- Otherwise → preserve main tier, audit + return 200 with `side_purchase_refund: true`.
- Both branches write an `audit_log` row using the existing `subscription_changed` enum value (**no migration required**). `metadata.event_subtype` is the SOC2 discriminator (`order_refunded_main` vs `order_refunded_side_purchase`).
- `TODO(H3 wiring)` markers placed for the refund-email helper — gated by `isMainSubRefund` so seat-addon refunds don't email "your tier was reset".

## Tests

3 new tests, all green; suite total 29 passing:

- main subscription refund → tier reset to free, audit `event_subtype=order_refunded_main`
- side-purchase refund (`subscription_id !== main`) → main tier preserved, audit `event_subtype=order_refunded_side_purchase`, response `side_purchase_refund: true`
- refund event with missing `subscription_id` → graceful 200, no main reset, audit row records `refunded_subscription_id: null`

## Test plan

- [x] `pnpm vitest run src/app/api/webhooks/polar/__tests__/route.test.ts` — 29/29 passing
- [x] `pnpm tsc --noEmit` — only pre-existing unrelated `shiki` error
- [x] Surgical diff: only `route.ts` and its test file touched
- [x] No conflict with PR #182 (different region — that PR owns the `tierRank` table around line 1108; this PR adds a new case at line ~1271)
- [x] No new audit_action enum values needed — uses existing `subscription_changed` with `metadata.event_subtype` discriminator

🤖 Generated with [Claude Code](https://claude.com/claude-code)