### PR TITLE
fix(shared): expand AGENT_CONFIG to 11 agents (Phase H22)

### DIFF
--- a/packages/styrby-shared/src/constants.ts
+++ b/packages/styrby-shared/src/constants.ts
@@ -54,6 +54,54 @@ export const AGENT_CONFIG = {
     icon: 'users',
     provider: 'Open Source',
   },
+  goose: {
+    name: 'Goose',
+    id: 'goose',
+    description: 'Block/Square open-source AI agent with MCP-native architecture',
+    color: '#EAB308', // Yellow
+    icon: 'feather',
+    provider: 'Block',
+  },
+  amp: {
+    name: 'Amp',
+    id: 'amp',
+    description: 'Sourcegraph deep-mode coding agent with sub-agent orchestration',
+    color: '#0EA5E9', // Sky blue
+    icon: 'zap',
+    provider: 'Sourcegraph',
+  },
+  crush: {
+    name: 'Crush',
+    id: 'crush',
+    description: 'Charmbracelet ACP-compatible terminal coding agent',
+    color: '#A855F7', // Purple
+    icon: 'sparkle',
+    provider: 'Charmbracelet',
+  },
+  kilo: {
+    name: 'Kilo',
+    id: 'kilo',
+    description: 'Community-built coding agent supporting 500+ models with Memory Bank',
+    color: '#14B8A6', // Teal
+    icon: 'brain',
+    provider: 'Kilo',
+  },
+  kiro: {
+    name: 'Kiro',
+    id: 'kiro',
+    description: 'AWS-backed coding agent with per-prompt credit billing',
+    color: '#F59E0B', // Amber
+    icon: 'cloud',
+    provider: 'AWS',
+  },
+  droid: {
+    name: 'Droid',
+    id: 'droid',
+    description: 'BYOK multi-backend coding agent powered by LiteLLM',
+    color: '#6366F1', // Indigo
+    icon: 'bot',
+    provider: 'Droid',
+  },
 } as const;
 
 /** Error source colors for UI */

--- a/packages/styrby-shared/tests/constants.test.ts
+++ b/packages/styrby-shared/tests/constants.test.ts
@@ -19,7 +19,19 @@ import {
 // =============================================================================
 
 describe('AGENT_CONFIG', () => {
-  const EXPECTED_AGENTS = ['claude', 'codex', 'gemini', 'opencode', 'aider'] as const;
+  const EXPECTED_AGENTS = [
+    'claude',
+    'codex',
+    'gemini',
+    'opencode',
+    'aider',
+    'goose',
+    'amp',
+    'crush',
+    'kilo',
+    'kiro',
+    'droid',
+  ] as const;
 
   it('contains all expected agent keys', () => {
     for (const agent of EXPECTED_AGENTS) {


### PR DESCRIPTION
## Summary

Brings `@styrby/shared`'s `AGENT_CONFIG` map in line with the 11 agents Styrby actually ships factories for in `packages/styrby-cli/src/agent/factories/` (aider, amp, claude, codex, crush, droid, gemini, goose, kilo, kiro, opencode) and that the pricing FAQ + marketing docs advertise.

## Drift Source

Surfaced during the Styrby-features.md catalog review (Phase H22, `.audit/styrby-fulltest.md`). The CLI, pricing tiers, and docs all reference 11 agents, but `AGENT_CONFIG` only had entries for the original 5 (claude, codex, gemini, opencode, aider). Web and mobile consumers that look up agent metadata (name, color, icon, provider, description) silently fell back to placeholder values for the other 6 (goose, amp, crush, kilo, kiro, droid).

## What's Added

| Agent | Provider | Color | Icon | Why |
|-------|----------|-------|------|-----|
| goose | Block | `#EAB308` Yellow | feather | Goose's MCP-native lightweight footprint cues feather; yellow distinct from existing palette |
| amp | Sourcegraph | `#0EA5E9` Sky | zap | "Amp" connotes power/electricity; sky blue mirrors Sourcegraph brand |
| crush | Charmbracelet | `#A855F7` Purple | sparkle | Charmbracelet's brand vibe (singular `sparkle`, not banned plural `sparkles`) |
| kilo | Kilo | `#14B8A6` Teal | brain | Memory Bank feature → brain; teal is unused elsewhere |
| kiro | AWS | `#F59E0B` Amber | cloud | AWS-backed → cloud; amber close to AWS orange |
| droid | Droid | `#6366F1` Indigo | bot | Droid → bot icon; indigo unused in palette |

All 6 colors verified distinct from the existing 5 and from each other (the `agent colors are distinct` test passes across all 11).

## Constraints Honored

- Pure append before closing brace - existing 5 entries untouched
- No new `sparkles` (plural) icons introduced; pre-existing `claude.icon = 'sparkles'` flagged separately as legacy debt, not in scope here
- No new dependencies, no icon library changes
- Only files modified: `packages/styrby-shared/src/constants.ts` + the corresponding test that asserts the agent list

## Verification

```
packages/styrby-shared $ pnpm run build           # OK (tsc clean)
packages/styrby-shared $ pnpm vitest run          # 1444/1444 pass (49 files)
packages/styrby-web    $ pnpm tsc --noEmit        # only pre-existing shiki error (unrelated)
packages/styrby-mobile $ pnpm tsc --noEmit        # clean
```

The `tests/constants.test.ts` `EXPECTED_AGENTS` array was expanded from 5 to 11 so every existing structural assertion (id matches key, hex color, non-empty icon/name/description/provider, distinct colors) now runs across all 11 entries.

## Consumers Surveyed

Searched `grep -rn "AGENT_CONFIG" packages/`. None of the consumers crash or narrow against `keyof typeof AGENT_CONFIG` from `@styrby/shared` directly - most either use safe `??` fallback or carry their own local `AGENT_CONFIG` map keyed on `AgentType`. Follow-up sync work (out of scope for this PR):

- `packages/styrby-web/src/components/agent-badge.tsx` (local copy)
- `packages/styrby-mobile/src/components/AgentSelector.tsx` (local copy)
- `packages/styrby-mobile/src/components/SessionCarousel.tsx`
- `packages/styrby-mobile/src/components/ChatMessage.tsx`
- `packages/styrby-mobile/src/components/chat/agent-config.ts`
- `packages/styrby-mobile/src/components/sessions/constants.ts`
- `packages/styrby-mobile/app/session/[id].tsx`
- `packages/styrby-mobile/app/shared/[shareId].tsx`

## Test Plan

- [x] `pnpm run build` in styrby-shared
- [x] `pnpm vitest run` in styrby-shared (1444 pass)
- [x] `pnpm tsc --noEmit` in styrby-web (no new errors)
- [x] `pnpm tsc --noEmit` in styrby-mobile (clean)
- [ ] CI green, then auto-merge

Refs: `.audit/styrby-fulltest.md` Phase H22