### PR TITLE
fix(shared): crush agent icon sparkle → wand-2 (H23)

### DIFF
--- a/packages/styrby-shared/src/constants.ts
+++ b/packages/styrby-shared/src/constants.ts
@@ -75,7 +75,7 @@ export const AGENT_CONFIG = {
     id: 'crush',
     description: 'Charmbracelet ACP-compatible terminal coding agent',
     color: '#A855F7', // Purple
-    icon: 'sparkle',
+    icon: 'wand-2',
     provider: 'Charmbracelet',
   },
   kilo: {


### PR DESCRIPTION
## Summary

PR #189 expanded `AGENT_CONFIG` from 5 to 11 entries and picked `'sparkle'` (singular lucide variant) for `crush.icon`, interpreting CLAUDE.md's ban on `Sparkles` / ✨ literally. The spirit of the rule covers all sparkle-like icons regardless of pluralization or capitalization.

This 1-line fix swaps `crush.icon` from `'sparkle'` to `'wand-2'`, the project-standard substitute that doesn't carry the AI-magic-dust connotation.

Phase H23 in `.audit/styrby-fulltest.md`.

## Changes

- `packages/styrby-shared/src/constants.ts` — `crush.icon: 'sparkle'` → `'wand-2'` (1 line)

No other agent entries, colors, names, descriptions, or providers touched.

## Test plan

- [x] `pnpm run build` (styrby-shared) — clean
- [x] `pnpm vitest run` (styrby-shared) — 1444/1444 passing
- [x] `pnpm tsc --noEmit` (styrby-web) — clean (pre-existing `shiki` module error is unrelated)
- [x] Diff is exactly 1 line

🤖 Generated with [Claude Code](https://claude.com/claude-code)