### PR TITLE
fix(supabase): fall back to NEXT_PUBLIC_SUPABASE_URL — prod 500 hotfix

### DIFF
--- a/packages/styrby-web/src/app/api/v1/costs/breakdown/route.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/breakdown/route.ts
@@ -48,7 +48,7 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {

--- a/packages/styrby-web/src/app/api/v1/costs/export/route.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/export/route.ts
@@ -56,7 +56,7 @@ const QuerySchema = z.object({
  */
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {

--- a/packages/styrby-web/src/app/api/v1/costs/route.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/route.ts
@@ -51,7 +51,7 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {

--- a/packages/styrby-web/src/app/api/v1/machines/route.ts
+++ b/packages/styrby-web/src/app/api/v1/machines/route.ts
@@ -45,7 +45,7 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/route.ts
@@ -106,7 +106,7 @@ const PostBodySchema = z.object({
  */
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/route.ts
@@ -54,7 +54,7 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/route.ts
@@ -20,7 +20,7 @@ import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middlew
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {

--- a/packages/styrby-web/src/app/api/v1/sessions/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/route.ts
@@ -43,7 +43,7 @@ const QuerySchema = z.object({
 
 function createApiAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {

--- a/packages/styrby-web/src/lib/supabase/server.ts
+++ b/packages/styrby-web/src/lib/supabase/server.ts
@@ -42,11 +42,20 @@ export async function createClient() {
  * Creates a Supabase admin client with service role key.
  * Bypasses RLS - use only for trusted server-side operations.
  *
+ * WHY the URL fallback: Vercel preview/production scopes only carry
+ * `NEXT_PUBLIC_SUPABASE_URL` — not the bare `SUPABASE_URL`. Reading
+ * the unprefixed env var alone caused this function to receive
+ * `undefined` at runtime in prod (the `!` non-null assertion is a
+ * compile-time lie), and `@supabase/ssr` then threw "Your project's
+ * URL and Key are required". Falling back to the public-prefixed
+ * value is safe because both env vars hold the same Supabase project
+ * URL by convention; only the SERVICE ROLE KEY is a secret here.
+ *
  * @returns Supabase admin client instance
  */
 export function createAdminClient() {
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {

--- a/packages/styrby-web/src/middleware/api-auth.ts
+++ b/packages/styrby-web/src/middleware/api-auth.ts
@@ -172,8 +172,12 @@ async function checkApiRateLimit(keyId: string): Promise<{ allowed: boolean; rem
  * so we need service role access to look up keys.
  */
 function createApiAdminClient() {
+  // WHY the URL fallback: Vercel scopes set NEXT_PUBLIC_SUPABASE_URL but
+  // not the bare SUPABASE_URL. Reading SUPABASE_URL! alone made this
+  // throw "URL and Key required" in prod for any well-formed API key,
+  // returning a generic 500 instead of a clean 401.
   return createServerClient(
-    process.env.SUPABASE_URL!,
+    (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL)!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     {
       cookies: {


### PR DESCRIPTION
## Summary
- 10 server-side files read `process.env.SUPABASE_URL!` but Vercel only configures `NEXT_PUBLIC_SUPABASE_URL` — the bang-assertion lies, runtime gets undefined, `@supabase/ssr` throws and Next.js returns 500.
- Adds `?? process.env.NEXT_PUBLIC_SUPABASE_URL` fallback in 10 files (1 lib helper, 1 middleware, 8 v1 API routes).
- Discovered by sandbox e2e driver during dev; confirmed in production by direct curl.

## Reproduction (prod, before this fix)

```bash
curl -sL -H "Authorization: Bearer styrby_$(uuidgen | tr -d '-' | head -c 32)" -w "\n=> %{http_code}\n" https://www.styrbyapp.com/api/v1/sessions
```

→ `=> 500` (empty body, generic Next.js crash). Same for `/api/v1/costs`.

Expected (after this fix): clean `401 {"error":"Invalid API key"}` because the unknown-but-valid-format key would now reach the DB lookup and return "not found".

## Customer impact
- Any v1 API caller hitting an unknown-but-valid-format API key sees 500 instead of 401
- Any code path crossing `createApiAdminClient` or `createAdminClient` silently fails in prod
- Webhook handler may also hit the same crash on subscription paths (not verified end-to-end against prod yet — needs Polar event delivery)

## Test plan
- [x] `vitest run src/middleware/__tests__/api-auth.test.ts` → 23/23 passing
- [x] `tsc --noEmit` clean on changed files (only pre-existing `Database` generic warnings remain)
- [ ] CI green
- [ ] Post-merge: re-run prod repro — expect 401 instead of 500
- [ ] Post-merge: verify webhook handler success path against sandbox preview deploy

## Why both names exist
- Browser-side code reads `NEXT_PUBLIC_SUPABASE_URL` (must be public to ship in client bundles)
- Server-side code historically read `SUPABASE_URL` (server-only convention) — but Vercel was never configured with it
- The values are the same Supabase project URL by convention; only the SERVICE ROLE KEY is a secret here

## Follow-up (separate PRs, not in this fix)
- H99: consider extracting `getSupabaseUrl()` helper to centralize the fallback
- H94: investigate whether prod webhook handler has been silently 500'ing on subscription events since 2026-04-23 (migration 031 deploy date) — `polar_webhook_events` table is empty in prod
- H99: consider adding `SUPABASE_URL` to Vercel env vars as belt-and-suspenders (so server-only callsites work without the fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)