### PR TITLE
fix(cli): budget monitor uses pre-built caches to avoid N+1 queries (H-1)

### DIFF
--- a/packages/styrby-cli/src/costs/__tests__/budget-monitor.test.ts
+++ b/packages/styrby-cli/src/costs/__tests__/budget-monitor.test.ts
@@ -728,6 +728,87 @@ describe('BudgetMonitor.checkAllAlerts', () => {
     // Only 1 unique key (daily:all) → only 1 cost fetch.
     expect(vi.mocked(getCostsForDateRange)).toHaveBeenCalledTimes(1);
   });
+
+  // --------------------------------------------------------------------------
+  // H-1 regression: subscription_quota + credits caches must be USED, not void'd
+  // --------------------------------------------------------------------------
+
+  it('[H-1] N subscription_quota alerts with the same key issue exactly 1 Supabase cost_records query (not N)', async () => {
+    // WHY: Before the H-1 fix, checkAllAlerts() built quotaCache via a parallel
+    // Supabase pre-fetch then discarded it with `void fraction`. Each alert's
+    // checkAlert() call re-issued getSubscriptionFractionForPeriod independently,
+    // producing N Supabase round-trips for N alerts sharing the same key.
+    // After the fix, checkAlert() receives the pre-resolved fraction and never
+    // calls getSubscriptionFractionForPeriod itself.
+    //
+    // Setup: 5 subscription_quota alerts all sharing 'daily:all' key.
+    // The Supabase mock tracks cost_records calls. We assert exactly 1 call
+    // (the one in the pre-fetch step) regardless of alert count.
+    const N = 5;
+    const quotaAlerts = Array.from({ length: N }, (_, i) =>
+      makeAlert({
+        name: `Quota-${i}`,
+        alert_type: 'subscription_quota',
+        threshold_quota_fraction: 0.80,
+        threshold_usd: 0,
+        period: 'daily',
+        agent_type: null,
+      })
+    );
+
+    const costRecordsRows = [{ subscription_fraction_used: '0.5000' }];
+    const supabase = makeSupabase(quotaAlerts, null, costRecordsRows);
+
+    const monitor = new BudgetMonitor({ supabase, userId: VALID_UUID });
+    const results = await monitor.checkAllAlerts();
+
+    // All 5 alerts must be returned with the pre-fetched fraction (0.5 of 0.80 = 62.5% → ok).
+    expect(results).toHaveLength(N);
+    expect(results.every((r) => r.level === 'ok')).toBe(true);
+    expect(results.every((r) => Math.abs(r.currentSpendUsd - 0.5) < 0.001)).toBe(true);
+
+    // The critical regression guard: cost_records must have been queried exactly
+    // ONCE (the pre-fetch), NOT N times (one per alert).
+    // supabase.from('cost_records') is called once per unique (period, agentType) key.
+    // With 5 alerts all sharing 'daily:all', that is exactly 1 call.
+    const costRecordsCalls = (supabase.from as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (args: unknown[]) => args[0] === 'cost_records'
+    );
+    expect(costRecordsCalls).toHaveLength(1); // 1 pre-fetch, NOT 5
+  });
+
+  it('[H-1] N credits alerts with the same key issue exactly 1 Supabase cost_records query (not N)', async () => {
+    // WHY: Mirror of the subscription_quota regression above, but for credits type.
+    // Before the fix, each alert re-queried getCreditsConsumedForPeriod independently.
+    const N = 5;
+    const creditAlerts = Array.from({ length: N }, (_, i) =>
+      makeAlert({
+        name: `Credits-${i}`,
+        alert_type: 'credits',
+        threshold_credits: 500,
+        threshold_usd: 0,
+        period: 'daily',
+        agent_type: null,
+      })
+    );
+
+    const costRecordsRows = [{ credits_consumed: 200 }];
+    const supabase = makeSupabase(creditAlerts, null, costRecordsRows);
+
+    const monitor = new BudgetMonitor({ supabase, userId: VALID_UUID });
+    const results = await monitor.checkAllAlerts();
+
+    // All 5 alerts must use the pre-fetched 200 credits (200/500 = 40% → ok).
+    expect(results).toHaveLength(N);
+    expect(results.every((r) => r.level === 'ok')).toBe(true);
+    expect(results.every((r) => r.currentSpendUsd === 200)).toBe(true);
+
+    // cost_records queried exactly ONCE (the pre-fetch), NOT 5 times.
+    const costRecordsCalls = (supabase.from as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (args: unknown[]) => args[0] === 'cost_records'
+    );
+    expect(costRecordsCalls).toHaveLength(1); // 1 pre-fetch, NOT 5
+  });
 });
 
 // ============================================================================

--- a/packages/styrby-cli/src/costs/budget-monitor.ts
+++ b/packages/styrby-cli/src/costs/budget-monitor.ts
@@ -138,6 +138,29 @@ export interface BudgetCheckResult {
 }
 
 /**
+ * Pre-resolved Supabase values for non-cost_usd alert types.
+ *
+ * Populated by `checkAllAlerts()` after its bulk pre-fetch step and injected
+ * into `checkAlert()` so the per-alert call can skip the individual Supabase
+ * round-trip that would otherwise be issued by the private helper methods.
+ *
+ * WHY both fields optional: a given alert is exactly one of the three types, so
+ * only the field matching its `alert_type` will be populated on each invocation.
+ */
+export interface PreResolvedAlertValues {
+  /**
+   * Pre-fetched MAX(subscription_fraction_used) for subscription_quota alerts.
+   * When present, `checkAlert()` uses this directly instead of querying Supabase.
+   */
+  fraction?: number;
+  /**
+   * Pre-fetched sum(credits_consumed) for credits alerts.
+   * When present, `checkAlert()` uses this directly instead of querying Supabase.
+   */
+  credits?: number;
+}
+
+/**
  * Configuration for the budget monitor
  */
 export interface BudgetMonitorConfig {
@@ -247,12 +270,18 @@ export class BudgetMonitor {
    *
    * @param alert - Budget alert to check
    * @param currentCosts - Optional pre-fetched cost summary (cost_usd type only).
-   *                       Ignored for subscription_quota and credits alert types
-   *                       because those require Supabase queries not covered by
-   *                       the local JSONL cost summary.
+   *                       Ignored for subscription_quota and credits alert types.
+   * @param preResolved - Optional pre-fetched values for subscription_quota and
+   *                      credits alert types, populated by checkAllAlerts() to
+   *                      avoid N Supabase round-trips when N alerts share the same
+   *                      period+agentType key.
    * @returns Budget check result
    */
-  async checkAlert(alert: BudgetAlert, currentCosts?: CostSummary): Promise<BudgetCheckResult> {
+  async checkAlert(
+    alert: BudgetAlert,
+    currentCosts?: CostSummary,
+    preResolved?: PreResolvedAlertValues
+  ): Promise<BudgetCheckResult> {
     // Resolve the effective alert type, defaulting to 'cost_usd' for pre-023 rows.
     const alertType: BudgetAlertType = alert.alert_type ?? 'cost_usd';
 
@@ -267,7 +296,15 @@ export class BudgetMonitor {
       // all subscription rows in the period, since consecutive sessions accumulate.
       // We then express it as a USD-equivalent percentage of the quota threshold
       // so the generic level-determination logic below works unchanged.
-      const fraction = await this.getSubscriptionFractionForPeriod(alert.period, alert.agent_type ?? undefined);
+      //
+      // WHY preResolved.fraction: checkAllAlerts() pre-fetches one Supabase query
+      // per unique (period, agentType) key and injects the result here. Without
+      // this, N subscription_quota alerts with the same key would each issue their
+      // own Supabase round-trip (N queries instead of 1).
+      const fraction =
+        preResolved?.fraction !== undefined
+          ? preResolved.fraction
+          : await this.getSubscriptionFractionForPeriod(alert.period, alert.agent_type ?? undefined);
       const quotaThreshold = alert.threshold_quota_fraction ?? 0;
 
       // WHY: Represent the fraction as a pseudo-USD so the existing
@@ -285,7 +322,12 @@ export class BudgetMonitor {
       // not USD. We sum credits_consumed for billing_model = 'credit' rows and
       // compare against the integer threshold_credits. We represent credits as
       // a pseudo-USD to reuse the percentUsed / exceeded / remainingUsd math.
-      const creditsConsumed = await this.getCreditsConsumedForPeriod(alert.period, alert.agent_type ?? undefined);
+      //
+      // WHY preResolved.credits: same deduplication rationale as fraction above.
+      const creditsConsumed =
+        preResolved?.credits !== undefined
+          ? preResolved.credits
+          : await this.getCreditsConsumedForPeriod(alert.period, alert.agent_type ?? undefined);
       const creditsThreshold = alert.threshold_credits ?? 0;
 
       spendingUsd = creditsConsumed;
@@ -421,33 +463,27 @@ export class BudgetMonitor {
 
     // WHY: checkAlert calls are independent once caches are populated.
     // Run them in parallel to avoid sequential latency.
+    //
+    // WHY preResolved injection: each alert receives the pre-fetched value for its
+    // (period, agentType) key so checkAlert() uses the cached result directly
+    // instead of issuing a fresh Supabase query per alert. Without this, N alerts
+    // sharing the same key would produce N Supabase round-trips; with it, only
+    // 1 query per unique key was issued in the parallel pre-fetch above.
     const results = await Promise.all(
       alerts.map((alert) => {
         const cacheKey = `${alert.period}:${alert.agent_type ?? 'all'}`;
         const alertType = alert.alert_type ?? 'cost_usd';
 
         if (alertType === 'subscription_quota') {
-          // WHY: Inject the pre-fetched fraction as a synthetic CostSummary so
-          // checkAlert's subscription_quota branch uses cached data instead of
-          // issuing a fresh Supabase query.
-          const fraction = quotaCache.get(cacheKey) ?? 0;
-          // We pass null for currentCosts to force checkAlert to do the Supabase
-          // branch — but we've already pre-fetched; inject via a different strategy:
-          // we call checkAlert without a pre-fetched CostSummary, and it will call
-          // getSubscriptionFractionForPeriod which we can't easily cache-inject.
-          // Instead we use a small inline workaround: pass the cost_usd cache only
-          // for cost_usd type, let subscription/credits re-query via helpers.
-          // WHY this is acceptable: subscription_quota and credits do a single
-          // Supabase query each; the cache above just proves deduplication works,
-          // but for simplicity of the call site we let the helpers run again.
-          // The cost is bounded to O(unique keys) Supabase round-trips total.
-          void fraction; // suppress unused warning
-          return this.checkAlert(alert, undefined);
+          // Pass the pre-fetched fraction so checkAlert skips the Supabase re-query.
+          const preResolved: PreResolvedAlertValues = { fraction: quotaCache.get(cacheKey) ?? 0 };
+          return this.checkAlert(alert, undefined, preResolved);
         }
 
         if (alertType === 'credits') {
-          void creditCache.get(cacheKey);
-          return this.checkAlert(alert, undefined);
+          // Pass the pre-fetched credit total so checkAlert skips the Supabase re-query.
+          const preResolved: PreResolvedAlertValues = { credits: creditCache.get(cacheKey) ?? 0 };
+          return this.checkAlert(alert, undefined, preResolved);
         }
 
         // cost_usd: pass pre-fetched summary to avoid re-reading JSONL


### PR DESCRIPTION
## Summary

- **Finding:** H-1 from `cli-correctness-audit-2026-04-28.md` — `checkAllAlerts()` built `quotaCache` and `creditCache` via parallel Supabase pre-fetches then discarded both with `void`, causing each `checkAlert()` call to re-query Supabase independently. For N alerts sharing the same `(period, agentType)` key this produced N round-trips instead of 1.
- **Approach:** Approach 1 (smaller diff, public API unchanged internally). Added an optional `preResolved?: PreResolvedAlertValues` parameter to `checkAlert()`. When provided, the method uses the injected value directly instead of calling the private helper. Falls back to individual Supabase queries when called standalone (no behaviour change for existing callers).
- **Audit artifacts untouched:** All `audit_log` writes in the cost pipeline are unchanged.

## Before / After

**Before** — caches built, immediately discarded:
```typescript
if (alertType === 'subscription_quota') {
  const fraction = quotaCache.get(cacheKey) ?? 0;
  void fraction; // suppress unused warning  ← cache read discarded
  return this.checkAlert(alert, undefined);  // ← re-queries Supabase
}
if (alertType === 'credits') {
  void creditCache.get(cacheKey);            // ← cache read discarded
  return this.checkAlert(alert, undefined);  // ← re-queries Supabase
}
```

**After** — pre-fetched values injected via `preResolved`:
```typescript
if (alertType === 'subscription_quota') {
  const preResolved: PreResolvedAlertValues = { fraction: quotaCache.get(cacheKey) ?? 0 };
  return this.checkAlert(alert, undefined, preResolved);
}
if (alertType === 'credits') {
  const preResolved: PreResolvedAlertValues = { credits: creditCache.get(cacheKey) ?? 0 };
  return this.checkAlert(alert, undefined, preResolved);
}
```

Inside `checkAlert()`:
```typescript
const fraction =
  preResolved?.fraction !== undefined
    ? preResolved.fraction
    : await this.getSubscriptionFractionForPeriod(alert.period, alert.agent_type ?? undefined);
```

## Supabase round-trip count (N=10 alerts, same key)

| Alert type | Before | After |
|------------|--------|-------|
| `subscription_quota` | 10 | 1 |
| `credits` | 10 | 1 |
| `cost_usd` | 1 (unchanged) | 1 |

## Test results

```
✓ src/costs/__tests__/budget-monitor.test.ts (66 tests) 103ms
✓ All 6 cost test files: 222 passed
```

**New regression tests (H-1):**
- `[H-1] N subscription_quota alerts with the same key issue exactly 1 Supabase cost_records query (not N)` — asserts `supabase.from('cost_records')` called exactly 1 time for N=5 quota alerts sharing `daily:all`
- `[H-1] N credits alerts with the same key issue exactly 1 Supabase cost_records query (not N)` — same for N=5 credits alerts

TypeScript: `tsc --noEmit` clean.

## Approach rationale

Approach 1 was chosen over Approach 2 (inlining per-alert logic into `checkAllAlerts()`) because:
1. Smaller diff — only 2 files changed
2. Public API of `checkAlert()` is additive (new optional param with default behaviour unchanged)
3. `checkAlert()` remains callable standalone without needing the cache populated
4. The level-determination logic stays in one place; no duplication risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)