### PR TITLE
fix(cli): mechanical security fixes — execSync, file mode, dynamic Function

### DIFF
--- a/packages/styrby-cli/src/__tests__/configuration.test.ts
+++ b/packages/styrby-cli/src/__tests__/configuration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for configuration.ts — ~/.styrby/config.json read/write.
+ *
+ * Covers:
+ * - saveConfig creates a new file with mode 0o600  (sec H-05 fix: new file)
+ * - saveConfig calls chmodSync 0o600 on existing file  (sec H-05 fix: upgrade path)
+ * - loadConfig returns correct values round-trip
+ * - setConfigValue merges without clobbering other keys
+ *
+ * WHY: config.json holds the auth token and machine ID. World-readable permissions
+ * would expose credentials to other local users. The chmodSync call in saveConfig
+ * was added to repair pre-existing files that were created without the restrictive
+ * mode. These tests guard that both the new-file and existing-file paths enforce
+ * mode 0o600. (sec H-05)
+ *
+ * @module __tests__/configuration.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+
+// ---------------------------------------------------------------------------
+// Mock node:fs so we don't touch the real filesystem.
+// vi.mock is hoisted by vitest to the top of the file, so it runs before
+// any module-level imports — the mocked fs is in place when configuration.ts
+// is first evaluated.
+// ---------------------------------------------------------------------------
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    chmodSync: vi.fn(),
+    readFileSync: vi.fn().mockImplementation(() => { throw new Error('ENOENT'); }),
+  };
+});
+
+// Import after mocks are set up so the module-under-test picks up mocked fs.
+import { saveConfig, loadConfig, setConfigValue } from '../configuration';
+
+describe('saveConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: dir and file both exist
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('no file'); });
+  });
+
+  it('writes config.json with mode 0o600 (new file path)', () => {
+    saveConfig({ machineId: 'test-machine' });
+
+    expect(fs.writeFileSync).toHaveBeenCalledOnce();
+    const [, , opts] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string, { mode: number }];
+    expect(opts.mode).toBe(0o600);
+  });
+
+  it('calls chmodSync 0o600 after writing (existing file path — upgrade fix)', () => {
+    saveConfig({ machineId: 'test-machine' });
+
+    expect(fs.chmodSync).toHaveBeenCalledOnce();
+    const [filePath, mode] = vi.mocked(fs.chmodSync).mock.calls[0] as [string, number];
+    expect(filePath).toContain('config.json');
+    expect(mode).toBe(0o600);
+  });
+
+  it('chmodSync is called AFTER writeFileSync (order matters)', () => {
+    const callOrder: string[] = [];
+    vi.mocked(fs.writeFileSync).mockImplementation(() => { callOrder.push('write'); });
+    vi.mocked(fs.chmodSync).mockImplementation(() => { callOrder.push('chmod'); });
+
+    saveConfig({ debug: true });
+
+    expect(callOrder).toEqual(['write', 'chmod']);
+  });
+});
+
+describe('loadConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  it('returns parsed JSON when file exists', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ machineId: 'abc', debug: false }));
+    const config = loadConfig();
+    expect(config.machineId).toBe('abc');
+    expect(config.debug).toBe(false);
+  });
+
+  it('returns empty object when file read throws', () => {
+    vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
+    const config = loadConfig();
+    expect(config).toEqual({});
+  });
+});
+
+describe('setConfigValue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    // Simulate an existing config with a machineId already set
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ machineId: 'existing-id' }));
+  });
+
+  it('merges new key without clobbering existing keys', () => {
+    setConfigValue('debug', true);
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    const parsed = JSON.parse(written);
+    expect(parsed.machineId).toBe('existing-id');
+    expect(parsed.debug).toBe(true);
+  });
+});

--- a/packages/styrby-cli/src/commands/daemon.ts
+++ b/packages/styrby-cli/src/commands/daemon.ts
@@ -15,7 +15,7 @@
 import { homedir, platform } from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import chalk from 'chalk';
 import { logger } from '@/ui/logger';
 
@@ -533,9 +533,16 @@ async function handleDaemonServiceStatus(): Promise<void> {
     }
 
     // Check if loaded
+    // WHY: Previously used execSync(`launchctl list | grep ${MACOS_LABEL}`) which
+    // passes a shell-interpolated string through /bin/sh. Even though MACOS_LABEL
+    // is currently a hardcoded constant, the pattern is unsafe: if the label ever
+    // becomes config-driven, it opens a shell-injection vector. Using spawnSync
+    // with an explicit argv array (no shell) and filtering stdout in JS eliminates
+    // the shell entirely. (sec H-04)
     try {
-      const result = execSync(`launchctl list | grep ${MACOS_LABEL}`, { encoding: 'utf-8' });
-      if (result.includes(MACOS_LABEL)) {
+      const { stdout, status } = spawnSync('launchctl', ['list'], { encoding: 'utf-8' });
+      const loaded = status === 0 && stdout.split('\n').some(line => line.includes(MACOS_LABEL));
+      if (loaded) {
         console.log(chalk.green('Daemon installed and loaded'));
         console.log(chalk.gray(`Plist: ${MACOS_PLIST_PATH}`));
       } else {

--- a/packages/styrby-cli/src/configuration.ts
+++ b/packages/styrby-cli/src/configuration.ts
@@ -71,13 +71,22 @@ export function loadConfig(): StyrbyConfig {
 /**
  * Save configuration to disk.
  *
+ * WHY: We pass `mode: 0o600` so newly created files get owner-only permissions.
+ * However, on Linux/macOS the `mode` flag in writeFileSync is only applied when
+ * the kernel creates a new file (O_CREAT). If config.json already exists from a
+ * previous install that had world-readable permissions, the file inherits its
+ * old mode. The explicit `chmodSync` call below repairs existing-file permissions
+ * on every write, covering the upgrade path. (sec H-05)
+ *
  * @param config - Configuration to save
  */
 export function saveConfig(config: StyrbyConfig): void {
   ensureConfigDir();
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), {
-    mode: 0o600, // Owner read/write only
+    mode: 0o600, // Owner read/write only — applies only to newly created file
   });
+  // Repair permissions on existing files (upgrade path).
+  fs.chmodSync(CONFIG_FILE, 0o600);
 }
 
 /**

--- a/packages/styrby-cli/src/costs/jsonl-parser.ts
+++ b/packages/styrby-cli/src/costs/jsonl-parser.ts
@@ -276,16 +276,17 @@ export async function parseJsonlFile(filePath: string): Promise<TokenUsage[]> {
   // env var. Defaulting to JS keeps CI green without requiring a Rust toolchain.
   if (process.env.STYRBY_NATIVE_PARSER === 'true') {
     try {
-      // WHY: We use a computed module specifier via `Function` to prevent
-      // TypeScript from statically resolving `@styrby/native`. The native
-      // package is an optional peer — it may not be installed in all
-      // environments (e.g., CI without a Rust toolchain). A static `import()`
-      // would cause `tsc --noEmit` to fail with TS2307 if the package isn't
-      // present, blocking typecheck for the entire CLI. Using an indirection
-      // keeps the import fully dynamic at runtime while satisfying TypeScript.
-      const specifier = '@styrby/native';
-      // eslint-disable-next-line @typescript-eslint/no-implied-eval
-      const native = await (new Function('s', 'return import(s)'))(specifier) as {
+      // WHY: `@styrby/native` is an optional peer — it may not be present in
+      // all environments (CI without a Rust toolchain). A static import would
+      // cause `tsc --noEmit` to fail with TS2307 when the package is absent.
+      // The previous workaround used `new Function('s', 'return import(s)')`
+      // which bypasses TypeScript's static-analysis safety net and triggers the
+      // `no-implied-eval` lint rule. The correct fix is a plain `await import()`
+      // suppressed with `@ts-ignore` so TypeScript skips the unresolved-module
+      // check while the import itself remains a native ES dynamic import — no
+      // eval, no shell, no string construction at runtime. (sec H-03)
+      // @ts-ignore — @styrby/native is an optional peer; TS2307 is expected
+      const native = await import('@styrby/native') as {
         isNativeLoaded: boolean;
         parseJsonlFileBatch: (path: string) => Promise<Array<{
           input_tokens: number;


### PR DESCRIPTION
## Summary

Three HIGH-severity mechanical security fixes from cli-audit-2026-04-28. No behavioural changes — pure security hardening with minimal diffs.

---

### sec H-04 — `execSync` shell injection pattern (daemon.ts:537)

**Before:**
\`\`\`ts
const result = execSync(`launchctl list | grep ${MACOS_LABEL}`, { encoding: 'utf-8' });
if (result.includes(MACOS_LABEL)) { ... }
\`\`\`

**After:**
\`\`\`ts
const { stdout, status } = spawnSync('launchctl', ['list'], { encoding: 'utf-8' });
const loaded = status === 0 && stdout.split('\n').some(line => line.includes(MACOS_LABEL));
\`\`\`

`MACOS_LABEL` is a hardcoded constant today, but the template-literal-in-a-shell-pipeline pattern is unsafe if the label ever becomes config-driven. `spawnSync` with an explicit argv array passes no shell at all.

---

### sec H-05 — config.json not chmod'd on existing files (configuration.ts:78)

**Before:**
\`\`\`ts
fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), { mode: 0o600 });
\`\`\`

**After:**
\`\`\`ts
fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), { mode: 0o600 });
fs.chmodSync(CONFIG_FILE, 0o600);  // repair existing-install permissions
\`\`\`

On Linux/macOS, `writeFileSync` with `mode` only applies the mode via `O_CREAT` on new files. Pre-existing `config.json` files from older installs keep whatever permissions they were created with. The `chmodSync` call repairs them on every write.

New unit tests: `src/__tests__/configuration.test.ts` (6 tests — covers new-file mode, existing-file chmod, write-before-chmod ordering, round-trip, empty fallback, and merge behaviour).

---

### sec H-03 — `new Function()` implied eval in jsonl-parser.ts:288

**Before:**
\`\`\`ts
// eslint-disable-next-line @typescript-eslint/no-implied-eval
const native = await (new Function('s', 'return import(s)'))(specifier) as { ... };
\`\`\`

**After:**
\`\`\`ts
// @ts-ignore — @styrby/native is an optional peer; TS2307 is expected
const native = await import('@styrby/native') as { ... };
\`\`\`

The original workaround used `new Function` to prevent TypeScript from statically resolving the optional `@styrby/native` peer (which triggers TS2307 when absent). The correct fix is a `// @ts-ignore` directive on a plain `await import()` — same runtime skip behaviour, zero eval surface.

---

## Test plan

- [ ] `cd packages/styrby-cli && npm test` — all existing tests pass (2 pre-existing startup-budget flakes on dev machine are unrelated and pre-date this PR)
- [ ] `cd packages/styrby-cli && node_modules/.bin/tsc --noEmit` — clean
- [ ] 6 new tests in `src/__tests__/configuration.test.ts` all green
- [ ] No changes to correctness-audit findings (other cluster)
- [ ] All Sentry integration and logging calls untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)