### PR TITLE
fix(cli): wire resolve-approval edge function + fail-closed on errors (H-6)

### DIFF
--- a/packages/styrby-cli/src/approvals/__tests__/policyEngine.failClosed.test.ts
+++ b/packages/styrby-cli/src/approvals/__tests__/policyEngine.failClosed.test.ts
@@ -1,0 +1,391 @@
+/**
+ * H-6 regression tests — policy engine fail-closed behavior.
+ *
+ * Verifies three correctness properties introduced to fix audit finding H-6:
+ *
+ *   1. `teamId` is forwarded on the submit call so the edge function can
+ *      look up the right policy and eligible approvers.
+ *
+ *   2. `approvalToken` returned by submit is forwarded on every subsequent
+ *      poll and cancel call (ISO 27001 A.9.1 — IDOR guard).
+ *
+ *   3. FAIL-CLOSED: any non-2xx response or network error from the edge
+ *      function results in an explicit DENY (exitCode 10) rather than a
+ *      silent pass-through. This satisfies OWASP A01:2021 (Broken Access
+ *      Control) — the policy engine must fail closed, never open.
+ *
+ * All tests stub `fetch` — no network traffic occurs.
+ *
+ * @module approvals/__tests__/policyEngine.failClosed
+ */
+
+import { describe, it, expect } from 'vitest';
+import { POLICY_ENGINE_EXIT_CODES } from 'styrby-shared';
+import { runPolicyEngine } from '../policyEngine.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const UUID = '00000000-0000-0000-0000-000000000001';
+const TEAM_ID = '00000000-0000-0000-0000-000000000010';
+const APPROVAL_ID = '00000000-0000-0000-0000-000000000099';
+const APPROVAL_TOKEN = 'deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678';
+
+const BASE_INPUT = {
+  sessionId: UUID,
+  teamId: TEAM_ID,
+  riskLevel: 'high' as const,
+  toolName: 'Bash',
+  supabaseUrl: 'https://test.supabase.co',
+  authToken: 'test-jwt',
+  pollIntervalMs: 5,
+  timeoutMs: 500,
+};
+
+// ─── Fetch stub helpers ───────────────────────────────────────────────────────
+
+/**
+ * Builds a fetch stub that returns a successful submit response then
+ * records all subsequent calls.
+ */
+function makeSuccessfulSubmitFetch(
+  submitResponse: { approvalId: string; approvalToken: string; status: 'pending' | 'approved' | 'denied' },
+  subsequentResponses: Array<{ approvalId: string; status: 'pending' | 'approved' | 'denied'; reason?: string }>,
+): { fetchImpl: typeof fetch; calls: Array<{ url: string; body: Record<string, unknown> }> } {
+  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+  let callIndex = 0;
+
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const body = init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : {};
+    calls.push({ url: url as string, body });
+
+    const thisIndex = callIndex++;
+    // First call is submit
+    const resp = thisIndex === 0
+      ? { ...submitResponse, approvalToken: submitResponse.approvalToken }
+      : (subsequentResponses[Math.min(thisIndex - 1, subsequentResponses.length - 1)] as { approvalId: string; status: string; reason?: string; approvalToken?: string });
+
+    return {
+      ok: true,
+      status: 200,
+      async json() { return { approvalToken: APPROVAL_TOKEN, ...resp }; },
+      async text() { return ''; },
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+
+  return { fetchImpl, calls };
+}
+
+/**
+ * Builds a fetch stub that returns HTTP non-2xx (e.g. 404) on the first call.
+ */
+function makeHttpErrorFetch(httpStatus: number): typeof fetch {
+  return (async (_url: string) => {
+    return {
+      ok: false,
+      status: httpStatus,
+      statusText: httpStatus === 404 ? 'Not Found' : 'Service Unavailable',
+      async text() { return `{"error":"HTTP ${httpStatus}"}` ; },
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+/**
+ * Builds a fetch stub that throws a network error (e.g. ECONNREFUSED).
+ */
+function makeNetworkErrorFetch(message: string): typeof fetch {
+  return (async () => {
+    throw new Error(message);
+  }) as unknown as typeof fetch;
+}
+
+/**
+ * Builds a fetch stub that succeeds on submit but throws on the first poll.
+ */
+function makeSubmitOkPollErrorFetch(pollError: Error): typeof fetch {
+  let callCount = 0;
+  return (async (_url: string, init?: RequestInit) => {
+    callCount++;
+    if (callCount === 1) {
+      // submit succeeds
+      return {
+        ok: true,
+        status: 201,
+        async json() {
+          return { approvalId: APPROVAL_ID, approvalToken: APPROVAL_TOKEN, status: 'pending' };
+        },
+        async text() { return ''; },
+      } as unknown as Response;
+    }
+    // poll throws
+    throw pollError;
+  }) as unknown as typeof fetch;
+}
+
+// ============================================================================
+// 1. teamId is forwarded on submit
+// ============================================================================
+
+describe('H-6 — teamId forwarded on submit', () => {
+  it('includes teamId in the submit request body', async () => {
+    const { fetchImpl, calls } = makeSuccessfulSubmitFetch(
+      { approvalId: APPROVAL_ID, approvalToken: APPROVAL_TOKEN, status: 'approved' },
+      [],
+    );
+
+    await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    const submitCall = calls.find((c) => c.body.action === 'submit');
+    expect(submitCall).toBeDefined();
+    expect(submitCall!.body.teamId).toBe(TEAM_ID);
+  });
+
+  it('does NOT include teamId in poll requests (only approvalId + approvalToken)', async () => {
+    const { fetchImpl, calls } = makeSuccessfulSubmitFetch(
+      { approvalId: APPROVAL_ID, approvalToken: APPROVAL_TOKEN, status: 'pending' },
+      [{ approvalId: APPROVAL_ID, status: 'approved' }],
+    );
+
+    await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    const pollCall = calls.find((c) => c.body.action === 'poll');
+    expect(pollCall).toBeDefined();
+    // teamId is a submit-only field; polls identify the row via approvalId + approvalToken
+    expect(pollCall!.body.teamId).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// 2. approvalToken round-trip
+// ============================================================================
+
+describe('H-6 — approvalToken forwarded on poll and cancel', () => {
+  it('forwards the submit-returned approvalToken on poll requests', async () => {
+    const { fetchImpl, calls } = makeSuccessfulSubmitFetch(
+      { approvalId: APPROVAL_ID, approvalToken: APPROVAL_TOKEN, status: 'pending' },
+      [{ approvalId: APPROVAL_ID, status: 'approved' }],
+    );
+
+    await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    const pollCall = calls.find((c) => c.body.action === 'poll');
+    expect(pollCall).toBeDefined();
+    expect(pollCall!.body.approvalToken).toBe(APPROVAL_TOKEN);
+  });
+
+  it('forwards the approvalToken on cancel when timeout fires', async () => {
+    const { fetchImpl, calls } = makeSuccessfulSubmitFetch(
+      { approvalId: APPROVAL_ID, approvalToken: APPROVAL_TOKEN, status: 'pending' },
+      [{ approvalId: APPROVAL_ID, status: 'pending' }],
+    );
+
+    // Set timeoutMs < pollIntervalMs so deadline fires immediately
+    await runPolicyEngine({
+      ...BASE_INPUT,
+      fetchImpl,
+      pollIntervalMs: 100,
+      timeoutMs: 1,
+    });
+
+    const cancelCall = calls.find((c) => c.body.action === 'cancel');
+    expect(cancelCall).toBeDefined();
+    expect(cancelCall!.body.approvalToken).toBe(APPROVAL_TOKEN);
+  });
+
+  it('forwards the approvalToken on cancel when user aborts', async () => {
+    const { fetchImpl, calls } = makeSuccessfulSubmitFetch(
+      { approvalId: APPROVAL_ID, approvalToken: APPROVAL_TOKEN, status: 'pending' },
+      [{ approvalId: APPROVAL_ID, status: 'pending' }],
+    );
+
+    const controller = new AbortController();
+    const promise = runPolicyEngine({
+      ...BASE_INPUT,
+      fetchImpl,
+      pollIntervalMs: 50,
+      timeoutMs: 5_000,
+      signal: controller.signal,
+    });
+
+    setTimeout(() => controller.abort(), 15);
+    await promise;
+
+    const cancelCall = calls.find((c) => c.body.action === 'cancel');
+    expect(cancelCall).toBeDefined();
+    expect(cancelCall!.body.approvalToken).toBe(APPROVAL_TOKEN);
+  });
+});
+
+// ============================================================================
+// 3. Fail-closed — non-2xx HTTP on submit
+// ============================================================================
+
+describe('H-6 — fail-closed: HTTP errors on submit → DENY', () => {
+  it('returns DENIED (10) when submit returns HTTP 404 (edge function not found)', async () => {
+    const fetchImpl = makeHttpErrorFetch(404);
+    const messages: string[] = [];
+
+    const res = await runPolicyEngine({
+      ...BASE_INPUT,
+      fetchImpl,
+      onStatus: (m) => messages.push(m),
+    });
+
+    // OWASP A01: fail closed, never open
+    expect(res.status).toBe('denied');
+    expect(res.exitCode).toBe(POLICY_ENGINE_EXIT_CODES.DENIED);
+    expect(res.reason).toMatch(/policy engine unavailable/i);
+    // Must emit a status message so the CLI can surface it to the user
+    expect(messages.some((m) => /submit failed/i.test(m))).toBe(true);
+  });
+
+  it('returns DENIED (10) when submit returns HTTP 503 (service unavailable)', async () => {
+    const fetchImpl = makeHttpErrorFetch(503);
+
+    const res = await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    expect(res.status).toBe('denied');
+    expect(res.exitCode).toBe(POLICY_ENGINE_EXIT_CODES.DENIED);
+  });
+
+  it('returns DENIED (10) when submit returns HTTP 500 (internal server error)', async () => {
+    const fetchImpl = makeHttpErrorFetch(500);
+
+    const res = await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    expect(res.status).toBe('denied');
+    expect(res.exitCode).toBe(POLICY_ENGINE_EXIT_CODES.DENIED);
+  });
+
+  it('does NOT perform a cancel request when submit fails (no row was created)', async () => {
+    const fetchImpl = makeHttpErrorFetch(404);
+    const calls: Array<Record<string, unknown>> = [];
+
+    const trackingFetch = (async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      calls.push(body);
+      return (fetchImpl as unknown as (u: string, i?: RequestInit) => Promise<Response>)(url, init);
+    }) as unknown as typeof fetch;
+
+    await runPolicyEngine({ ...BASE_INPUT, fetchImpl: trackingFetch });
+
+    // No cancel should be sent — the row was never created
+    expect(calls.every((c) => c['action'] !== 'cancel')).toBe(true);
+  });
+});
+
+// ============================================================================
+// 4. Fail-closed — network errors on submit
+// ============================================================================
+
+describe('H-6 — fail-closed: network errors on submit → DENY', () => {
+  it('returns DENIED (10) when submit throws ECONNREFUSED', async () => {
+    const fetchImpl = makeNetworkErrorFetch('connect ECONNREFUSED 127.0.0.1:54321');
+
+    const res = await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    expect(res.status).toBe('denied');
+    expect(res.exitCode).toBe(POLICY_ENGINE_EXIT_CODES.DENIED);
+    expect(res.reason).toContain('ECONNREFUSED');
+  });
+
+  it('returns DENIED (10) when submit throws a timeout error', async () => {
+    const fetchImpl = makeNetworkErrorFetch('The operation was aborted due to timeout');
+
+    const res = await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    expect(res.status).toBe('denied');
+    expect(res.exitCode).toBe(POLICY_ENGINE_EXIT_CODES.DENIED);
+    expect(res.reason).toContain('aborted');
+  });
+
+  it('includes the error message in the reason so the CLI can log it', async () => {
+    const errorMessage = 'getaddrinfo ENOTFOUND test.supabase.co';
+    const fetchImpl = makeNetworkErrorFetch(errorMessage);
+
+    const res = await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    expect(res.reason).toContain(errorMessage);
+  });
+});
+
+// ============================================================================
+// 5. Fail-closed — errors during polling
+// ============================================================================
+
+describe('H-6 — fail-closed: network errors during poll → DENY', () => {
+  it('returns DENIED (10) when a poll throws a network error', async () => {
+    const fetchImpl = makeSubmitOkPollErrorFetch(new Error('Network timeout during poll'));
+    const messages: string[] = [];
+
+    const res = await runPolicyEngine({
+      ...BASE_INPUT,
+      fetchImpl,
+      onStatus: (m) => messages.push(m),
+    });
+
+    expect(res.status).toBe('denied');
+    expect(res.exitCode).toBe(POLICY_ENGINE_EXIT_CODES.DENIED);
+    expect(res.reason).toMatch(/policy engine unavailable during poll/i);
+    expect(messages.some((m) => /poll failed/i.test(m))).toBe(true);
+  });
+
+  it('attempts to cancel the pending row when a poll error triggers fail-closed', async () => {
+    let cancelAttempted = false;
+    let callCount = 0;
+
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : {};
+      callCount++;
+
+      if (body['action'] === 'cancel') {
+        cancelAttempted = true;
+        return { ok: true, status: 200, async json() { return { approvalId: APPROVAL_ID, status: 'cancelled' }; }, async text() { return ''; } } as unknown as Response;
+      }
+      if (callCount === 1) {
+        // Submit
+        return {
+          ok: true,
+          status: 201,
+          async json() { return { approvalId: APPROVAL_ID, approvalToken: APPROVAL_TOKEN, status: 'pending' }; },
+          async text() { return ''; },
+        } as unknown as Response;
+      }
+      // Poll throws
+      throw new Error('Network failure on poll');
+    }) as unknown as typeof fetch;
+
+    await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    // The engine must try to cancel the pending row so it doesn't block other calls
+    expect(cancelAttempted).toBe(true);
+  });
+
+  it('passes the approvalToken on the fail-closed cancel call', async () => {
+    let cancelBody: Record<string, unknown> | null = null;
+    let callCount = 0;
+
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : {};
+      callCount++;
+
+      if (body['action'] === 'cancel') {
+        cancelBody = body;
+        return { ok: true, status: 200, async json() { return { approvalId: APPROVAL_ID, status: 'cancelled' }; }, async text() { return ''; } } as unknown as Response;
+      }
+      if (callCount === 1) {
+        return {
+          ok: true,
+          status: 201,
+          async json() { return { approvalId: APPROVAL_ID, approvalToken: APPROVAL_TOKEN, status: 'pending' }; },
+          async text() { return ''; },
+        } as unknown as Response;
+      }
+      throw new Error('Network failure on poll');
+    }) as unknown as typeof fetch;
+
+    await runPolicyEngine({ ...BASE_INPUT, fetchImpl });
+
+    expect(cancelBody).not.toBeNull();
+    expect(cancelBody!['approvalToken']).toBe(APPROVAL_TOKEN);
+  });
+});

--- a/packages/styrby-cli/src/approvals/__tests__/policyEngine.phase2.4.test.ts
+++ b/packages/styrby-cli/src/approvals/__tests__/policyEngine.phase2.4.test.ts
@@ -39,8 +39,11 @@ const UUID = (n: number) => `00000000-0000-0000-0000-${String(n).padStart(12, '0
 const SESSION_ID = UUID(1);
 const APPROVAL_ID = UUID(99);
 
+const TEAM_ID = UUID(20);
+
 const BASE_INPUT = {
   sessionId: SESSION_ID,
+  teamId: TEAM_ID,
   riskLevel: 'high' as const,
   toolName: 'Bash',
   supabaseUrl: 'https://test.supabase.co',
@@ -309,30 +312,32 @@ describe('Phase 2.4 — offline approver', () => {
     expect(pendingMessages.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('handles a transient network error during polling gracefully and retries', async () => {
-    // Network error on poll #1, then success on poll #2
+  it('handles a transient network error during polling by failing closed (DENY), not retrying', async () => {
+    // Network error on poll #1.
+    // WHY fail-closed and not retry:
+    //   The policy engine's security contract is: if we cannot verify that an
+    //   approver granted access, we MUST NOT allow the tool call to proceed.
+    //   Retrying a network error could mask an intentional DoS of the approval
+    //   endpoint (attacker causes 503s to pass all tool calls). Fail-closed on
+    //   any poll error is the correct OWASP A01 posture.
+    //   (This behavior changed from H-6 fix: the old code re-threw, causing
+    //   runPolicyEngine to reject. The new behavior returns an explicit DENY.)
     const { fetchImpl } = makeFetch([
       { status: 'pending' },          // submit
-      new Error('Network timeout'),   // poll #1 — transient failure
-      { status: 'approved' },         // poll #2
+      new Error('Network timeout'),   // poll #1 — transient failure → DENY
     ]);
 
-    // WHY this test should see an approved result:
-    //   The policyEngine's poll loop catches fetch errors and propagates them
-    //   (throws), causing runPolicyEngine to reject. This test verifies the
-    //   current behaviour: a fetch error IS a terminal failure. If the engine
-    //   ever adds retry logic, this test documents the expected retry count.
-    //
-    //   Current engine behaviour: throws on fetch error → the test should
-    //   expect rejection. We assert the rejection message contains the error.
-    await expect(
-      runPolicyEngine({
-        ...BASE_INPUT,
-        fetchImpl,
-        pollIntervalMs: 5,
-        timeoutMs: 500,
-      }),
-    ).rejects.toThrow('Network timeout');
+    const res = await runPolicyEngine({
+      ...BASE_INPUT,
+      fetchImpl,
+      pollIntervalMs: 5,
+      timeoutMs: 500,
+    });
+
+    expect(res.status).toBe('denied');
+    expect(res.exitCode).toBe(10);
+    expect(res.reason).toMatch(/policy engine unavailable during poll/i);
+    expect(res.reason).toContain('Network timeout');
   });
 });
 

--- a/packages/styrby-cli/src/approvals/__tests__/policyEngine.test.ts
+++ b/packages/styrby-cli/src/approvals/__tests__/policyEngine.test.ts
@@ -19,7 +19,7 @@ const UUID = '00000000-0000-0000-0000-000000000001';
 
 function makeFetch(
   responses: Array<
-    | { status: 'pending' | 'approved' | 'denied'; approvalId?: string; reason?: string }
+    | { status: 'pending' | 'approved' | 'denied'; approvalId?: string; approvalToken?: string; reason?: string }
     | Error
   >,
 ): { fetchImpl: typeof fetch; calls: Array<{ body: any }> } {
@@ -38,6 +38,7 @@ function makeFetch(
       async json() {
         return {
           approvalId: next.approvalId ?? UUID,
+          approvalToken: next.approvalToken ?? 'stub-token',
           status: next.status,
           reason: next.reason,
         };
@@ -52,6 +53,7 @@ function makeFetch(
 
 const baseInput = {
   sessionId: UUID,
+  teamId: '00000000-0000-0000-0000-000000000002',
   riskLevel: 'high' as const,
   toolName: 'Bash',
   supabaseUrl: 'https://example.supabase.co',

--- a/packages/styrby-cli/src/approvals/policyEngine.ts
+++ b/packages/styrby-cli/src/approvals/policyEngine.ts
@@ -43,6 +43,16 @@ export interface PolicyEngineInput {
   /** Active Styrby session id. */
   sessionId: string;
 
+  /**
+   * Team ID that owns this session.
+   *
+   * Required by the `resolve-approval` edge function (`handleSubmit`)
+   * to associate the pending approval row with a team and look up the
+   * correct policy + eligible approvers. Callers obtain this from the
+   * session's `team_id` column or from the authenticated user's primary team.
+   */
+  teamId: string;
+
   /** Tool-call risk classification. */
   riskLevel: RiskLevel;
 
@@ -136,6 +146,7 @@ export async function runPolicyEngine(
 ): Promise<PolicyEngineResult> {
   const {
     sessionId,
+    teamId,
     riskLevel,
     toolName,
     estimatedCostUsd,
@@ -182,29 +193,60 @@ export async function runPolicyEngine(
   }
 
   let approvalId: string | undefined;
+  // WHY we store approvalToken separately from approvalId:
+  //   The `resolve-approval` edge function uses HMAC-SHA256 token verification
+  //   on poll and cancel to prevent IDOR — knowing an approvalId UUID alone is
+  //   insufficient to drive the row. The token is returned by submit and must
+  //   be forwarded on every subsequent call (ISO 27001 A.9.1).
+  let approvalToken: string | undefined;
 
   try {
-    // --- Submit the approval request ---------------------------------------
-    // TODO(pr-3): stub until PR #3 adds the `resolve-approval` edge function.
-    //   That PR wires up POST /functions/v1/resolve-approval which (a)
-    //   creates the pending approval row when one doesn't yet exist and
-    //   (b) returns `{ approvalId, status }` on every subsequent poll.
-    //   For now this module calls the endpoint optimistically; in
-    //   unit tests the fetch is stubbed, so no network traffic occurs.
-    const submitResult = await postResolveApproval(fetchImpl, {
-      supabaseUrl,
-      authToken,
-      body: {
-        sessionId,
-        riskLevel,
-        toolName,
-        estimatedCostUsd,
-        requestPayload: requestPayload ?? {},
-        action: 'submit',
-      },
-      signal: controller.signal,
-    });
+    // --- Submit the approval request --------------------------------------
+    // The `resolve-approval` edge function is ACTIVE on Supabase (verified
+    // 2026-04-28). It requires `teamId` to associate the row with a team and
+    // look up the correct policy. On success it returns `{ approvalId,
+    // approvalToken, status }` where approvalToken is HMAC-SHA256(approvalId)
+    // and MUST be forwarded on all poll/cancel calls.
+    //
+    // FAIL-CLOSED policy (OWASP A01 — Broken Access Control):
+    //   Any non-2xx response from the edge function, or a network error,
+    //   results in an explicit DENY rather than a silent pass-through.
+    //   This ensures that if the endpoint is unreachable (503, 404, cold-start
+    //   timeout), tool calls are blocked rather than accidentally allowed.
+    let submitResult: ResolveApprovalResponse;
+    try {
+      submitResult = await postResolveApproval(fetchImpl, {
+        supabaseUrl,
+        authToken,
+        body: {
+          sessionId,
+          teamId,
+          riskLevel,
+          toolName,
+          estimatedCostUsd,
+          requestPayload: requestPayload ?? {},
+          action: 'submit',
+        },
+        signal: controller.signal,
+      });
+    } catch (err) {
+      // Fail closed: any submit failure (network error, 4xx/5xx) is treated
+      // as an explicit denial rather than a pass-through.
+      const reason =
+        err instanceof Error
+          ? `policy engine unavailable — defaulting to deny (${err.message})`
+          : 'policy engine unavailable — defaulting to deny';
+      onStatus(`[policyEngine] Submit failed: ${reason}`);
+      return {
+        exitCode: POLICY_ENGINE_EXIT_CODES.DENIED,
+        status: 'denied',
+        approvalId: undefined,
+        reason,
+      };
+    }
+
     approvalId = submitResult.approvalId;
+    approvalToken = submitResult.approvalToken;
 
     if (submitResult.status === 'approved' || submitResult.status === 'denied') {
       // Server can short-circuit (e.g., policy action = 'block').
@@ -217,7 +259,7 @@ export async function runPolicyEngine(
       const remaining = deadline - Date.now();
       if (remaining <= 0) {
         onStatus(`Approval timed out after ${timeoutMs} ms.`);
-        await safeCancel(fetchImpl, supabaseUrl, authToken, approvalId);
+        await safeCancel(fetchImpl, supabaseUrl, authToken, approvalId, approvalToken);
         return {
           exitCode: POLICY_ENGINE_EXIT_CODES.TIMEOUT,
           status: 'timeout',
@@ -231,12 +273,30 @@ export async function runPolicyEngine(
 
       if (controller.signal.aborted) break;
 
-      const poll = await postResolveApproval(fetchImpl, {
-        supabaseUrl,
-        authToken,
-        body: { approvalId, action: 'poll' },
-        signal: controller.signal,
-      });
+      // Fail-closed on poll errors: a transient network failure during polling
+      // is treated as a denial rather than an optimistic pass-through.
+      let poll: ResolveApprovalResponse;
+      try {
+        poll = await postResolveApproval(fetchImpl, {
+          supabaseUrl,
+          authToken,
+          body: { approvalId, approvalToken, action: 'poll' },
+          signal: controller.signal,
+        });
+      } catch (err) {
+        const reason =
+          err instanceof Error
+            ? `policy engine unavailable during poll — defaulting to deny (${err.message})`
+            : 'policy engine unavailable during poll — defaulting to deny';
+        onStatus(`[policyEngine] Poll failed: ${reason}`);
+        await safeCancel(fetchImpl, supabaseUrl, authToken, approvalId, approvalToken);
+        return {
+          exitCode: POLICY_ENGINE_EXIT_CODES.DENIED,
+          status: 'denied',
+          approvalId,
+          reason,
+        };
+      }
 
       if (poll.status === 'approved' || poll.status === 'denied') {
         return terminalResult(poll.status, approvalId, poll.reason);
@@ -245,7 +305,7 @@ export async function runPolicyEngine(
     }
 
     // --- Cancelled ---------------------------------------------------------
-    await safeCancel(fetchImpl, supabaseUrl, authToken, approvalId);
+    await safeCancel(fetchImpl, supabaseUrl, authToken, approvalId, approvalToken);
     return {
       exitCode: POLICY_ENGINE_EXIT_CODES.CANCELLED,
       status: 'cancelled',
@@ -266,12 +326,24 @@ export async function runPolicyEngine(
 
 /** Payload the `resolve-approval` edge function speaks. */
 interface ResolveApprovalRequest {
+  // submit fields
   sessionId?: string;
+  /** Team ID — required for action="submit" (looked up for policy + approvers). */
+  teamId?: string;
   riskLevel?: RiskLevel;
   toolName?: string;
   estimatedCostUsd?: number;
   requestPayload?: Record<string, unknown>;
+  // poll / cancel fields
   approvalId?: string;
+  /**
+   * HMAC-SHA256 token returned by submit.
+   *
+   * Required for action="poll" and action="cancel" to prevent IDOR:
+   * knowing the approvalId UUID alone is insufficient to drive the row
+   * (ISO 27001 A.9.1 — timing-safe ownership verification).
+   */
+  approvalToken?: string;
   action: 'submit' | 'poll' | 'cancel';
 }
 
@@ -279,6 +351,13 @@ interface ResolveApprovalRequest {
 interface ResolveApprovalResponse {
   approvalId: string;
   status: Approval['status'];
+  /**
+   * HMAC-SHA256 approval token, returned only on action="submit".
+   *
+   * Must be forwarded on all subsequent poll and cancel calls to satisfy
+   * the edge function's IDOR guard.
+   */
+  approvalToken?: string;
   reason?: string;
 }
 
@@ -317,16 +396,20 @@ async function safeCancel(
   supabaseUrl: string,
   authToken: string,
   approvalId: string | undefined,
+  approvalToken: string | undefined,
 ): Promise<void> {
   if (!approvalId) return;
   // WHY we swallow errors here: we are already on the exit path. Failing
   //   to cancel a row is noisy but not fatal — the cron sweeper defined
   //   in migration 021 will mark it 'expired' within 15 minutes.
+  // WHY we pass approvalToken: the edge function verifies it in constant time
+  //   for cancel operations. Omitting it would cause a 403 from the server,
+  //   leaving an orphaned 'pending' row that only the cron sweeper can clean up.
   try {
     await postResolveApproval(fetchImpl, {
       supabaseUrl,
       authToken,
-      body: { approvalId, action: 'cancel' },
+      body: { approvalId, approvalToken, action: 'cancel' },
       signal: neverAbort,
     });
   } catch {


### PR DESCRIPTION
## Summary

**Path A taken**: `resolve-approval` is confirmed ACTIVE on Supabase (verified via Management API - status: ACTIVE, version 2, deployed ~2026-04-21).

The `TODO(pr-3)` comment was stale. The edge function was already live. However, the CLI had three correctness gaps that would cause 403s and broken behavior in production:

- `teamId` was never sent on submit (edge fn requires it to find the team policy + approvers)
- `approvalToken` (HMAC-SHA256 IDOR guard returned by submit) was never forwarded on polls or cancels (would cause HTTP 403 on every poll)
- Network errors and non-2xx responses were unhandled rejections rather than explicit DENY

## Changes

- Remove stale `TODO(pr-3)` - replaced with accurate doc comment
- Add `teamId: string` to `PolicyEngineInput` (required field, forwarded on submit body)
- Capture `approvalToken` from submit response and forward on all poll + cancel calls (ISO 27001 A.9.1)
- Add fail-closed error handling on submit: any throw or non-2xx = explicit DENY, no cancel attempt (no row was created)
- Add fail-closed error handling on poll: any throw or non-2xx = DENY + safeCancel attempt with approvalToken
- Update `safeCancel` to accept + forward `approvalToken` to avoid orphaned pending rows

## Security posture

Per OWASP A01:2021 (Broken Access Control): the policy engine must fail closed. If the approval endpoint is unreachable, tool calls are blocked - not allowed. This prevents a DoS-based bypass where an attacker causes the endpoint to return 503s to silently pass all guarded tool calls.

## Tests

36 tests total, all passing:

| File | Tests | What's covered |
|------|-------|----------------|
| `policyEngine.failClosed.test.ts` | 15 new | teamId forwarded on submit, approvalToken round-trip on poll/cancel/timeout-cancel/abort-cancel, HTTP 404/503/500 -> DENY, ECONNREFUSED/timeout -> DENY, poll error -> DENY + cancel with token |
| `policyEngine.phase2.4.test.ts` | 14 (1 updated) | Updated network-error test: documents new fail-closed contract (DENY not rejection) |
| `policyEngine.test.ts` | 7 (updated) | Added teamId to baseInput, approvalToken to makeFetch stub |

## Test plan

- [ ] `cd packages/styrby-cli && vitest run src/approvals/` - 36 tests pass
- [ ] `tsc --noEmit` - clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)