### PR TITLE
feat(security): HMAC verification on all external-vendor webhooks (H42 Layer 5)

### DIFF
--- a/packages/styrby-web/src/app/api/webhooks/polar/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/route.ts
@@ -1,9 +1,14 @@
+// WEBHOOK-VERIFIED: polar
+// Inbound webhook from Polar billing platform. HMAC-SHA256 verified via
+// `verifyPolarSignatureOrThrow` (lib/polar-webhook-signature.ts) before any
+// business logic executes. Audited H42 Layer 5 (2026-04-28).
+
 /**
  * Polar Webhook Handler
  *
  * POST /api/webhooks/polar
  *
- * @auth None (public endpoint — secured by HMAC-SHA256 signature verification)
+ * @auth None (public endpoint - secured by HMAC-SHA256 signature verification)
  * @rateLimit 100 requests per 60 seconds per IP (Upstash Redis; skipped in dev/CI)
  *
  * Handles subscription lifecycle events from Polar:

--- a/packages/styrby-web/src/app/api/webhooks/user/deliveries/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/user/deliveries/route.ts
@@ -1,3 +1,9 @@
+// WEBHOOK-INTERNAL: delivery log reader
+// This is NOT an inbound vendor webhook receiver. It reads Styrby's own
+// outbound webhook delivery history for a given user. Access requires a valid
+// Supabase Auth JWT cookie - no external vendor calls this endpoint.
+// Audited H42 Layer 5 (2026-04-28).
+
 /**
  * Webhook Deliveries API Route
  *

--- a/packages/styrby-web/src/app/api/webhooks/user/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/user/route.ts
@@ -1,3 +1,9 @@
+// WEBHOOK-INTERNAL: user webhook management
+// This is NOT an inbound vendor webhook receiver. It is Styrby's own REST API
+// for users to create/update/delete their outbound webhook configurations.
+// Every method requires a valid Supabase Auth JWT cookie - no external vendor
+// calls this endpoint. Audited H42 Layer 5 (2026-04-28).
+
 /**
  * User Webhooks API Route
  *

--- a/packages/styrby-web/src/app/api/webhooks/user/test/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/user/test/route.ts
@@ -1,3 +1,9 @@
+// WEBHOOK-INTERNAL: test event trigger
+// This is NOT an inbound vendor webhook receiver. It enqueues a test delivery
+// to the user's own registered endpoint to verify their server is reachable.
+// Access requires a valid Supabase Auth JWT cookie - no external vendor calls
+// this endpoint. Audited H42 Layer 5 (2026-04-28).
+
 /**
  * Webhook Test API Route
  *


### PR DESCRIPTION
## Webhook Signature Audit - H42 Layer 5

Full inventory and classification of all POST routes in `packages/styrby-web/src/app/api/**/route.ts` that could receive external-vendor traffic.

## Per-Vendor Results

| Vendor | Endpoint Path | Status | Notes |
|--------|--------------|--------|-------|
| Polar | `/api/webhooks/polar` | Already verified | HMAC-SHA256 + timing-safe + env-aware secret per PR #195. Annotated `// WEBHOOK-VERIFIED: polar`. |
| Resend | - | Not present | Resend is outbound-only (transactional email via API key). No inbound webhook receiver exists. |
| Sentry | - | Not present | Sentry is ingest-only (DSN-based error reporting). No inbound webhook receiver exists. |
| Vercel | - | Not present | Vercel deploy hooks are outbound from Vercel to our deploys, not inbound to our API. No receiver exists. |

## Internal Routes Classified

These routes contain "webhook" in their path but are NOT external-vendor receivers - they are Styrby's own REST API for managing user-configured outbound webhooks:

| Route | Classification | Auth |
|-------|---------------|------|
| `POST/GET/PATCH/DELETE /api/webhooks/user` | WEBHOOK-INTERNAL | Supabase Auth JWT required |
| `GET /api/webhooks/user/deliveries` | WEBHOOK-INTERNAL | Supabase Auth JWT required |
| `POST /api/webhooks/user/test` | WEBHOOK-INTERNAL | Supabase Auth JWT required |

All three annotated with `// WEBHOOK-INTERNAL` comments.

## Changes

- Added `// WEBHOOK-VERIFIED: polar` annotation to `/api/webhooks/polar/route.ts`
- Added `// WEBHOOK-INTERNAL` annotations to all three `/api/webhooks/user*` routes
- No new HMAC verifier code needed (no unprotected receivers found)

## Summary

- Receivers inventoried: 4 (1 external vendor + 3 internal)
- Already verified: 1 (Polar)
- Newly verified: 0 (no unprotected receivers)
- Not present (Resend/Sentry/Vercel): 3 vendors
- Ambiguous: 0

## No-merge note

Auto-merge is OFF per task spec. Human review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)