### PR TITLE
fix(security): mass-assignment guard on user-mutable UPDATEs (H42)

### DIFF
--- a/packages/styrby-web/src/app/api/account/delete/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/account/delete/__tests__/route.test.ts
@@ -452,4 +452,45 @@ describe('DELETE /api/account/delete', () => {
     expect(response.status).toBe(500);
     expect(data.error).toBe('Failed to delete account');
   });
+
+  // ── OWASP A04:2021 Mass-Assignment Guard ────────────────────────────────────
+
+  /**
+   * WHY: Confirms that the .strict() schema rejects any unknown key before any
+   * DB write occurs. An attacker cannot inject fields like `is_admin` or `tier`
+   * alongside a valid confirmation to attempt privilege escalation via
+   * mass-assignment. The route must return 400 without touching the database.
+   *
+   * Note: the .update() calls in the delete route use only server-computed
+   * values (e.g. `{ deleted_at: now }`) — NOT the parsed body. This test
+   * validates that the body schema itself blocks at the validation layer.
+   */
+  it('OWASP A04 — returns 400 and never reaches DB when request includes unknown key is_admin: true', async () => {
+    // No DB queue entries pushed — any DB call would consume from an empty queue
+    // and return { data: null, error: null }, which would let the test pass
+    // incorrectly. We assert queue stays at 0 to prove no DB access occurred.
+
+    const request = createRequest({
+      confirmation: 'DELETE MY ACCOUNT',
+      is_admin: true,
+    });
+
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(400);
+    // Queue untouched proves .from() was never called
+    expect(fromCallQueue.length).toBe(0);
+  });
+
+  it('OWASP A04 — returns 400 and never reaches DB when request includes unknown key tier: enterprise', async () => {
+    const request = createRequest({
+      confirmation: 'DELETE MY ACCOUNT',
+      tier: 'enterprise',
+    });
+
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(400);
+    expect(fromCallQueue.length).toBe(0);
+  });
 });

--- a/packages/styrby-web/src/app/api/account/delete/route.ts
+++ b/packages/styrby-web/src/app/api/account/delete/route.ts
@@ -35,11 +35,19 @@ import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
  * Zod schema for delete request validation.
  * WHY: The confirmation literal ensures users consciously acknowledge deletion.
  * This prevents accidental deletions from automated tools or misclicks.
+ *
+ * MASS-ASSIGN-SAFE: OWASP A04:2021 — only `confirmation` and `reason` are
+ * accepted. `.strict()` causes Zod to reject any unrecognized key (e.g.
+ * `is_admin`, `tier`) at parse time and return 400 before any DB write occurs.
+ * The `.update()` calls below use only server-computed values (e.g. `deleted_at`),
+ * never the raw user-supplied object.
  */
-const DeleteRequestSchema = z.object({
-  confirmation: z.literal('DELETE MY ACCOUNT'),
-  reason: z.string().optional(),
-});
+const DeleteRequestSchema = z
+  .object({
+    confirmation: z.literal('DELETE MY ACCOUNT'),
+    reason: z.string().optional(),
+  })
+  .strict(); // OWASP A04:2021 — reject unknown keys (mass-assignment guard)
 
 /**
  * Handles account deletion requests.

--- a/packages/styrby-web/src/app/api/account/retention/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/account/retention/__tests__/route.test.ts
@@ -254,4 +254,56 @@ describe('PUT /api/account/retention', () => {
       expect(response.status).toBe(200);
     }
   });
+
+  // ── OWASP A04:2021 Mass-Assignment Guard ──────────────────────────────────
+
+  /**
+   * WHY this test: confirms that the .strict() schema rejects unknown keys at
+   * the validation layer, so an attacker cannot inject fields like `is_admin`
+   * or `tier` that would be mass-assigned into the profiles.update() call.
+   * The DB must never be reached when unknown keys are present.
+   */
+  it('OWASP A04 — returns 400 and never calls .update() when request includes unknown key is_admin: true', async () => {
+    setupAuthUser();
+
+    const profileUpdateSpy = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      if (table === 'profiles') {
+        return {
+          update: profileUpdateSpy,
+        };
+      }
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    // Malicious payload: valid retention_days + injected privilege-escalation key
+    const response = await PUT(makeRequest('PUT', { retention_days: 30, is_admin: true }));
+
+    expect(response.status).toBe(400);
+    // Critical: .update() must NOT have been called — the schema guard stopped the request
+    expect(profileUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it('OWASP A04 — returns 400 and never calls .update() when request includes unknown key tier: enterprise', async () => {
+    setupAuthUser();
+
+    const profileUpdateSpy = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      if (table === 'profiles') {
+        return { update: profileUpdateSpy };
+      }
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    const response = await PUT(makeRequest('PUT', { retention_days: 7, tier: 'enterprise' }));
+
+    expect(response.status).toBe(400);
+    expect(profileUpdateSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/styrby-web/src/app/api/account/retention/route.ts
+++ b/packages/styrby-web/src/app/api/account/retention/route.ts
@@ -39,17 +39,24 @@ const ALLOWED_RETENTION_DAYS = [7, 30, 90, 365] as const;
  * WHY nullable union: retention_days: null is a valid payload meaning
  * "clear my retention policy — never auto-delete". Without explicit null
  * support, users couldn't revert to "never delete" after setting a window.
+ *
+ * MASS-ASSIGN-SAFE: OWASP A04:2021 — only `retention_days` is accepted.
+ * `.strict()` rejects unknown keys (e.g. `is_admin`, `tier`) at parse time,
+ * returning 400 before any DB write occurs. The `.update()` call below writes
+ * only `{ retention_days: parsed.data.retention_days }` — never raw user input.
  */
-const RetentionUpdateSchema = z.object({
-  retention_days: z.union([
-    z.enum(['7', '30', '90', '365'] as unknown as [string, ...string[]]).transform(Number),
-    z.literal(7),
-    z.literal(30),
-    z.literal(90),
-    z.literal(365),
-    z.null(),
-  ]),
-});
+const RetentionUpdateSchema = z
+  .object({
+    retention_days: z.union([
+      z.enum(['7', '30', '90', '365'] as unknown as [string, ...string[]]).transform(Number),
+      z.literal(7),
+      z.literal(30),
+      z.literal(90),
+      z.literal(365),
+      z.null(),
+    ]),
+  })
+  .strict(); // OWASP A04:2021 — reject unknown keys (mass-assignment guard)
 
 /**
  * Resolve the Supabase client from cookie session or Bearer token.

--- a/packages/styrby-web/src/app/api/account/retention/session/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/account/retention/session/__tests__/route.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Per-Session Retention Override API Route Tests
+ *
+ * PUT /api/account/retention/session
+ *
+ * WHY: Validates that the per-session retention override endpoint correctly
+ * enforces schema-level mass-assignment protection (OWASP A04:2021). An
+ * attacker cannot inject extra fields (e.g. `user_id`, `is_admin`) into the
+ * sessions.update() call via a crafted request body.
+ *
+ * Audit: OWASP A04:2021 — Insecure Design (mass-assignment); OWASP A01:2021
+ * — Broken Access Control (session ownership verification).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn(() => ({ allowed: true })),
+  RATE_LIMITS: { sensitive: { windowMs: 60000, maxRequests: 10 } },
+  rateLimitResponse: vi.fn((retryAfter: number) =>
+    new Response(JSON.stringify({ error: 'RATE_LIMITED', retryAfter }), { status: 429 }),
+  ),
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const VALID_SESSION_ID = '00000000-0000-0000-0000-000000000001';
+
+function makeRequest(body: object): Request {
+  return new Request('http://localhost/api/account/retention/session', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupAuthUser(userId = 'user-abc') {
+  mockGetUser.mockResolvedValue({ data: { user: { id: userId } }, error: null });
+}
+
+function setupSessionFound(sessionId = VALID_SESSION_ID, userId = 'user-abc') {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    single: vi
+      .fn()
+      .mockResolvedValue({ data: { id: sessionId, user_id: userId }, error: null }),
+  };
+}
+
+// ============================================================================
+// Basic validation tests
+// ============================================================================
+
+describe('PUT /api/account/retention/session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('Not authed') });
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: VALID_SESSION_ID, retention_override: 'inherit' }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 400 for invalid UUID in session_id', async () => {
+    setupAuthUser();
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: 'not-a-uuid', retention_override: 'inherit' }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('UUID');
+  });
+
+  it('returns 400 for invalid retention_override value', async () => {
+    setupAuthUser();
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: VALID_SESSION_ID, retention_override: 'pin_days:999' }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 404 when session is not found or owned by another user', async () => {
+    setupAuthUser();
+
+    mockFrom.mockImplementation(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Row not found' } }),
+    }));
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: VALID_SESSION_ID, retention_override: 'pin_forever' }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 200 for a valid inherit override', async () => {
+    setupAuthUser();
+
+    // Track how many times 'sessions' has been called to distinguish SELECT vs UPDATE
+    let sessionsCallCount = 0;
+    const sessionMock = setupSessionFound();
+
+    // Update chain: .update().eq().eq() — both .eq() calls must be chainable,
+    // with the second resolving the final promise ({ error: null }).
+    const secondEqSpy = vi.fn().mockResolvedValue({ error: null });
+    const firstEqSpy = vi.fn().mockReturnValue({ eq: secondEqSpy });
+    const sessionUpdateChain = {
+      update: vi.fn().mockReturnValue({ eq: firstEqSpy }),
+    };
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        sessionsCallCount++;
+        // First call is the SELECT ownership check; second is the UPDATE.
+        return sessionsCallCount === 1 ? sessionMock : sessionUpdateChain;
+      }
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: VALID_SESSION_ID, retention_override: 'inherit' }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.retention_override).toBe('inherit');
+  });
+
+  // ── OWASP A04:2021 Mass-Assignment Guard ──────────────────────────────────
+
+  /**
+   * WHY: Confirms that the .strict() schema rejects any unknown key before the
+   * sessions.update() call is reached. An attacker cannot inject `user_id`,
+   * `is_admin`, or `tier` alongside a valid session_id to perform privilege
+   * escalation or session takeover via mass-assignment.
+   */
+  it('OWASP A04 — returns 400 and never calls sessions.update() when request includes unknown key is_admin: true', async () => {
+    setupAuthUser();
+
+    const sessionUpdateSpy = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          is: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: { id: VALID_SESSION_ID, user_id: 'user-abc' },
+            error: null,
+          }),
+          update: sessionUpdateSpy,
+        };
+      }
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    // Malicious payload: valid fields + injected privilege-escalation key
+    const response = await PUT(
+      makeRequest({
+        session_id: VALID_SESSION_ID,
+        retention_override: 'pin_forever',
+        is_admin: true,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    // Critical: .update() must NOT have been called — the schema stopped it
+    expect(sessionUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it('OWASP A04 — returns 400 and never calls sessions.update() when request includes unknown key user_id targeting another account', async () => {
+    setupAuthUser('user-abc');
+
+    const sessionUpdateSpy = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          is: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: { id: VALID_SESSION_ID, user_id: 'user-abc' },
+            error: null,
+          }),
+          update: sessionUpdateSpy,
+        };
+      }
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    // Attacker attempts to overwrite user_id on the session row
+    const response = await PUT(
+      makeRequest({
+        session_id: VALID_SESSION_ID,
+        retention_override: 'inherit',
+        user_id: 'victim-user-id',
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(sessionUpdateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/styrby-web/src/app/api/account/retention/session/route.ts
+++ b/packages/styrby-web/src/app/api/account/retention/session/route.ts
@@ -38,13 +38,19 @@ import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
  */
 const VALID_OVERRIDE_PATTERN = /^(inherit|pin_forever|pin_days:(7|30|90|365))$/;
 
-const SessionRetentionSchema = z.object({
-  session_id: z.string().uuid('session_id must be a valid UUID'),
-  retention_override: z.string().regex(
-    VALID_OVERRIDE_PATTERN,
-    'retention_override must be: inherit, pin_forever, pin_days:7, pin_days:30, pin_days:90, or pin_days:365',
-  ),
-});
+// MASS-ASSIGN-SAFE: OWASP A04:2021 — only `session_id` and `retention_override`
+// are accepted. `.strict()` rejects unknown keys (e.g. `user_id`, `is_admin`)
+// at parse time, returning 400 before any DB write occurs. The `.update()` call
+// below writes only `{ retention_override }` extracted from `parsed.data`.
+const SessionRetentionSchema = z
+  .object({
+    session_id: z.string().uuid('session_id must be a valid UUID'),
+    retention_override: z.string().regex(
+      VALID_OVERRIDE_PATTERN,
+      'retention_override must be: inherit, pin_forever, pin_days:7, pin_days:30, pin_days:90, or pin_days:365',
+    ),
+  })
+  .strict(); // OWASP A04:2021 — reject unknown keys (mass-assignment guard)
 
 async function resolveClient(request: Request) {
   const authHeader = request.headers.get('Authorization');


### PR DESCRIPTION
## Summary

- **Scope audited**: all `.update()` callsites under `packages/styrby-web/src/app/api/v1/` and `packages/styrby-web/src/app/api/account/` that take user input via `request.json()`
- **Unsafe callsites found**: 0 (zero) - every `.update()` call was already gated behind a Zod schema or used only server-computed values
- **Schemas hardened**: 3 schemas upgraded from `z.object()` to `z.object().strict()` (OWASP A04:2021 explicit guard)
- **Tests added**: 6 new OWASP A04 guard tests across 3 test files; 1 new test file created for the session-retention route

## Callsite audit results

| File | `.update()` call | Source of data written | Pre-fix status | Post-fix status |
|------|-----------------|----------------------|----------------|-----------------|
| `account/delete/route.ts` | `profiles.update({ deleted_at: now })` | Server-computed timestamp | SAFE - server value only | MASS-ASSIGN-SAFE: `.strict()` added to schema |
| `account/delete/route.ts` | `sessions.update({ deleted_at: now })` | Server-computed timestamp | SAFE - server value only | MASS-ASSIGN-SAFE: `.strict()` added to schema |
| `account/retention/route.ts` | `profiles.update({ retention_days })` | Zod-validated `parsed.data` | SAFE - Zod-validated | MASS-ASSIGN-SAFE: `.strict()` added to schema |
| `account/retention/session/route.ts` | `sessions.update({ retention_override })` | Zod-validated `parsed.data` | SAFE - Zod-validated | MASS-ASSIGN-SAFE: `.strict()` added to schema |
| `api/v1/` directory | (no `.update()` calls found) | N/A | SAFE | SAFE |

**Finding**: No mass-assignment vulnerability existed. All schemas now carry `.strict()` to make this guarantee explicit and regression-proof.

## Changes

- `account/delete/route.ts` - `DeleteRequestSchema` now `.strict()` + `MASS-ASSIGN-SAFE` OWASP A04 annotation
- `account/retention/route.ts` - `RetentionUpdateSchema` now `.strict()` + `MASS-ASSIGN-SAFE` annotation
- `account/retention/session/route.ts` - `SessionRetentionSchema` now `.strict()` + `MASS-ASSIGN-SAFE` annotation
- `account/delete/__tests__/route.test.ts` - 2 new OWASP A04 guard tests (`is_admin: true`, `tier: enterprise`)
- `account/retention/__tests__/route.test.ts` - 2 new OWASP A04 guard tests (`is_admin: true`, `tier: enterprise`)
- `account/retention/session/__tests__/route.test.ts` - new file, 7 tests total (5 baseline + 2 OWASP A04 guard tests)

## Verification

- `npx tsc --noEmit` - no errors in changed files
- `npx vitest run src/app/api/account/` - 45/45 tests pass
- All 6 new OWASP A04 tests confirm `.update()` is never called when unknown keys are present in request body

## Test plan

- [ ] Confirm all 45 account-route tests pass in CI
- [ ] Confirm TypeScript is clean on changed files
- [ ] Manual: send `PUT /api/account/retention` with `{"retention_days":30,"is_admin":true}` - must return 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)