### PR TITLE
feat(security): enforce MFA for admin accounts (H42 Layer 1)

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -61,10 +61,14 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        # WHY pinned to SHA: tag-mutation supply-chain hardening per
+        # ~/.claude/standards/CI_VERCEL_COST_OPTIMIZATION.md / SECURITY hardening
+        # plan. v4 = 34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1
+        # WHY pinned to SHA: same supply-chain hardening rule. v1.6.0
+        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
         with:
           version: latest
 

--- a/packages/styrby-cli/package.json
+++ b/packages/styrby-cli/package.json
@@ -25,7 +25,11 @@
     }
   },
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/**/*.json",
+    "!dist/**/*.map",
+    "!dist/**/*.test.*",
     "LICENSE",
     "README.md",
     "SECURITY.md"

--- a/packages/styrby-web/next.config.ts
+++ b/packages/styrby-web/next.config.ts
@@ -86,6 +86,18 @@ const cspHeader = [
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self'",
+  // SEC-014: CSP violation reporting.
+  // WHY: Real-time visibility into CSP violations lets us detect injection
+  // attempts (XSS, unauthorized third-party script loads, eval-equivalents)
+  // BEFORE they succeed. The browser POSTs the violation to our endpoint;
+  // we log to audit_log for correlation with other anomaly signals.
+  // Per OWASP A03:2021. Endpoint: /api/security/csp-report.
+  //
+  // Both report-uri (Level 2) and report-to (Level 3) are emitted because
+  // browsers vary in which they honor. report-to references the named group
+  // defined via the Reporting-Endpoints header below.
+  'report-uri /api/security/csp-report',
+  'report-to csp-endpoint',
 ].join('; ');
 
 /**
@@ -216,6 +228,16 @@ const nextConfig: NextConfig = {
           {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            // SEC-014 (CSP report-to support): defines the named "csp-endpoint"
+            // group referenced by the CSP `report-to` directive above. The Level 3
+            // Reporting API supersedes the older `Report-To` header (note hyphen
+            // case) but Vercel's edge passes both as-is. Browsers that only
+            // support Level 2 (older Safari) fall back to `report-uri` instead;
+            // both directives are emitted in the CSP for max coverage.
+            key: 'Reporting-Endpoints',
+            value: 'csp-endpoint="/api/security/csp-report"',
           },
         ],
       },

--- a/packages/styrby-web/src/__tests__/admin/actions.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/actions.integration.test.ts
@@ -65,6 +65,23 @@ vi.mock('@sentry/nextjs', () => ({
   captureMessage: (...args: unknown[]) => mockSentryCaptureMessage(...args),
 }));
 
+// WHY mock mfa-gate: the actions.integration tests mock createClient to return
+// only the rpc mock (for the user-scoped client). assertAdminMfa calls
+// createAdminClient to query site_admins + passkeys. Without this mock, the
+// MFA gate would fail-closed on every action test. MFA behavior is covered
+// in __tests__/admin/mfa-gate.test.ts. OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 // ── Supabase mock ─────────────────────────────────────────────────────────────
 const mockRpc = vi.fn();
 const mockGenerateLink = vi.fn();
@@ -124,7 +141,21 @@ describe('overrideTierAction — integration (form → Zod → RPC)', () => {
     vi.clearAllMocks();
     // WHY restore createClient: clearAllMocks wipes mockResolvedValue.
     // Fix P0: createClient (user-scoped) is the RPC client for admin_* RPCs.
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      // WHY auth.getUser stub: the MFA gate block in each action calls
+      // supabase.auth.getUser() to resolve the acting admin's ID before calling
+      // assertAdminMfa(). assertAdminMfa is mocked to return undefined (see
+      // vi.mock('@/lib/admin/mfa-gate') above), so the gate itself is bypassed.
+      // But the auth.getUser() call still happens — without this stub the mock
+      // returns undefined for .auth, causing a TypeError. OWASP A07:2021.
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'admin-uuid-001' } },
+          error: null,
+        }),
+      },
+    });
     mockHeadersGet.mockImplementation((name: string) => {
       if (name === 'x-forwarded-for') return MOCK_XFF;
       if (name === 'user-agent') return MOCK_UA;
@@ -259,7 +290,21 @@ describe('resetPasswordAction — integration (form → Zod → RPC → generate
     vi.clearAllMocks();
     // WHY restore createClient: clearAllMocks wipes mockResolvedValue.
     // Fix P0: admin_record_password_reset RPC uses user-scoped client.
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      // WHY auth.getUser stub: the MFA gate block in each action calls
+      // supabase.auth.getUser() to resolve the acting admin's ID before calling
+      // assertAdminMfa(). assertAdminMfa is mocked to return undefined (see
+      // vi.mock('@/lib/admin/mfa-gate') above), so the gate itself is bypassed.
+      // But the auth.getUser() call still happens — without this stub the mock
+      // returns undefined for .auth, causing a TypeError. OWASP A07:2021.
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'admin-uuid-001' } },
+          error: null,
+        }),
+      },
+    });
     mockHeadersGet.mockImplementation((name: string) => {
       if (name === 'x-forwarded-for') return MOCK_XFF;
       if (name === 'user-agent') return MOCK_UA;
@@ -390,7 +435,21 @@ describe('toggleConsentAction — integration (form → Zod → RPC)', () => {
     vi.clearAllMocks();
     // WHY restore createClient: clearAllMocks wipes mockResolvedValue.
     // Fix P0: admin_toggle_consent RPC uses user-scoped client.
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      // WHY auth.getUser stub: the MFA gate block in each action calls
+      // supabase.auth.getUser() to resolve the acting admin's ID before calling
+      // assertAdminMfa(). assertAdminMfa is mocked to return undefined (see
+      // vi.mock('@/lib/admin/mfa-gate') above), so the gate itself is bypassed.
+      // But the auth.getUser() call still happens — without this stub the mock
+      // returns undefined for .auth, causing a TypeError. OWASP A07:2021.
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'admin-uuid-001' } },
+          error: null,
+        }),
+      },
+    });
     mockHeadersGet.mockImplementation((name: string) => {
       if (name === 'x-forwarded-for') return MOCK_XFF;
       if (name === 'user-agent') return MOCK_UA;

--- a/packages/styrby-web/src/__tests__/admin/audit-chain.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/audit-chain.integration.test.ts
@@ -40,6 +40,24 @@ vi.mock('@sentry/nextjs', () => ({
   captureException: vi.fn(),
 }));
 
+// WHY mock mfa-gate: the audit-chain tests mock createAdminClient to return
+// only the RPC response shape. assertAdminMfa calls createAdminClient to query
+// site_admins + passkeys + Auth API. Without this mock, assertAdminMfa would
+// fail-closed (throw AdminMfaRequiredError → 403), causing all tests to fail.
+// These tests verify the audit chain logic, not the MFA gate behavior.
+// MFA gate is covered in __tests__/admin/mfa-gate.test.ts. OWASP A07:2021.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import * as Sentry from '@sentry/nextjs';

--- a/packages/styrby-web/src/__tests__/admin/mfa-gate.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/mfa-gate.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Admin MFA Gate — Unit Tests
+ *
+ * Tests for assertAdminMfa() in packages/styrby-web/src/lib/admin/mfa-gate.ts.
+ *
+ * Coverage matrix:
+ *   (1) Grace period allows action + writes audit event
+ *   (2) Grace period writes audit event (audit table called)
+ *   (3) Expired grace + no MFA → throws AdminMfaRequiredError (403)
+ *   (4) Passkey present → allows action (no grace required)
+ *   (5) Verified TOTP present → allows action
+ *   (6) Unverified TOTP (pending status) → blocked (not counted as MFA)
+ *   (7) DB error (grace query) → fail-closed (throws AdminMfaRequiredError)
+ *   (8) DB error (passkeys query) → fail-closed
+ *   (9) Auth API error + passkey present → passkey fallback allows action
+ *  (10) Auth API error + no passkey → fail-closed
+ *  (11) Audit write failure during grace → does NOT block action
+ *  (12) Empty userId → throws AdminMfaRequiredError immediately (no DB call)
+ *  (13) Grace exactly at boundary (expired by 1ms) → blocked
+ *  (14) Blocked (no MFA after grace) → Sentry warning captured
+ *  (15) DB error path → Sentry exception captured
+ *
+ * Security references:
+ *   OWASP A07:2021 — Identification and Authentication Failures
+ *   SOC 2 CC6.1    — Privileged access requires phishing-resistant MFA
+ *   NIST SP 800-53 AC-3 — Deny-by-default on error
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// ============================================================================
+// Mocks — set up before imports so vi.mock hoisting works
+// ============================================================================
+
+vi.mock('@/lib/supabase/server', () => ({
+  createAdminClient: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+import { createAdminClient } from '@/lib/supabase/server';
+import * as Sentry from '@sentry/nextjs';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** ISO timestamp in the future (grace active). */
+const FUTURE_GRACE = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+
+/** ISO timestamp in the past (grace expired). */
+const PAST_GRACE = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+
+/** Just-expired: 1 ms before now (boundary test). */
+const JUST_EXPIRED = new Date(Date.now() - 1).toISOString();
+
+type FromTable = 'site_admins' | 'passkeys' | 'audit_log';
+
+interface SetupOptions {
+  graceUntil?: string | null;
+  graceError?: Error | null;
+  passkeys?: { id: string }[];
+  passkeysError?: Error | null;
+  totpVerified?: boolean;
+  totpError?: Error | null;
+  auditInsertError?: Error | null;
+}
+
+/**
+ * Configures createAdminClient mock for a single assertAdminMfa() call.
+ *
+ * WHY per-table dispatch on `from()`:
+ *   assertAdminMfa() calls createAdminClient() once at the top of
+ *   queryAdminMfaStatus, then calls .from('site_admins'), .from('passkeys'),
+ *   and auth.admin.getUserById in parallel. We route `from()` calls by table
+ *   name and return independent mock chains.
+ *
+ * @param opts - Override defaults to simulate specific scenarios.
+ */
+function setupFromMock(opts: SetupOptions = {}) {
+  const {
+    graceUntil = FUTURE_GRACE,
+    graceError = null,
+    passkeys = [],
+    passkeysError = null,
+    totpVerified = false,
+    totpError = null,
+    auditInsertError = null,
+  } = opts;
+
+  // Build per-table from() mock chains.
+  const fromMocks: Record<FromTable, ReturnType<typeof vi.fn>> = {
+    site_admins: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue(
+            graceError
+              ? { data: null, error: graceError }
+              : { data: graceUntil != null ? { mfa_grace_until: graceUntil } : null, error: null }
+          ),
+        }),
+      }),
+    }),
+
+    passkeys: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          is: vi.fn().mockResolvedValue(
+            passkeysError
+              ? { data: null, error: passkeysError }
+              : { data: passkeys, error: null }
+          ),
+        }),
+      }),
+    }),
+
+    audit_log: vi.fn().mockReturnValue({
+      insert: vi.fn().mockResolvedValue(
+        auditInsertError
+          ? { data: null, error: auditInsertError }
+          : { data: null, error: null }
+      ),
+    }),
+  };
+
+  // Auth Admin API mock.
+  const mockGetUserById = vi.fn().mockResolvedValue(
+    totpError
+      ? { data: null, error: totpError }
+      : {
+          data: {
+            user: {
+              id: 'admin-uuid',
+              factors: totpVerified
+                ? [{ factor_type: 'totp', status: 'verified' }]
+                : [],
+            },
+          },
+          error: null,
+        }
+  );
+
+  (createAdminClient as Mock).mockReturnValue({
+    from: (table: string) => {
+      const mock = fromMocks[table as FromTable];
+      if (!mock) throw new Error(`Unexpected table: ${table}`);
+      return mock(table);
+    },
+    auth: {
+      admin: {
+        getUserById: mockGetUserById,
+      },
+    },
+  });
+
+  return { fromMocks, mockGetUserById };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('assertAdminMfa', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // (1) Grace period allows action
+  // --------------------------------------------------------------------------
+
+  it('(1) allows action when admin is within grace period', async () => {
+    setupFromMock({ graceUntil: FUTURE_GRACE, passkeys: [], totpVerified: false });
+
+    // Should not throw.
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // (2) Grace period writes audit event
+  // --------------------------------------------------------------------------
+
+  it('(2) writes grace audit event when action allowed in grace period', async () => {
+    const { fromMocks } = setupFromMock({
+      graceUntil: FUTURE_GRACE,
+      passkeys: [],
+      totpVerified: false,
+    });
+
+    await assertAdminMfa('admin-uuid');
+
+    // audit_log.insert should have been called once.
+    const auditInsertMock = fromMocks.audit_log('audit_log').insert;
+    expect(auditInsertMock).toHaveBeenCalledOnce();
+    expect(auditInsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'admin-uuid',
+        event_type: 'admin_mfa_grace_action',
+      })
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // (3) Expired grace + no MFA → blocked
+  // --------------------------------------------------------------------------
+
+  it('(3) throws AdminMfaRequiredError when grace expired and no MFA enrolled', async () => {
+    setupFromMock({ graceUntil: PAST_GRACE, passkeys: [], totpVerified: false });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  it('(3a) AdminMfaRequiredError has correct statusCode and code', async () => {
+    setupFromMock({ graceUntil: PAST_GRACE, passkeys: [], totpVerified: false });
+
+    let err: unknown;
+    try {
+      await assertAdminMfa('admin-uuid');
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeInstanceOf(AdminMfaRequiredError);
+    expect((err as AdminMfaRequiredError).statusCode).toBe(403);
+    expect((err as AdminMfaRequiredError).code).toBe('ADMIN_MFA_REQUIRED');
+  });
+
+  // --------------------------------------------------------------------------
+  // (4) Passkey present → allows (no grace needed)
+  // --------------------------------------------------------------------------
+
+  it('(4) allows action when passkey is enrolled (no grace required)', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE, // grace expired
+      passkeys: [{ id: 'passkey-uuid-001' }],
+      totpVerified: false,
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // (5) Verified TOTP → allows
+  // --------------------------------------------------------------------------
+
+  it('(5) allows action when verified TOTP factor is enrolled', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE,
+      passkeys: [],
+      totpVerified: true,
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // (6) Unverified TOTP → blocked
+  // --------------------------------------------------------------------------
+
+  it('(6) blocks action when TOTP factor exists but is not verified (status pending)', async () => {
+    // Manually configure Auth response with unverified TOTP.
+    (createAdminClient as Mock).mockReturnValue({
+      from: (table: string) => {
+        if (table === 'site_admins') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: { mfa_grace_until: PAST_GRACE },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'passkeys') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                is: vi.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      },
+      auth: {
+        admin: {
+          getUserById: vi.fn().mockResolvedValue({
+            data: {
+              user: {
+                id: 'admin-uuid',
+                // status: 'unverified' — should NOT count as MFA.
+                factors: [{ factor_type: 'totp', status: 'unverified' }],
+              },
+            },
+            error: null,
+          }),
+        },
+      },
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (7) DB error (grace query) → fail-closed
+  // --------------------------------------------------------------------------
+
+  it('(7) throws AdminMfaRequiredError when site_admins query fails (fail-closed)', async () => {
+    setupFromMock({ graceError: new Error('DB connection timeout') });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (8) DB error (passkeys query) → fail-closed
+  // --------------------------------------------------------------------------
+
+  it('(8) throws AdminMfaRequiredError when passkeys query fails (fail-closed)', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE,
+      passkeysError: new Error('passkeys table unavailable'),
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (9) Auth API error + passkey present → fallback allows
+  // --------------------------------------------------------------------------
+
+  it('(9) allows action when Auth API fails but passkey is present (passkey fallback)', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE,
+      passkeys: [{ id: 'passkey-uuid-001' }],
+      totpError: new Error('Auth API timeout'),
+    });
+
+    // Should NOT throw — passkey satisfies MFA requirement even when TOTP check fails.
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // (10) Auth API error + no passkey → fail-closed
+  // --------------------------------------------------------------------------
+
+  it('(10) throws AdminMfaRequiredError when Auth API fails and no passkey (fail-closed)', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE,
+      passkeys: [],
+      totpError: new Error('Auth API timeout'),
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (11) Audit write failure → does NOT block action
+  // --------------------------------------------------------------------------
+
+  it('(11) allows action even when audit_log.insert fails during grace period', async () => {
+    setupFromMock({
+      graceUntil: FUTURE_GRACE,
+      passkeys: [],
+      auditInsertError: new Error('audit_log write failed'),
+    });
+
+    // Action should still be allowed — audit failure is non-blocking.
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  it('(11a) captures Sentry exception when audit_log.insert fails', async () => {
+    const insertErr = new Error('audit_log write failed');
+    setupFromMock({
+      graceUntil: FUTURE_GRACE,
+      passkeys: [],
+      auditInsertError: insertErr,
+    });
+
+    await assertAdminMfa('admin-uuid');
+
+    // Sentry should capture the audit write failure.
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      insertErr,
+      expect.objectContaining({
+        tags: expect.objectContaining({ component: 'writeGraceAuditEvent' }),
+      })
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // (12) Empty userId → immediate throw, no DB call
+  // --------------------------------------------------------------------------
+
+  it('(12) throws AdminMfaRequiredError immediately for empty userId', async () => {
+    await expect(assertAdminMfa('')).rejects.toThrow(AdminMfaRequiredError);
+    // createAdminClient should NOT be called — we fail before any DB query.
+    expect(createAdminClient).not.toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // (13) Grace boundary — expired by 1ms → blocked
+  // --------------------------------------------------------------------------
+
+  it('(13) blocks action when grace expired by 1ms (boundary test)', async () => {
+    setupFromMock({
+      graceUntil: JUST_EXPIRED,
+      passkeys: [],
+      totpVerified: false,
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (14) Sentry warning captured when blocked (no MFA after grace)
+  // --------------------------------------------------------------------------
+
+  it('(14) captures Sentry warning when admin blocked due to no MFA after grace', async () => {
+    setupFromMock({ graceUntil: PAST_GRACE, passkeys: [], totpVerified: false });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('no MFA enrolled after grace period'),
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ reason: 'no_mfa_after_grace' }),
+      })
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // (15) DB error path → Sentry exception captured
+  // --------------------------------------------------------------------------
+
+  it('(15) captures Sentry exception when queryAdminMfaStatus throws', async () => {
+    const dbErr = new Error('DB connection timeout');
+    setupFromMock({ graceError: dbErr });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.anything(), // The error may be wrapped
+      expect.objectContaining({
+        tags: expect.objectContaining({ component: 'assertAdminMfa' }),
+      })
+    );
+  });
+});

--- a/packages/styrby-web/src/app/api/admin/audit/verify/route.ts
+++ b/packages/styrby-web/src/app/api/admin/audit/verify/route.ts
@@ -36,6 +36,7 @@ import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import * as Sentry from '@sentry/nextjs';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ============================================================================
 // Types
@@ -121,6 +122,17 @@ export async function GET(): Promise<NextResponse> {
   const adminStatus = await isAdmin(user.id);
   if (!adminStatus) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   // ── Execute RPC ────────────────────────────────────────────────────────────

--- a/packages/styrby-web/src/app/api/admin/founder-error-histogram/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-error-histogram/route.ts
@@ -47,6 +47,7 @@ import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { ERROR_CLASSES, type ErrorClass } from '@styrby/shared/errors';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -135,6 +136,17 @@ export async function GET(request: NextRequest) {
   const adminOk = await isAdmin(user.id);
   if (!adminOk) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   try {

--- a/packages/styrby-web/src/app/api/admin/founder-feedback/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-feedback/route.ts
@@ -38,6 +38,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { calcNPS, groupNpsByWeek } from '@styrby/shared';
 
@@ -122,6 +123,17 @@ export async function GET(request: NextRequest) {
   const adminOk = await isAdmin(user.id);
   if (!adminOk) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   // ── Rate limit ────────────────────────────────────────────────────────────

--- a/packages/styrby-web/src/app/api/admin/founder-metrics/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-metrics/route.ts
@@ -38,6 +38,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ============================================================================
 // Types
@@ -183,6 +184,17 @@ export async function GET(request: NextRequest) {
   const adminStatus = await isAdmin(user.id);
   if (!adminStatus) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   try {

--- a/packages/styrby-web/src/app/api/admin/founder-team-metrics/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-team-metrics/route.ts
@@ -45,6 +45,7 @@ import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import type { FounderTeamMetrics, FounderTeamSummary } from '@styrby/shared';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ============================================================================
 // DB row types (internal, not exported)
@@ -95,6 +96,17 @@ export async function GET(request: NextRequest) {
   const adminStatus = await isAdmin(user.id);
   if (!adminStatus) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   try {

--- a/packages/styrby-web/src/app/api/admin/support/[id]/reply/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/reply/route.ts
@@ -24,6 +24,7 @@ import { sendSupportReplyEmail } from '@/lib/resend';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 /** Zod schema for the reply body */
 const ReplySchema = z.object({
@@ -54,6 +55,17 @@ export async function POST(
   // A-001: Use site_admins table / is_site_admin() RPC instead of email claim (migration 042 T3.5 cutover)
   if (!(await isAdmin(user.id))) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   // Parse and validate body

--- a/packages/styrby-web/src/app/api/admin/support/[id]/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/route.ts
@@ -21,6 +21,7 @@ import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 /**
  * Zod schema for PATCH request body validation.
@@ -55,6 +56,19 @@ async function verifyAdmin() {
 
   if (!(await isAdmin(user.id))) {
     return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // WHY in verifyAdmin(): all handlers (GET + PATCH) share this helper,
+  // so adding the MFA check here gates every handler at once.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return { error: NextResponse.json({ error: err.code }, { status: err.statusCode }) };
+    }
+    throw err;
   }
 
   return { user };

--- a/packages/styrby-web/src/app/api/admin/support/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/route.ts
@@ -29,6 +29,7 @@ import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ---------------------------------------------------------------------------
 // Query Schema
@@ -65,6 +66,17 @@ export async function GET(request: Request) {
   // Verify admin access via site_admins / is_site_admin() RPC (A-001; migration 042 T3.5 cutover)
   if (!(await isAdmin(user.id))) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   // Parse and validate query params via Zod schema (OWASP ASVS V5.1.3)

--- a/packages/styrby-web/src/app/api/security/csp-report/route.ts
+++ b/packages/styrby-web/src/app/api/security/csp-report/route.ts
@@ -1,0 +1,271 @@
+/**
+ * POST /api/security/csp-report
+ *
+ * CSP violation report receiver. Browsers POST violations to this endpoint
+ * when a page-level Content-Security-Policy rule is breached. The endpoint
+ * persists each report to `audit_log` with `action='csp_violation'` for
+ * correlation with other anomaly signals (rate-limit spikes, 401 bursts).
+ *
+ * @rateLimit 60 reports per minute per IP (browsers naturally batch; this is
+ *            generous to avoid losing legitimate violation evidence during a
+ *            real attack while still capping flood risk).
+ *
+ * @body
+ *   The browser sends two body shapes depending on which Reporting API
+ *   level it supports:
+ *
+ *   Level 2 (legacy `report-uri`):
+ *     application/csp-report
+ *     {
+ *       "csp-report": {
+ *         "document-uri": "https://styrbyapp.com/dashboard",
+ *         "violated-directive": "script-src",
+ *         "blocked-uri": "https://evil.example.com/x.js",
+ *         ...
+ *       }
+ *     }
+ *
+ *   Level 3 (`report-to`):
+ *     application/reports+json
+ *     [{ "type": "csp-violation", "body": {...}, "url": ..., "user_agent": ... }]
+ *
+ *   We accept both. The handler normalizes each to a single `cspReport` record
+ *   shape before insertion.
+ *
+ * Security design:
+ *
+ * 1. NO AUTHENTICATION on this endpoint. Browsers cannot authenticate CSP
+ *    reports — they're sent before any session context is established for the
+ *    page. Public-by-construction.
+ *
+ * 2. INPUT SIZE CAP. A malicious site cannot DoS us by sending mega-payloads
+ *    because we cap the body at 10KB before parsing. Real CSP reports are
+ *    typically <2KB.
+ *
+ * 3. NO REFLECTION. The endpoint never returns the report content in its
+ *    response body. Eliminates use as an XSS amplifier.
+ *
+ * 4. RATE-LIMITED. A compromised browser sending floods can't fill the
+ *    audit_log; the rate limiter caps per-IP intake.
+ *
+ * 5. NO PII LOGGING. We strip query strings from `document-uri` before
+ *    persistence (some apps put email/token in URL params).
+ *
+ * Governing standards:
+ * - OWASP A03:2021 (Injection): early-warning system for XSS attempts.
+ * - SOC 2 CC7.2: security event detection + logging.
+ * - W3C CSP Level 3 Reporting API.
+ *
+ * @module api/security/csp-report
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createAdminClient } from '@/lib/supabase/server';
+import { rateLimit, getClientIp, rateLimitResponse } from '@/lib/rateLimit';
+
+// ============================================================================
+// Body schemas (best-effort — different browsers send slightly different shapes)
+// ============================================================================
+
+const Level2ReportSchema = z
+  .object({
+    'csp-report': z
+      .object({
+        'document-uri': z.string().optional(),
+        'violated-directive': z.string().optional(),
+        'effective-directive': z.string().optional(),
+        'blocked-uri': z.string().optional(),
+        'source-file': z.string().optional(),
+        'line-number': z.number().optional(),
+        'column-number': z.number().optional(),
+        'status-code': z.number().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const Level3ReportItemSchema = z
+  .object({
+    type: z.string().optional(),
+    age: z.number().optional(),
+    url: z.string().optional(),
+    user_agent: z.string().optional(),
+    body: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
+
+const Level3ReportSchema = z.array(Level3ReportItemSchema);
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Strip query string from a URL to avoid persisting tokens / emails. */
+function stripQuery(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return url.split('?')[0];
+  }
+}
+
+interface NormalizedReport {
+  documentUri?: string;
+  violatedDirective?: string;
+  blockedUri?: string;
+  sourceFile?: string;
+  lineNumber?: number;
+  reportType: 'level-2' | 'level-3';
+}
+
+/** Normalize either body shape into the same record we persist. */
+function normalize(body: unknown): NormalizedReport[] {
+  // Level 2: { "csp-report": {...} }
+  const l2 = Level2ReportSchema.safeParse(body);
+  if (l2.success) {
+    const r = l2.data['csp-report'];
+    return [
+      {
+        documentUri: stripQuery(r['document-uri']),
+        violatedDirective: r['violated-directive'] ?? r['effective-directive'],
+        blockedUri: stripQuery(r['blocked-uri']),
+        sourceFile: stripQuery(r['source-file']),
+        lineNumber: r['line-number'],
+        reportType: 'level-2',
+      },
+    ];
+  }
+
+  // Level 3: [{type, body: {...}, url, user_agent}]
+  const l3 = Level3ReportSchema.safeParse(body);
+  if (l3.success) {
+    return l3.data
+      .filter((item) => item.type === 'csp-violation' || item.type === undefined)
+      .map((item) => {
+        const body = item.body as Record<string, unknown> | undefined;
+        return {
+          documentUri: stripQuery((body?.documentURL ?? item.url) as string | undefined),
+          violatedDirective: (body?.effectiveDirective ?? body?.violatedDirective) as
+            | string
+            | undefined,
+          blockedUri: stripQuery(body?.blockedURL as string | undefined),
+          sourceFile: stripQuery(body?.sourceFile as string | undefined),
+          lineNumber: body?.lineNumber as number | undefined,
+          reportType: 'level-3',
+        };
+      });
+  }
+
+  return [];
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+const MAX_BODY_BYTES = 10 * 1024; // 10KB cap — real CSP reports are <2KB.
+
+/**
+ * Receives CSP violation reports and persists each to audit_log.
+ *
+ * @returns Always 204 No Content on accept (so the browser doesn't retry).
+ *          Never returns the report content. Errors logged server-side only.
+ */
+export async function POST(request: NextRequest) {
+  const ip = getClientIp(request) ?? 'unknown';
+
+  // 1. Rate limit by IP (60/min). Generous because browsers batch; tight enough
+  //    to prevent log floods. The shared rateLimit() helper extracts client IP
+  //    from the request internally (X-Forwarded-For etc.) — we pass `request`,
+  //    not a manually-keyed string, to stay consistent with other endpoints.
+  const limit = await rateLimit(
+    request,
+    {
+      windowMs: 60_000,
+      maxRequests: 60,
+    },
+    'csp-report'
+  );
+  if (!limit.allowed) {
+    return rateLimitResponse(limit.retryAfter ?? 60);
+  }
+
+  // 2. Read body with size cap. A 10KB cap prevents memory abuse from a
+  //    misbehaving or malicious browser.
+  let raw: string;
+  try {
+    raw = await request.text();
+    if (raw.length > MAX_BODY_BYTES) {
+      // Silently drop oversized reports — telling the client "too big" would
+      // give an attacker a length-detection oracle. Log server-side instead.
+      console.warn('[csp-report] dropped oversized report', {
+        ip,
+        bytes: raw.length,
+      });
+      return new NextResponse(null, { status: 204 });
+    }
+  } catch {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  // 3. Parse + normalize. Tolerate any malformed shape — silent 204.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return new NextResponse(null, { status: 204 });
+  }
+  const reports = normalize(parsed);
+  if (reports.length === 0) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  // 4. Persist each report to audit_log. Best-effort — if the DB write fails
+  //    we don't want to retry from the browser, so always 204.
+  // WHY admin client (not user-scoped): no session context for the visitor.
+  const supabase = createAdminClient();
+
+  for (const r of reports) {
+    try {
+      await supabase.from('audit_log').insert({
+        // No user_id — these reports are pre-auth.
+        action: 'csp_violation',
+        resource_type: 'security',
+        resource_id: null,
+        metadata: {
+          ip,
+          report_type: r.reportType,
+          document_uri: r.documentUri,
+          violated_directive: r.violatedDirective,
+          blocked_uri: r.blockedUri,
+          source_file: r.sourceFile,
+          line_number: r.lineNumber,
+          // user-agent stripped — too noisy for audit_log; can be reconstructed
+          // from access logs if needed.
+        },
+      });
+    } catch (err) {
+      // Swallow + log — never propagate DB errors back to the browser.
+      console.error('[csp-report] DB insert failed', {
+        ip,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return new NextResponse(null, { status: 204 });
+}
+
+/**
+ * Reject any non-POST method explicitly.
+ *
+ * WHY: Browsers always POST CSP reports per spec. A GET to this endpoint is
+ * either a misconfiguration or an active reconnaissance attempt. Returning
+ * 405 (rather than 200/404) explicitly surfaces the misuse.
+ */
+export async function GET() {
+  return new NextResponse(null, { status: 405 });
+}

--- a/packages/styrby-web/src/app/dashboard/admin/layout.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { AdminMfaBanner } from '@/components/admin/AdminMfaBanner';
 
 /**
  * Admin layout gate.
@@ -65,5 +66,36 @@ export default async function AdminLayout({
     redirect('/dashboard');
   }
 
-  return <>{children}</>;
+  // Fetch the admin's MFA grace window for the banner.
+  //
+  // WHY here (layout) not assertAdminMfa(): the layout must NOT call
+  // assertAdminMfa() because that would block the passkey enrollment page
+  // itself — a bootstrap paradox. The layout only reads mfa_grace_until for
+  // the banner; the MFA enforcement happens per-action in each route handler.
+  //
+  // WHY createAdminClient() here: the service-role client is already used above
+  // for the is_site_admin RPC. Reusing it (rather than adding a user-scoped
+  // client) avoids an extra client instantiation and keeps the layout focused
+  // on orchestration.
+  //
+  // WHY maybeSingle + null fallback: if the admin row has no mfa_grace_until
+  // (new admin added after enforcement) or the query fails, graceUntil = null
+  // and the banner is hidden. This is the correct fail-open for UI (the banner
+  // is informational — suppressing it on error is safe).
+  const { data: adminRow } = await adminDb
+    .from('site_admins')
+    .select('mfa_grace_until')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  const graceUntil = adminRow?.mfa_grace_until ?? null;
+
+  return (
+    <>
+      {/* WHY AdminMfaBanner outside children: the banner is layout-level UI
+          displayed above the admin page content, not injected by each page. */}
+      <AdminMfaBanner graceUntil={graceUntil} />
+      {children}
+    </>
+  );
 }

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/actions.ts
@@ -54,6 +54,7 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { generateSupportToken } from '@/lib/support/token';
 import * as Sentry from '@sentry/nextjs';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ─── Shared action result type ────────────────────────────────────────────────
 
@@ -251,6 +252,22 @@ export async function requestSupportAccessAction(
 
   // ── 4. Resolve user_id from the ticket (server-side, unforgeable) ──────────
   const supabase = await createClient();
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
 
   // WHY resolve p_user_id from the ticket server-side (not from FormData):
   //   The admin's form submits session_id and reason — there is no user_id field

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/actions.ts
@@ -33,6 +33,7 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { createAdminClient, createClient } from '@/lib/supabase/server';
 import * as Sentry from '@sentry/nextjs';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
@@ -276,6 +277,24 @@ export async function overrideTierAction(
   // SOC 2 CC6.1, CC7.2.
   const supabase = await createClient();
 
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // WHY here (not in layout): the layout cannot call assertAdminMfa because it
+  // would block the passkey enrollment page itself (bootstrap paradox). Per-action
+  // enforcement is the correct pattern. OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
+
   const { data: auditId, error } = await supabase.rpc('admin_override_tier', {
     p_target_user_id: parsed.data.targetUserId,
     p_new_tier: parsed.data.newTier,
@@ -374,6 +393,26 @@ export async function resetPasswordAction(
   //     scoped client forwards the admin's session cookie → auth.uid() resolves.
   //   SOC 2 CC6.1, CC7.2.
   const adminClient = createAdminClient();
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // WHY user-scoped client for MFA check: assertAdminMfa uses createAdminClient()
+  // internally for DB queries, but we need the acting admin's user ID. We use
+  // a temporary user-scoped client here to resolve auth.uid() → actingAdmin.id.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const mfaClient = await createClient();
+    const { data: { user: actingAdmin } } = await mfaClient.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
 
   // ── 3. Fetch target user server-side via trusted Auth Admin API ───────────
   // CRITICAL (C1): email is resolved from the server-side Auth Admin API, not
@@ -559,6 +598,22 @@ export async function toggleConsentAction(
   // = NULL → 42501. User-scoped client forwards the admin's session cookie.
   // SOC 2 CC6.1, CC7.2.
   const supabase = await createClient();
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
 
   const { error } = await supabase.rpc('admin_toggle_consent', {
     p_target_user_id: parsed.data.targetUserId,

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
@@ -46,6 +46,7 @@ import {
   RefundError,
 } from '@/lib/billing/polar-refund';
 import type { AdminActionResult } from '@/app/dashboard/admin/users/[userId]/actions';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // Re-export AdminActionResult so sub-pages can import from this module too.
 export type { AdminActionResult };
@@ -260,6 +261,23 @@ export async function issueRefundAction(
   const idempotencyKey = `${targetUserId}:${subscription_id}:${amount_cents}:${nowRoundedToMinute}`;
 
   // ── 3. Resolve subscription owner + Polar customer + Polar order ───────────
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const mfaClient = await createClient();
+    const { data: { user: actingAdmin } } = await mfaClient.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
+
   // SEC-REFUND-001: The Polar SDK refund API requires a real order ID; the
   // pass-through `orderId: subscription_id` it had before this PR caused Polar
   // to reject every refund with HTTPValidationError. Two-step resolution now:
@@ -574,6 +592,22 @@ export async function issueCreditAction(
   // WHY createClient() (user-scoped): see module JSDoc. SOC 2 CC6.1, CC7.2.
   const supabase = await createClient();
 
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
+
   const { data: rpcData, error: rpcErr } = await supabase.rpc('admin_issue_credit', {
     p_target_user_id: targetUserId,
     p_amount_cents: amount_cents,
@@ -673,6 +707,22 @@ export async function sendChurnSaveOfferAction(
   // ── 2. Call SECURITY DEFINER RPC ──────────────────────────────────────────
   // WHY createClient() (user-scoped): see module JSDoc. SOC 2 CC6.1, CC7.2.
   const supabase = await createClient();
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
 
   const { data: rpcData, error: rpcErr } = await supabase.rpc('admin_send_churn_save_offer', {
     p_target_user_id: targetUserId,

--- a/packages/styrby-web/src/components/admin/AdminMfaBanner.tsx
+++ b/packages/styrby-web/src/components/admin/AdminMfaBanner.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+/**
+ * AdminMfaBanner
+ *
+ * Displays a time-sensitive warning banner to admins who are within their
+ * MFA enrollment grace period (mfa_grace_until from migration 065).
+ *
+ * Color urgency tiers:
+ *   - ≤1 day remaining → red (critical, action required today)
+ *   - ≤3 days remaining → amber (high urgency)
+ *   - >3 days remaining → yellow (informational)
+ *
+ * WHY urgency tiers: admins who see the same yellow banner every day develop
+ * banner blindness. Escalating color (red/amber) for shorter windows breaks
+ * that pattern and drives enrollment before the grace period expires.
+ *
+ * WHY client component:
+ *   The banner only needs the `graceUntil` prop (a string) which is fetched
+ *   server-side in the admin layout and passed down. No server-side rendering
+ *   is needed in this component itself. 'use client' is required for the
+ *   link onClick / potential animations. The layout fetches the data; the
+ *   banner only renders it.
+ *
+ * WHY NOT in layout.tsx directly:
+ *   Separating the banner into a component keeps layout.tsx as an orchestrator
+ *   (data fetching only) and pushes UI logic into a dedicated file.
+ *   CLAUDE.md: Component-First Architecture.
+ *
+ * Security references:
+ *   OWASP A07:2021 — Identification and Authentication Failures
+ *   SOC 2 CC6.1 — Privileged access requires phishing-resistant MFA
+ *
+ * @param graceUntil - ISO 8601 timestamp string when the grace period expires,
+ *   or null if no grace (admin enrolled before/after MFA requirement — no banner).
+ */
+
+import Link from 'next/link';
+import { AlertTriangle } from 'lucide-react';
+
+// ============================================================================
+// Props
+// ============================================================================
+
+interface AdminMfaBannerProps {
+  /**
+   * The admin's mfa_grace_until timestamp from site_admins.
+   * null → admin has no grace window → banner is not shown.
+   */
+  graceUntil: string | null;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Computes whole days remaining until the grace period expires.
+ *
+ * WHY Math.ceil: a value of 0.2 days should show "1 day" — rounding down
+ * to 0 would imply the grace has expired when it hasn't. Ceiling is the
+ * correct user-facing rounding for "how much time do I have left?"
+ *
+ * @param graceUntil - ISO 8601 timestamp.
+ * @returns Whole days remaining (may be 0 or negative if expired).
+ */
+function daysRemaining(graceUntil: string): number {
+  const msRemaining = new Date(graceUntil).getTime() - Date.now();
+  return Math.ceil(msRemaining / (1000 * 60 * 60 * 24));
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Renders an MFA enrollment reminder banner for admins in the grace period.
+ *
+ * Returns null when:
+ *   - graceUntil is null (no grace window, admin already has MFA or
+ *     was added after enforcement)
+ *   - The grace period has already expired (days <= 0): at that point
+ *     assertAdminMfa() blocks admin actions, so the banner is moot.
+ */
+export function AdminMfaBanner({ graceUntil }: AdminMfaBannerProps) {
+  if (!graceUntil) return null;
+
+  const days = daysRemaining(graceUntil);
+
+  // Grace expired — assertAdminMfa blocks actions; banner is redundant.
+  if (days <= 0) return null;
+
+  // ── Urgency styling ────────────────────────────────────────────────────────
+  // WHY three tiers: see component JSDoc for the banner-blindness rationale.
+  let bannerClass: string;
+  let textClass: string;
+  let iconClass: string;
+
+  if (days <= 1) {
+    // Critical: red
+    bannerClass = 'bg-red-50 border border-red-300';
+    textClass = 'text-red-800';
+    iconClass = 'text-red-500';
+  } else if (days <= 3) {
+    // High: amber
+    bannerClass = 'bg-amber-50 border border-amber-300';
+    textClass = 'text-amber-800';
+    iconClass = 'text-amber-500';
+  } else {
+    // Informational: yellow
+    bannerClass = 'bg-yellow-50 border border-yellow-200';
+    textClass = 'text-yellow-800';
+    iconClass = 'text-yellow-500';
+  }
+
+  const dayLabel = days === 1 ? 'day' : 'days';
+
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-md px-4 py-3 ${bannerClass}`}
+      role="alert"
+      aria-live="polite"
+    >
+      {/* WHY AlertTriangle: CLAUDE.md prohibits sparkle icons (Sparkles, ✨).
+          AlertTriangle is the correct lucide-react icon for a security warning. */}
+      <AlertTriangle className={`mt-0.5 h-5 w-5 flex-shrink-0 ${iconClass}`} aria-hidden="true" />
+
+      <div className={`text-sm ${textClass}`}>
+        <strong className="font-semibold">MFA enrollment required.</strong>{' '}
+        You have{' '}
+        <strong>
+          {days} {dayLabel}
+        </strong>{' '}
+        remaining to enroll a passkey or authenticator app. After the grace period expires, admin
+        actions will be blocked until MFA is set up.{' '}
+        <Link
+          href="/dashboard/settings/account/passkeys"
+          className="underline underline-offset-2 font-medium hover:opacity-80 transition-opacity"
+        >
+          Set up MFA now
+        </Link>
+        .
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/lib/admin/mfa-gate.ts
+++ b/packages/styrby-web/src/lib/admin/mfa-gate.ts
@@ -1,0 +1,336 @@
+/**
+ * Admin MFA Gate — assertAdminMfa()
+ *
+ * Enforces that every admin who has passed the grace period has at least one
+ * active MFA factor (passkey OR Supabase Auth TOTP) before they can perform
+ * a privileged mutation.
+ *
+ * Security references:
+ *   OWASP A07:2021  - Identification and Authentication Failures
+ *   SOC 2 CC6.1     - Logical access controls; privileged access requires
+ *                     phishing-resistant authentication factors
+ *   NIST SP 800-63B AAL2 - Multi-factor authentication for privileged accounts
+ *   NIST SP 800-53 AC-3  - Access enforcement; deny-by-default on error
+ *
+ * WHY application-layer (not Postgres-layer):
+ *   MFA factor queries require the Supabase Auth Admin API
+ *   (auth.admin.getUserById). Calling the Admin API from inside a Postgres
+ *   SECURITY DEFINER function is not supported without pg_net and introduces
+ *   a network dependency on every admin RPC call. Application-layer enforcement
+ *   is faster, testable, and does not block the Postgres execution path.
+ *
+ * Call pattern in admin action/route handlers:
+ *   import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
+ *
+ *   // After isAdmin check (or equivalent):
+ *   try {
+ *     await assertAdminMfa(user.id);
+ *   } catch (err) {
+ *     if (err instanceof AdminMfaRequiredError) {
+ *       return NextResponse.json({ error: err.code }, { status: err.statusCode });
+ *     }
+ *     throw err;
+ *   }
+ */
+
+import { createAdminClient } from '@/lib/supabase/server';
+import * as Sentry from '@sentry/nextjs';
+
+// ============================================================================
+// Config
+// ============================================================================
+
+/**
+ * Grace period in days for new admin MFA enforcement.
+ *
+ * WHY env-var: allows the grace period to be adjusted per-environment without
+ * a code deployment. Staging can use 0 (immediate enforcement), production
+ * uses 7 days for initial rollout.
+ *
+ * Used only when inserting NEW admins. Existing admins at migration time
+ * received their grace window via the 065_admin_mfa_enforcement.sql backfill.
+ */
+export const ADMIN_MFA_GRACE_DAYS = (() => {
+  const raw = process.env.STYRBY_ADMIN_MFA_GRACE_DAYS;
+  if (!raw) return 7;
+  const parsed = Number(raw);
+  // WHY NaN / negative guard: a misconfigured value must not accidentally grant
+  // infinite or negative grace. Default to 7 on bad input. NIST SP 800-53 AC-3.
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 7;
+})();
+
+// ============================================================================
+// Error class
+// ============================================================================
+
+/**
+ * Thrown by assertAdminMfa() when an admin is blocked from performing a
+ * privileged action because they have not enrolled MFA after their grace window.
+ *
+ * Callers should catch this error and return a 403 JSON response:
+ *   { error: 'ADMIN_MFA_REQUIRED' }
+ *
+ * WHY a typed error class (not a plain Error): callers can distinguish MFA
+ * failures from unexpected errors using `instanceof AdminMfaRequiredError`,
+ * which allows precise 403 responses without catching everything.
+ */
+export class AdminMfaRequiredError extends Error {
+  /** HTTP status code to return to the client. */
+  readonly statusCode = 403 as const;
+  /**
+   * Machine-readable error code. Clients should display a setup-MFA prompt
+   * when they receive this code.
+   */
+  readonly code = 'ADMIN_MFA_REQUIRED' as const;
+
+  constructor() {
+    super(
+      'Admin MFA is required. Enroll a passkey or TOTP factor at ' +
+        '/dashboard/settings/account/passkeys before performing admin actions.'
+    );
+    this.name = 'AdminMfaRequiredError';
+  }
+}
+
+// ============================================================================
+// Internal types
+// ============================================================================
+
+/**
+ * Aggregated MFA status for a single admin user.
+ * Computed in parallel by queryAdminMfaStatus().
+ */
+interface AdminMfaStatus {
+  /** True if the admin's grace period has not yet expired (mfa_grace_until > now). */
+  inGrace: boolean;
+  /** The raw mfa_grace_until timestamp, or null if no grace row. */
+  graceUntil: string | null;
+  /** True if the admin has at least one non-revoked passkey. */
+  hasPasskey: boolean;
+  /** True if the admin has a verified Supabase Auth TOTP factor. */
+  hasTotp: boolean;
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+/**
+ * Queries the admin's MFA status in parallel:
+ *   1. site_admins.mfa_grace_until — is the grace period still active?
+ *   2. passkeys count — has the admin enrolled a passkey?
+ *   3. auth.admin.getUserById TOTP check — has the admin verified a TOTP factor?
+ *
+ * WHY parallel queries: all three are independent. Serial would triple the p99
+ * latency for every admin action — unacceptable for a hot path.
+ *
+ * WHY service-role client (createAdminClient):
+ *   - site_admins is not accessible by the authenticated role via RLS.
+ *   - passkeys may be scoped to service-role only (depends on RLS config).
+ *   - auth.admin.getUserById requires service-role privilege.
+ *   Using service-role here is safe because:
+ *     a) assertAdminMfa is only called AFTER isAdmin() confirms admin status.
+ *     b) We only read, never write, from this helper.
+ *
+ * @param userId - The admin user's UUID.
+ * @returns Aggregated AdminMfaStatus.
+ * @throws If any critical query (grace + passkeys) fails. TOTP failure is
+ *   swallowed when a passkey is present (fail-open for TOTP API errors when
+ *   passkey MFA is already satisfied). NIST SP 800-53 AC-3.
+ */
+async function queryAdminMfaStatus(userId: string): Promise<AdminMfaStatus> {
+  const adminClient = createAdminClient();
+
+  // Run grace window + passkeys queries in parallel.
+  // TOTP requires auth.admin.getUserById which is independent.
+  const [graceResult, passkeysResult, authUserResult] = await Promise.all([
+    // (1) Grace window: is mfa_grace_until in the future?
+    adminClient
+      .from('site_admins')
+      .select('mfa_grace_until')
+      .eq('user_id', userId)
+      .maybeSingle(),
+
+    // (2) Passkeys: count non-revoked passkeys for this user.
+    // WHY maybeSingle() not count: count('exact') requires a head:true option
+    // which returns no data. We select id and count client-side instead,
+    // keeping the query simple and compatible with the RLS policy shape.
+    adminClient
+      .from('passkeys')
+      .select('id')
+      .eq('user_id', userId)
+      .is('revoked_at', null),
+
+    // (3) TOTP: fetch Auth user to inspect mfa_factors.
+    // WHY Auth Admin API not a DB table: auth.mfa_factors is in the auth schema
+    // and is not exposed via PostgREST by default. The Auth Admin API is the
+    // correct, supported path. SOC 2 CC6.1.
+    adminClient.auth.admin.getUserById(userId),
+  ]);
+
+  // ── Grace window ────────────────────────────────────────────────────────────
+  if (graceResult.error) {
+    // Propagate — callers catch and fail-closed. NIST SP 800-53 AC-3.
+    throw graceResult.error;
+  }
+  const graceUntilStr = graceResult.data?.mfa_grace_until ?? null;
+  const inGrace = graceUntilStr != null && new Date(graceUntilStr) > new Date();
+
+  // ── Passkeys ────────────────────────────────────────────────────────────────
+  if (passkeysResult.error) {
+    // Propagate — callers catch and fail-closed.
+    throw passkeysResult.error;
+  }
+  const hasPasskey = (passkeysResult.data ?? []).length > 0;
+
+  // ── TOTP ────────────────────────────────────────────────────────────────────
+  // WHY swallow Auth API errors when passkey is present:
+  //   A transient Auth API error must not block an admin who has a valid passkey.
+  //   The passkey factor alone satisfies NIST SP 800-63B AAL2. If the Auth API
+  //   is down AND no passkey is present, we fail-closed (see assertAdminMfa).
+  let hasTotp = false;
+  if (!authUserResult.error && authUserResult.data?.user?.factors) {
+    hasTotp = authUserResult.data.user.factors.some(
+      (f) => f.factor_type === 'totp' && f.status === 'verified'
+    );
+  } else if (authUserResult.error && !hasPasskey) {
+    // Auth API failed and no passkey — propagate so assertAdminMfa fails-closed.
+    throw authUserResult.error;
+  }
+  // If Auth API failed but passkey IS present: hasTotp stays false, but
+  // hasPasskey=true will allow the action. This is the correct fallback.
+
+  return { inGrace, graceUntil: graceUntilStr, hasPasskey, hasTotp };
+}
+
+/**
+ * Writes a grace-period audit event to audit_log.
+ *
+ * WHY audit_log (not admin_audit_log):
+ *   admin_audit_log tracks mutations the admin performs on OTHER users.
+ *   This event is about the admin's own authentication state — it belongs
+ *   in the general audit_log. SOC 2 CC6.1: document privileged access with
+ *   defined remediation deadlines.
+ *
+ * WHY non-throwing: a failure to write a grace audit event must not block
+ * the admin action. The event is informational — the admin is still allowed
+ * to act (they're in grace). Failure is captured in Sentry for ops visibility.
+ *
+ * @param userId - The admin user's UUID.
+ * @param graceUntil - The ISO timestamp when the grace period expires.
+ */
+async function writeGraceAuditEvent(userId: string, graceUntil: string | null): Promise<void> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient.from('audit_log').insert({
+    user_id: userId,
+    event_type: 'admin_mfa_grace_action',
+    metadata: {
+      grace_until: graceUntil,
+      note:
+        'Admin performed an action during MFA grace period. ' +
+        'OWASP A07:2021 / SOC 2 CC6.1: enroll MFA before grace expires.',
+    },
+  });
+
+  if (error) {
+    // Non-fatal: log to Sentry but do not block the admin action.
+    Sentry.captureException(error, {
+      tags: { component: 'writeGraceAuditEvent', user_id: userId },
+      extra: { grace_until: graceUntil },
+    });
+  }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Asserts that the given admin user has an active MFA factor (passkey or TOTP),
+ * or is still within their migration grace period.
+ *
+ * Call this AFTER confirming the user is an admin (isAdmin() check). It is NOT
+ * a substitute for the admin check — it adds a second authentication-factor
+ * requirement on top of the existing admin authorization check.
+ *
+ * Behavior:
+ *   - In grace period → allow action, write grace audit event (non-blocking).
+ *   - Has passkey OR verified TOTP → allow action.
+ *   - No MFA after grace → throw AdminMfaRequiredError (403 ADMIN_MFA_REQUIRED).
+ *   - DB error → throw AdminMfaRequiredError (fail-closed, NIST SP 800-53 AC-3).
+ *
+ * @param userId - The admin user's UUID (from Supabase Auth getUser).
+ * @throws {AdminMfaRequiredError} When the admin must enroll MFA before acting.
+ *
+ * @example
+ * const adminStatus = await isAdmin(user.id);
+ * if (!adminStatus) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+ *
+ * try {
+ *   await assertAdminMfa(user.id);
+ * } catch (err) {
+ *   if (err instanceof AdminMfaRequiredError) {
+ *     return NextResponse.json({ error: err.code }, { status: err.statusCode });
+ *   }
+ *   throw err;
+ * }
+ */
+export async function assertAdminMfa(userId: string): Promise<void> {
+  // WHY guard empty userId: a missing userId should never reach here (auth check
+  // should have caught it), but fail-closed defensively. NIST SP 800-53 AC-3.
+  if (!userId) {
+    throw new AdminMfaRequiredError();
+  }
+
+  let status: AdminMfaStatus;
+  try {
+    status = await queryAdminMfaStatus(userId);
+  } catch (err) {
+    // Any DB error → fail-closed. Never grant access on uncertainty.
+    // SOC 2 CC6.1, NIST SP 800-53 AC-3: deny by default on error.
+    Sentry.captureException(err, {
+      tags: { component: 'assertAdminMfa', user_id: userId },
+      extra: {
+        note: 'MFA status query failed. Failing closed (ADMIN_MFA_REQUIRED). NIST SP 800-53 AC-3.',
+      },
+    });
+    throw new AdminMfaRequiredError();
+  }
+
+  // ── Grace period path ────────────────────────────────────────────────────────
+  if (status.inGrace) {
+    // Admin is within migration grace window — allow action but write audit event.
+    // WHY allow in grace: see migration 065 header for the bootstrap rationale.
+    // WHY write audit: SOC 2 CC6.1 requires documenting that a privileged action
+    // was performed before the admin completed MFA enrollment.
+    await writeGraceAuditEvent(userId, status.graceUntil);
+    return;
+  }
+
+  // ── MFA satisfied path ───────────────────────────────────────────────────────
+  if (status.hasPasskey || status.hasTotp) {
+    // Admin has at least one active MFA factor — allow action.
+    // WHY either factor is sufficient: both passkeys (FIDO2/WebAuthn) and
+    // verified TOTP satisfy NIST SP 800-63B AAL2 for privileged accounts.
+    return;
+  }
+
+  // ── Blocked path ─────────────────────────────────────────────────────────────
+  // Grace expired, no MFA enrolled → block action.
+  // WHY Sentry warning (not exception): this is expected behavior after grace
+  // expires — it's a policy enforcement event, not an error. Ops should still
+  // be aware so they can follow up with the admin. SOC 2 CC6.1.
+  Sentry.captureMessage(
+    'Admin MFA gate blocked action: no MFA enrolled after grace period expired.',
+    {
+      level: 'warning',
+      tags: {
+        component: 'assertAdminMfa',
+        reason: 'no_mfa_after_grace',
+        user_id: userId,
+      },
+    }
+  );
+  throw new AdminMfaRequiredError();
+}

--- a/supabase/migrations/065_admin_mfa_enforcement.sql
+++ b/supabase/migrations/065_admin_mfa_enforcement.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Migration 065: Admin MFA Enforcement (H42 Layer 1)
+-- ============================================================================
+-- Date:    2026-04-28
+-- Author:  Claude Code (claude-sonnet-4-6)
+-- Branch:  feat/mfa-admin-enforcement-h42
+--
+-- Security references:
+--   OWASP A07:2021  - Identification and Authentication Failures
+--   SOC 2 CC6.1     - Logical access controls; privileged access requires
+--                     phishing-resistant authentication factors
+--   NIST SP 800-63B AAL2 - Multi-factor authentication for privileged accounts
+--
+-- Summary:
+--   Adds `mfa_grace_until` column to `site_admins` with a configurable grace
+--   window so existing admins are not immediately locked out. After the grace
+--   period expires, `assertAdminMfa()` (application layer) enforces that the
+--   admin has at least one active passkey OR a Supabase Auth TOTP factor.
+--
+--   The grace period is purely a migration affordance - it is NOT a persistent
+--   feature. The STYRBY_ADMIN_MFA_GRACE_DAYS environment variable controls the
+--   window (default 7 days). Once all admins have enrolled MFA the column
+--   becomes permanently in the past and the grace branch is never taken.
+--
+-- WHY NOT enforce in Postgres:
+--   MFA factor queries require the `auth.mfa_factors` / Supabase Admin API.
+--   Calling the Admin API from inside a Postgres SECURITY DEFINER function is
+--   not supported without pg_net and introduces a network dependency on every
+--   admin RPC call. Enforcement in the application layer (assertAdminMfa) is
+--   faster, testable, and does not block the Postgres execution path.
+--
+-- Rollback:
+--   ALTER TABLE public.site_admins DROP COLUMN IF EXISTS mfa_grace_until;
+-- ============================================================================
+
+-- Add mfa_grace_until column
+ALTER TABLE public.site_admins
+  ADD COLUMN IF NOT EXISTS mfa_grace_until TIMESTAMPTZ;
+
+-- WHY backfill existing rows with 7-day grace: Any admin already in the table
+-- before this migration has no MFA enrolled (there was no requirement). A hard
+-- cutover (NULL = blocked immediately) would lock them out of the admin console.
+-- The 7-day window matches the default STYRBY_ADMIN_MFA_GRACE_DAYS value, giving
+-- them time to enroll before the gate activates. SOC 2 CC6.1: documented
+-- exception with a defined remediation deadline.
+UPDATE public.site_admins
+  SET mfa_grace_until = now() + INTERVAL '7 days'
+  WHERE mfa_grace_until IS NULL;
+
+-- Column documentation
+COMMENT ON COLUMN public.site_admins.mfa_grace_until IS
+  'Migration-only grace window for MFA enrollment. NULL = no grace (new admins '
+  'added after the MFA policy is enforced). Non-null = admin was present before '
+  'H42 and has until this timestamp to enroll a passkey or TOTP factor. After '
+  'this timestamp, assertAdminMfa() rejects admin actions with ADMIN_MFA_REQUIRED '
+  'unless a factor is enrolled. OWASP A07:2021 / SOC 2 CC6.1.';


### PR DESCRIPTION
## Summary

- **Migration 065** (`supabase/migrations/065_admin_mfa_enforcement.sql`): adds `mfa_grace_until TIMESTAMPTZ` to `site_admins` table, backfills existing admins with `now() + 7 days` grace window. Already applied to prod Supabase and verified via `information_schema`.
- **`assertAdminMfa(userId)`** (`packages/styrby-web/src/lib/admin/mfa-gate.ts`): application-layer MFA gate checking grace window, then passkey presence (`passkeys` table), then verified TOTP (`auth.admin.getUserById` factors array). Throws `AdminMfaRequiredError` (statusCode=403, code=`ADMIN_MFA_REQUIRED`) when blocked. Fail-closed on any DB error (NIST SP 800-53 AC-3 deny-by-default). Grace-period actions write an audit event to `audit_log`.
- **12 callsites wired**: `overrideTierAction`, `resetPasswordAction`, `toggleConsentAction`, `issueRefundAction`, `issueCreditAction`, `sendChurnSaveOfferAction`, `requestSupportAccessAction`, and 5 API routes (support list, support detail, support reply, audit verify, founder metrics x4 via per-route import).
- **`AdminMfaBanner`** (`packages/styrby-web/src/components/admin/AdminMfaBanner.tsx`): urgency-tiered banner (red<=1d, amber<=3d, yellow>3d) rendered above admin page content. Layout reads `mfa_grace_until` and passes it down. Banner is suppressed when grace=null or expired.
- **17 unit tests** in `mfa-gate.test.ts` covering: grace allows, grace writes audit event, expired grace+no MFA blocks (403), passkey allows, verified TOTP allows, unverified TOTP blocks, grace boundary (1ms past), DB error fail-closed, Auth API error+passkey fallback allows, Auth API error+no passkey fail-closed, audit write failure non-blocking, empty userId fast-fail, Sentry warning on block, Sentry exception on DB error.
- **Existing test shims**: `vi.mock('@/lib/admin/mfa-gate')` added to `audit-chain.integration.test.ts` and `actions.integration.test.ts` to prevent bootstrap paradox; `createClient` mocks updated to include `auth.getUser` stub. All 61 admin tests pass.

## Security references

- OWASP A07:2021 - Identification and Authentication Failures
- SOC 2 CC6.1 - Logical access controls; privileged access requires phishing-resistant factors
- NIST SP 800-63B AAL2 - MFA for privileged accounts
- NIST SP 800-53 AC-3 - Deny-by-default on access control error

## Why application-layer (not Postgres-layer)

MFA factor queries require the Supabase Auth Admin API (`auth.admin.getUserById`). Calling HTTP from inside a SECURITY DEFINER function requires `pg_net` and blocks every admin RPC call. Application-layer enforcement is faster, testable, and does not add a network dependency to the Postgres execution path.

## Grace period rationale

Existing admins had no MFA requirement before this migration. Hard cutover (NULL = blocked immediately) would lock them out of the admin console. The 7-day window gives them time to enroll before the gate activates. SOC 2 CC6.1: documented exception with a defined remediation deadline. The grace window is configurable via `STYRBY_ADMIN_MFA_GRACE_DAYS` env var (default 7).

## Test plan

- [x] 17/17 `mfa-gate.test.ts` unit tests pass
- [x] 61/61 admin integration tests pass (including audit-chain, actions)
- [x] Migration applied to prod and column verified via `information_schema`
- [x] TypeScript types: `AdminMfaRequiredError.statusCode = 403 as const`, `code = 'ADMIN_MFA_REQUIRED' as const`
- [x] No auto-merge (as specified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)