### PR TITLE
chore(security): batch H42 — quick wins + idempotency + mass-assign + MFA + API hardening

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -61,10 +61,14 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        # WHY pinned to SHA: tag-mutation supply-chain hardening per
+        # ~/.claude/standards/CI_VERCEL_COST_OPTIMIZATION.md / SECURITY hardening
+        # plan. v4 = 34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1
+        # WHY pinned to SHA: same supply-chain hardening rule. v1.6.0
+        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
         with:
           version: latest
 

--- a/packages/styrby-cli/package.json
+++ b/packages/styrby-cli/package.json
@@ -25,7 +25,11 @@
     }
   },
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/**/*.json",
+    "!dist/**/*.map",
+    "!dist/**/*.test.*",
     "LICENSE",
     "README.md",
     "SECURITY.md"

--- a/packages/styrby-web/next.config.ts
+++ b/packages/styrby-web/next.config.ts
@@ -86,6 +86,18 @@ const cspHeader = [
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self'",
+  // SEC-014: CSP violation reporting.
+  // WHY: Real-time visibility into CSP violations lets us detect injection
+  // attempts (XSS, unauthorized third-party script loads, eval-equivalents)
+  // BEFORE they succeed. The browser POSTs the violation to our endpoint;
+  // we log to audit_log for correlation with other anomaly signals.
+  // Per OWASP A03:2021. Endpoint: /api/security/csp-report.
+  //
+  // Both report-uri (Level 2) and report-to (Level 3) are emitted because
+  // browsers vary in which they honor. report-to references the named group
+  // defined via the Reporting-Endpoints header below.
+  'report-uri /api/security/csp-report',
+  'report-to csp-endpoint',
 ].join('; ');
 
 /**
@@ -216,6 +228,16 @@ const nextConfig: NextConfig = {
           {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            // SEC-014 (CSP report-to support): defines the named "csp-endpoint"
+            // group referenced by the CSP `report-to` directive above. The Level 3
+            // Reporting API supersedes the older `Report-To` header (note hyphen
+            // case) but Vercel's edge passes both as-is. Browsers that only
+            // support Level 2 (older Safari) fall back to `report-uri` instead;
+            // both directives are emitted in the CSP for max coverage.
+            key: 'Reporting-Endpoints',
+            value: 'csp-endpoint="/api/security/csp-report"',
           },
         ],
       },

--- a/packages/styrby-web/src/__tests__/admin/actions.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/actions.integration.test.ts
@@ -65,6 +65,23 @@ vi.mock('@sentry/nextjs', () => ({
   captureMessage: (...args: unknown[]) => mockSentryCaptureMessage(...args),
 }));
 
+// WHY mock mfa-gate: the actions.integration tests mock createClient to return
+// only the rpc mock (for the user-scoped client). assertAdminMfa calls
+// createAdminClient to query site_admins + passkeys. Without this mock, the
+// MFA gate would fail-closed on every action test. MFA behavior is covered
+// in __tests__/admin/mfa-gate.test.ts. OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 // ── Supabase mock ─────────────────────────────────────────────────────────────
 const mockRpc = vi.fn();
 const mockGenerateLink = vi.fn();
@@ -124,7 +141,21 @@ describe('overrideTierAction — integration (form → Zod → RPC)', () => {
     vi.clearAllMocks();
     // WHY restore createClient: clearAllMocks wipes mockResolvedValue.
     // Fix P0: createClient (user-scoped) is the RPC client for admin_* RPCs.
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      // WHY auth.getUser stub: the MFA gate block in each action calls
+      // supabase.auth.getUser() to resolve the acting admin's ID before calling
+      // assertAdminMfa(). assertAdminMfa is mocked to return undefined (see
+      // vi.mock('@/lib/admin/mfa-gate') above), so the gate itself is bypassed.
+      // But the auth.getUser() call still happens — without this stub the mock
+      // returns undefined for .auth, causing a TypeError. OWASP A07:2021.
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'admin-uuid-001' } },
+          error: null,
+        }),
+      },
+    });
     mockHeadersGet.mockImplementation((name: string) => {
       if (name === 'x-forwarded-for') return MOCK_XFF;
       if (name === 'user-agent') return MOCK_UA;
@@ -259,7 +290,21 @@ describe('resetPasswordAction — integration (form → Zod → RPC → generate
     vi.clearAllMocks();
     // WHY restore createClient: clearAllMocks wipes mockResolvedValue.
     // Fix P0: admin_record_password_reset RPC uses user-scoped client.
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      // WHY auth.getUser stub: the MFA gate block in each action calls
+      // supabase.auth.getUser() to resolve the acting admin's ID before calling
+      // assertAdminMfa(). assertAdminMfa is mocked to return undefined (see
+      // vi.mock('@/lib/admin/mfa-gate') above), so the gate itself is bypassed.
+      // But the auth.getUser() call still happens — without this stub the mock
+      // returns undefined for .auth, causing a TypeError. OWASP A07:2021.
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'admin-uuid-001' } },
+          error: null,
+        }),
+      },
+    });
     mockHeadersGet.mockImplementation((name: string) => {
       if (name === 'x-forwarded-for') return MOCK_XFF;
       if (name === 'user-agent') return MOCK_UA;
@@ -390,7 +435,21 @@ describe('toggleConsentAction — integration (form → Zod → RPC)', () => {
     vi.clearAllMocks();
     // WHY restore createClient: clearAllMocks wipes mockResolvedValue.
     // Fix P0: admin_toggle_consent RPC uses user-scoped client.
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      // WHY auth.getUser stub: the MFA gate block in each action calls
+      // supabase.auth.getUser() to resolve the acting admin's ID before calling
+      // assertAdminMfa(). assertAdminMfa is mocked to return undefined (see
+      // vi.mock('@/lib/admin/mfa-gate') above), so the gate itself is bypassed.
+      // But the auth.getUser() call still happens — without this stub the mock
+      // returns undefined for .auth, causing a TypeError. OWASP A07:2021.
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'admin-uuid-001' } },
+          error: null,
+        }),
+      },
+    });
     mockHeadersGet.mockImplementation((name: string) => {
       if (name === 'x-forwarded-for') return MOCK_XFF;
       if (name === 'user-agent') return MOCK_UA;

--- a/packages/styrby-web/src/__tests__/admin/audit-chain.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/audit-chain.integration.test.ts
@@ -40,6 +40,24 @@ vi.mock('@sentry/nextjs', () => ({
   captureException: vi.fn(),
 }));
 
+// WHY mock mfa-gate: the audit-chain tests mock createAdminClient to return
+// only the RPC response shape. assertAdminMfa calls createAdminClient to query
+// site_admins + passkeys + Auth API. Without this mock, assertAdminMfa would
+// fail-closed (throw AdminMfaRequiredError → 403), causing all tests to fail.
+// These tests verify the audit chain logic, not the MFA gate behavior.
+// MFA gate is covered in __tests__/admin/mfa-gate.test.ts. OWASP A07:2021.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import * as Sentry from '@sentry/nextjs';

--- a/packages/styrby-web/src/__tests__/admin/mfa-gate.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/mfa-gate.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Admin MFA Gate — Unit Tests
+ *
+ * Tests for assertAdminMfa() in packages/styrby-web/src/lib/admin/mfa-gate.ts.
+ *
+ * Coverage matrix:
+ *   (1) Grace period allows action + writes audit event
+ *   (2) Grace period writes audit event (audit table called)
+ *   (3) Expired grace + no MFA → throws AdminMfaRequiredError (403)
+ *   (4) Passkey present → allows action (no grace required)
+ *   (5) Verified TOTP present → allows action
+ *   (6) Unverified TOTP (pending status) → blocked (not counted as MFA)
+ *   (7) DB error (grace query) → fail-closed (throws AdminMfaRequiredError)
+ *   (8) DB error (passkeys query) → fail-closed
+ *   (9) Auth API error + passkey present → passkey fallback allows action
+ *  (10) Auth API error + no passkey → fail-closed
+ *  (11) Audit write failure during grace → does NOT block action
+ *  (12) Empty userId → throws AdminMfaRequiredError immediately (no DB call)
+ *  (13) Grace exactly at boundary (expired by 1ms) → blocked
+ *  (14) Blocked (no MFA after grace) → Sentry warning captured
+ *  (15) DB error path → Sentry exception captured
+ *
+ * Security references:
+ *   OWASP A07:2021 — Identification and Authentication Failures
+ *   SOC 2 CC6.1    — Privileged access requires phishing-resistant MFA
+ *   NIST SP 800-53 AC-3 — Deny-by-default on error
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// ============================================================================
+// Mocks — set up before imports so vi.mock hoisting works
+// ============================================================================
+
+vi.mock('@/lib/supabase/server', () => ({
+  createAdminClient: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+import { createAdminClient } from '@/lib/supabase/server';
+import * as Sentry from '@sentry/nextjs';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** ISO timestamp in the future (grace active). */
+const FUTURE_GRACE = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+
+/** ISO timestamp in the past (grace expired). */
+const PAST_GRACE = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+
+/** Just-expired: 1 ms before now (boundary test). */
+const JUST_EXPIRED = new Date(Date.now() - 1).toISOString();
+
+type FromTable = 'site_admins' | 'passkeys' | 'audit_log';
+
+interface SetupOptions {
+  graceUntil?: string | null;
+  graceError?: Error | null;
+  passkeys?: { id: string }[];
+  passkeysError?: Error | null;
+  totpVerified?: boolean;
+  totpError?: Error | null;
+  auditInsertError?: Error | null;
+}
+
+/**
+ * Configures createAdminClient mock for a single assertAdminMfa() call.
+ *
+ * WHY per-table dispatch on `from()`:
+ *   assertAdminMfa() calls createAdminClient() once at the top of
+ *   queryAdminMfaStatus, then calls .from('site_admins'), .from('passkeys'),
+ *   and auth.admin.getUserById in parallel. We route `from()` calls by table
+ *   name and return independent mock chains.
+ *
+ * @param opts - Override defaults to simulate specific scenarios.
+ */
+function setupFromMock(opts: SetupOptions = {}) {
+  const {
+    graceUntil = FUTURE_GRACE,
+    graceError = null,
+    passkeys = [],
+    passkeysError = null,
+    totpVerified = false,
+    totpError = null,
+    auditInsertError = null,
+  } = opts;
+
+  // Build per-table from() mock chains.
+  const fromMocks: Record<FromTable, ReturnType<typeof vi.fn>> = {
+    site_admins: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue(
+            graceError
+              ? { data: null, error: graceError }
+              : { data: graceUntil != null ? { mfa_grace_until: graceUntil } : null, error: null }
+          ),
+        }),
+      }),
+    }),
+
+    passkeys: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          is: vi.fn().mockResolvedValue(
+            passkeysError
+              ? { data: null, error: passkeysError }
+              : { data: passkeys, error: null }
+          ),
+        }),
+      }),
+    }),
+
+    audit_log: vi.fn().mockReturnValue({
+      insert: vi.fn().mockResolvedValue(
+        auditInsertError
+          ? { data: null, error: auditInsertError }
+          : { data: null, error: null }
+      ),
+    }),
+  };
+
+  // Auth Admin API mock.
+  const mockGetUserById = vi.fn().mockResolvedValue(
+    totpError
+      ? { data: null, error: totpError }
+      : {
+          data: {
+            user: {
+              id: 'admin-uuid',
+              factors: totpVerified
+                ? [{ factor_type: 'totp', status: 'verified' }]
+                : [],
+            },
+          },
+          error: null,
+        }
+  );
+
+  (createAdminClient as Mock).mockReturnValue({
+    from: (table: string) => {
+      const mock = fromMocks[table as FromTable];
+      if (!mock) throw new Error(`Unexpected table: ${table}`);
+      return mock(table);
+    },
+    auth: {
+      admin: {
+        getUserById: mockGetUserById,
+      },
+    },
+  });
+
+  return { fromMocks, mockGetUserById };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('assertAdminMfa', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // (1) Grace period allows action
+  // --------------------------------------------------------------------------
+
+  it('(1) allows action when admin is within grace period', async () => {
+    setupFromMock({ graceUntil: FUTURE_GRACE, passkeys: [], totpVerified: false });
+
+    // Should not throw.
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // (2) Grace period writes audit event
+  // --------------------------------------------------------------------------
+
+  it('(2) writes grace audit event when action allowed in grace period', async () => {
+    const { fromMocks } = setupFromMock({
+      graceUntil: FUTURE_GRACE,
+      passkeys: [],
+      totpVerified: false,
+    });
+
+    await assertAdminMfa('admin-uuid');
+
+    // audit_log.insert should have been called once.
+    const auditInsertMock = fromMocks.audit_log('audit_log').insert;
+    expect(auditInsertMock).toHaveBeenCalledOnce();
+    expect(auditInsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'admin-uuid',
+        event_type: 'admin_mfa_grace_action',
+      })
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // (3) Expired grace + no MFA → blocked
+  // --------------------------------------------------------------------------
+
+  it('(3) throws AdminMfaRequiredError when grace expired and no MFA enrolled', async () => {
+    setupFromMock({ graceUntil: PAST_GRACE, passkeys: [], totpVerified: false });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  it('(3a) AdminMfaRequiredError has correct statusCode and code', async () => {
+    setupFromMock({ graceUntil: PAST_GRACE, passkeys: [], totpVerified: false });
+
+    let err: unknown;
+    try {
+      await assertAdminMfa('admin-uuid');
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeInstanceOf(AdminMfaRequiredError);
+    expect((err as AdminMfaRequiredError).statusCode).toBe(403);
+    expect((err as AdminMfaRequiredError).code).toBe('ADMIN_MFA_REQUIRED');
+  });
+
+  // --------------------------------------------------------------------------
+  // (4) Passkey present → allows (no grace needed)
+  // --------------------------------------------------------------------------
+
+  it('(4) allows action when passkey is enrolled (no grace required)', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE, // grace expired
+      passkeys: [{ id: 'passkey-uuid-001' }],
+      totpVerified: false,
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // (5) Verified TOTP → allows
+  // --------------------------------------------------------------------------
+
+  it('(5) allows action when verified TOTP factor is enrolled', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE,
+      passkeys: [],
+      totpVerified: true,
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // (6) Unverified TOTP → blocked
+  // --------------------------------------------------------------------------
+
+  it('(6) blocks action when TOTP factor exists but is not verified (status pending)', async () => {
+    // Manually configure Auth response with unverified TOTP.
+    (createAdminClient as Mock).mockReturnValue({
+      from: (table: string) => {
+        if (table === 'site_admins') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: { mfa_grace_until: PAST_GRACE },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'passkeys') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                is: vi.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      },
+      auth: {
+        admin: {
+          getUserById: vi.fn().mockResolvedValue({
+            data: {
+              user: {
+                id: 'admin-uuid',
+                // status: 'unverified' — should NOT count as MFA.
+                factors: [{ factor_type: 'totp', status: 'unverified' }],
+              },
+            },
+            error: null,
+          }),
+        },
+      },
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (7) DB error (grace query) → fail-closed
+  // --------------------------------------------------------------------------
+
+  it('(7) throws AdminMfaRequiredError when site_admins query fails (fail-closed)', async () => {
+    setupFromMock({ graceError: new Error('DB connection timeout') });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (8) DB error (passkeys query) → fail-closed
+  // --------------------------------------------------------------------------
+
+  it('(8) throws AdminMfaRequiredError when passkeys query fails (fail-closed)', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE,
+      passkeysError: new Error('passkeys table unavailable'),
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (9) Auth API error + passkey present → fallback allows
+  // --------------------------------------------------------------------------
+
+  it('(9) allows action when Auth API fails but passkey is present (passkey fallback)', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE,
+      passkeys: [{ id: 'passkey-uuid-001' }],
+      totpError: new Error('Auth API timeout'),
+    });
+
+    // Should NOT throw — passkey satisfies MFA requirement even when TOTP check fails.
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // (10) Auth API error + no passkey → fail-closed
+  // --------------------------------------------------------------------------
+
+  it('(10) throws AdminMfaRequiredError when Auth API fails and no passkey (fail-closed)', async () => {
+    setupFromMock({
+      graceUntil: PAST_GRACE,
+      passkeys: [],
+      totpError: new Error('Auth API timeout'),
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (11) Audit write failure → does NOT block action
+  // --------------------------------------------------------------------------
+
+  it('(11) allows action even when audit_log.insert fails during grace period', async () => {
+    setupFromMock({
+      graceUntil: FUTURE_GRACE,
+      passkeys: [],
+      auditInsertError: new Error('audit_log write failed'),
+    });
+
+    // Action should still be allowed — audit failure is non-blocking.
+    await expect(assertAdminMfa('admin-uuid')).resolves.toBeUndefined();
+  });
+
+  it('(11a) captures Sentry exception when audit_log.insert fails', async () => {
+    const insertErr = new Error('audit_log write failed');
+    setupFromMock({
+      graceUntil: FUTURE_GRACE,
+      passkeys: [],
+      auditInsertError: insertErr,
+    });
+
+    await assertAdminMfa('admin-uuid');
+
+    // Sentry should capture the audit write failure.
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      insertErr,
+      expect.objectContaining({
+        tags: expect.objectContaining({ component: 'writeGraceAuditEvent' }),
+      })
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // (12) Empty userId → immediate throw, no DB call
+  // --------------------------------------------------------------------------
+
+  it('(12) throws AdminMfaRequiredError immediately for empty userId', async () => {
+    await expect(assertAdminMfa('')).rejects.toThrow(AdminMfaRequiredError);
+    // createAdminClient should NOT be called — we fail before any DB query.
+    expect(createAdminClient).not.toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // (13) Grace boundary — expired by 1ms → blocked
+  // --------------------------------------------------------------------------
+
+  it('(13) blocks action when grace expired by 1ms (boundary test)', async () => {
+    setupFromMock({
+      graceUntil: JUST_EXPIRED,
+      passkeys: [],
+      totpVerified: false,
+    });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+  });
+
+  // --------------------------------------------------------------------------
+  // (14) Sentry warning captured when blocked (no MFA after grace)
+  // --------------------------------------------------------------------------
+
+  it('(14) captures Sentry warning when admin blocked due to no MFA after grace', async () => {
+    setupFromMock({ graceUntil: PAST_GRACE, passkeys: [], totpVerified: false });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('no MFA enrolled after grace period'),
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ reason: 'no_mfa_after_grace' }),
+      })
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // (15) DB error path → Sentry exception captured
+  // --------------------------------------------------------------------------
+
+  it('(15) captures Sentry exception when queryAdminMfaStatus throws', async () => {
+    const dbErr = new Error('DB connection timeout');
+    setupFromMock({ graceError: dbErr });
+
+    await expect(assertAdminMfa('admin-uuid')).rejects.toThrow(AdminMfaRequiredError);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.anything(), // The error may be wrapped
+      expect.objectContaining({
+        tags: expect.objectContaining({ component: 'assertAdminMfa' }),
+      })
+    );
+  });
+});

--- a/packages/styrby-web/src/__tests__/billing-ops/churn-save-acceptance.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/churn-save-acceptance.integration.test.ts
@@ -45,7 +45,7 @@
  * @module __tests__/billing-ops/churn-save-acceptance.integration.test
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock, type MockInstance } from 'vitest';
 
 // ============================================================================
 // Mocks
@@ -84,6 +84,24 @@ vi.mock('@/lib/supabase/server', () => ({
   createAdminClient: () => ({ auth: { admin: {} } }),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): every admin action (sendChurnSaveOfferAction)
+// calls assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the integration test env.
+// MFA gate behaviour is covered in src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 // Polar refund helper — not used in churn-save flow; mock to prevent import errors.
 vi.mock('@/lib/billing/polar-refund', () => ({
   createPolarRefund: vi.fn(),
@@ -96,6 +114,8 @@ vi.mock('@/lib/billing/polar-refund', () => ({
     }
   },
 }));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ============================================================================
 // Helpers
@@ -135,7 +155,17 @@ describe('Churn-save lifecycle — send + accept + guards', () => {
 
     const serverModule = await import('@/lib/supabase/server');
     createClient = serverModule.createClient as Mock;
-    createClient.mockResolvedValue({ rpc: mockRpc });
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // admin actions to resolve the acting admin for the MFA gate. The mock must
+    // return a valid admin user so assertAdminMfa (mocked above) receives the ID.
+    createClient.mockResolvedValue({
+      rpc: mockRpc,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
 
     const adminActionsModule = await import(
       '../../app/dashboard/admin/users/[userId]/billing/actions'
@@ -291,7 +321,16 @@ describe('Churn-save lifecycle — send + accept + guards', () => {
     ).rejects.toThrow(/NEXT_REDIRECT/);
 
     vi.clearAllMocks();
-    createClient.mockResolvedValue({ rpc: mockRpc });
+    // WHY include auth.getUser: must be present after clearAllMocks to support
+    // the H42 Layer 1 MFA gate (assertAdminMfa) wired into sendChurnSaveOfferAction.
+    createClient.mockResolvedValue({
+      rpc: mockRpc,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
 
     // Second admin send: RPC returns SQLSTATE 22023 (partial unique index guard).
     // WHY 22023 for duplicate send: admin_send_churn_save_offer raises
@@ -423,5 +462,24 @@ describe('Churn-save lifecycle — send + accept + guards', () => {
     // schema comment in actions.ts.
     const rpcArgs = mockRpc.mock.calls[0]![1] as Record<string, unknown>;
     expect(rpcArgs.p_polar_discount_code).toBeNull();
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves sendChurnSaveOfferAction calls assertAdminMfa before running the
+  // RPC. If the gate throws AdminMfaRequiredError, the action must short-circuit
+  // and return { ok: false, error: 'ADMIN_MFA_REQUIRED' } without calling the RPC.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) sendChurnSaveOfferAction returns ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const result = await sendChurnSaveOfferAction(TARGET_UUID, makeOfferFormData()) as {
+      ok: boolean;
+      error: string;
+    };
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ADMIN_UUID);
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/__tests__/billing-ops/churn-save-acceptance.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/churn-save-acceptance.integration.test.ts
@@ -45,7 +45,7 @@
  * @module __tests__/billing-ops/churn-save-acceptance.integration.test
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach, type Mock, type MockInstance } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 
 // ============================================================================
 // Mocks

--- a/packages/styrby-web/src/__tests__/billing-ops/credit-lifecycle.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/credit-lifecycle.integration.test.ts
@@ -91,6 +91,24 @@ vi.mock('@/lib/supabase/server', () => ({
   }),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): every admin action (issueCreditAction)
+// calls assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the integration test env.
+// MFA gate behaviour is covered in src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 // Polar refund helper — not used in credit flow; mock to prevent import errors.
 vi.mock('@/lib/billing/polar-refund', () => ({
   createPolarRefund: vi.fn(),
@@ -107,6 +125,8 @@ vi.mock('@/lib/billing/polar-refund', () => ({
 // ============================================================================
 // Helpers
 // ============================================================================
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 const ADMIN_UUID  = 'a1b2c3d4-e5f6-7890-abcd-000000000011';
 const TARGET_UUID = 'b2c3d4e5-f6a7-8901-bcde-000000000022';
@@ -148,9 +168,17 @@ describe('Credit lifecycle — issue + revoke + RLS', () => {
     const serverModule = await import('@/lib/supabase/server');
     createClient = serverModule.createClient as Mock;
     // Provide both rpc (for mutation tests) and from (for RLS tests).
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // admin actions to resolve the acting admin for the MFA gate. The mock must
+    // return a valid admin user so assertAdminMfa (mocked above) receives the ID.
     createClient.mockResolvedValue({
       rpc: mockRpc,
       from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
     });
 
     const actionsModule = await import(
@@ -386,5 +414,24 @@ describe('Credit lifecycle — issue + revoke + RLS', () => {
     expect(result.error).toContain('mismatch');
     expect(mockRpc).not.toHaveBeenCalled();
     expect(mockSentryCaptureMessage).toHaveBeenCalledOnce();
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves issueCreditAction calls assertAdminMfa before running the RPC.
+  // If the gate throws AdminMfaRequiredError, the action must short-circuit and
+  // return { ok: false, error: 'ADMIN_MFA_REQUIRED' } without calling the RPC.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) issueCreditAction returns ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const result = await issueCreditAction(
+      TARGET_UUID,
+      makeCreditFormData()
+    ) as { ok: boolean; error: string };
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ADMIN_UUID);
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/__tests__/billing-ops/refund-flow.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/refund-flow.integration.test.ts
@@ -74,6 +74,24 @@ vi.mock('@/lib/supabase/server', () => ({
   }),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): every admin action (issueRefundAction)
+// calls assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the integration test env.
+// MFA gate behaviour is covered in src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 // ── Polar refund helper mock ──────────────────────────────────────────────────
 // WHY mock @/lib/billing/polar-refund (not the Polar SDK directly):
 //   The integration boundary we're testing is actions.ts ↔ the refund helper +
@@ -108,6 +126,8 @@ vi.mock('@/lib/billing/polar-refund', () => ({
 // ============================================================================
 // Helpers
 // ============================================================================
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 const ADMIN_UUID  = 'a1b2c3d4-e5f6-7890-abcd-000000000001';
 const TARGET_UUID = 'b2c3d4e5-f6a7-8901-bcde-000000000002';
@@ -148,6 +168,9 @@ describe('issueRefundAction — end-to-end refund flow', () => {
     // SEC-REFUND-001: client now needs both .rpc (audit RPC) and .from (subscription
     // owner + polar_customer_id lookup before the refund). Default the lookup to a
     // valid row owned by TARGET_UUID so happy-path tests don't re-stub the chain.
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // admin actions to resolve the acting admin for the MFA gate. The mock must
+    // return a valid admin user so assertAdminMfa (mocked above) receives the ID.
     createClient.mockResolvedValue({
       rpc: mockRpc,
       from: vi.fn().mockReturnValue({
@@ -160,6 +183,11 @@ describe('issueRefundAction — end-to-end refund flow', () => {
           }),
         }),
       }),
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
     });
     // SEC-REFUND-001: order resolver — default returns ample refundable balance
     // so amount checks don't trip on the default. Tests that want the resolver
@@ -306,7 +334,8 @@ describe('issueRefundAction — end-to-end refund flow', () => {
     const key1 = (mockCreatePolarRefund.mock.calls[0]![0] as Record<string, unknown>).idempotencyKey as string;
 
     vi.clearAllMocks();
-    // Re-stub the full client shape (rpc + from) since clearAllMocks wiped it.
+    // Re-stub the full client shape (rpc + from + auth) since clearAllMocks wiped it.
+    // WHY include auth.getUser: H42 Layer 1 requires auth.getUser() for the MFA gate.
     createClient.mockResolvedValue({
       rpc: mockRpc,
       from: vi.fn().mockReturnValue({
@@ -319,6 +348,11 @@ describe('issueRefundAction — end-to-end refund flow', () => {
           }),
         }),
       }),
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
     });
     mockFindRefundableOrder.mockResolvedValue({
       orderId: 'ord_integration_default',
@@ -445,5 +479,26 @@ describe('issueRefundAction — end-to-end refund flow', () => {
     expect(result.error).toBe('Internal error');
     expect(mockRpc).not.toHaveBeenCalled();
     expect(mockSentryCapture).toHaveBeenCalledOnce();
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves issueRefundAction calls assertAdminMfa before running the Polar
+  // refund or the RPC. If the gate throws AdminMfaRequiredError, the action must
+  // short-circuit and return { ok: false, error: 'ADMIN_MFA_REQUIRED' } without
+  // calling Polar or the audit RPC.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) issueRefundAction returns ADMIN_MFA_REQUIRED and skips Polar + RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const result = await issueRefundAction(
+      TARGET_UUID,
+      makeRefundFormData()
+    ) as { ok: boolean; error: string };
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ADMIN_UUID);
+    expect(mockCreatePolarRefund).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
@@ -118,7 +118,26 @@ vi.mock('@/lib/supabase/server', () => ({
   createAdminClient: vi.fn(),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): requestSupportAccessAction calls
+// assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the integration test env.
+// MFA gate behaviour is covered in src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient } from '@/lib/supabase/server';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ─── Shared support_tickets mock chain ────────────────────────────────────────
 
@@ -161,6 +180,9 @@ function makeRequestFormData(overrides: Partial<{
   return fd;
 }
 
+// Acting admin ID for MFA gate wiring tests across all describe blocks.
+const ACTING_ADMIN_ID = 'aabbccdd-eeff-0011-2233-445566778899';
+
 // ============================================================================
 // Step 1 — Admin requestSupportAccessAction
 // ============================================================================
@@ -192,8 +214,18 @@ describe('Step 1: Admin requestSupportAccessAction', () => {
     vi.clearAllMocks();
     // WHY include from: the action SELECTs support_tickets to resolve p_user_id
     // server-side before the RPC call (see actions.ts header).
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // the action to resolve the acting admin for the MFA gate.
     mockFrom.mockImplementation(() => makeTicketFromChain());
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, from: mockFrom });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
     // Default: both RPCs succeed.
     configureRpcSequence();
   });
@@ -356,6 +388,27 @@ describe('Step 1: Admin requestSupportAccessAction', () => {
     // Sentry captures the stash failure for ops.
     expect(mockSentryCapture).toHaveBeenCalled();
   });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves requestSupportAccessAction calls assertAdminMfa before running the
+  // admin_request_support_access RPC. If the gate throws AdminMfaRequiredError,
+  // the action must short-circuit and return { ok: false, error: 'ADMIN_MFA_REQUIRED' }
+  // without calling any RPC. OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) requestSupportAccessAction returns ADMIN_MFA_REQUIRED and skips RPCs when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { requestSupportAccessAction } = await import(
+      '../../app/dashboard/admin/support/[id]/actions'
+    );
+
+    const result = await requestSupportAccessAction(TICKET_ID, makeRequestFormData());
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    // Neither RPC must have been called when the gate fires.
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
 });
 
 // ============================================================================
@@ -513,8 +566,17 @@ describe('Audit side effects — RPC is the sole audit channel', () => {
     // WHY include from: mockFrom — Fix 1 adds a server-side SELECT on
     // support_tickets. Without this, requestSupportAccessAction returns
     // { ok: false, error: 'Ticket not found' } before calling the RPC.
+    // WHY include auth.getUser: H42 Layer 1 requires auth.getUser() for MFA gate.
     mockFrom.mockImplementation(() => makeTicketFromChain());
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, from: mockFrom });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
     mockRpc.mockResolvedValue({ data: null, error: null });
   });
 
@@ -538,9 +600,16 @@ describe('Audit side effects — RPC is the sole audit channel', () => {
       update: mockUpdate,
     }));
 
+    // WHY include auth.getUser: H42 Layer 1 requires auth.getUser() so the action
+    // can resolve the acting admin for the MFA gate (assertAdminMfa).
     (createClient as Mock).mockResolvedValue({
       rpc:  mockRpc,
       from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+        }),
+      },
     });
     // WHY two RPC calls now (post SEC-ADV-001):
     //   1. admin_request_support_access — writes grant row + audit entry

--- a/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
@@ -181,7 +181,7 @@ function makeRequestFormData(overrides: Partial<{
 }
 
 // Acting admin ID for MFA gate wiring tests across all describe blocks.
-const ACTING_ADMIN_ID = 'aabbccdd-eeff-0011-2233-445566778899';
+const ACTING_ADMIN_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
 // ============================================================================
 // Step 1 — Admin requestSupportAccessAction

--- a/packages/styrby-web/src/app/api/account/delete/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/account/delete/__tests__/route.test.ts
@@ -452,4 +452,45 @@ describe('DELETE /api/account/delete', () => {
     expect(response.status).toBe(500);
     expect(data.error).toBe('Failed to delete account');
   });
+
+  // ── OWASP A04:2021 Mass-Assignment Guard ────────────────────────────────────
+
+  /**
+   * WHY: Confirms that the .strict() schema rejects any unknown key before any
+   * DB write occurs. An attacker cannot inject fields like `is_admin` or `tier`
+   * alongside a valid confirmation to attempt privilege escalation via
+   * mass-assignment. The route must return 400 without touching the database.
+   *
+   * Note: the .update() calls in the delete route use only server-computed
+   * values (e.g. `{ deleted_at: now }`) — NOT the parsed body. This test
+   * validates that the body schema itself blocks at the validation layer.
+   */
+  it('OWASP A04 — returns 400 and never reaches DB when request includes unknown key is_admin: true', async () => {
+    // No DB queue entries pushed — any DB call would consume from an empty queue
+    // and return { data: null, error: null }, which would let the test pass
+    // incorrectly. We assert queue stays at 0 to prove no DB access occurred.
+
+    const request = createRequest({
+      confirmation: 'DELETE MY ACCOUNT',
+      is_admin: true,
+    });
+
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(400);
+    // Queue untouched proves .from() was never called
+    expect(fromCallQueue.length).toBe(0);
+  });
+
+  it('OWASP A04 — returns 400 and never reaches DB when request includes unknown key tier: enterprise', async () => {
+    const request = createRequest({
+      confirmation: 'DELETE MY ACCOUNT',
+      tier: 'enterprise',
+    });
+
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(400);
+    expect(fromCallQueue.length).toBe(0);
+  });
 });

--- a/packages/styrby-web/src/app/api/account/delete/route.ts
+++ b/packages/styrby-web/src/app/api/account/delete/route.ts
@@ -36,11 +36,19 @@ import { checkIdempotency, storeIdempotencyResult } from '@/lib/middleware/idemp
  * Zod schema for delete request validation.
  * WHY: The confirmation literal ensures users consciously acknowledge deletion.
  * This prevents accidental deletions from automated tools or misclicks.
+ *
+ * MASS-ASSIGN-SAFE: OWASP A04:2021 — only `confirmation` and `reason` are
+ * accepted. `.strict()` causes Zod to reject any unrecognized key (e.g.
+ * `is_admin`, `tier`) at parse time and return 400 before any DB write occurs.
+ * The `.update()` calls below use only server-computed values (e.g. `deleted_at`),
+ * never the raw user-supplied object.
  */
-const DeleteRequestSchema = z.object({
-  confirmation: z.literal('DELETE MY ACCOUNT'),
-  reason: z.string().optional(),
-});
+const DeleteRequestSchema = z
+  .object({
+    confirmation: z.literal('DELETE MY ACCOUNT'),
+    reason: z.string().optional(),
+  })
+  .strict(); // OWASP A04:2021 — reject unknown keys (mass-assignment guard)
 
 /**
  * Handles account deletion requests.

--- a/packages/styrby-web/src/app/api/account/delete/route.ts
+++ b/packages/styrby-web/src/app/api/account/delete/route.ts
@@ -30,6 +30,7 @@ import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
+import { checkIdempotency, storeIdempotencyResult } from '@/lib/middleware/idempotency';
 
 /**
  * Zod schema for delete request validation.
@@ -109,6 +110,23 @@ export async function DELETE(request: Request) {
 
   if (authError || !user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // ── Idempotency check ────────────────────────────────────────────────────
+
+  // WHY: Account deletion is irreversible within the 30-day grace window.
+  // A CLI retry on transient error must not soft-delete the account again
+  // (which would reset the deleted_at timestamp and defer the hard-delete
+  // deadline). The cached success response lets the client confirm the
+  // deletion without re-executing all the cleanup steps.
+  // OWASP A04:2021 replay protection.
+  const ROUTE_ACCOUNT_DELETE = '/api/account/delete';
+  const idemResult = await checkIdempotency(request, user.id, ROUTE_ACCOUNT_DELETE);
+  if ('conflict' in idemResult) {
+    return NextResponse.json({ error: 'CONFLICT', message: idemResult.message }, { status: 409 });
+  }
+  if (idemResult.replayed) {
+    return NextResponse.json(idemResult.body, { status: idemResult.status });
   }
 
   // Validate request body
@@ -323,11 +341,18 @@ export async function DELETE(request: Request) {
       supabase.auth.signOut(),
     ]);
 
-    return NextResponse.json({
+    const deleteResponseBody = {
       success: true,
       message:
         'Account scheduled for deletion. Data will be permanently removed in 30 days.',
-    });
+    };
+
+    // WHY store before returning: ensures a CLI retry after a transient network
+    // failure receives the cached success response and does not re-execute the
+    // deletion sequence (which would reset deleted_at and the 30-day deadline).
+    await storeIdempotencyResult(request, user.id, ROUTE_ACCOUNT_DELETE, 200, deleteResponseBody);
+
+    return NextResponse.json(deleteResponseBody);
   } catch (error) {
     const isDev = process.env.NODE_ENV === 'development';
     console.error(

--- a/packages/styrby-web/src/app/api/account/export/route.ts
+++ b/packages/styrby-web/src/app/api/account/export/route.ts
@@ -40,6 +40,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
+import { checkIdempotency, storeIdempotencyResult } from '@/lib/middleware/idempotency';
 
 /**
  * Handles GDPR data export requests.
@@ -68,6 +69,37 @@ export async function POST(request: Request) {
 
   if (authError || !user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // ── Idempotency check ────────────────────────────────────────────────────
+
+  // WHY: A GDPR export queues expensive parallel Supabase queries (43 tables).
+  // A CLI retry on transient network error must not re-execute all 43 queries —
+  // instead return the cached export response. The 1 request/hour rate limit
+  // already guards against abuse; idempotency prevents duplicate heavy reads.
+  // OWASP A04:2021 replay protection.
+  //
+  // NOTE: The export response is a JSON blob which can be large. We store it
+  // in the idempotency cache (JSONB in Postgres) only when the client supplies
+  // the Idempotency-Key header, making caching strictly opt-in.
+  const ROUTE_ACCOUNT_EXPORT = '/api/account/export';
+  const idemResult = await checkIdempotency(request, user.id, ROUTE_ACCOUNT_EXPORT);
+  if ('conflict' in idemResult) {
+    return NextResponse.json({ error: 'CONFLICT', message: idemResult.message }, { status: 409 });
+  }
+  if (idemResult.replayed) {
+    // Reconstruct the file download response from the cached body.
+    // The cached body is the full exportData JSON object.
+    const date = new Date().toISOString().split('T')[0];
+    const filename = `styrby-data-export-${date}.json`;
+    return new Response(JSON.stringify(idemResult.body, null, 2), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Cache-Control': 'no-store',
+      },
+    });
   }
 
   try {
@@ -410,6 +442,11 @@ export async function POST(request: Request) {
     // Generate filename with date for user reference
     const date = new Date().toISOString().split('T')[0];
     const filename = `styrby-data-export-${date}.json`;
+
+    // WHY store before returning: caches the exportData object so a CLI retry
+    // on transient network failure receives the cached payload and does not
+    // re-execute 43 parallel Supabase queries. The cache entry lives for 24h.
+    await storeIdempotencyResult(request, user.id, ROUTE_ACCOUNT_EXPORT, 200, exportData);
 
     // Return as downloadable JSON file
     // WHY: Content-Disposition header triggers browser download

--- a/packages/styrby-web/src/app/api/account/retention/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/account/retention/__tests__/route.test.ts
@@ -254,4 +254,56 @@ describe('PUT /api/account/retention', () => {
       expect(response.status).toBe(200);
     }
   });
+
+  // ── OWASP A04:2021 Mass-Assignment Guard ──────────────────────────────────
+
+  /**
+   * WHY this test: confirms that the .strict() schema rejects unknown keys at
+   * the validation layer, so an attacker cannot inject fields like `is_admin`
+   * or `tier` that would be mass-assigned into the profiles.update() call.
+   * The DB must never be reached when unknown keys are present.
+   */
+  it('OWASP A04 — returns 400 and never calls .update() when request includes unknown key is_admin: true', async () => {
+    setupAuthUser();
+
+    const profileUpdateSpy = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      if (table === 'profiles') {
+        return {
+          update: profileUpdateSpy,
+        };
+      }
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    // Malicious payload: valid retention_days + injected privilege-escalation key
+    const response = await PUT(makeRequest('PUT', { retention_days: 30, is_admin: true }));
+
+    expect(response.status).toBe(400);
+    // Critical: .update() must NOT have been called — the schema guard stopped the request
+    expect(profileUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it('OWASP A04 — returns 400 and never calls .update() when request includes unknown key tier: enterprise', async () => {
+    setupAuthUser();
+
+    const profileUpdateSpy = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      if (table === 'profiles') {
+        return { update: profileUpdateSpy };
+      }
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    const response = await PUT(makeRequest('PUT', { retention_days: 7, tier: 'enterprise' }));
+
+    expect(response.status).toBe(400);
+    expect(profileUpdateSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/styrby-web/src/app/api/account/retention/route.ts
+++ b/packages/styrby-web/src/app/api/account/retention/route.ts
@@ -39,17 +39,24 @@ const ALLOWED_RETENTION_DAYS = [7, 30, 90, 365] as const;
  * WHY nullable union: retention_days: null is a valid payload meaning
  * "clear my retention policy — never auto-delete". Without explicit null
  * support, users couldn't revert to "never delete" after setting a window.
+ *
+ * MASS-ASSIGN-SAFE: OWASP A04:2021 — only `retention_days` is accepted.
+ * `.strict()` rejects unknown keys (e.g. `is_admin`, `tier`) at parse time,
+ * returning 400 before any DB write occurs. The `.update()` call below writes
+ * only `{ retention_days: parsed.data.retention_days }` — never raw user input.
  */
-const RetentionUpdateSchema = z.object({
-  retention_days: z.union([
-    z.enum(['7', '30', '90', '365'] as unknown as [string, ...string[]]).transform(Number),
-    z.literal(7),
-    z.literal(30),
-    z.literal(90),
-    z.literal(365),
-    z.null(),
-  ]),
-});
+const RetentionUpdateSchema = z
+  .object({
+    retention_days: z.union([
+      z.enum(['7', '30', '90', '365'] as unknown as [string, ...string[]]).transform(Number),
+      z.literal(7),
+      z.literal(30),
+      z.literal(90),
+      z.literal(365),
+      z.null(),
+    ]),
+  })
+  .strict(); // OWASP A04:2021 — reject unknown keys (mass-assignment guard)
 
 /**
  * Resolve the Supabase client from cookie session or Bearer token.

--- a/packages/styrby-web/src/app/api/account/retention/session/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/account/retention/session/__tests__/route.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Per-Session Retention Override API Route Tests
+ *
+ * PUT /api/account/retention/session
+ *
+ * WHY: Validates that the per-session retention override endpoint correctly
+ * enforces schema-level mass-assignment protection (OWASP A04:2021). An
+ * attacker cannot inject extra fields (e.g. `user_id`, `is_admin`) into the
+ * sessions.update() call via a crafted request body.
+ *
+ * Audit: OWASP A04:2021 — Insecure Design (mass-assignment); OWASP A01:2021
+ * — Broken Access Control (session ownership verification).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimit: vi.fn(() => ({ allowed: true })),
+  RATE_LIMITS: { sensitive: { windowMs: 60000, maxRequests: 10 } },
+  rateLimitResponse: vi.fn((retryAfter: number) =>
+    new Response(JSON.stringify({ error: 'RATE_LIMITED', retryAfter }), { status: 429 }),
+  ),
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const VALID_SESSION_ID = '00000000-0000-0000-0000-000000000001';
+
+function makeRequest(body: object): Request {
+  return new Request('http://localhost/api/account/retention/session', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupAuthUser(userId = 'user-abc') {
+  mockGetUser.mockResolvedValue({ data: { user: { id: userId } }, error: null });
+}
+
+function setupSessionFound(sessionId = VALID_SESSION_ID, userId = 'user-abc') {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    single: vi
+      .fn()
+      .mockResolvedValue({ data: { id: sessionId, user_id: userId }, error: null }),
+  };
+}
+
+// ============================================================================
+// Basic validation tests
+// ============================================================================
+
+describe('PUT /api/account/retention/session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('Not authed') });
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: VALID_SESSION_ID, retention_override: 'inherit' }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 400 for invalid UUID in session_id', async () => {
+    setupAuthUser();
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: 'not-a-uuid', retention_override: 'inherit' }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('UUID');
+  });
+
+  it('returns 400 for invalid retention_override value', async () => {
+    setupAuthUser();
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: VALID_SESSION_ID, retention_override: 'pin_days:999' }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 404 when session is not found or owned by another user', async () => {
+    setupAuthUser();
+
+    mockFrom.mockImplementation(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Row not found' } }),
+    }));
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: VALID_SESSION_ID, retention_override: 'pin_forever' }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 200 for a valid inherit override', async () => {
+    setupAuthUser();
+
+    // Track how many times 'sessions' has been called to distinguish SELECT vs UPDATE
+    let sessionsCallCount = 0;
+    const sessionMock = setupSessionFound();
+
+    // Update chain: .update().eq().eq() — both .eq() calls must be chainable,
+    // with the second resolving the final promise ({ error: null }).
+    const secondEqSpy = vi.fn().mockResolvedValue({ error: null });
+    const firstEqSpy = vi.fn().mockReturnValue({ eq: secondEqSpy });
+    const sessionUpdateChain = {
+      update: vi.fn().mockReturnValue({ eq: firstEqSpy }),
+    };
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        sessionsCallCount++;
+        // First call is the SELECT ownership check; second is the UPDATE.
+        return sessionsCallCount === 1 ? sessionMock : sessionUpdateChain;
+      }
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    const response = await PUT(
+      makeRequest({ session_id: VALID_SESSION_ID, retention_override: 'inherit' }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.retention_override).toBe('inherit');
+  });
+
+  // ── OWASP A04:2021 Mass-Assignment Guard ──────────────────────────────────
+
+  /**
+   * WHY: Confirms that the .strict() schema rejects any unknown key before the
+   * sessions.update() call is reached. An attacker cannot inject `user_id`,
+   * `is_admin`, or `tier` alongside a valid session_id to perform privilege
+   * escalation or session takeover via mass-assignment.
+   */
+  it('OWASP A04 — returns 400 and never calls sessions.update() when request includes unknown key is_admin: true', async () => {
+    setupAuthUser();
+
+    const sessionUpdateSpy = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          is: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: { id: VALID_SESSION_ID, user_id: 'user-abc' },
+            error: null,
+          }),
+          update: sessionUpdateSpy,
+        };
+      }
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    // Malicious payload: valid fields + injected privilege-escalation key
+    const response = await PUT(
+      makeRequest({
+        session_id: VALID_SESSION_ID,
+        retention_override: 'pin_forever',
+        is_admin: true,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    // Critical: .update() must NOT have been called — the schema stopped it
+    expect(sessionUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it('OWASP A04 — returns 400 and never calls sessions.update() when request includes unknown key user_id targeting another account', async () => {
+    setupAuthUser('user-abc');
+
+    const sessionUpdateSpy = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'sessions') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          is: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: { id: VALID_SESSION_ID, user_id: 'user-abc' },
+            error: null,
+          }),
+          update: sessionUpdateSpy,
+        };
+      }
+      if (table === 'audit_log') return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      return {};
+    });
+
+    const { PUT } = await import('../route');
+    // Attacker attempts to overwrite user_id on the session row
+    const response = await PUT(
+      makeRequest({
+        session_id: VALID_SESSION_ID,
+        retention_override: 'inherit',
+        user_id: 'victim-user-id',
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(sessionUpdateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/styrby-web/src/app/api/account/retention/session/route.ts
+++ b/packages/styrby-web/src/app/api/account/retention/session/route.ts
@@ -38,13 +38,19 @@ import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
  */
 const VALID_OVERRIDE_PATTERN = /^(inherit|pin_forever|pin_days:(7|30|90|365))$/;
 
-const SessionRetentionSchema = z.object({
-  session_id: z.string().uuid('session_id must be a valid UUID'),
-  retention_override: z.string().regex(
-    VALID_OVERRIDE_PATTERN,
-    'retention_override must be: inherit, pin_forever, pin_days:7, pin_days:30, pin_days:90, or pin_days:365',
-  ),
-});
+// MASS-ASSIGN-SAFE: OWASP A04:2021 — only `session_id` and `retention_override`
+// are accepted. `.strict()` rejects unknown keys (e.g. `user_id`, `is_admin`)
+// at parse time, returning 400 before any DB write occurs. The `.update()` call
+// below writes only `{ retention_override }` extracted from `parsed.data`.
+const SessionRetentionSchema = z
+  .object({
+    session_id: z.string().uuid('session_id must be a valid UUID'),
+    retention_override: z.string().regex(
+      VALID_OVERRIDE_PATTERN,
+      'retention_override must be: inherit, pin_forever, pin_days:7, pin_days:30, pin_days:90, or pin_days:365',
+    ),
+  })
+  .strict(); // OWASP A04:2021 — reject unknown keys (mass-assignment guard)
 
 async function resolveClient(request: Request) {
   const authHeader = request.headers.get('Authorization');

--- a/packages/styrby-web/src/app/api/admin/audit/verify/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/audit/verify/__tests__/route.test.ts
@@ -38,8 +38,27 @@ vi.mock('@sentry/nextjs', () => ({
   captureException: vi.fn(),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate tries to query the DB via
+// createAdminClient which has no passkeys table in the test environment. Mocking
+// at the public contract level keeps the unit test focused on route logic while
+// the MFA gate's own behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import * as Sentry from '@sentry/nextjs';
 import { GET } from '../route';
 
@@ -270,5 +289,24 @@ describe('GET /api/admin/audit/verify', () => {
         tags: expect.objectContaining({ schema_drift: 'true' }),
       }),
     );
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ─────────────────────────────────────
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — the RPC must never run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (isAdmin as Mock).mockResolvedValue(true);
+    mockSupabaseUser({ id: 'admin-1' });
+    (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const res = await GET();
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+    // RPC must not be called when MFA gate fires.
+    // (createClient mock's rpc is not set up in this test path — if the RPC
+    // were called, it would throw, causing a 500 rather than the expected 403.)
   });
 });

--- a/packages/styrby-web/src/app/api/admin/audit/verify/route.ts
+++ b/packages/styrby-web/src/app/api/admin/audit/verify/route.ts
@@ -36,6 +36,7 @@ import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import * as Sentry from '@sentry/nextjs';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ============================================================================
 // Types
@@ -121,6 +122,17 @@ export async function GET(): Promise<NextResponse> {
   const adminStatus = await isAdmin(user.id);
   if (!adminStatus) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   // ── Execute RPC ────────────────────────────────────────────────────────────

--- a/packages/styrby-web/src/app/api/admin/founder-error-histogram/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-error-histogram/__tests__/route.test.ts
@@ -65,6 +65,24 @@ vi.mock('@/lib/rateLimit', () => ({
   ),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { GET } from '../route';
 
 // ============================================================================
@@ -229,5 +247,29 @@ describe('GET /api/admin/founder-error-histogram', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('INTERNAL_ERROR');
+  });
+
+  // --------------------------------------------------------------------------
+  // MFA gate wiring (H42 Layer 1)
+  // --------------------------------------------------------------------------
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — the DB query must never run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips DB query when assertAdminMfa throws', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'admin-1', email: 'admin@styrby.test' } },
+      error: null,
+    });
+    mockIsAdmin.mockResolvedValue(true);
+    (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+    // The admin DB query must not have been triggered.
+    expect(mockAdminFrom).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/app/api/admin/founder-error-histogram/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-error-histogram/route.ts
@@ -47,6 +47,7 @@ import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { ERROR_CLASSES, type ErrorClass } from '@styrby/shared/errors';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -135,6 +136,17 @@ export async function GET(request: NextRequest) {
   const adminOk = await isAdmin(user.id);
   if (!adminOk) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   try {

--- a/packages/styrby-web/src/app/api/admin/founder-feedback/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-feedback/route.ts
@@ -38,6 +38,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { calcNPS, groupNpsByWeek } from '@styrby/shared';
 
@@ -122,6 +123,17 @@ export async function GET(request: NextRequest) {
   const adminOk = await isAdmin(user.id);
   if (!adminOk) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   // ── Rate limit ────────────────────────────────────────────────────────────

--- a/packages/styrby-web/src/app/api/admin/founder-metrics/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-metrics/route.ts
@@ -38,6 +38,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ============================================================================
 // Types
@@ -183,6 +184,17 @@ export async function GET(request: NextRequest) {
   const adminStatus = await isAdmin(user.id);
   if (!adminStatus) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   try {

--- a/packages/styrby-web/src/app/api/admin/founder-team-metrics/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-team-metrics/__tests__/route.test.ts
@@ -42,9 +42,27 @@ vi.mock('@/lib/rateLimit', () => ({
   },
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import { rateLimit } from '@/lib/rateLimit';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { GET } from '../route';
 
 // ---------------------------------------------------------------------------
@@ -393,5 +411,24 @@ describe('GET /api/admin/founder-team-metrics — error handling', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('INTERNAL_ERROR');
+  });
+
+  // ── MFA gate wiring (H42 Layer 1) ───────────────────────────────────────────
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — DB queries must not run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips DB queries when assertAdminMfa throws', async () => {
+    mockSupabaseUser({ id: 'admin-1' });
+    (isAdmin as import('vitest').Mock).mockResolvedValue(true);
+    (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const res = await GET(makeRequest() as never);
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+    // The admin DB client must not have been used.
+    expect(createAdminClient).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/app/api/admin/founder-team-metrics/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-team-metrics/route.ts
@@ -45,6 +45,7 @@ import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import type { FounderTeamMetrics, FounderTeamSummary } from '@styrby/shared';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ============================================================================
 // DB row types (internal, not exported)
@@ -95,6 +96,17 @@ export async function GET(request: NextRequest) {
   const adminStatus = await isAdmin(user.id);
   if (!adminStatus) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   try {

--- a/packages/styrby-web/src/app/api/admin/support/[id]/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/__tests__/route.test.ts
@@ -110,6 +110,24 @@ vi.mock('@/lib/rateLimit', () => ({
   ),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { GET, PATCH } from '../route';
 
 // ============================================================================
@@ -614,6 +632,40 @@ describe('PATCH /api/admin/support/[id]', () => {
 
       const body = await response.json();
       expect(body.error).toBe('Failed to update ticket');
+    });
+  });
+
+  // ── MFA gate wiring (H42 Layer 1) ───────────────────────────────────────────
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — DB queries must not run on gate failure.
+  // Applies to both GET and PATCH since the same gate code path is hit for each.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  describe('MFA gate', () => {
+    it('(MFA gate) GET returns 403 ADMIN_MFA_REQUIRED when assertAdminMfa throws', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      mockIsAdmin.mockResolvedValue(true);
+      (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+      const response = await GET(makeGetRequest(), makeContext());
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+      // Ensure no DB call was made — adminFromQueue should still be empty.
+      expect(adminFromQueue).toHaveLength(0);
+    });
+
+    it('(MFA gate) PATCH returns 403 ADMIN_MFA_REQUIRED when assertAdminMfa throws', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      mockIsAdmin.mockResolvedValue(true);
+      (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+      const response = await PATCH(makePatchRequest({ status: 'resolved' }), makeContext());
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe('ADMIN_MFA_REQUIRED');
     });
   });
 });

--- a/packages/styrby-web/src/app/api/admin/support/[id]/reply/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/reply/__tests__/route.test.ts
@@ -112,6 +112,24 @@ vi.mock('@/lib/rateLimit', () => ({
   ),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { POST } from '../route';
 
 // ============================================================================
@@ -536,6 +554,30 @@ describe('POST /api/admin/support/[id]/reply', () => {
 
       const body = await response.json();
       expect(body.error).toBe('Failed to add reply');
+    });
+  });
+
+  // ── MFA gate wiring (H42 Layer 1) ───────────────────────────────────────────
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — DB mutations must not run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  describe('MFA gate', () => {
+    it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips DB mutation when assertAdminMfa throws', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      mockIsAdmin.mockResolvedValue(true);
+      (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+      const response = await POST(
+        makePostRequest({ message: 'Test reply message for gate wiring test.' }),
+        makeContext()
+      );
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+      // The reply insert and audit log must not have been called.
+      expect(mockAuditLogInsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/styrby-web/src/app/api/admin/support/[id]/reply/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/reply/route.ts
@@ -24,6 +24,7 @@ import { sendSupportReplyEmail } from '@/lib/resend';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 /** Zod schema for the reply body */
 const ReplySchema = z.object({
@@ -54,6 +55,17 @@ export async function POST(
   // A-001: Use site_admins table / is_site_admin() RPC instead of email claim (migration 042 T3.5 cutover)
   if (!(await isAdmin(user.id))) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   // Parse and validate body

--- a/packages/styrby-web/src/app/api/admin/support/[id]/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/route.ts
@@ -21,6 +21,7 @@ import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 /**
  * Zod schema for PATCH request body validation.
@@ -55,6 +56,19 @@ async function verifyAdmin() {
 
   if (!(await isAdmin(user.id))) {
     return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // WHY in verifyAdmin(): all handlers (GET + PATCH) share this helper,
+  // so adding the MFA check here gates every handler at once.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return { error: NextResponse.json({ error: err.code }, { status: err.statusCode }) };
+    }
+    throw err;
   }
 
   return { user };

--- a/packages/styrby-web/src/app/api/admin/support/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/support/__tests__/route.test.ts
@@ -92,6 +92,24 @@ vi.mock('@/lib/rateLimit', () => ({
   ),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { GET } from '../route';
 
 // ============================================================================
@@ -404,5 +422,26 @@ describe('GET /api/admin/support', () => {
         expect(response.status).toBe(200);
       }
     );
+  });
+
+  // ── MFA gate wiring (H42 Layer 1) ───────────────────────────────────────────
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — DB queries must not run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  describe('MFA gate', () => {
+    it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips DB query when assertAdminMfa throws', async () => {
+      mockAuthenticated(ADMIN_USER);
+      mockIsAdmin.mockResolvedValue(true);
+      (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+      const response = await GET(makeRequest());
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+      // Ensure no DB call was made — adminFromQueue should still be empty.
+      expect(adminFromQueue).toHaveLength(0);
+    });
   });
 });

--- a/packages/styrby-web/src/app/api/admin/support/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/route.ts
@@ -29,6 +29,7 @@ import { isAdmin } from '@/lib/admin';
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ---------------------------------------------------------------------------
 // Query Schema
@@ -65,6 +66,17 @@ export async function GET(request: Request) {
   // Verify admin access via site_admins / is_site_admin() RPC (A-001; migration 042 T3.5 cutover)
   if (!(await isAdmin(user.id))) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  try {
+    await assertAdminMfa(user.id);
+  } catch (err) {
+    if (err instanceof AdminMfaRequiredError) {
+      return NextResponse.json({ error: err.code }, { status: err.statusCode });
+    }
+    throw err;
   }
 
   // Parse and validate query params via Zod schema (OWASP ASVS V5.1.3)

--- a/packages/styrby-web/src/app/api/auth/passkey/__tests__/verify.test.ts
+++ b/packages/styrby-web/src/app/api/auth/passkey/__tests__/verify.test.ts
@@ -8,6 +8,7 @@
  * - Edge function 422 (bad signature) propagated to caller
  * - 502 returned on fetch failure
  * - Response body forwarded verbatim (including session cookie on login)
+ * - Account lockout blocks verify-login with 423 (H42 Item 3)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -21,6 +22,27 @@ const mockRateLimitResponse = vi.fn();
 vi.mock('@/lib/rateLimit', () => ({
   rateLimit: mockRateLimit,
   rateLimitResponse: mockRateLimitResponse,
+}));
+
+/** Mock auth-lockout utilities — default to unlocked (no lockout) */
+const mockCheckLockoutStatus = vi.fn();
+const mockRecordLoginFailure = vi.fn();
+const mockResetLoginFailures = vi.fn();
+const mockLockoutResponse = vi.fn();
+
+vi.mock('@/lib/auth-lockout', () => ({
+  checkLockoutStatus: (...args: unknown[]) => mockCheckLockoutStatus(...args),
+  recordLoginFailure: (...args: unknown[]) => mockRecordLoginFailure(...args),
+  resetLoginFailures: (...args: unknown[]) => mockResetLoginFailures(...args),
+  lockoutResponse: (...args: unknown[]) => mockLockoutResponse(...args),
+}));
+
+/** Mock Supabase admin client used by resolveUserIdByEmail */
+const mockRpc = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+  createAdminClient: vi.fn(() => ({
+    rpc: mockRpc,
+  })),
 }));
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -42,6 +64,22 @@ describe('POST /api/auth/passkey/verify', () => {
     vi.resetAllMocks();
     vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co');
     mockRateLimit.mockResolvedValue({ allowed: true, retryAfter: null });
+
+    // Default lockout state: unlocked
+    mockCheckLockoutStatus.mockResolvedValue({
+      isLocked: false,
+      lockedUntil: null,
+      failedCount: 0,
+    });
+    mockRecordLoginFailure.mockResolvedValue({
+      isLocked: false,
+      lockedUntil: null,
+      failedCount: 1,
+    });
+    mockResetLoginFailures.mockResolvedValue(undefined);
+
+    // Default: email lookup returns null (no matching user)
+    mockRpc.mockResolvedValue({ data: [], error: null });
 
     const mod = await import('../verify/route');
     POST = mod.POST;
@@ -135,5 +173,103 @@ describe('POST /api/auth/passkey/verify', () => {
       'https://test.supabase.co/functions/v1/verify-passkey',
       expect.any(Object),
     );
+  });
+
+  // ── Lockout tests (H42 Item 3) ───────────────────────────────────────────
+
+  it('returns 423 when account is locked (verify-login only)', async () => {
+    const lockedUntil = new Date(Date.now() + 600_000).toISOString();
+
+    // Mock user found by email
+    mockRpc.mockResolvedValue({
+      data: [{ id: 'user-uuid-locked', email: 'locked@example.com' }],
+      error: null,
+    });
+    // Mock account locked
+    mockCheckLockoutStatus.mockResolvedValue({
+      isLocked: true,
+      lockedUntil,
+      failedCount: 5,
+    });
+    mockLockoutResponse.mockReturnValue(
+      new Response(JSON.stringify({ error: 'ACCOUNT_LOCKED', retryAfter: 600 }), {
+        status: 423,
+        headers: { 'Retry-After': '600', 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const req = makeRequest({
+      action: 'verify-login',
+      email: 'locked@example.com',
+      response: { id: 'cred' },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(423);
+    const json = await res.json();
+    expect(json.error).toBe('ACCOUNT_LOCKED');
+    // Should NOT forward to edge function when locked
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not apply lockout check to verify-register actions', async () => {
+    const edgePayload = { success: true };
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(edgePayload), { status: 200 }),
+    ) as typeof fetch;
+
+    const req = makeRequest({ action: 'verify-register', response: { id: 'cred' } });
+    await POST(req);
+
+    // checkLockoutStatus should NOT be called for verify-register
+    expect(mockCheckLockoutStatus).not.toHaveBeenCalled();
+  });
+
+  it('records failure when verify-login returns 4xx from edge function', async () => {
+    // User is found
+    mockRpc.mockResolvedValue({
+      data: [{ id: 'user-uuid-1', email: 'user@example.com' }],
+      error: null,
+    });
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'INVALID_SIGNATURE' }), { status: 422 }),
+    ) as typeof fetch;
+
+    const req = makeRequest({ action: 'verify-login', email: 'user@example.com', response: { id: 'cred' } });
+    await POST(req);
+
+    // Give the fire-and-forget a tick to run
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockRecordLoginFailure).toHaveBeenCalledWith('user-uuid-1');
+  });
+
+  it('resets failure counter on successful verify-login', async () => {
+    // User is found
+    mockRpc.mockResolvedValue({
+      data: [{ id: 'user-uuid-2', email: 'success@example.com' }],
+      error: null,
+    });
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: 'tok' }), { status: 200 }),
+    ) as typeof fetch;
+
+    const req = makeRequest({ action: 'verify-login', email: 'success@example.com', response: { id: 'cred' } });
+    await POST(req);
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockResetLoginFailures).toHaveBeenCalledWith('user-uuid-2');
+  });
+
+  it('skips lockout check when email is missing from verify-login', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    ) as typeof fetch;
+
+    // No email in body
+    const req = makeRequest({ action: 'verify-login', response: { id: 'cred' } });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mockCheckLockoutStatus).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/app/api/auth/passkey/verify/route.ts
+++ b/packages/styrby-web/src/app/api/auth/passkey/verify/route.ts
@@ -11,6 +11,13 @@
  * WHY rate-limit here: Verification carries the signed credential response.
  * 10/min per IP blocks brute-force and replay automation. (SOC2 CC6.6)
  *
+ * WHY lockout here (verify-login only): We apply account lockout after 5
+ * consecutive `verify-login` failures within 1 hour. This is the only
+ * user-facing auth endpoint (passkey-based; no password). The lockout check
+ * requires resolving the user from the email field before forwarding so we
+ * can gate on a per-user basis rather than per-IP (which can be spoofed).
+ * (H42 Item 3, SOC2 CC6.6, NIST SP 800-63B §5.2.2)
+ *
  * @auth Not required at proxy layer — `verify-register` requires a valid
  *       Supabase session (enforced inside the edge function).
  * @rateLimit 10 requests per minute per IP
@@ -25,6 +32,7 @@
  *
  * @error 400 { error: 'INVALID_ACTION' | 'INVALID_JSON' }
  * @error 422 { error: string }  — verification failed (bad signature, expired challenge, etc.)
+ * @error 423 { error: 'ACCOUNT_LOCKED', retryAfter: number }  — too many failures
  * @error 429 { error: 'RATE_LIMITED', retryAfter: number }
  * @error 502 { error: 'EDGE_FUNCTION_ERROR' }
  */
@@ -33,6 +41,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { rateLimit, rateLimitResponse } from '@/lib/rateLimit';
 import { Logger } from '@styrby/shared/logging';
 import * as Sentry from '@sentry/nextjs';
+import { createAdminClient } from '@/lib/supabase/server';
+import {
+  checkLockoutStatus,
+  recordLoginFailure,
+  resetLoginFailures,
+  lockoutResponse,
+} from '@/lib/auth-lockout';
 
 /**
  * Structured logger for passkey auth flow events.
@@ -67,6 +82,46 @@ function getEdgeFunctionUrl(): string {
   return `${base}/functions/v1/verify-passkey`;
 }
 
+/**
+ * Resolves a Supabase user_id from an email address using the admin client.
+ *
+ * WHY: The passkey verify request includes email for `verify-login` so the
+ * edge function can look up the credential. We reuse it here to look up
+ * user_id for per-user lockout checks before forwarding the credential.
+ *
+ * @param email - The email address supplied in the verify-login request body
+ * @returns The Supabase user_id, or null if not found or lookup errors
+ */
+async function resolveUserIdByEmail(email: string): Promise<string | null> {
+  const supabase = createAdminClient();
+
+  // WHY search_users_by_email_for_admin instead of profiles query: profiles.id
+  // mirrors auth.users.id but profiles has no email column (email lives in
+  // auth.users). The search RPC (migration 064) queries auth.users directly
+  // with a SECURITY DEFINER function, returning user_id for an exact match.
+  // We pass limit=1 since we only need to check whether a lockout record exists.
+  const { data, error } = await supabase
+    .rpc('search_users_by_email_for_admin', {
+      p_query: email,
+      p_limit: 1,
+      p_offset: 0,
+    });
+
+  if (error || !data?.length) {
+    // WHY: Return null rather than throwing — lockout pre-check is fail-open.
+    // An unknown email means there is no account to lock. The edge function
+    // will handle the 404/422 for the actual credential check.
+    return null;
+  }
+
+  // RPC returns rows with `id` (auth.users.id), `email`, tier, etc.
+  // Find an exact case-insensitive match (RPC uses ILIKE which may be partial).
+  const exactMatch = (data as Array<{ id: string; email: string }>).find(
+    (u) => u.email?.toLowerCase() === email.toLowerCase()
+  );
+  return exactMatch?.id ?? null;
+}
+
 export async function POST(request: NextRequest) {
   // ── Rate limiting ──────────────────────────────────────────────────────────
   const { allowed, retryAfter } = await rateLimit(
@@ -92,6 +147,30 @@ export async function POST(request: NextRequest) {
       { error: 'INVALID_ACTION', message: "action must be 'verify-register' or 'verify-login'" },
       { status: 400 },
     );
+  }
+
+  // ── Lockout pre-check (verify-login only, H42 Item 3) ─────────────────────
+  // WHY: Only verify-login maps to a real user account. verify-register is
+  // gated by an existing authenticated session inside the edge function;
+  // applying lockout there would create a confusing error surface.
+  let resolvedUserId: string | null = null;
+
+  if (action === 'verify-login') {
+    const email = (body as Record<string, unknown>)?.email;
+    if (typeof email === 'string' && email.length > 0) {
+      resolvedUserId = await resolveUserIdByEmail(email);
+    }
+
+    if (resolvedUserId) {
+      const lockout = await checkLockoutStatus(resolvedUserId);
+      if (lockout.isLocked && lockout.lockedUntil) {
+        authLog.warn('auth.passkey_login_blocked_lockout', {
+          userId: resolvedUserId,
+          lockedUntil: lockout.lockedUntil,
+        });
+        return lockoutResponse(lockout.lockedUntil) as NextResponse;
+      }
+    }
   }
 
   // ── Forward to edge function ───────────────────────────────────────────────
@@ -136,6 +215,28 @@ export async function POST(request: NextRequest) {
   }
 
   const responseBody = await edgeResponse.text();
+
+  // ── Lockout accounting (verify-login only) ─────────────────────────────────
+  // WHY: Only update failure counts when we have a resolved user_id.
+  // If we couldn't resolve the user (unknown email), there is no account
+  // to lock — the edge function will return 404/422 on its own.
+  if (action === 'verify-login' && resolvedUserId) {
+    if (edgeResponse.status >= 400) {
+      // Fire-and-forget: record failure and update lock if threshold reached.
+      // We do NOT await here to avoid delaying the response.
+      void recordLoginFailure(resolvedUserId).then((lockout) => {
+        if (lockout.isLocked) {
+          authLog.warn('auth.passkey_lockout_triggered', {
+            userId: resolvedUserId,
+            lockedUntil: lockout.lockedUntil,
+          });
+        }
+      });
+    } else {
+      // Successful login — reset failure counter (fire-and-forget).
+      void resetLoginFailures(resolvedUserId);
+    }
+  }
 
   if (edgeResponse.status >= 400) {
     authLog.warn('auth.passkey_verify_failed', {

--- a/packages/styrby-web/src/app/api/billing/checkout/team/route.ts
+++ b/packages/styrby-web/src/app/api/billing/checkout/team/route.ts
@@ -60,6 +60,7 @@ import {
 import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
 import { getAppUrl } from '@/lib/config';
 import { getEnv } from '@/lib/env';
+import { checkIdempotency, storeIdempotencyResult } from '@/lib/middleware/idempotency';
 
 // ============================================================================
 // Polar SDK client
@@ -229,6 +230,22 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
+  // ── Step 3b: Idempotency check ────────────────────────────────────────────
+
+  // WHY: Team checkout creates a Polar session which initiates a payment flow.
+  // If the CLI retries on a transient network error, a second checkout session
+  // is created for the same payment intent. The idempotency cache returns the
+  // original checkout URL so the user lands on the same Polar page, not a
+  // duplicate. OWASP A04:2021 replay protection.
+  const ROUTE_TEAM_CHECKOUT = '/api/billing/checkout/team';
+  const idemResult = await checkIdempotency(request, user.id, ROUTE_TEAM_CHECKOUT);
+  if ('conflict' in idemResult) {
+    return NextResponse.json({ error: 'CONFLICT', message: idemResult.message }, { status: 409 });
+  }
+  if (idemResult.replayed) {
+    return NextResponse.json(idemResult.body, { status: idemResult.status });
+  }
+
   // ── Step 4: Verify caller is owner/admin of the team ─────────────────────
 
   // WHY user-scoped client (not admin): RLS on team_members ensures the query
@@ -380,5 +397,11 @@ export async function POST(request: Request): Promise<Response> {
 
   // ── Step 9: Return checkout URL ───────────────────────────────────────────
 
-  return NextResponse.json({ checkout_url: checkoutUrl }, { status: 200 });
+  // WHY store before returning: ensures concurrent duplicate requests receive
+  // the cached response on their next retry rather than creating a second
+  // Polar checkout session.
+  const responseBody = { checkout_url: checkoutUrl };
+  await storeIdempotencyResult(request, user.id, ROUTE_TEAM_CHECKOUT, 200, responseBody);
+
+  return NextResponse.json(responseBody, { status: 200 });
 }

--- a/packages/styrby-web/src/app/api/cron/idempotency-cleanup/route.ts
+++ b/packages/styrby-web/src/app/api/cron/idempotency-cleanup/route.ts
@@ -1,0 +1,112 @@
+/**
+ * Idempotency Key Cleanup Cron
+ *
+ * POST /api/cron/idempotency-cleanup
+ *
+ * Deletes expired idempotency_keys rows (expires_at < NOW()). Runs daily at
+ * 02:00 CT (08:00 UTC) — off-peak for US traffic, avoids locking contention
+ * with peak-hour user requests.
+ *
+ * WHY a cron instead of relying on Postgres pg_cron or TTL triggers:
+ * - pg_cron is available on Supabase but requires the cron.schedule() call to
+ *   live in a migration, which couples schema migrations to operational schedules.
+ * - Vercel crons are already used for all other cleanup jobs (retention, digests)
+ *   and provide centralized scheduling visibility in the Vercel dashboard.
+ * - The idx_idempotency_keys_expires index makes this DELETE highly efficient
+ *   even at scale (B-tree range scan, not full table scan).
+ *
+ * Scale expectation: At 10k mutating requests/day with ~20% using idempotency
+ * keys = ~2k rows/day. 24h expiry = ~2k rows at steady state. Batch size of
+ * 5000 is more than sufficient; added for safety parity with retention cron.
+ *
+ * @auth Required - CRON_SECRET header must match CRON_SECRET env var
+ * @schedule Daily at 02:00 CT (08:00 UTC) — see vercel.json
+ *
+ * @returns 200 { success: true, deleted: number }
+ *
+ * @error 401 { error: 'Unauthorized' }
+ * @error 500 { error: string }
+ *
+ * @module api/cron/idempotency-cleanup/route
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase/server';
+import crypto from 'crypto';
+
+/**
+ * Maximum rows to delete per cron run.
+ *
+ * WHY: Prevents runaway DELETE queries that could hold row-level locks for
+ * too long under load. At steady state this table has ~2k rows; 5000 rows
+ * is a safe ceiling even after a missed run.
+ */
+const BATCH_SIZE = 5000;
+
+/**
+ * Handles the daily idempotency key cleanup.
+ *
+ * WHY POST not GET: Vercel crons send POST requests. Matching the method
+ * prevents accidental invocation via browser GET (which would trigger
+ * the CRON_SECRET check but is still a best-practice hygiene item).
+ *
+ * @param request - Incoming cron request from Vercel infrastructure
+ * @returns JSON response with count of deleted rows
+ */
+export async function POST(request: NextRequest): Promise<Response> {
+  // ── Auth: CRON_SECRET guard ───────────────────────────────────────────────
+
+  // WHY timing-safe comparison: prevent timing attacks that could enumerate
+  // valid CRON_SECRET values by measuring response latency differences.
+  // OWASP ASVS V2.9.1 — use constant-time comparison for secret values.
+  const cronSecret = process.env.CRON_SECRET;
+  const incomingSecret = request.headers.get('authorization')?.replace('Bearer ', '') ?? '';
+
+  if (!cronSecret) {
+    console.error('[idempotency-cleanup] CRON_SECRET env var is not set');
+    return NextResponse.json({ error: 'Server misconfiguration' }, { status: 500 });
+  }
+
+  const secretsMatch = crypto.timingSafeEqual(
+    Buffer.from(incomingSecret, 'utf8'),
+    Buffer.from(cronSecret, 'utf8'),
+  );
+
+  if (!secretsMatch) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // ── Cleanup ───────────────────────────────────────────────────────────────
+
+  const adminClient = createAdminClient();
+
+  try {
+    // Delete all expired rows in a single DELETE with a LIMIT via a subquery.
+    // WHY subquery with ctid: Postgres DELETE does not support LIMIT directly.
+    // Using a subquery that selects ctid (the physical row identifier) is the
+    // idiomatic pattern for batched deletes in Postgres.
+    //
+    // Alternative considered: multiple small batches in a loop. Rejected because
+    // the expected row count (~2k/day) does not justify the round-trip overhead.
+    // The BATCH_SIZE ceiling provides the safety guarantee without looping.
+    const { error, count } = await adminClient
+      .from('idempotency_keys')
+      .delete({ count: 'exact' })
+      .lt('expires_at', new Date().toISOString())
+      .limit(BATCH_SIZE);
+
+    if (error) {
+      console.error('[idempotency-cleanup] Delete failed:', error.message);
+      return NextResponse.json({ error: 'Cleanup query failed' }, { status: 500 });
+    }
+
+    const deleted = count ?? 0;
+    console.log(`[idempotency-cleanup] Deleted ${deleted} expired idempotency key(s)`);
+
+    return NextResponse.json({ success: true, deleted });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[idempotency-cleanup] Unexpected error:', message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/packages/styrby-web/src/app/api/keys/route.ts
+++ b/packages/styrby-web/src/app/api/keys/route.ts
@@ -306,13 +306,16 @@ export async function POST(request: NextRequest) {
     // Hash the key with bcrypt
     const keyHash = await hashApiKey(plaintextKey);
 
-    // Calculate expiration if specified
-    let expiresAt: string | null = null;
-    if (parseResult.data.expires_in_days) {
-      const expDate = new Date();
-      expDate.setDate(expDate.getDate() + parseResult.data.expires_in_days);
-      expiresAt = expDate.toISOString();
-    }
+    // Calculate expiration.
+    // WHY default to 1 year: Keys without expiry never rotate, which is
+    // a security antipattern (H42 Item 2, SOC2 CC6.1). Defaulting to 365 days
+    // ensures every key has a finite lifetime while remaining practical for
+    // automation use-cases. Users can still specify a shorter window via
+    // expires_in_days. The CLI surfaces a rotation prompt at <30 days remaining.
+    const expiryDays = parseResult.data.expires_in_days ?? 365;
+    const expDate = new Date();
+    expDate.setDate(expDate.getDate() + expiryDays);
+    const expiresAt: string = expDate.toISOString();
 
     // Insert the key
     const { data: keyRecord, error: insertError } = await supabase

--- a/packages/styrby-web/src/app/api/security/csp-report/route.ts
+++ b/packages/styrby-web/src/app/api/security/csp-report/route.ts
@@ -1,0 +1,271 @@
+/**
+ * POST /api/security/csp-report
+ *
+ * CSP violation report receiver. Browsers POST violations to this endpoint
+ * when a page-level Content-Security-Policy rule is breached. The endpoint
+ * persists each report to `audit_log` with `action='csp_violation'` for
+ * correlation with other anomaly signals (rate-limit spikes, 401 bursts).
+ *
+ * @rateLimit 60 reports per minute per IP (browsers naturally batch; this is
+ *            generous to avoid losing legitimate violation evidence during a
+ *            real attack while still capping flood risk).
+ *
+ * @body
+ *   The browser sends two body shapes depending on which Reporting API
+ *   level it supports:
+ *
+ *   Level 2 (legacy `report-uri`):
+ *     application/csp-report
+ *     {
+ *       "csp-report": {
+ *         "document-uri": "https://styrbyapp.com/dashboard",
+ *         "violated-directive": "script-src",
+ *         "blocked-uri": "https://evil.example.com/x.js",
+ *         ...
+ *       }
+ *     }
+ *
+ *   Level 3 (`report-to`):
+ *     application/reports+json
+ *     [{ "type": "csp-violation", "body": {...}, "url": ..., "user_agent": ... }]
+ *
+ *   We accept both. The handler normalizes each to a single `cspReport` record
+ *   shape before insertion.
+ *
+ * Security design:
+ *
+ * 1. NO AUTHENTICATION on this endpoint. Browsers cannot authenticate CSP
+ *    reports — they're sent before any session context is established for the
+ *    page. Public-by-construction.
+ *
+ * 2. INPUT SIZE CAP. A malicious site cannot DoS us by sending mega-payloads
+ *    because we cap the body at 10KB before parsing. Real CSP reports are
+ *    typically <2KB.
+ *
+ * 3. NO REFLECTION. The endpoint never returns the report content in its
+ *    response body. Eliminates use as an XSS amplifier.
+ *
+ * 4. RATE-LIMITED. A compromised browser sending floods can't fill the
+ *    audit_log; the rate limiter caps per-IP intake.
+ *
+ * 5. NO PII LOGGING. We strip query strings from `document-uri` before
+ *    persistence (some apps put email/token in URL params).
+ *
+ * Governing standards:
+ * - OWASP A03:2021 (Injection): early-warning system for XSS attempts.
+ * - SOC 2 CC7.2: security event detection + logging.
+ * - W3C CSP Level 3 Reporting API.
+ *
+ * @module api/security/csp-report
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createAdminClient } from '@/lib/supabase/server';
+import { rateLimit, getClientIp, rateLimitResponse } from '@/lib/rateLimit';
+
+// ============================================================================
+// Body schemas (best-effort — different browsers send slightly different shapes)
+// ============================================================================
+
+const Level2ReportSchema = z
+  .object({
+    'csp-report': z
+      .object({
+        'document-uri': z.string().optional(),
+        'violated-directive': z.string().optional(),
+        'effective-directive': z.string().optional(),
+        'blocked-uri': z.string().optional(),
+        'source-file': z.string().optional(),
+        'line-number': z.number().optional(),
+        'column-number': z.number().optional(),
+        'status-code': z.number().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const Level3ReportItemSchema = z
+  .object({
+    type: z.string().optional(),
+    age: z.number().optional(),
+    url: z.string().optional(),
+    user_agent: z.string().optional(),
+    body: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
+
+const Level3ReportSchema = z.array(Level3ReportItemSchema);
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Strip query string from a URL to avoid persisting tokens / emails. */
+function stripQuery(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return url.split('?')[0];
+  }
+}
+
+interface NormalizedReport {
+  documentUri?: string;
+  violatedDirective?: string;
+  blockedUri?: string;
+  sourceFile?: string;
+  lineNumber?: number;
+  reportType: 'level-2' | 'level-3';
+}
+
+/** Normalize either body shape into the same record we persist. */
+function normalize(body: unknown): NormalizedReport[] {
+  // Level 2: { "csp-report": {...} }
+  const l2 = Level2ReportSchema.safeParse(body);
+  if (l2.success) {
+    const r = l2.data['csp-report'];
+    return [
+      {
+        documentUri: stripQuery(r['document-uri']),
+        violatedDirective: r['violated-directive'] ?? r['effective-directive'],
+        blockedUri: stripQuery(r['blocked-uri']),
+        sourceFile: stripQuery(r['source-file']),
+        lineNumber: r['line-number'],
+        reportType: 'level-2',
+      },
+    ];
+  }
+
+  // Level 3: [{type, body: {...}, url, user_agent}]
+  const l3 = Level3ReportSchema.safeParse(body);
+  if (l3.success) {
+    return l3.data
+      .filter((item) => item.type === 'csp-violation' || item.type === undefined)
+      .map((item) => {
+        const body = item.body as Record<string, unknown> | undefined;
+        return {
+          documentUri: stripQuery((body?.documentURL ?? item.url) as string | undefined),
+          violatedDirective: (body?.effectiveDirective ?? body?.violatedDirective) as
+            | string
+            | undefined,
+          blockedUri: stripQuery(body?.blockedURL as string | undefined),
+          sourceFile: stripQuery(body?.sourceFile as string | undefined),
+          lineNumber: body?.lineNumber as number | undefined,
+          reportType: 'level-3',
+        };
+      });
+  }
+
+  return [];
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+const MAX_BODY_BYTES = 10 * 1024; // 10KB cap — real CSP reports are <2KB.
+
+/**
+ * Receives CSP violation reports and persists each to audit_log.
+ *
+ * @returns Always 204 No Content on accept (so the browser doesn't retry).
+ *          Never returns the report content. Errors logged server-side only.
+ */
+export async function POST(request: NextRequest) {
+  const ip = getClientIp(request) ?? 'unknown';
+
+  // 1. Rate limit by IP (60/min). Generous because browsers batch; tight enough
+  //    to prevent log floods. The shared rateLimit() helper extracts client IP
+  //    from the request internally (X-Forwarded-For etc.) — we pass `request`,
+  //    not a manually-keyed string, to stay consistent with other endpoints.
+  const limit = await rateLimit(
+    request,
+    {
+      windowMs: 60_000,
+      maxRequests: 60,
+    },
+    'csp-report'
+  );
+  if (!limit.allowed) {
+    return rateLimitResponse(limit.retryAfter ?? 60);
+  }
+
+  // 2. Read body with size cap. A 10KB cap prevents memory abuse from a
+  //    misbehaving or malicious browser.
+  let raw: string;
+  try {
+    raw = await request.text();
+    if (raw.length > MAX_BODY_BYTES) {
+      // Silently drop oversized reports — telling the client "too big" would
+      // give an attacker a length-detection oracle. Log server-side instead.
+      console.warn('[csp-report] dropped oversized report', {
+        ip,
+        bytes: raw.length,
+      });
+      return new NextResponse(null, { status: 204 });
+    }
+  } catch {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  // 3. Parse + normalize. Tolerate any malformed shape — silent 204.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return new NextResponse(null, { status: 204 });
+  }
+  const reports = normalize(parsed);
+  if (reports.length === 0) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  // 4. Persist each report to audit_log. Best-effort — if the DB write fails
+  //    we don't want to retry from the browser, so always 204.
+  // WHY admin client (not user-scoped): no session context for the visitor.
+  const supabase = createAdminClient();
+
+  for (const r of reports) {
+    try {
+      await supabase.from('audit_log').insert({
+        // No user_id — these reports are pre-auth.
+        action: 'csp_violation',
+        resource_type: 'security',
+        resource_id: null,
+        metadata: {
+          ip,
+          report_type: r.reportType,
+          document_uri: r.documentUri,
+          violated_directive: r.violatedDirective,
+          blocked_uri: r.blockedUri,
+          source_file: r.sourceFile,
+          line_number: r.lineNumber,
+          // user-agent stripped — too noisy for audit_log; can be reconstructed
+          // from access logs if needed.
+        },
+      });
+    } catch (err) {
+      // Swallow + log — never propagate DB errors back to the browser.
+      console.error('[csp-report] DB insert failed', {
+        ip,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return new NextResponse(null, { status: 204 });
+}
+
+/**
+ * Reject any non-POST method explicitly.
+ *
+ * WHY: Browsers always POST CSP reports per spec. A GET to this endpoint is
+ * either a misconfiguration or an active reconnaissance attempt. Returning
+ * 405 (rather than 200/404) explicitly surfaces the misuse.
+ */
+export async function GET() {
+  return new NextResponse(null, { status: 405 });
+}

--- a/packages/styrby-web/src/app/api/v1/costs/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/__tests__/route.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/costs/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/__tests__/route.test.ts
@@ -24,8 +24,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -123,9 +127,13 @@ describe('GET /api/v1/costs', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/costs/breakdown/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/breakdown/__tests__/route.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/costs/breakdown/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/breakdown/__tests__/route.test.ts
@@ -23,8 +23,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -123,9 +127,13 @@ describe('GET /api/v1/costs/breakdown', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/costs/breakdown/route.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/breakdown/route.ts
@@ -31,7 +31,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
-import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { withApiAuthAndRateLimit, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
@@ -69,7 +69,7 @@ async function handler(
   request: NextRequest,
   context: ApiAuthContext
 ): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   // Parse query parameters
   const url = new URL(request.url);
@@ -191,7 +191,7 @@ async function handler(
     },
   });
 
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
-export const GET = withApiAuth(handler);
+export const GET = withApiAuthAndRateLimit(handler);

--- a/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
@@ -247,4 +247,28 @@ describe('GET /api/v1/costs/export', () => {
     const res = await GET(makeRequest());
     expect(res.status).toBe(429);
   });
+
+  // --------------------------------------------------------------------------
+  // Auth wiring (H42 Layer 5)
+  // --------------------------------------------------------------------------
+
+  // WHY this test exists: H42 Layer 5 wraps the route with withApiAuthAndRateLimit.
+  // If a future refactor unwraps the route or swaps the middleware, this test
+  // catches it — the handler must NOT execute when the wrapper short-circuits.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('returns 401 when withApiAuthAndRateLimit rejects the request', async () => {
+    const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+    vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
+      return NextResponse.json(
+        { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
+        { status: 401 }
+      );
+    });
+
+    vi.resetModules();
+    const { GET: freshGET } = await import('../route');
+
+    const res = await freshGET(makeRequest());
+    expect(res.status).toBe(401);
+  });
 });

--- a/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
@@ -21,8 +21,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),

--- a/packages/styrby-web/src/app/api/v1/costs/export/route.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/export/route.ts
@@ -29,7 +29,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
-import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { withApiAuthAndRateLimit, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
 import { rateLimit, RATE_LIMITS } from '@/lib/rateLimit';
 import { normalizeEffectiveTier } from '@/lib/tier-enforcement';
@@ -124,7 +124,7 @@ async function handler(
   request: NextRequest,
   context: ApiAuthContext
 ): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   // Apply strict rate limiting - 1 export per hour per IP.
   // WHY: A full 365-day export scans up to 50,000 rows. This is orders of
@@ -257,7 +257,7 @@ async function handler(
     },
   });
 
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
-export const GET = withApiAuth(handler);
+export const GET = withApiAuthAndRateLimit(handler);

--- a/packages/styrby-web/src/app/api/v1/costs/route.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/route.ts
@@ -34,7 +34,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
-import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { withApiAuthAndRateLimit, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
@@ -95,7 +95,7 @@ async function handler(
   request: NextRequest,
   context: ApiAuthContext
 ): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   // Parse query parameters
   const url = new URL(request.url);
@@ -235,7 +235,7 @@ async function handler(
     breakdown,
   });
 
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
-export const GET = withApiAuth(handler);
+export const GET = withApiAuthAndRateLimit(handler);

--- a/packages/styrby-web/src/app/api/v1/machines/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/machines/__tests__/route.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/machines/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/machines/__tests__/route.test.ts
@@ -23,8 +23,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -127,9 +131,13 @@ describe('GET /api/v1/machines', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/machines/route.ts
+++ b/packages/styrby-web/src/app/api/v1/machines/route.ts
@@ -28,7 +28,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
-import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { withApiAuthAndRateLimit, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
@@ -66,7 +66,7 @@ async function handler(
   request: NextRequest,
   context: ApiAuthContext
 ): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   // Parse query parameters
   const url = new URL(request.url);
@@ -145,7 +145,7 @@ async function handler(
     count: transformedMachines.length,
   });
 
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
-export const GET = withApiAuth(handler);
+export const GET = withApiAuthAndRateLimit(handler);

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/__tests__/route.test.ts
@@ -22,8 +22,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -141,9 +145,13 @@ describe('GET /api/v1/sessions/[id]', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/__tests__/route.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
@@ -302,4 +302,31 @@ describe('Session Checkpoints API', () => {
       expect(res.status).toBe(200);
     });
   });
+
+  // --------------------------------------------------------------------------
+  // Auth wiring (H42 Layer 5)
+  // --------------------------------------------------------------------------
+
+  // WHY this test exists: H42 Layer 5 wraps GET, POST, and DELETE with
+  // withApiAuthAndRateLimit. If a future refactor unwraps any of them or swaps
+  // the middleware, this test catches it — the handler must NOT execute when
+  // the wrapper short-circuits. One test covers all three verbs since they
+  // share the same wrapper. OWASP A07:2021, SOC 2 CC6.1.
+  describe('auth wiring', () => {
+    it('returns 401 when withApiAuthAndRateLimit rejects the request', async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
+        return NextResponse.json(
+          { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
+          { status: 401 }
+        );
+      });
+
+      vi.resetModules();
+      const { GET: freshGET } = await import('../route');
+
+      const res = await freshGET(makeRequest('GET', VALID_SESSION_ID));
+      expect(res.status).toBe(401);
+    });
+  });
 });

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
@@ -21,8 +21,12 @@ const mockAuthContext = {
   scopes: ['read', 'write'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/route.ts
@@ -40,7 +40,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
-import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { withApiAuthAndRateLimit, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import type { SessionCheckpoint } from '@styrby/shared';
 import { normalizeEffectiveTier } from '@/lib/tier-enforcement';
 import { z } from 'zod';
@@ -154,7 +154,7 @@ async function getHandler(
   request: NextRequest,
   context: ApiAuthContext
 ): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   const url = new URL(request.url);
   const segments = url.pathname.split('/');
@@ -197,7 +197,7 @@ async function getHandler(
   );
 
   const response = NextResponse.json({ checkpoints });
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
 // ============================================================================
@@ -215,7 +215,7 @@ async function postHandler(
   request: NextRequest,
   context: ApiAuthContext
 ): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   const url = new URL(request.url);
   const segments = url.pathname.split('/');
@@ -319,7 +319,7 @@ async function postHandler(
 
   const checkpoint = rowToCheckpoint(inserted as Record<string, unknown>);
   const response = NextResponse.json({ checkpoint }, { status: 201 });
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
 // ============================================================================
@@ -342,7 +342,7 @@ async function deleteHandler(
   request: NextRequest,
   context: ApiAuthContext
 ): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   const url = new URL(request.url);
   const segments = url.pathname.split('/');
@@ -392,13 +392,13 @@ async function deleteHandler(
   }
 
   const response = NextResponse.json({ deleted: true });
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
 // ============================================================================
 // Exports
 // ============================================================================
 
-export const GET = withApiAuth(getHandler);
-export const POST = withApiAuth(postHandler);
-export const DELETE = withApiAuth(deleteHandler);
+export const GET = withApiAuthAndRateLimit(getHandler);
+export const POST = withApiAuthAndRateLimit(postHandler);
+export const DELETE = withApiAuthAndRateLimit(deleteHandler);

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/__tests__/route.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/__tests__/route.test.ts
@@ -23,8 +23,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -139,9 +143,13 @@ describe('GET /api/v1/sessions/[id]/messages', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/route.ts
@@ -23,7 +23,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
-import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { withApiAuthAndRateLimit, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
@@ -75,7 +75,7 @@ async function handler(
   request: NextRequest,
   context: ApiAuthContext
 ): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   // Extract session ID from URL
   const url = new URL(request.url);
@@ -187,7 +187,7 @@ async function handler(
     },
   });
 
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
-export const GET = withApiAuth(handler);
+export const GET = withApiAuthAndRateLimit(handler);

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/route.ts
@@ -12,7 +12,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
-import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { withApiAuthAndRateLimit, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 
 // ---------------------------------------------------------------------------
 // Supabase Admin Client
@@ -41,7 +41,7 @@ async function handler(
   request: NextRequest,
   context: ApiAuthContext
 ): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   // Extract session ID from URL
   const url = new URL(request.url);
@@ -111,7 +111,7 @@ async function handler(
   }
 
   const response = NextResponse.json({ session });
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
-export const GET = withApiAuth(handler);
+export const GET = withApiAuthAndRateLimit(handler);

--- a/packages/styrby-web/src/app/api/v1/sessions/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/__tests__/route.test.ts
@@ -13,12 +13,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 /**
  * Default auth context injected by the mocked middleware.
- * WHY: v1 routes use API key auth (withApiAuth), not cookie auth.
+ * WHY: v1 routes use API key auth (withApiAuthAndRateLimit), not cookie auth.
  * Mocking the middleware to pass through lets us test the handler logic directly.
  */
 const mockAuthContext = {
@@ -27,8 +27,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -148,11 +152,15 @@ describe('GET /api/v1/sessions', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
       // WHY: Override the mock to simulate auth failure. This tests that the
-      // withApiAuth wrapper correctly short-circuits before reaching the handler.
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      // withApiAuthAndRateLimit wrapper correctly short-circuits before reaching the handler.
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/sessions/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/route.ts
@@ -22,7 +22,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
-import { withApiAuth, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { withApiAuthAndRateLimit, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
@@ -61,7 +61,7 @@ function createApiAdminClient() {
 // ---------------------------------------------------------------------------
 
 async function handler(request: NextRequest, context: ApiAuthContext): Promise<NextResponse> {
-  const { userId, keyId } = context;
+  const { userId, keyId, keyExpiresAt } = context;
 
   // Parse query parameters
   const url = new URL(request.url);
@@ -161,7 +161,7 @@ async function handler(request: NextRequest, context: ApiAuthContext): Promise<N
     { headers: { 'Cache-Control': 'no-store' } }
   );
 
-  return addRateLimitHeaders(response, keyId);
+  return addRateLimitHeaders(response, keyId, keyExpiresAt);
 }
 
-export const GET = withApiAuth(handler);
+export const GET = withApiAuthAndRateLimit(handler);

--- a/packages/styrby-web/src/app/dashboard/admin/layout.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { AdminMfaBanner } from '@/components/admin/AdminMfaBanner';
 
 /**
  * Admin layout gate.
@@ -65,5 +66,36 @@ export default async function AdminLayout({
     redirect('/dashboard');
   }
 
-  return <>{children}</>;
+  // Fetch the admin's MFA grace window for the banner.
+  //
+  // WHY here (layout) not assertAdminMfa(): the layout must NOT call
+  // assertAdminMfa() because that would block the passkey enrollment page
+  // itself — a bootstrap paradox. The layout only reads mfa_grace_until for
+  // the banner; the MFA enforcement happens per-action in each route handler.
+  //
+  // WHY createAdminClient() here: the service-role client is already used above
+  // for the is_site_admin RPC. Reusing it (rather than adding a user-scoped
+  // client) avoids an extra client instantiation and keeps the layout focused
+  // on orchestration.
+  //
+  // WHY maybeSingle + null fallback: if the admin row has no mfa_grace_until
+  // (new admin added after enforcement) or the query fails, graceUntil = null
+  // and the banner is hidden. This is the correct fail-open for UI (the banner
+  // is informational — suppressing it on error is safe).
+  const { data: adminRow } = await adminDb
+    .from('site_admins')
+    .select('mfa_grace_until')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  const graceUntil = adminRow?.mfa_grace_until ?? null;
+
+  return (
+    <>
+      {/* WHY AdminMfaBanner outside children: the banner is layout-level UI
+          displayed above the admin page content, not injected by each page. */}
+      <AdminMfaBanner graceUntil={graceUntil} />
+      {children}
+    </>
+  );
 }

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/__tests__/actions.test.ts
@@ -141,7 +141,7 @@ const VALID_SESSION_ID = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
 const VALID_GRANT_ID = '42';
 const VALID_USER_ID = 'ccccdddd-eeee-ffff-aaaa-bbbbccccdddd';
 /** Acting admin ID returned by auth.getUser() for assertAdminMfa wiring tests. */
-const ACTING_ADMIN_ID = 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb';
+const ACTING_ADMIN_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
 /** Minimal valid form data for happy-path tests. */
 function validFormData(overrides: Record<string, string> = {}): FormData {

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/__tests__/actions.test.ts
@@ -101,7 +101,26 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): requestSupportAccessAction calls
+// assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient } from '@/lib/supabase/server';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import type { Mock } from 'vitest';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -121,6 +140,8 @@ const VALID_TICKET_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
 const VALID_SESSION_ID = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
 const VALID_GRANT_ID = '42';
 const VALID_USER_ID = 'ccccdddd-eeee-ffff-aaaa-bbbbccccdddd';
+/** Acting admin ID returned by auth.getUser() for assertAdminMfa wiring tests. */
+const ACTING_ADMIN_ID = 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb';
 
 /** Minimal valid form data for happy-path tests. */
 function validFormData(overrides: Record<string, string> = {}): FormData {
@@ -170,7 +191,18 @@ describe('requestSupportAccessAction', () => {
     const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
     mockFrom.mockReturnValue({ select: mockSelect });
 
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, from: mockFrom });
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // admin actions to resolve the acting admin for the MFA gate (assertAdminMfa).
+    // The mock must return a valid admin user so the gate is genuinely exercised.
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
 
     // Default: both RPCs succeed.
     configureRpc();
@@ -526,5 +558,22 @@ describe('requestSupportAccessAction', () => {
       'admin_request_support_access',
       'admin_stash_grant_token',
     ]);
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves requestSupportAccessAction calls assertAdminMfa before running any
+  // RPC. If the gate throws AdminMfaRequiredError, the action must short-circuit
+  // and return { ok: false, error: 'ADMIN_MFA_REQUIRED' } without calling any RPC.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) returns ADMIN_MFA_REQUIRED and skips both RPCs when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { requestSupportAccessAction } = await import('../actions');
+    const result = await requestSupportAccessAction(VALID_TICKET_ID, validFormData());
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/actions.ts
@@ -54,6 +54,7 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { generateSupportToken } from '@/lib/support/token';
 import * as Sentry from '@sentry/nextjs';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ─── Shared action result type ────────────────────────────────────────────────
 
@@ -251,6 +252,22 @@ export async function requestSupportAccessAction(
 
   // ── 4. Resolve user_id from the ticket (server-side, unforgeable) ──────────
   const supabase = await createClient();
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
 
   // WHY resolve p_user_id from the ticket server-side (not from FormData):
   //   The admin's form submits session_id and reason — there is no user_id field

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/__tests__/actions.test.ts
@@ -100,6 +100,25 @@ const mockRpc = vi.fn();
 const mockGenerateLink = vi.fn();
 const mockGetUserById = vi.fn();
 
+// WHY mock mfa-gate (H42 Layer 1): every admin action now calls
+// `assertAdminMfa(actingAdmin.id)` before running its RPC. Without this mock
+// the gate would call createAdminClient → site_admins lookup, which is not
+// stubbed at unit-test layer. Mirrors src/__tests__/admin/actions.integration.test.ts.
+// MFA gate behavior itself is covered in src/lib/admin/__tests__/mfa-gate.test.ts;
+// these unit tests assert each action wires the gate correctly via dedicated
+// `(MFA)` test cases below. OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 vi.mock('@/lib/supabase/server', () => ({
   // WHY createClient is plain vi.fn() here (not .mockResolvedValue):
   //   vi.mock factories are hoisted to the top of the file by Vitest. At hoist
@@ -127,9 +146,29 @@ vi.mock('@/lib/supabase/server', () => ({
 // WHY import after vi.mock: Vitest hoists vi.mock calls to the top, so these
 // imports get the mocked versions regardless of declaration order in the file.
 import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import type { Mock } from 'vitest';
 
+const ACTING_ADMIN_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Builds an `auth.getUser()` stub for the mocked Supabase client.
+ * WHY: H42 Layer 1 added `supabase.auth.getUser()` calls inside every admin action
+ * to capture the acting admin for the MFA gate. Returning a real admin user
+ * (rather than null) means the gate is genuinely exercised on every test path —
+ * `assertAdminMfa` (mocked at module level) runs and resolves by default,
+ * proving the gate is wired correctly. Per-case overrides simulate gate failure
+ * via `(assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError())`.
+ */
+function makeAuthMock() {
+  return {
+    getUser: vi.fn().mockResolvedValue({
+      data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+    }),
+  };
+}
 
 /**
  * Builds a FormData object from a plain record.
@@ -156,7 +195,7 @@ describe('overrideTierAction', () => {
     // WHY restore after clearAllMocks: clearAllMocks wipes mockResolvedValue.
     // createClient must return an object with rpc so actions can call it.
     // Fix P0: createClient (user-scoped) is now the RPC client for all admin_* calls.
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, auth: makeAuthMock() });
   });
 
   // ── (a) Zod validation ────────────────────────────────────────────────────
@@ -385,6 +424,24 @@ describe('overrideTierAction', () => {
     //     (createAdminClient has no rpc property in the mock setup).
     expect(mockRpc).toHaveBeenCalledWith('admin_override_tier', expect.any(Object));
   });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ───────────────────────────────────
+  // WHY this test exists: the action calls assertAdminMfa(actingAdmin.id) before
+  // running the RPC. If a future refactor moves the gate or skips it, this test
+  // catches it — the RPC must NOT execute when the gate throws.
+  it('(MFA gate) returns ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { overrideTierAction } = await import('../actions');
+    const result = await overrideTierAction(
+      VALID_UUID,
+      makeFormData({ targetUserId: VALID_UUID, newTier: 'pro', reason: 'test reason' })
+    );
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
 });
 
 // ─── resetPasswordAction ─────────────────────────────────────────────────────
@@ -394,7 +451,7 @@ describe('resetPasswordAction', () => {
     vi.clearAllMocks();
     // WHY restore after clearAllMocks: createClient must return {rpc} for RPC calls.
     // Fix P0: user-scoped client is now the RPC client for admin_record_password_reset.
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, auth: makeAuthMock() });
     // Restore header mock to return valid values by default.
     mockHeadersGet.mockImplementation((name: string) => {
       if (name === 'x-forwarded-for') return MOCK_XFF;
@@ -703,6 +760,22 @@ describe('resetPasswordAction', () => {
     const [, sentryCtx] = mockSentryCaptureMessage.mock.calls[0];
     expect(sentryCtx.tags.target_status).toBe('deleted');
   });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ───────────────────────────────────
+  it('(MFA gate) returns ADMIN_MFA_REQUIRED and skips RPC + generateLink when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { resetPasswordAction } = await import('../actions');
+    const result = await resetPasswordAction(
+      VALID_UUID,
+      makeFormData({ targetUserId: VALID_UUID, reason: 'forgot password' })
+    );
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    expect(mockRpc).not.toHaveBeenCalled();
+    expect(mockGenerateLink).not.toHaveBeenCalled();
+  });
 });
 
 // ─── toggleConsentAction ─────────────────────────────────────────────────────
@@ -712,7 +785,7 @@ describe('toggleConsentAction', () => {
     vi.clearAllMocks();
     // WHY restore after clearAllMocks: createClient must return {rpc} for RPC calls.
     // Fix P0: user-scoped client is now the RPC client for admin_toggle_consent.
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, auth: makeAuthMock() });
     mockHeadersGet.mockImplementation((name: string) => {
       if (name === 'x-forwarded-for') return MOCK_XFF;
       if (name === 'user-agent') return MOCK_UA;
@@ -924,5 +997,25 @@ describe('toggleConsentAction', () => {
     expect(mockSentryCaptureMessage).toHaveBeenCalledOnce();
     const [, sentryCtx] = mockSentryCaptureMessage.mock.calls[0];
     expect(sentryCtx.tags.admin_action).toBe('toggle_consent');
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ───────────────────────────────────
+  it('(MFA gate) returns ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { toggleConsentAction } = await import('../actions');
+    const result = await toggleConsentAction(
+      VALID_UUID,
+      makeFormData({
+        targetUserId: VALID_UUID,
+        purpose: 'support_read_metadata',
+        grant: 'true',
+        reason: 'support request',
+      })
+    );
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/actions.ts
@@ -33,6 +33,7 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { createAdminClient, createClient } from '@/lib/supabase/server';
 import * as Sentry from '@sentry/nextjs';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
@@ -276,6 +277,24 @@ export async function overrideTierAction(
   // SOC 2 CC6.1, CC7.2.
   const supabase = await createClient();
 
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // WHY here (not in layout): the layout cannot call assertAdminMfa because it
+  // would block the passkey enrollment page itself (bootstrap paradox). Per-action
+  // enforcement is the correct pattern. OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
+
   const { data: auditId, error } = await supabase.rpc('admin_override_tier', {
     p_target_user_id: parsed.data.targetUserId,
     p_new_tier: parsed.data.newTier,
@@ -374,6 +393,26 @@ export async function resetPasswordAction(
   //     scoped client forwards the admin's session cookie → auth.uid() resolves.
   //   SOC 2 CC6.1, CC7.2.
   const adminClient = createAdminClient();
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // WHY user-scoped client for MFA check: assertAdminMfa uses createAdminClient()
+  // internally for DB queries, but we need the acting admin's user ID. We use
+  // a temporary user-scoped client here to resolve auth.uid() → actingAdmin.id.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const mfaClient = await createClient();
+    const { data: { user: actingAdmin } } = await mfaClient.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
 
   // ── 3. Fetch target user server-side via trusted Auth Admin API ───────────
   // CRITICAL (C1): email is resolved from the server-side Auth Admin API, not
@@ -559,6 +598,22 @@ export async function toggleConsentAction(
   // = NULL → 42501. User-scoped client forwards the admin's session cookie.
   // SOC 2 CC6.1, CC7.2.
   const supabase = await createClient();
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
 
   const { error } = await supabase.rpc('admin_toggle_consent', {
     p_target_user_id: parsed.data.targetUserId,

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/__tests__/actions.test.ts
@@ -97,6 +97,25 @@ vi.mock('@sentry/nextjs', () => ({
  *   elsewhere — only the returned object's .rpc/.from need to be reachable
  *   from tests, and that comes via mockRpc (hoisted above).
  */
+// WHY mock mfa-gate (H42 Layer 1): every billing admin action now calls
+// `assertAdminMfa(actingAdmin.id)` before running its RPC. Without this mock
+// the gate would call createAdminClient → site_admins lookup, which is not
+// stubbed at this unit-test layer. MFA gate behavior itself is covered in
+// src/lib/admin/__tests__/mfa-gate.test.ts; these unit tests assert each
+// action wires the gate correctly via dedicated `(MFA)` test cases below.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
   createAdminClient: vi.fn(),
@@ -143,9 +162,29 @@ vi.mock('@/lib/billing/polar-refund', () => {
 // Import mocked modules so tests can assert on them.
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { RefundError } from '@/lib/billing/polar-refund';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import type { Mock } from 'vitest';
 
+const ACTING_ADMIN_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Builds an `auth.getUser()` stub for the mocked Supabase client.
+ * WHY: H42 Layer 1 added `supabase.auth.getUser()` calls inside every admin action
+ * to capture the acting admin for the MFA gate. Returning a real admin user
+ * (rather than null) means the gate is genuinely exercised on every test path —
+ * `assertAdminMfa` (mocked at module level) runs and resolves by default.
+ * Per-case overrides simulate gate failure via
+ * `(assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError())`.
+ */
+function makeAuthMock() {
+  return {
+    getUser: vi.fn().mockResolvedValue({
+      data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+    }),
+  };
+}
 
 /**
  * Builds a FormData object from a plain record.
@@ -186,6 +225,7 @@ describe('issueRefundAction', () => {
     // DB error) reassign the maybeSingle resolver per-case.
     (createClient as Mock).mockResolvedValue({
       rpc: mockRpc,
+      auth: makeAuthMock(),
       from: vi.fn().mockReturnValue({
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
@@ -604,6 +644,7 @@ describe('issueRefundAction', () => {
     function setSubscriptionLookup(value: { data: unknown; error: unknown }) {
       (createClient as Mock).mockResolvedValue({
         rpc: mockRpc,
+        auth: makeAuthMock(),
         from: vi.fn().mockReturnValue({
           select: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({
@@ -746,6 +787,29 @@ describe('issueRefundAction', () => {
       expect(mockRpc).not.toHaveBeenCalled();
     });
   });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ───────────────────────────────────
+  // WHY: action calls assertAdminMfa(actingAdmin.id) before Polar+RPC. Catches
+  // any future refactor that bypasses the gate.
+  it('(MFA gate) returns ADMIN_MFA_REQUIRED and skips Polar + RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { issueRefundAction } = await import('../actions');
+    const result = await issueRefundAction(
+      VALID_UUID,
+      makeFormData({
+        targetUserId: VALID_UUID,
+        subscriptionId: 'sub_polar_123',
+        amount_cents: '4900',
+        reason: 'Customer requested refund for billing error',
+      })
+    );
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    expect(mockCreatePolarRefund).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
 });
 
 // ─── issueCreditAction ────────────────────────────────────────────────────────
@@ -753,7 +817,7 @@ describe('issueRefundAction', () => {
 describe('issueCreditAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, auth: makeAuthMock() });
     mockRpc.mockResolvedValue({ data: { audit_id: 10, credit_id: 99 }, error: null });
   });
 
@@ -974,6 +1038,25 @@ describe('issueCreditAction', () => {
     expect(sentryCtx.tags.admin_action).toBe('issue_credit');
     expect(sentryCtx.tags.sqlstate).toBe('P0001');
   });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ───────────────────────────────────
+  it('(MFA gate) returns ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { issueCreditAction } = await import('../actions');
+    const result = await issueCreditAction(
+      VALID_UUID,
+      makeFormData({
+        targetUserId: VALID_UUID,
+        amount_cents: '1000',
+        reason: 'Valid reason here, 10+ chars',
+      })
+    );
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
 });
 
 // ─── sendChurnSaveOfferAction ─────────────────────────────────────────────────
@@ -981,7 +1064,7 @@ describe('issueCreditAction', () => {
 describe('sendChurnSaveOfferAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc });
+    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, auth: makeAuthMock() });
     mockRpc.mockResolvedValue({
       data: { audit_id: 20, offer_id: 88 },
       error: null,
@@ -1159,5 +1242,24 @@ describe('sendChurnSaveOfferAction', () => {
     const [, sentryCtx] = mockSentryCapture.mock.calls[0];
     expect(sentryCtx.tags.admin_action).toBe('send_churn_save_offer');
     expect(sentryCtx.tags.sqlstate).toBe('XX999');
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ───────────────────────────────────
+  it('(MFA gate) returns ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { sendChurnSaveOfferAction } = await import('../actions');
+    const result = await sendChurnSaveOfferAction(
+      VALID_UUID,
+      makeFormData({
+        targetUserId: VALID_UUID,
+        kind: 'monthly_1mo_50pct',
+        reason: 'Valid reason here, 10+ chars',
+      })
+    );
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
@@ -46,6 +46,7 @@ import {
   RefundError,
 } from '@/lib/billing/polar-refund';
 import type { AdminActionResult } from '@/app/dashboard/admin/users/[userId]/actions';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // Re-export AdminActionResult so sub-pages can import from this module too.
 export type { AdminActionResult };
@@ -260,6 +261,23 @@ export async function issueRefundAction(
   const idempotencyKey = `${targetUserId}:${subscription_id}:${amount_cents}:${nowRoundedToMinute}`;
 
   // ── 3. Resolve subscription owner + Polar customer + Polar order ───────────
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const mfaClient = await createClient();
+    const { data: { user: actingAdmin } } = await mfaClient.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
+
   // SEC-REFUND-001: The Polar SDK refund API requires a real order ID; the
   // pass-through `orderId: subscription_id` it had before this PR caused Polar
   // to reject every refund with HTTPValidationError. Two-step resolution now:
@@ -574,6 +592,22 @@ export async function issueCreditAction(
   // WHY createClient() (user-scoped): see module JSDoc. SOC 2 CC6.1, CC7.2.
   const supabase = await createClient();
 
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
+
   const { data: rpcData, error: rpcErr } = await supabase.rpc('admin_issue_credit', {
     p_target_user_id: targetUserId,
     p_amount_cents: amount_cents,
@@ -673,6 +707,22 @@ export async function sendChurnSaveOfferAction(
   // ── 2. Call SECURITY DEFINER RPC ──────────────────────────────────────────
   // WHY createClient() (user-scoped): see module JSDoc. SOC 2 CC6.1, CC7.2.
   const supabase = await createClient();
+
+  // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
+  // OWASP A07:2021, SOC 2 CC6.1.
+  {
+    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
+    if (actingAdmin) {
+      try {
+        await assertAdminMfa(actingAdmin.id);
+      } catch (err) {
+        if (err instanceof AdminMfaRequiredError) {
+          return { ok: false, error: err.code };
+        }
+        throw err;
+      }
+    }
+  }
 
   const { data: rpcData, error: rpcErr } = await supabase.rpc('admin_send_churn_save_offer', {
     p_target_user_id: targetUserId,

--- a/packages/styrby-web/src/components/admin/AdminMfaBanner.tsx
+++ b/packages/styrby-web/src/components/admin/AdminMfaBanner.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+/**
+ * AdminMfaBanner
+ *
+ * Displays a time-sensitive warning banner to admins who are within their
+ * MFA enrollment grace period (mfa_grace_until from migration 065).
+ *
+ * Color urgency tiers:
+ *   - ≤1 day remaining → red (critical, action required today)
+ *   - ≤3 days remaining → amber (high urgency)
+ *   - >3 days remaining → yellow (informational)
+ *
+ * WHY urgency tiers: admins who see the same yellow banner every day develop
+ * banner blindness. Escalating color (red/amber) for shorter windows breaks
+ * that pattern and drives enrollment before the grace period expires.
+ *
+ * WHY client component:
+ *   The banner only needs the `graceUntil` prop (a string) which is fetched
+ *   server-side in the admin layout and passed down. No server-side rendering
+ *   is needed in this component itself. 'use client' is required for the
+ *   link onClick / potential animations. The layout fetches the data; the
+ *   banner only renders it.
+ *
+ * WHY NOT in layout.tsx directly:
+ *   Separating the banner into a component keeps layout.tsx as an orchestrator
+ *   (data fetching only) and pushes UI logic into a dedicated file.
+ *   CLAUDE.md: Component-First Architecture.
+ *
+ * Security references:
+ *   OWASP A07:2021 — Identification and Authentication Failures
+ *   SOC 2 CC6.1 — Privileged access requires phishing-resistant MFA
+ *
+ * @param graceUntil - ISO 8601 timestamp string when the grace period expires,
+ *   or null if no grace (admin enrolled before/after MFA requirement — no banner).
+ */
+
+import Link from 'next/link';
+import { AlertTriangle } from 'lucide-react';
+
+// ============================================================================
+// Props
+// ============================================================================
+
+interface AdminMfaBannerProps {
+  /**
+   * The admin's mfa_grace_until timestamp from site_admins.
+   * null → admin has no grace window → banner is not shown.
+   */
+  graceUntil: string | null;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Computes whole days remaining until the grace period expires.
+ *
+ * WHY Math.ceil: a value of 0.2 days should show "1 day" — rounding down
+ * to 0 would imply the grace has expired when it hasn't. Ceiling is the
+ * correct user-facing rounding for "how much time do I have left?"
+ *
+ * @param graceUntil - ISO 8601 timestamp.
+ * @returns Whole days remaining (may be 0 or negative if expired).
+ */
+function daysRemaining(graceUntil: string): number {
+  const msRemaining = new Date(graceUntil).getTime() - Date.now();
+  return Math.ceil(msRemaining / (1000 * 60 * 60 * 24));
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Renders an MFA enrollment reminder banner for admins in the grace period.
+ *
+ * Returns null when:
+ *   - graceUntil is null (no grace window, admin already has MFA or
+ *     was added after enforcement)
+ *   - The grace period has already expired (days <= 0): at that point
+ *     assertAdminMfa() blocks admin actions, so the banner is moot.
+ */
+export function AdminMfaBanner({ graceUntil }: AdminMfaBannerProps) {
+  if (!graceUntil) return null;
+
+  const days = daysRemaining(graceUntil);
+
+  // Grace expired — assertAdminMfa blocks actions; banner is redundant.
+  if (days <= 0) return null;
+
+  // ── Urgency styling ────────────────────────────────────────────────────────
+  // WHY three tiers: see component JSDoc for the banner-blindness rationale.
+  let bannerClass: string;
+  let textClass: string;
+  let iconClass: string;
+
+  if (days <= 1) {
+    // Critical: red
+    bannerClass = 'bg-red-50 border border-red-300';
+    textClass = 'text-red-800';
+    iconClass = 'text-red-500';
+  } else if (days <= 3) {
+    // High: amber
+    bannerClass = 'bg-amber-50 border border-amber-300';
+    textClass = 'text-amber-800';
+    iconClass = 'text-amber-500';
+  } else {
+    // Informational: yellow
+    bannerClass = 'bg-yellow-50 border border-yellow-200';
+    textClass = 'text-yellow-800';
+    iconClass = 'text-yellow-500';
+  }
+
+  const dayLabel = days === 1 ? 'day' : 'days';
+
+  return (
+    <div
+      className={`flex items-start gap-3 rounded-md px-4 py-3 ${bannerClass}`}
+      role="alert"
+      aria-live="polite"
+    >
+      {/* WHY AlertTriangle: CLAUDE.md prohibits sparkle icons (Sparkles, ✨).
+          AlertTriangle is the correct lucide-react icon for a security warning. */}
+      <AlertTriangle className={`mt-0.5 h-5 w-5 flex-shrink-0 ${iconClass}`} aria-hidden="true" />
+
+      <div className={`text-sm ${textClass}`}>
+        <strong className="font-semibold">MFA enrollment required.</strong>{' '}
+        You have{' '}
+        <strong>
+          {days} {dayLabel}
+        </strong>{' '}
+        remaining to enroll a passkey or authenticator app. After the grace period expires, admin
+        actions will be blocked until MFA is set up.{' '}
+        <Link
+          href="/dashboard/settings/account/passkeys"
+          className="underline underline-offset-2 font-medium hover:opacity-80 transition-opacity"
+        >
+          Set up MFA now
+        </Link>
+        .
+      </div>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/lib/__tests__/auth-lockout.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/auth-lockout.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Auth Lockout Tests (H42 Item 3)
+ *
+ * Tests the account lockout utility functions:
+ * - checkLockoutStatus: returns correct locked/unlocked state
+ * - recordLoginFailure: increments counter; triggers lockout after 5 failures within 1 hour
+ * - resetLoginFailures: resets counter on successful auth
+ * - lockoutResponse: returns 423 with Retry-After header
+ * - Admin exemption: site admins are never locked out
+ *
+ * WHY: Lockout is a security-critical control (SOC2 CC6.6, NIST SP 800-63B §5.2.2).
+ * Bugs could either allow brute-force attacks (lockout never fires) or
+ * create denial-of-service (lockout fires too aggressively or never resets).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockRpc = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createAdminClient: vi.fn(() => ({
+    rpc: mockRpc,
+    from: mockFrom,
+  })),
+}));
+
+// Import AFTER mocks
+import {
+  checkLockoutStatus,
+  recordLoginFailure,
+  resetLoginFailures,
+  lockoutResponse,
+  LOCKOUT_MAX_FAILURES,
+  LOCKOUT_DURATION_SECONDS,
+  LOCKOUT_WINDOW_SECONDS,
+} from '../auth-lockout';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** A non-admin user profile mock */
+function mockNonAdminProfile() {
+  mockFrom.mockReturnValue({
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: { is_site_admin: false }, error: null }),
+  });
+}
+
+/** An admin user profile mock */
+function mockAdminProfile() {
+  mockFrom.mockReturnValue({
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: { is_site_admin: true }, error: null }),
+  });
+}
+
+const TEST_USER_ID = 'user-uuid-test-0001';
+const FUTURE_LOCKED_UNTIL = new Date(Date.now() + LOCKOUT_DURATION_SECONDS * 1000).toISOString();
+const PAST_LOCKED_UNTIL = new Date(Date.now() - 1000).toISOString();
+
+// ============================================================================
+// checkLockoutStatus
+// ============================================================================
+
+describe('checkLockoutStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns isLocked=false when no lockout record exists', async () => {
+    mockNonAdminProfile();
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    const status = await checkLockoutStatus(TEST_USER_ID);
+
+    expect(status.isLocked).toBe(false);
+    expect(status.lockedUntil).toBeNull();
+    expect(status.failedCount).toBe(0);
+  });
+
+  it('returns isLocked=false when locked_until is in the past (expired lockout)', async () => {
+    mockNonAdminProfile();
+    mockRpc.mockResolvedValue({
+      data: [{ is_locked: false, locked_until: PAST_LOCKED_UNTIL, failed_count: 3 }],
+      error: null,
+    });
+
+    const status = await checkLockoutStatus(TEST_USER_ID);
+
+    expect(status.isLocked).toBe(false);
+  });
+
+  it('returns isLocked=true when locked_until is in the future', async () => {
+    mockNonAdminProfile();
+    mockRpc.mockResolvedValue({
+      data: [{ is_locked: true, locked_until: FUTURE_LOCKED_UNTIL, failed_count: 5 }],
+      error: null,
+    });
+
+    const status = await checkLockoutStatus(TEST_USER_ID);
+
+    expect(status.isLocked).toBe(true);
+    expect(status.lockedUntil).toBe(FUTURE_LOCKED_UNTIL);
+  });
+
+  it('returns isLocked=false when RPC errors (fail-open policy)', async () => {
+    mockNonAdminProfile();
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'DB error' } });
+
+    const status = await checkLockoutStatus(TEST_USER_ID);
+
+    // WHY fail-open: a DB outage should not block all logins
+    expect(status.isLocked).toBe(false);
+    expect(status.lockedUntil).toBeNull();
+  });
+
+  it('always returns isLocked=false for site admins (exempt)', async () => {
+    mockAdminProfile();
+    // RPC should NOT be called for admins
+    mockRpc.mockResolvedValue({ data: [{ is_locked: true, locked_until: FUTURE_LOCKED_UNTIL, failed_count: 5 }], error: null });
+
+    const status = await checkLockoutStatus(TEST_USER_ID);
+
+    expect(status.isLocked).toBe(false);
+    // Admin short-circuits before the lockout RPC
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// recordLoginFailure
+// ============================================================================
+
+describe('recordLoginFailure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns isLocked=false when failure count is below threshold', async () => {
+    mockNonAdminProfile();
+    // RPC returns null locked_until (not yet locked)
+    mockRpc.mockResolvedValue({ data: null, error: null });
+
+    const status = await recordLoginFailure(TEST_USER_ID);
+
+    expect(status.isLocked).toBe(false);
+    expect(status.lockedUntil).toBeNull();
+  });
+
+  it('returns isLocked=true when threshold is reached (5th failure)', async () => {
+    mockNonAdminProfile();
+    // RPC returns a locked_until in the future
+    mockRpc.mockResolvedValue({ data: FUTURE_LOCKED_UNTIL, error: null });
+
+    const status = await recordLoginFailure(TEST_USER_ID);
+
+    expect(status.isLocked).toBe(true);
+    expect(status.lockedUntil).toBe(FUTURE_LOCKED_UNTIL);
+  });
+
+  it('triggers lockout after LOCKOUT_MAX_FAILURES failures', async () => {
+    // Simulate 5 sequential failure calls, last one returning locked_until
+    mockNonAdminProfile();
+
+    // First 4 calls: not yet locked
+    for (let i = 0; i < LOCKOUT_MAX_FAILURES - 1; i++) {
+      mockNonAdminProfile(); // re-mock for each call
+      mockRpc.mockResolvedValueOnce({ data: null, error: null });
+      const s = await recordLoginFailure(TEST_USER_ID);
+      expect(s.isLocked).toBe(false);
+    }
+
+    // 5th call: locked
+    mockNonAdminProfile();
+    mockRpc.mockResolvedValueOnce({ data: FUTURE_LOCKED_UNTIL, error: null });
+    const finalStatus = await recordLoginFailure(TEST_USER_ID);
+
+    expect(finalStatus.isLocked).toBe(true);
+    expect(LOCKOUT_MAX_FAILURES).toBe(5);
+    expect(LOCKOUT_DURATION_SECONDS).toBe(900); // 15 minutes
+  });
+
+  it('returns isLocked=false when RPC errors (fail-open)', async () => {
+    mockNonAdminProfile();
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'DB write failed' } });
+
+    const status = await recordLoginFailure(TEST_USER_ID);
+
+    expect(status.isLocked).toBe(false);
+  });
+
+  it('is a no-op for site admins (exempt from lockout)', async () => {
+    mockAdminProfile();
+    // RPC should NOT be called
+    mockRpc.mockResolvedValue({ data: FUTURE_LOCKED_UNTIL, error: null });
+
+    const status = await recordLoginFailure(TEST_USER_ID);
+
+    expect(status.isLocked).toBe(false);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('lockout expires after LOCKOUT_DURATION_SECONDS (15 min) — constant check', () => {
+    // Validate our policy constants match the spec (H42 Item 3)
+    expect(LOCKOUT_DURATION_SECONDS).toBe(900); // 15 * 60
+    expect(LOCKOUT_WINDOW_SECONDS).toBe(3600);  // 1 hour
+    expect(LOCKOUT_MAX_FAILURES).toBe(5);
+  });
+});
+
+// ============================================================================
+// resetLoginFailures
+// ============================================================================
+
+describe('resetLoginFailures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls reset RPC for non-admin users', async () => {
+    mockNonAdminProfile();
+    mockRpc.mockResolvedValue({ data: null, error: null });
+
+    await resetLoginFailures(TEST_USER_ID);
+
+    expect(mockRpc).toHaveBeenCalledWith('reset_login_failures', { p_user_id: TEST_USER_ID });
+  });
+
+  it('does not call reset RPC for admin users (exempt)', async () => {
+    mockAdminProfile();
+
+    await resetLoginFailures(TEST_USER_ID);
+
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when RPC errors (non-critical path)', async () => {
+    mockNonAdminProfile();
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'transient error' } });
+
+    // Should not throw — failure to reset is non-critical
+    await expect(resetLoginFailures(TEST_USER_ID)).resolves.toBeUndefined();
+  });
+});
+
+// ============================================================================
+// lockoutResponse
+// ============================================================================
+
+describe('lockoutResponse', () => {
+  it('returns status 423', async () => {
+    const lockedUntil = new Date(Date.now() + 600000).toISOString(); // 10 min
+    const response = lockoutResponse(lockedUntil);
+
+    expect(response.status).toBe(423);
+  });
+
+  it('includes Retry-After header', async () => {
+    const lockedUntil = new Date(Date.now() + 600000).toISOString(); // 10 min
+    const response = lockoutResponse(lockedUntil);
+
+    const retryAfter = response.headers.get('Retry-After');
+    expect(retryAfter).not.toBeNull();
+    const retrySeconds = Number(retryAfter);
+    expect(retrySeconds).toBeGreaterThan(0);
+    expect(retrySeconds).toBeLessThanOrEqual(600); // ≤ 10 min
+  });
+
+  it('includes Content-Type: application/json', async () => {
+    const lockedUntil = new Date(Date.now() + 60000).toISOString();
+    const response = lockoutResponse(lockedUntil);
+
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('body contains ACCOUNT_LOCKED error code', async () => {
+    const lockedUntil = new Date(Date.now() + 60000).toISOString();
+    const response = lockoutResponse(lockedUntil);
+    const body = await response.json();
+
+    expect(body.error).toBe('ACCOUNT_LOCKED');
+    expect(typeof body.retryAfter).toBe('number');
+    expect(body.retryAfter).toBeGreaterThan(0);
+  });
+
+  it('Retry-After is at least 1 second even for very near lock expiry', async () => {
+    // Lock expires in 1ms — should round up to 1 second
+    const almostNow = new Date(Date.now() + 1).toISOString();
+    const response = lockoutResponse(almostNow);
+
+    const retryAfter = Number(response.headers.get('Retry-After'));
+    expect(retryAfter).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/styrby-web/src/lib/admin/mfa-gate.ts
+++ b/packages/styrby-web/src/lib/admin/mfa-gate.ts
@@ -1,0 +1,336 @@
+/**
+ * Admin MFA Gate — assertAdminMfa()
+ *
+ * Enforces that every admin who has passed the grace period has at least one
+ * active MFA factor (passkey OR Supabase Auth TOTP) before they can perform
+ * a privileged mutation.
+ *
+ * Security references:
+ *   OWASP A07:2021  - Identification and Authentication Failures
+ *   SOC 2 CC6.1     - Logical access controls; privileged access requires
+ *                     phishing-resistant authentication factors
+ *   NIST SP 800-63B AAL2 - Multi-factor authentication for privileged accounts
+ *   NIST SP 800-53 AC-3  - Access enforcement; deny-by-default on error
+ *
+ * WHY application-layer (not Postgres-layer):
+ *   MFA factor queries require the Supabase Auth Admin API
+ *   (auth.admin.getUserById). Calling the Admin API from inside a Postgres
+ *   SECURITY DEFINER function is not supported without pg_net and introduces
+ *   a network dependency on every admin RPC call. Application-layer enforcement
+ *   is faster, testable, and does not block the Postgres execution path.
+ *
+ * Call pattern in admin action/route handlers:
+ *   import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
+ *
+ *   // After isAdmin check (or equivalent):
+ *   try {
+ *     await assertAdminMfa(user.id);
+ *   } catch (err) {
+ *     if (err instanceof AdminMfaRequiredError) {
+ *       return NextResponse.json({ error: err.code }, { status: err.statusCode });
+ *     }
+ *     throw err;
+ *   }
+ */
+
+import { createAdminClient } from '@/lib/supabase/server';
+import * as Sentry from '@sentry/nextjs';
+
+// ============================================================================
+// Config
+// ============================================================================
+
+/**
+ * Grace period in days for new admin MFA enforcement.
+ *
+ * WHY env-var: allows the grace period to be adjusted per-environment without
+ * a code deployment. Staging can use 0 (immediate enforcement), production
+ * uses 7 days for initial rollout.
+ *
+ * Used only when inserting NEW admins. Existing admins at migration time
+ * received their grace window via the 065_admin_mfa_enforcement.sql backfill.
+ */
+export const ADMIN_MFA_GRACE_DAYS = (() => {
+  const raw = process.env.STYRBY_ADMIN_MFA_GRACE_DAYS;
+  if (!raw) return 7;
+  const parsed = Number(raw);
+  // WHY NaN / negative guard: a misconfigured value must not accidentally grant
+  // infinite or negative grace. Default to 7 on bad input. NIST SP 800-53 AC-3.
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 7;
+})();
+
+// ============================================================================
+// Error class
+// ============================================================================
+
+/**
+ * Thrown by assertAdminMfa() when an admin is blocked from performing a
+ * privileged action because they have not enrolled MFA after their grace window.
+ *
+ * Callers should catch this error and return a 403 JSON response:
+ *   { error: 'ADMIN_MFA_REQUIRED' }
+ *
+ * WHY a typed error class (not a plain Error): callers can distinguish MFA
+ * failures from unexpected errors using `instanceof AdminMfaRequiredError`,
+ * which allows precise 403 responses without catching everything.
+ */
+export class AdminMfaRequiredError extends Error {
+  /** HTTP status code to return to the client. */
+  readonly statusCode = 403 as const;
+  /**
+   * Machine-readable error code. Clients should display a setup-MFA prompt
+   * when they receive this code.
+   */
+  readonly code = 'ADMIN_MFA_REQUIRED' as const;
+
+  constructor() {
+    super(
+      'Admin MFA is required. Enroll a passkey or TOTP factor at ' +
+        '/dashboard/settings/account/passkeys before performing admin actions.'
+    );
+    this.name = 'AdminMfaRequiredError';
+  }
+}
+
+// ============================================================================
+// Internal types
+// ============================================================================
+
+/**
+ * Aggregated MFA status for a single admin user.
+ * Computed in parallel by queryAdminMfaStatus().
+ */
+interface AdminMfaStatus {
+  /** True if the admin's grace period has not yet expired (mfa_grace_until > now). */
+  inGrace: boolean;
+  /** The raw mfa_grace_until timestamp, or null if no grace row. */
+  graceUntil: string | null;
+  /** True if the admin has at least one non-revoked passkey. */
+  hasPasskey: boolean;
+  /** True if the admin has a verified Supabase Auth TOTP factor. */
+  hasTotp: boolean;
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+/**
+ * Queries the admin's MFA status in parallel:
+ *   1. site_admins.mfa_grace_until — is the grace period still active?
+ *   2. passkeys count — has the admin enrolled a passkey?
+ *   3. auth.admin.getUserById TOTP check — has the admin verified a TOTP factor?
+ *
+ * WHY parallel queries: all three are independent. Serial would triple the p99
+ * latency for every admin action — unacceptable for a hot path.
+ *
+ * WHY service-role client (createAdminClient):
+ *   - site_admins is not accessible by the authenticated role via RLS.
+ *   - passkeys may be scoped to service-role only (depends on RLS config).
+ *   - auth.admin.getUserById requires service-role privilege.
+ *   Using service-role here is safe because:
+ *     a) assertAdminMfa is only called AFTER isAdmin() confirms admin status.
+ *     b) We only read, never write, from this helper.
+ *
+ * @param userId - The admin user's UUID.
+ * @returns Aggregated AdminMfaStatus.
+ * @throws If any critical query (grace + passkeys) fails. TOTP failure is
+ *   swallowed when a passkey is present (fail-open for TOTP API errors when
+ *   passkey MFA is already satisfied). NIST SP 800-53 AC-3.
+ */
+async function queryAdminMfaStatus(userId: string): Promise<AdminMfaStatus> {
+  const adminClient = createAdminClient();
+
+  // Run grace window + passkeys queries in parallel.
+  // TOTP requires auth.admin.getUserById which is independent.
+  const [graceResult, passkeysResult, authUserResult] = await Promise.all([
+    // (1) Grace window: is mfa_grace_until in the future?
+    adminClient
+      .from('site_admins')
+      .select('mfa_grace_until')
+      .eq('user_id', userId)
+      .maybeSingle(),
+
+    // (2) Passkeys: count non-revoked passkeys for this user.
+    // WHY maybeSingle() not count: count('exact') requires a head:true option
+    // which returns no data. We select id and count client-side instead,
+    // keeping the query simple and compatible with the RLS policy shape.
+    adminClient
+      .from('passkeys')
+      .select('id')
+      .eq('user_id', userId)
+      .is('revoked_at', null),
+
+    // (3) TOTP: fetch Auth user to inspect mfa_factors.
+    // WHY Auth Admin API not a DB table: auth.mfa_factors is in the auth schema
+    // and is not exposed via PostgREST by default. The Auth Admin API is the
+    // correct, supported path. SOC 2 CC6.1.
+    adminClient.auth.admin.getUserById(userId),
+  ]);
+
+  // ── Grace window ────────────────────────────────────────────────────────────
+  if (graceResult.error) {
+    // Propagate — callers catch and fail-closed. NIST SP 800-53 AC-3.
+    throw graceResult.error;
+  }
+  const graceUntilStr = graceResult.data?.mfa_grace_until ?? null;
+  const inGrace = graceUntilStr != null && new Date(graceUntilStr) > new Date();
+
+  // ── Passkeys ────────────────────────────────────────────────────────────────
+  if (passkeysResult.error) {
+    // Propagate — callers catch and fail-closed.
+    throw passkeysResult.error;
+  }
+  const hasPasskey = (passkeysResult.data ?? []).length > 0;
+
+  // ── TOTP ────────────────────────────────────────────────────────────────────
+  // WHY swallow Auth API errors when passkey is present:
+  //   A transient Auth API error must not block an admin who has a valid passkey.
+  //   The passkey factor alone satisfies NIST SP 800-63B AAL2. If the Auth API
+  //   is down AND no passkey is present, we fail-closed (see assertAdminMfa).
+  let hasTotp = false;
+  if (!authUserResult.error && authUserResult.data?.user?.factors) {
+    hasTotp = authUserResult.data.user.factors.some(
+      (f) => f.factor_type === 'totp' && f.status === 'verified'
+    );
+  } else if (authUserResult.error && !hasPasskey) {
+    // Auth API failed and no passkey — propagate so assertAdminMfa fails-closed.
+    throw authUserResult.error;
+  }
+  // If Auth API failed but passkey IS present: hasTotp stays false, but
+  // hasPasskey=true will allow the action. This is the correct fallback.
+
+  return { inGrace, graceUntil: graceUntilStr, hasPasskey, hasTotp };
+}
+
+/**
+ * Writes a grace-period audit event to audit_log.
+ *
+ * WHY audit_log (not admin_audit_log):
+ *   admin_audit_log tracks mutations the admin performs on OTHER users.
+ *   This event is about the admin's own authentication state — it belongs
+ *   in the general audit_log. SOC 2 CC6.1: document privileged access with
+ *   defined remediation deadlines.
+ *
+ * WHY non-throwing: a failure to write a grace audit event must not block
+ * the admin action. The event is informational — the admin is still allowed
+ * to act (they're in grace). Failure is captured in Sentry for ops visibility.
+ *
+ * @param userId - The admin user's UUID.
+ * @param graceUntil - The ISO timestamp when the grace period expires.
+ */
+async function writeGraceAuditEvent(userId: string, graceUntil: string | null): Promise<void> {
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient.from('audit_log').insert({
+    user_id: userId,
+    event_type: 'admin_mfa_grace_action',
+    metadata: {
+      grace_until: graceUntil,
+      note:
+        'Admin performed an action during MFA grace period. ' +
+        'OWASP A07:2021 / SOC 2 CC6.1: enroll MFA before grace expires.',
+    },
+  });
+
+  if (error) {
+    // Non-fatal: log to Sentry but do not block the admin action.
+    Sentry.captureException(error, {
+      tags: { component: 'writeGraceAuditEvent', user_id: userId },
+      extra: { grace_until: graceUntil },
+    });
+  }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Asserts that the given admin user has an active MFA factor (passkey or TOTP),
+ * or is still within their migration grace period.
+ *
+ * Call this AFTER confirming the user is an admin (isAdmin() check). It is NOT
+ * a substitute for the admin check — it adds a second authentication-factor
+ * requirement on top of the existing admin authorization check.
+ *
+ * Behavior:
+ *   - In grace period → allow action, write grace audit event (non-blocking).
+ *   - Has passkey OR verified TOTP → allow action.
+ *   - No MFA after grace → throw AdminMfaRequiredError (403 ADMIN_MFA_REQUIRED).
+ *   - DB error → throw AdminMfaRequiredError (fail-closed, NIST SP 800-53 AC-3).
+ *
+ * @param userId - The admin user's UUID (from Supabase Auth getUser).
+ * @throws {AdminMfaRequiredError} When the admin must enroll MFA before acting.
+ *
+ * @example
+ * const adminStatus = await isAdmin(user.id);
+ * if (!adminStatus) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+ *
+ * try {
+ *   await assertAdminMfa(user.id);
+ * } catch (err) {
+ *   if (err instanceof AdminMfaRequiredError) {
+ *     return NextResponse.json({ error: err.code }, { status: err.statusCode });
+ *   }
+ *   throw err;
+ * }
+ */
+export async function assertAdminMfa(userId: string): Promise<void> {
+  // WHY guard empty userId: a missing userId should never reach here (auth check
+  // should have caught it), but fail-closed defensively. NIST SP 800-53 AC-3.
+  if (!userId) {
+    throw new AdminMfaRequiredError();
+  }
+
+  let status: AdminMfaStatus;
+  try {
+    status = await queryAdminMfaStatus(userId);
+  } catch (err) {
+    // Any DB error → fail-closed. Never grant access on uncertainty.
+    // SOC 2 CC6.1, NIST SP 800-53 AC-3: deny by default on error.
+    Sentry.captureException(err, {
+      tags: { component: 'assertAdminMfa', user_id: userId },
+      extra: {
+        note: 'MFA status query failed. Failing closed (ADMIN_MFA_REQUIRED). NIST SP 800-53 AC-3.',
+      },
+    });
+    throw new AdminMfaRequiredError();
+  }
+
+  // ── Grace period path ────────────────────────────────────────────────────────
+  if (status.inGrace) {
+    // Admin is within migration grace window — allow action but write audit event.
+    // WHY allow in grace: see migration 065 header for the bootstrap rationale.
+    // WHY write audit: SOC 2 CC6.1 requires documenting that a privileged action
+    // was performed before the admin completed MFA enrollment.
+    await writeGraceAuditEvent(userId, status.graceUntil);
+    return;
+  }
+
+  // ── MFA satisfied path ───────────────────────────────────────────────────────
+  if (status.hasPasskey || status.hasTotp) {
+    // Admin has at least one active MFA factor — allow action.
+    // WHY either factor is sufficient: both passkeys (FIDO2/WebAuthn) and
+    // verified TOTP satisfy NIST SP 800-63B AAL2 for privileged accounts.
+    return;
+  }
+
+  // ── Blocked path ─────────────────────────────────────────────────────────────
+  // Grace expired, no MFA enrolled → block action.
+  // WHY Sentry warning (not exception): this is expected behavior after grace
+  // expires — it's a policy enforcement event, not an error. Ops should still
+  // be aware so they can follow up with the admin. SOC 2 CC6.1.
+  Sentry.captureMessage(
+    'Admin MFA gate blocked action: no MFA enrolled after grace period expired.',
+    {
+      level: 'warning',
+      tags: {
+        component: 'assertAdminMfa',
+        reason: 'no_mfa_after_grace',
+        user_id: userId,
+      },
+    }
+  );
+  throw new AdminMfaRequiredError();
+}

--- a/packages/styrby-web/src/lib/auth-lockout.ts
+++ b/packages/styrby-web/src/lib/auth-lockout.ts
@@ -1,0 +1,258 @@
+/**
+ * Authentication Lockout Utilities
+ *
+ * Implements account lockout after N consecutive failed login attempts
+ * within a rolling time window. Applied to passkey verification to
+ * protect against credential stuffing and brute-force attacks.
+ *
+ * Policy (H42 Item 3, SOC2 CC6.6, NIST SP 800-63B §5.2.2):
+ * - 5 failed attempts within 1 hour → 15-minute lockout
+ * - Successful auth resets the counter
+ * - Locked accounts return 423 Locked + Retry-After header
+ * - Admins (is_site_admin=true) are exempt — see WHY comment below
+ *
+ * WHY admins are exempt:
+ * Admin lockout creates an unrecoverable denial-of-service with no
+ * self-service path. Admins authenticate via hardware-backed passkeys
+ * which are phishing-resistant by design. Auto-lockout provides marginal
+ * additional protection while creating a high-severity availability risk.
+ * (NIST SP 800-63B §5.2.2 explicitly permits this exception when
+ * compensating controls — e.g., MFA, hardware-bound credentials — exist.)
+ *
+ * All three DB operations use SECURITY DEFINER functions via the admin
+ * client so the application layer never has direct table access to
+ * user_lockout. This prevents privilege escalation via RLS bypass.
+ */
+
+import { createAdminClient } from '@/lib/supabase/server';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Rolling window in seconds for failure counting.
+ * 5 failures within this window triggers lockout.
+ */
+export const LOCKOUT_WINDOW_SECONDS = 3600; // 1 hour
+
+/**
+ * Maximum consecutive failures within LOCKOUT_WINDOW_SECONDS before lockout.
+ */
+export const LOCKOUT_MAX_FAILURES = 5;
+
+/**
+ * Duration of the lockout in seconds once triggered.
+ */
+export const LOCKOUT_DURATION_SECONDS = 900; // 15 minutes
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a lockout status check.
+ */
+export interface LockoutStatus {
+  /** Whether the account is currently locked out. */
+  isLocked: boolean;
+  /**
+   * ISO 8601 timestamp when the lockout expires.
+   * Only present when isLocked is true.
+   */
+  lockedUntil: string | null;
+  /**
+   * Number of consecutive failures recorded.
+   * Useful for surfacing a warning before lockout triggers.
+   */
+  failedCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Admin check (exempts site admins from lockout)
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks whether a user is a site admin and therefore exempt from lockout.
+ *
+ * WHY: See module-level docstring for the rationale. We query the profiles
+ * table rather than auth.users so no service-role expansion is needed.
+ *
+ * @param userId - The Supabase user ID to check
+ * @returns true if the user is a site admin
+ */
+async function isSiteAdmin(userId: string): Promise<boolean> {
+  const supabase = createAdminClient();
+  const { data } = await supabase
+    .from('profiles')
+    .select('is_site_admin')
+    .eq('id', userId)
+    .single();
+  return data?.is_site_admin === true;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks whether a user account is currently locked out.
+ *
+ * Call this at the START of every login attempt before performing any
+ * credential verification to prevent unnecessary bcrypt/WebAuthn work.
+ *
+ * Admins always return { isLocked: false } regardless of failure count.
+ *
+ * @param userId - The Supabase user ID to check
+ * @returns The current lockout status
+ *
+ * @example
+ * const lockout = await checkLockoutStatus(userId);
+ * if (lockout.isLocked) {
+ *   const retryAfter = Math.ceil((new Date(lockout.lockedUntil!).getTime() - Date.now()) / 1000);
+ *   return NextResponse.json({ error: 'ACCOUNT_LOCKED' }, {
+ *     status: 423,
+ *     headers: { 'Retry-After': String(retryAfter) },
+ *   });
+ * }
+ */
+export async function checkLockoutStatus(userId: string): Promise<LockoutStatus> {
+  // Admins are exempt — short-circuit before DB call
+  if (await isSiteAdmin(userId)) {
+    return { isLocked: false, lockedUntil: null, failedCount: 0 };
+  }
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .rpc('check_lockout_status', { p_user_id: userId });
+
+  if (error) {
+    // WHY: If the lockout check fails, we log and allow the request.
+    // Blocking all logins due to a DB error is worse than a brief window
+    // without lockout protection. This mirrors the rate-limit fail-open policy.
+    console.error('[auth-lockout] check_lockout_status RPC failed:', error.message);
+    return { isLocked: false, lockedUntil: null, failedCount: 0 };
+  }
+
+  // RPC returns a single row (or empty for no-failure users)
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) {
+    return { isLocked: false, lockedUntil: null, failedCount: 0 };
+  }
+
+  return {
+    isLocked: row.is_locked === true,
+    lockedUntil: row.locked_until ?? null,
+    failedCount: row.failed_count ?? 0,
+  };
+}
+
+/**
+ * Records a failed login attempt and returns the updated lockout state.
+ *
+ * Call this AFTER a credential verification failure (e.g., passkey
+ * assertion rejected by the edge function). Do NOT call on network errors
+ * or internal failures — only on actual credential mismatches.
+ *
+ * Admins: call is a no-op; returns unlocked status.
+ *
+ * @param userId - The Supabase user ID that failed authentication
+ * @returns The lockout state after recording the failure
+ *
+ * @example
+ * const lockout = await recordLoginFailure(userId);
+ * if (lockout.isLocked) {
+ *   const retryAfter = Math.ceil((new Date(lockout.lockedUntil!).getTime() - Date.now()) / 1000);
+ *   return NextResponse.json({ error: 'ACCOUNT_LOCKED' }, {
+ *     status: 423,
+ *     headers: { 'Retry-After': String(retryAfter) },
+ *   });
+ * }
+ */
+export async function recordLoginFailure(userId: string): Promise<LockoutStatus> {
+  // Admins are exempt
+  if (await isSiteAdmin(userId)) {
+    return { isLocked: false, lockedUntil: null, failedCount: 0 };
+  }
+
+  const supabase = createAdminClient();
+  const { data: lockedUntil, error } = await supabase
+    .rpc('record_login_failure', {
+      p_user_id:         userId,
+      p_window_seconds:  LOCKOUT_WINDOW_SECONDS,
+      p_max_failures:    LOCKOUT_MAX_FAILURES,
+      p_lockout_seconds: LOCKOUT_DURATION_SECONDS,
+    });
+
+  if (error) {
+    // Fail-open: log and return unlocked to avoid blocking all logins
+    console.error('[auth-lockout] record_login_failure RPC failed:', error.message);
+    return { isLocked: false, lockedUntil: null, failedCount: 0 };
+  }
+
+  const lockedUntilStr = lockedUntil as string | null;
+  const isLocked = !!lockedUntilStr && new Date(lockedUntilStr) > new Date();
+
+  return {
+    isLocked,
+    lockedUntil: lockedUntilStr,
+    // Re-check status for accurate failure count
+    failedCount: LOCKOUT_MAX_FAILURES, // conservative upper bound when locked
+  };
+}
+
+/**
+ * Resets the failure counter for a user after a successful authentication.
+ *
+ * Call this AFTER successful credential verification and session creation.
+ * Fire-and-forget is acceptable — failure to reset is not security-critical
+ * (the counter will naturally expire with the window).
+ *
+ * Admins: call is a no-op.
+ *
+ * @param userId - The Supabase user ID that succeeded authentication
+ *
+ * @example
+ * // After successful passkey verify:
+ * void resetLoginFailures(userId); // fire and forget
+ */
+export async function resetLoginFailures(userId: string): Promise<void> {
+  // Admins are exempt (no row to reset anyway)
+  if (await isSiteAdmin(userId)) return;
+
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .rpc('reset_login_failures', { p_user_id: userId });
+
+  if (error) {
+    // Non-critical: log but don't fail the request
+    console.error('[auth-lockout] reset_login_failures RPC failed:', error.message);
+  }
+}
+
+/**
+ * Creates a 423 Locked NextResponse with Retry-After header.
+ *
+ * @param lockedUntil - ISO 8601 timestamp when the lockout expires
+ * @returns NextResponse with status 423 and Retry-After header
+ */
+export function lockoutResponse(lockedUntil: string): Response {
+  const retryAfter = Math.max(
+    1,
+    Math.ceil((new Date(lockedUntil).getTime() - Date.now()) / 1000)
+  );
+  return new Response(
+    JSON.stringify({
+      error: 'ACCOUNT_LOCKED',
+      message: 'Too many failed attempts. Please try again later.',
+      retryAfter,
+    }),
+    {
+      status: 423,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': String(retryAfter),
+      },
+    }
+  );
+}

--- a/packages/styrby-web/src/lib/middleware/__tests__/idempotency.test.ts
+++ b/packages/styrby-web/src/lib/middleware/__tests__/idempotency.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Unit tests for idempotency key middleware.
+ *
+ * Covers:
+ * 1. First call with key → returns replayed: false (cache miss)
+ * 2. Second call same key + same body → replayed: true with cached response
+ * 3. Second call same key + different body → conflict (409 semantics)
+ * 4. Different user, same key → independent (no collision)
+ * 5. No key supplied → replayed: false (no DB access)
+ * 6. Expired cache entry → replayed: false (treats as miss)
+ * 7. DB error on select → replayed: false (fail-open, non-blocking)
+ * 8. storeIdempotencyResult only caches 2xx responses
+ * 9. storeIdempotencyResult no-ops when no Idempotency-Key header
+ *
+ * @module lib/middleware/__tests__/idempotency.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkIdempotency, storeIdempotencyResult } from '../idempotency';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+/**
+ * Tracks upsert calls to verify storeIdempotencyResult writes.
+ */
+const mockUpsert = vi.fn();
+
+/**
+ * Tracks maybeSingle calls; returns whatever selectReturnValue holds.
+ */
+const mockMaybeSingle = vi.fn();
+
+/**
+ * The value returned by .maybeSingle() in the current test case.
+ * Set this before calling checkIdempotency to control the DB response.
+ */
+let selectReturnValue: { data: unknown; error: unknown } = { data: null, error: null };
+
+// Build a full chainable Supabase mock for .from().select().eq().eq().eq().maybeSingle()
+const mockFrom = vi.fn(() => ({
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  maybeSingle: mockMaybeSingle,
+  upsert: mockUpsert,
+}));
+
+/**
+ * Mock createAdminClient so tests don't need a real Supabase connection.
+ * WHY factory mock: each test may need a fresh chain instance.
+ */
+vi.mock('@/lib/supabase/server', () => ({
+  createAdminClient: vi.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Creates a minimal Request object with an optional Idempotency-Key header
+ * and body.
+ *
+ * @param opts.key - Value for the Idempotency-Key header (omitted if not provided)
+ * @param opts.body - Request body string (defaults to '{}')
+ * @param opts.method - HTTP method (defaults to 'POST')
+ * @param opts.path - Request path (defaults to '/api/test')
+ * @returns A standard Request object
+ */
+function makeRequest(opts: {
+  key?: string;
+  body?: string;
+  method?: string;
+  path?: string;
+} = {}): Request {
+  const { key, body = '{}', method = 'POST', path = '/api/test' } = opts;
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  if (key) {
+    headers.set('Idempotency-Key', key);
+  }
+  return new Request(`http://localhost:3000${path}`, {
+    method,
+    headers,
+    body,
+  });
+}
+
+// ============================================================================
+// Test suite
+// ============================================================================
+
+describe('checkIdempotency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectReturnValue = { data: null, error: null };
+    mockMaybeSingle.mockImplementation(() => selectReturnValue);
+    mockUpsert.mockResolvedValue({ error: null });
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 5: No Idempotency-Key header
+  // --------------------------------------------------------------------------
+
+  it('returns replayed: false when no Idempotency-Key header is supplied', async () => {
+    const req = makeRequest({ key: undefined });
+    const result = await checkIdempotency(req, 'user-abc', '/api/test');
+
+    expect(result).toEqual({ replayed: false });
+    // WHY: No DB access should occur when the header is absent.
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 1: Cache miss (first call with key)
+  // --------------------------------------------------------------------------
+
+  it('returns replayed: false on first call with key (cache miss)', async () => {
+    selectReturnValue = { data: null, error: null };
+    mockMaybeSingle.mockResolvedValueOnce(selectReturnValue);
+
+    const req = makeRequest({ key: 'idem-key-001' });
+    const result = await checkIdempotency(req, 'user-abc', '/api/test');
+
+    expect(result).toEqual({ replayed: false });
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 2: Cache hit — same key + same body → replay
+  // --------------------------------------------------------------------------
+
+  it('returns replayed: true with cached response on second call with same key and body', async () => {
+    // Simulate a cached row with a non-expired timestamp
+    const futureExpiry = new Date(Date.now() + 23 * 60 * 60 * 1000).toISOString();
+
+    // The request hash must match. We pre-compute what the middleware will
+    // compute: sha256('POST:/api/test:{}')
+    const { createHash } = await import('crypto');
+    const expectedHash = createHash('sha256')
+      .update('POST:/api/test:{}')
+      .digest('hex');
+
+    selectReturnValue = {
+      data: {
+        request_hash: expectedHash,
+        response_status: 200,
+        response_body: { checkout_url: 'https://polar.sh/checkout/abc' },
+        expires_at: futureExpiry,
+      },
+      error: null,
+    };
+    mockMaybeSingle.mockResolvedValueOnce(selectReturnValue);
+
+    const req = makeRequest({ key: 'idem-key-001', body: '{}' });
+    const result = await checkIdempotency(req, 'user-abc', '/api/test');
+
+    expect(result).toEqual({
+      replayed: true,
+      status: 200,
+      body: { checkout_url: 'https://polar.sh/checkout/abc' },
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 3: Cache hit — same key + DIFFERENT body → conflict
+  // --------------------------------------------------------------------------
+
+  it('returns conflict when same key is replayed with a different body', async () => {
+    const futureExpiry = new Date(Date.now() + 23 * 60 * 60 * 1000).toISOString();
+
+    // Return a hash that does NOT match the incoming request body
+    selectReturnValue = {
+      data: {
+        request_hash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        response_status: 200,
+        response_body: { checkout_url: 'https://polar.sh/checkout/abc' },
+        expires_at: futureExpiry,
+      },
+      error: null,
+    };
+    mockMaybeSingle.mockResolvedValueOnce(selectReturnValue);
+
+    const req = makeRequest({ key: 'idem-key-001', body: '{"tier":"business"}' });
+    const result = await checkIdempotency(req, 'user-abc', '/api/test');
+
+    expect(result).toMatchObject({ conflict: true });
+    expect((result as { conflict: true; message: string }).message).toContain(
+      'Idempotency-Key has already been used with a different request body',
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 4: Different user, same key → independent (no collision)
+  // --------------------------------------------------------------------------
+
+  it('treats same key for different users as independent cache entries', async () => {
+    // Both users get a cache miss (data: null)
+    const missMock = { data: null, error: null };
+    mockMaybeSingle
+      .mockResolvedValueOnce(missMock)
+      .mockResolvedValueOnce(missMock);
+
+    const req1 = makeRequest({ key: 'shared-key' });
+    const req2 = makeRequest({ key: 'shared-key' });
+
+    const result1 = await checkIdempotency(req1, 'user-alice', '/api/test');
+    const result2 = await checkIdempotency(req2, 'user-bob', '/api/test');
+
+    // Both are cache misses — no collision
+    expect(result1).toEqual({ replayed: false });
+    expect(result2).toEqual({ replayed: false });
+
+    // Verify the eq() call received different user IDs on each invocation
+    // (the second .eq() call on the chain is the user_id filter)
+    const allEqCalls = mockFrom.mock.results.flatMap(() => []);
+    // The key assertion is that both calls reached the DB independently
+    expect(mockFrom).toHaveBeenCalledTimes(2);
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 6: Expired cache entry → treat as miss
+  // --------------------------------------------------------------------------
+
+  it('returns replayed: false when cache entry has expired', async () => {
+    const pastExpiry = new Date(Date.now() - 1000).toISOString();
+    const { createHash } = await import('crypto');
+    const hash = createHash('sha256').update('POST:/api/test:{}').digest('hex');
+
+    selectReturnValue = {
+      data: {
+        request_hash: hash,
+        response_status: 200,
+        response_body: { ok: true },
+        expires_at: pastExpiry,
+      },
+      error: null,
+    };
+    mockMaybeSingle.mockResolvedValueOnce(selectReturnValue);
+
+    const req = makeRequest({ key: 'expired-key' });
+    const result = await checkIdempotency(req, 'user-abc', '/api/test');
+
+    // Expired entry treated as a miss — handler should re-execute
+    expect(result).toEqual({ replayed: false });
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 7: DB error on select → fail-open (replayed: false)
+  // --------------------------------------------------------------------------
+
+  it('returns replayed: false when a DB error occurs during select', async () => {
+    selectReturnValue = {
+      data: null,
+      error: { message: 'connection refused' },
+    };
+    mockMaybeSingle.mockResolvedValueOnce(selectReturnValue);
+
+    const req = makeRequest({ key: 'idem-key-err' });
+    const result = await checkIdempotency(req, 'user-abc', '/api/test');
+
+    // WHY fail-open: a DB error should not block the request. The handler
+    // runs normally; worst case is a duplicate execution.
+    expect(result).toEqual({ replayed: false });
+  });
+});
+
+// ============================================================================
+// storeIdempotencyResult tests
+// ============================================================================
+
+describe('storeIdempotencyResult', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpsert.mockResolvedValue({ error: null });
+    // Reset the from mock to return the upsert chain
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: mockMaybeSingle,
+      upsert: mockUpsert,
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 8a: Only 2xx responses are cached
+  // --------------------------------------------------------------------------
+
+  it('calls upsert when status is 200', async () => {
+    const req = makeRequest({ key: 'store-key-001' });
+    await storeIdempotencyResult(req, 'user-abc', '/api/test', 200, { ok: true });
+    expect(mockUpsert).toHaveBeenCalled();
+  });
+
+  it('calls upsert when status is 201', async () => {
+    const req = makeRequest({ key: 'store-key-002' });
+    await storeIdempotencyResult(req, 'user-abc', '/api/test', 201, { created: true });
+    expect(mockUpsert).toHaveBeenCalled();
+  });
+
+  it('does NOT call upsert when status is 400', async () => {
+    const req = makeRequest({ key: 'store-key-003' });
+    await storeIdempotencyResult(req, 'user-abc', '/api/test', 400, { error: 'Bad Request' });
+    // WHY: Caching 4xx would prevent clients from retrying with a corrected body.
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call upsert when status is 500', async () => {
+    const req = makeRequest({ key: 'store-key-004' });
+    await storeIdempotencyResult(req, 'user-abc', '/api/test', 500, { error: 'Internal Error' });
+    // WHY: Caching 5xx would prevent clients from retrying after server recovery.
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call upsert when status is 409 (conflict)', async () => {
+    const req = makeRequest({ key: 'store-key-005' });
+    await storeIdempotencyResult(req, 'user-abc', '/api/test', 409, { error: 'Conflict' });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // Test 9: No Idempotency-Key header → no-op
+  // --------------------------------------------------------------------------
+
+  it('does NOT call upsert when no Idempotency-Key header is present', async () => {
+    const req = makeRequest({ key: undefined });
+    await storeIdempotencyResult(req, 'user-abc', '/api/test', 200, { ok: true });
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // Additional: upsert called with correct shape
+  // --------------------------------------------------------------------------
+
+  it('passes correct fields to upsert including user_id and route', async () => {
+    const req = makeRequest({ key: 'shape-key', body: '{"tier":"team"}', path: '/api/billing/checkout/team' });
+    await storeIdempotencyResult(req, 'user-xyz', '/api/billing/checkout/team', 200, {
+      checkout_url: 'https://polar.sh/checkout/xyz',
+    });
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'shape-key',
+        user_id: 'user-xyz',
+        route: '/api/billing/checkout/team',
+        response_status: 200,
+        response_body: { checkout_url: 'https://polar.sh/checkout/xyz' },
+      }),
+      expect.objectContaining({ onConflict: 'key,user_id,route' }),
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // Additional: DB write error is swallowed (non-fatal)
+  // --------------------------------------------------------------------------
+
+  it('does not throw when upsert returns an error', async () => {
+    mockUpsert.mockResolvedValueOnce({ error: { message: 'write failed' } });
+    const req = makeRequest({ key: 'err-key' });
+    // Should not throw — write failure is logged but not propagated
+    await expect(
+      storeIdempotencyResult(req, 'user-abc', '/api/test', 200, { ok: true }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/styrby-web/src/lib/middleware/idempotency.ts
+++ b/packages/styrby-web/src/lib/middleware/idempotency.ts
@@ -1,0 +1,291 @@
+/**
+ * Idempotency Key Middleware
+ *
+ * Server-side deduplication for state-mutating endpoints (POST, PATCH, DELETE).
+ * Mirrors the Stripe idempotency key pattern + Standard Webhooks spec.
+ *
+ * WHY: The Styrby CLI retries network-failed requests automatically. Without
+ * server-side deduplication, a transient error on a checkout or deletion
+ * request can cause the operation to execute twice — double-charge or
+ * double-delete. This middleware caches successful responses keyed to
+ * (Idempotency-Key header, user_id, route) and replays the cached response
+ * on duplicate submissions within 24 hours.
+ *
+ * OWASP A04:2021 (Insecure Design): replay protection.
+ *
+ * @see https://stripe.com/docs/idempotency
+ * @see https://owasp.org/Top10/A04_2021-Insecure_Design/
+ * @module lib/middleware/idempotency
+ */
+
+import { createHash } from 'crypto';
+import { createAdminClient } from '@/lib/supabase/server';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Result returned by {@link checkIdempotency}.
+ *
+ * Discriminated union: when `replayed` is false, the caller should proceed
+ * with normal handler logic. When `replayed` is true, the caller should
+ * return the cached response immediately.
+ */
+export type IdempotencyResult =
+  | {
+      /** No cached response found — proceed with handler logic. */
+      replayed: false;
+    }
+  | {
+      /** Cached response found — return this to the client without re-executing. */
+      replayed: true;
+      /** HTTP status code of the original response. */
+      status: number;
+      /** Response body of the original response, to be returned verbatim. */
+      body: unknown;
+    };
+
+// ============================================================================
+// Request hashing
+// ============================================================================
+
+/**
+ * Computes a deterministic SHA-256 hash of the request identity.
+ *
+ * WHY include method + path + body: the hash is used to detect body mismatch
+ * on key replay. If a client sends the same Idempotency-Key with a different
+ * request body (e.g. different tier, different amount), that is a client bug
+ * and must be rejected with 409 Conflict.
+ *
+ * @param method - HTTP method (e.g. 'POST')
+ * @param path - Request pathname (e.g. '/api/billing/checkout/team')
+ * @param body - Raw request body string (may be empty string for bodyless requests)
+ * @returns Hex-encoded SHA-256 digest
+ */
+function computeRequestHash(method: string, path: string, body: string): string {
+  return createHash('sha256')
+    .update(`${method.toUpperCase()}:${path}:${body}`)
+    .digest('hex');
+}
+
+// ============================================================================
+// Public API — check
+// ============================================================================
+
+/**
+ * Checks whether the incoming request is a replay of a previously processed
+ * idempotent operation.
+ *
+ * Call this at the top of every state-mutating handler, before any business
+ * logic runs. If `result.replayed` is true, return the cached response
+ * immediately and skip all handler logic.
+ *
+ * Idempotency is opt-in via the `Idempotency-Key` request header. If the
+ * header is absent, the function returns `replayed: false` without any
+ * database access.
+ *
+ * Only 2xx responses are cached (set via {@link storeIdempotencyResult}).
+ * 4xx/5xx errors are never replayed — the client must retry and may get a
+ * different error or a success on the next attempt.
+ *
+ * @param request - The incoming Next.js request object (or standard Request)
+ * @param userId - Authenticated user ID (UUID). Must be resolved before calling.
+ * @param route - Normalized route identifier (e.g. '/api/billing/checkout/team').
+ *   Use a string constant, not the runtime pathname, to avoid query-string
+ *   differences invalidating the cache.
+ * @returns Idempotency check result — either `replayed: false` to proceed, or
+ *   `replayed: true` with cached status + body.
+ *
+ * @throws Returns a plain object with a `conflict: true` flag when the same
+ *   key was used with a different request body. Callers should detect this and
+ *   return 409 Conflict to the client.
+ *
+ * @example
+ * ```ts
+ * const idem = await checkIdempotency(req, userId, '/api/billing/checkout/team');
+ * if (idem.replayed) {
+ *   return NextResponse.json(idem.body, { status: idem.status });
+ * }
+ * // ... rest of handler ...
+ * ```
+ */
+export async function checkIdempotency(
+  request: Request,
+  userId: string,
+  route: string,
+): Promise<IdempotencyResult | { conflict: true; message: string }> {
+  // Idempotency is opt-in. No header → proceed without any DB access.
+  const idempotencyKey = request.headers.get('idempotency-key') ??
+    request.headers.get('Idempotency-Key');
+
+  if (!idempotencyKey) {
+    return { replayed: false };
+  }
+
+  // Read the body once and compute the request hash.
+  // WHY clone(): request body can only be consumed once. We clone so the
+  // original stream remains available for the handler to parse after this
+  // function returns.
+  let rawBody = '';
+  try {
+    rawBody = await request.clone().text();
+  } catch {
+    // Body may be unavailable (e.g. GET-like requests forwarded incorrectly).
+    // Fall through with empty string — the hash will still be deterministic.
+    rawBody = '';
+  }
+
+  const url = new URL(request.url);
+  const requestHash = computeRequestHash(request.method, url.pathname, rawBody);
+
+  // Service-role client: idempotency_keys has no client-accessible RLS policies.
+  // All access is server-side only.
+  const adminClient = createAdminClient();
+
+  const { data: existing, error: selectError } = await adminClient
+    .from('idempotency_keys')
+    .select('request_hash, response_status, response_body, expires_at')
+    .eq('key', idempotencyKey)
+    .eq('user_id', userId)
+    .eq('route', route)
+    .maybeSingle();
+
+  if (selectError) {
+    // WHY: A DB error on the idempotency check should not block the request.
+    // Log and fall through — the handler will run normally. The worst case is
+    // a duplicate execution, which is preferable to a hard failure.
+    console.error('[idempotency] select error:', selectError.message);
+    return { replayed: false };
+  }
+
+  if (!existing) {
+    // Cache miss — proceed with handler.
+    return { replayed: false };
+  }
+
+  // Check if the cached row has expired. The cleanup cron handles bulk
+  // expiry but we do an inline check here for correctness.
+  const expiresAt = new Date(existing.expires_at as string);
+  if (expiresAt < new Date()) {
+    // Expired entry — treat as a miss and let the handler run fresh.
+    return { replayed: false };
+  }
+
+  // Cache hit — verify request hash matches.
+  if (existing.request_hash !== requestHash) {
+    // WHY 409 not 422: the key is valid but the request is inconsistent with
+    // the prior use of this key. This is a client programming error (the client
+    // reused a key with a different body), not a server-side validation failure.
+    // Stripe uses 422 here; we use 409 Conflict to align with RFC 9110.
+    return {
+      conflict: true,
+      message:
+        'Idempotency-Key has already been used with a different request body. ' +
+        'Use a new key for a different request.',
+    };
+  }
+
+  // Cache hit — return the original response.
+  return {
+    replayed: true,
+    status: existing.response_status as number,
+    body: existing.response_body,
+  };
+}
+
+// ============================================================================
+// Public API — store
+// ============================================================================
+
+/**
+ * Stores a successful handler response in the idempotency cache.
+ *
+ * Call this immediately after the handler computes a successful (2xx) response,
+ * before returning it to the client. This ensures that a concurrent duplicate
+ * request received while the first is in-flight will receive the cached
+ * response on its next retry.
+ *
+ * WHY only cache 2xx: 4xx/5xx errors are transient or client-fixable. Caching
+ * a 500 would prevent the client from retrying after the server recovers.
+ * Caching a 400 would prevent the client from retrying with a corrected body.
+ * Only a successful outcome is idempotent by definition.
+ *
+ * WHY upsert not insert: a concurrent duplicate request may have already
+ * inserted a row between our SELECT (miss) and this INSERT. Upsert handles
+ * this race gracefully by overwriting the concurrent insert (the values are
+ * identical since the request hash matched).
+ *
+ * @param request - The incoming request (used to extract key, method, path, body)
+ * @param userId - Authenticated user ID
+ * @param route - Normalized route identifier (must match the value passed to checkIdempotency)
+ * @param status - HTTP status code of the response being stored (should be 2xx)
+ * @param body - Response body to cache (will be returned verbatim on replay)
+ * @returns Promise that resolves when the cache entry is written (or silently
+ *   fails — a write failure does not affect the response returned to the client)
+ *
+ * @example
+ * ```ts
+ * const responseBody = { checkout_url: checkout.url };
+ * await storeIdempotencyResult(req, userId, '/api/billing/checkout/team', 200, responseBody);
+ * return NextResponse.json(responseBody);
+ * ```
+ */
+export async function storeIdempotencyResult(
+  request: Request,
+  userId: string,
+  route: string,
+  status: number,
+  body: unknown,
+): Promise<void> {
+  // Only cache successes. Never cache 4xx/5xx — see JSDoc WHY above.
+  if (status < 200 || status >= 300) {
+    return;
+  }
+
+  const idempotencyKey = request.headers.get('idempotency-key') ??
+    request.headers.get('Idempotency-Key');
+
+  if (!idempotencyKey) {
+    // No key supplied — nothing to cache.
+    return;
+  }
+
+  let rawBody = '';
+  try {
+    rawBody = await request.clone().text();
+  } catch {
+    rawBody = '';
+  }
+
+  const url = new URL(request.url);
+  const requestHash = computeRequestHash(request.method, url.pathname, rawBody);
+
+  const adminClient = createAdminClient();
+
+  const { error } = await adminClient.from('idempotency_keys').upsert(
+    {
+      key: idempotencyKey,
+      user_id: userId,
+      route,
+      request_hash: requestHash,
+      response_status: status,
+      response_body: body,
+      created_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      onConflict: 'key,user_id,route',
+      // WHY ignoreDuplicates false: if a concurrent request already inserted
+      // the row, we upsert with the same values to handle the race without error.
+      ignoreDuplicates: false,
+    },
+  );
+
+  if (error) {
+    // WHY swallow: a cache write failure is non-fatal. The response was already
+    // computed and will be returned to the client. The worst outcome is that the
+    // next retry executes the handler again rather than getting the cached result.
+    console.error('[idempotency] store error:', error.message);
+  }
+}

--- a/packages/styrby-web/src/middleware/__tests__/api-auth.test.ts
+++ b/packages/styrby-web/src/middleware/__tests__/api-auth.test.ts
@@ -1,8 +1,8 @@
 /**
  * API Authentication Middleware Tests
  *
- * Tests the authenticateApiRequest, withApiAuth, apiAuthError, and
- * addRateLimitHeaders functions.
+ * Tests the authenticateApiRequest, withApiAuth, withApiAuthAndRateLimit,
+ * apiAuthError, addRateLimitHeaders, and isKeyNearExpiry functions.
  *
  * Key behaviors tested:
  * - Missing/malformed Authorization header
@@ -12,10 +12,14 @@
  * - Key hash verification (bcrypt)
  * - Expired key rejection
  * - Rate limiting (100 req/min per key)
+ * - IP-based pre-auth rate limit (60 req/min/IP) — H42 Item 1
+ * - withApiAuthAndRateLimit: per-key isolation + per-route limit override — H42 Item 1
+ * - API key TTL: near-expiry warning in headers — H42 Item 2
+ * - keyExpiresAt exposed in ApiAuthContext — H42 Item 2
  * - Successful authentication returns context
  * - withApiAuth HOF: scope checking, handler invocation
- * - apiAuthError: correct status codes and error codes
- * - addRateLimitHeaders: X-RateLimit-* headers
+ * - apiAuthError: correct status codes and error codes (including 423 LOCKED)
+ * - addRateLimitHeaders: X-RateLimit-* headers + expiry warning headers
  *
  * WHY: The API auth middleware is a security-critical path. Bugs could allow
  * unauthenticated access, skip rate limits, or expose other users' data.
@@ -58,16 +62,30 @@ vi.mock('@styrby/shared', () => ({
   }),
 }));
 
+/**
+ * Mock rateLimit to allow all requests by default.
+ * Individual tests override this to simulate IP rate limit exhaustion.
+ */
+const mockRateLimitFn = vi.fn().mockResolvedValue({
+  allowed: true,
+  remaining: 59,
+  resetAt: Date.now() + 60000,
+  retryAfter: undefined,
+});
+
 vi.mock('@/lib/rateLimit', () => ({
   getClientIp: vi.fn(() => '203.0.113.1'),
+  rateLimit: (...args: unknown[]) => mockRateLimitFn(...args),
 }));
 
 // Import AFTER mocks are set up
 import {
   authenticateApiRequest,
   withApiAuth,
+  withApiAuthAndRateLimit,
   apiAuthError,
   addRateLimitHeaders,
+  isKeyNearExpiry,
 } from '../api-auth';
 
 // ============================================================================
@@ -135,6 +153,13 @@ function mockKeyLookupError() {
 describe('authenticateApiRequest', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset IP rate limiter to allow by default
+    mockRateLimitFn.mockResolvedValue({
+      allowed: true,
+      remaining: 59,
+      resetAt: Date.now() + 60000,
+      retryAfter: undefined,
+    });
   });
 
   describe('Authorization header validation', () => {
@@ -176,9 +201,6 @@ describe('authenticateApiRequest', () => {
     });
 
     it('returns 401 when key prefix extraction fails', async () => {
-      // A key that passes format validation but has no valid prefix
-      // Our mock of isValidApiKeyFormat requires styrby_ prefix + 32 chars,
-      // so if it somehow passes format but not prefix... we test extractApiKeyPrefix returning null
       const req = createRequest({
         authorization: 'Bearer not_styrby_key_but_long_enough_1234',
       });
@@ -284,7 +306,6 @@ describe('authenticateApiRequest', () => {
         },
       ]);
 
-      // First key doesn't match, second does
       mockVerifyApiKey
         .mockResolvedValueOnce(false)
         .mockResolvedValueOnce(true);
@@ -330,7 +351,7 @@ describe('authenticateApiRequest', () => {
 
   describe('Key expiration', () => {
     it('returns 401 for expired key', async () => {
-      const pastDate = new Date(Date.now() - 86400000).toISOString(); // Yesterday
+      const pastDate = new Date(Date.now() - 86400000).toISOString();
 
       mockKeyLookupSuccess([
         {
@@ -356,7 +377,7 @@ describe('authenticateApiRequest', () => {
     });
 
     it('allows non-expired key', async () => {
-      const futureDate = new Date(Date.now() + 86400000).toISOString(); // Tomorrow
+      const futureDate = new Date(Date.now() + 86400000).toISOString();
 
       mockKeyLookupSuccess([
         {
@@ -402,6 +423,7 @@ describe('authenticateApiRequest', () => {
 describe('withApiAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRateLimitFn.mockResolvedValue({ allowed: true, remaining: 59, resetAt: Date.now() + 60000 });
   });
 
   it('calls handler with context on successful auth', async () => {
@@ -442,7 +464,7 @@ describe('withApiAuth', () => {
     const handler = vi.fn();
     const wrappedHandler = withApiAuth(handler);
 
-    const req = createRequest(); // No auth header
+    const req = createRequest();
     const response = await wrappedHandler(req);
 
     expect(handler).not.toHaveBeenCalled();
@@ -455,14 +477,14 @@ describe('withApiAuth', () => {
         id: 'key-001',
         user_id: 'user-001',
         key_hash: VALID_KEY_HASH,
-        scopes: ['read'], // Only has read
+        scopes: ['read'],
         expires_at: null,
       },
     ]);
     mockVerifyApiKey.mockResolvedValue(true);
 
     const handler = vi.fn();
-    const wrappedHandler = withApiAuth(handler, ['write']); // Requires write
+    const wrappedHandler = withApiAuth(handler, ['write']);
 
     const req = createRequest({
       authorization: `Bearer ${VALID_KEY}`,
@@ -518,7 +540,7 @@ describe('withApiAuth', () => {
     const handler = vi.fn().mockResolvedValue(
       NextResponse.json({ ok: true })
     );
-    const wrappedHandler = withApiAuth(handler); // No scopes specified
+    const wrappedHandler = withApiAuth(handler);
 
     const req = createRequest({
       authorization: `Bearer ${VALID_KEY}`,
@@ -540,6 +562,11 @@ describe('apiAuthError', () => {
     expect(response.status).toBe(429);
   });
 
+  it('returns LOCKED code for 423 status', () => {
+    const response = apiAuthError('Account locked', 423);
+    expect(response.status).toBe(423);
+  });
+
   it('returns ERROR code for other statuses', () => {
     const response = apiAuthError('Something went wrong', 500);
     expect(response.status).toBe(500);
@@ -549,6 +576,11 @@ describe('apiAuthError', () => {
     const response = apiAuthError('Error', 401);
     expect(response.headers.get('Content-Type')).toBe('application/json');
   });
+
+  it('includes extra headers when provided', () => {
+    const response = apiAuthError('Locked', 423, { 'Retry-After': '60' });
+    expect(response.headers.get('Retry-After')).toBe('60');
+  });
 });
 
 describe('addRateLimitHeaders', () => {
@@ -556,10 +588,257 @@ describe('addRateLimitHeaders', () => {
     const response = NextResponse.json({ data: 'test' });
     const result = addRateLimitHeaders(response, 'nonexistent-key');
 
-    // X-RateLimit-Limit is always set so clients know the policy
     expect(result.headers.get('X-RateLimit-Limit')).toBe('100');
-    // Remaining and Reset are not set without a store entry
     expect(result.headers.get('X-RateLimit-Remaining')).toBeNull();
     expect(result.headers.get('X-RateLimit-Reset')).toBeNull();
+  });
+
+  it('does NOT set expiry warning headers when keyExpiresAt is null', () => {
+    const response = NextResponse.json({ data: 'test' });
+    const result = addRateLimitHeaders(response, 'key-001', null);
+
+    expect(result.headers.get('X-Api-Key-Expires-At')).toBeNull();
+    expect(result.headers.get('X-Api-Key-Expiry-Warning')).toBeNull();
+  });
+
+  it('does NOT set expiry warning headers when key expires far in the future', () => {
+    const farFuture = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+    const response = NextResponse.json({ data: 'test' });
+    const result = addRateLimitHeaders(response, 'key-001', farFuture);
+
+    expect(result.headers.get('X-Api-Key-Expiry-Warning')).toBeNull();
+  });
+
+  it('sets expiry warning headers when key expires within 30 days', () => {
+    const nearFuture = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString();
+    const response = NextResponse.json({ data: 'test' });
+    const result = addRateLimitHeaders(response, 'key-001', nearFuture);
+
+    expect(result.headers.get('X-Api-Key-Expiry-Warning')).toBe('true');
+    expect(result.headers.get('X-Api-Key-Expires-At')).toBe(nearFuture);
+  });
+});
+
+// ============================================================================
+// H42 Item 1: IP-based pre-auth rate limiting
+// ============================================================================
+
+describe('IP-based pre-auth rate limiting (H42 Item 1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRateLimitFn.mockResolvedValue({
+      allowed: true,
+      remaining: 59,
+      resetAt: Date.now() + 60000,
+      retryAfter: undefined,
+    });
+  });
+
+  it('returns 429 when IP rate limit is exhausted before auth', async () => {
+    mockRateLimitFn.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60000,
+      retryAfter: 42,
+    });
+
+    const req = createRequest({
+      authorization: `Bearer ${VALID_KEY}`,
+    });
+    const result = await authenticateApiRequest(req);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.status).toBe(429);
+      expect(result.error).toContain('42');
+    }
+    // DB should NOT be called — short-circuit before key lookup
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it('allows request when IP rate limit has remaining capacity', async () => {
+    mockRateLimitFn.mockResolvedValue({
+      allowed: true,
+      remaining: 30,
+      resetAt: Date.now() + 60000,
+    });
+    mockKeyLookupSuccess([
+      {
+        id: 'key-001',
+        user_id: 'user-001',
+        key_hash: VALID_KEY_HASH,
+        scopes: ['read'],
+        expires_at: null,
+      },
+    ]);
+    mockVerifyApiKey.mockResolvedValue(true);
+
+    const req = createRequest({ authorization: `Bearer ${VALID_KEY}` });
+    const result = await authenticateApiRequest(req);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('withApiAuthAndRateLimit returns 429 when IP limit exhausted', async () => {
+    mockRateLimitFn.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60000,
+      retryAfter: 15,
+    });
+
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+    const wrapped = withApiAuthAndRateLimit(handler);
+    const req = createRequest({ authorization: `Bearer ${VALID_KEY}` });
+    const response = await wrapped(req);
+
+    expect(response.status).toBe(429);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('withApiAuthAndRateLimit calls handler when IP limit not exhausted', async () => {
+    mockKeyLookupSuccess([
+      {
+        id: 'key-001',
+        user_id: 'user-001',
+        key_hash: VALID_KEY_HASH,
+        scopes: ['read'],
+        expires_at: null,
+      },
+    ]);
+    mockVerifyApiKey.mockResolvedValue(true);
+
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+    const wrapped = withApiAuthAndRateLimit(handler);
+    const req = createRequest({ authorization: `Bearer ${VALID_KEY}` });
+    const response = await wrapped(req);
+
+    expect(response.status).toBe(200);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('per-key isolation: different key IDs produce independent auth contexts', async () => {
+    mockRateLimitFn.mockResolvedValue({ allowed: true, remaining: 50, resetAt: Date.now() + 60000 });
+
+    const makeKeyRequest = async (keyId: string, userId: string) => {
+      mockKeyLookupSuccess([
+        {
+          id: keyId,
+          user_id: userId,
+          key_hash: VALID_KEY_HASH,
+          scopes: ['read'],
+          expires_at: null,
+        },
+      ]);
+      mockVerifyApiKey.mockResolvedValue(true);
+      return authenticateApiRequest(createRequest({ authorization: `Bearer ${VALID_KEY}` }));
+    };
+
+    const result1 = await makeKeyRequest('key-A', 'user-A');
+    const result2 = await makeKeyRequest('key-B', 'user-B');
+
+    expect(result1.success).toBe(true);
+    expect(result2.success).toBe(true);
+    if (result1.success) expect(result1.context.keyId).toBe('key-A');
+    if (result2.success) expect(result2.context.keyId).toBe('key-B');
+  });
+});
+
+// ============================================================================
+// H42 Item 2: API key TTL — near-expiry warning
+// ============================================================================
+
+describe('isKeyNearExpiry (H42 Item 2)', () => {
+  it('returns false for null expires_at (no expiry set)', () => {
+    expect(isKeyNearExpiry(null)).toBe(false);
+  });
+
+  it('returns false when key expires more than 30 days away', () => {
+    const farFuture = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString();
+    expect(isKeyNearExpiry(farFuture)).toBe(false);
+  });
+
+  it('returns true when key expires in less than 30 days', () => {
+    const nearFuture = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    expect(isKeyNearExpiry(nearFuture)).toBe(true);
+  });
+
+  it('returns true when key expires in exactly 1 day', () => {
+    const oneDayFuture = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).toISOString();
+    expect(isKeyNearExpiry(oneDayFuture)).toBe(true);
+  });
+
+  it('returns false for already-expired key (expiry is in the past)', () => {
+    // WHY: Already-expired keys are rejected at auth time. isKeyNearExpiry
+    // is for warning about upcoming expiry, not re-checking rejection.
+    const pastDate = new Date(Date.now() - 1000).toISOString();
+    expect(isKeyNearExpiry(pastDate)).toBe(false);
+  });
+});
+
+describe('keyExpiresAt in ApiAuthContext (H42 Item 2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRateLimitFn.mockResolvedValue({ allowed: true, remaining: 59, resetAt: Date.now() + 60000 });
+  });
+
+  it('exposes keyExpiresAt = null when key has no expiry', async () => {
+    mockKeyLookupSuccess([
+      {
+        id: 'key-001',
+        user_id: 'user-001',
+        key_hash: VALID_KEY_HASH,
+        scopes: ['read'],
+        expires_at: null,
+      },
+    ]);
+    mockVerifyApiKey.mockResolvedValue(true);
+
+    const result = await authenticateApiRequest(createRequest({ authorization: `Bearer ${VALID_KEY}` }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.context.keyExpiresAt).toBeNull();
+    }
+  });
+
+  it('exposes keyExpiresAt = ISO string when key has expiry', async () => {
+    const futureDate = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString();
+    mockKeyLookupSuccess([
+      {
+        id: 'key-001',
+        user_id: 'user-001',
+        key_hash: VALID_KEY_HASH,
+        scopes: ['read'],
+        expires_at: futureDate,
+      },
+    ]);
+    mockVerifyApiKey.mockResolvedValue(true);
+
+    const result = await authenticateApiRequest(createRequest({ authorization: `Bearer ${VALID_KEY}` }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.context.keyExpiresAt).toBe(futureDate);
+    }
+  });
+
+  it('expired key returns 401 (not expiry warning)', async () => {
+    const pastDate = new Date(Date.now() - 86400000).toISOString();
+    mockKeyLookupSuccess([
+      {
+        id: 'key-001',
+        user_id: 'user-001',
+        key_hash: VALID_KEY_HASH,
+        scopes: ['read'],
+        expires_at: pastDate,
+      },
+    ]);
+    mockVerifyApiKey.mockResolvedValue(true);
+
+    const result = await authenticateApiRequest(createRequest({ authorization: `Bearer ${VALID_KEY}` }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.status).toBe(401);
+      expect(result.error).toContain('expired');
+    }
   });
 });

--- a/packages/styrby-web/src/middleware/api-auth.ts
+++ b/packages/styrby-web/src/middleware/api-auth.ts
@@ -6,17 +6,20 @@
  * user context to the request.
  *
  * Authentication Flow:
- * 1. Extract API key from Authorization: Bearer sk_live_xxx header
- * 2. Extract prefix and look up candidate keys in database
- * 3. Verify full key against bcrypt hash
- * 4. Check key is not expired or revoked
- * 5. Update last_used_at tracking
- * 6. Attach user_id to request context
- * 7. Rate limit: 100 requests per minute per key
+ * 1. IP-based pre-auth rate limit (60 req/min/IP) — stops unauthenticated floods
+ * 2. Extract API key from Authorization: Bearer sk_live_xxx header
+ * 3. Extract prefix and look up candidate keys in database
+ * 4. Verify full key against bcrypt hash
+ * 5. Check key is not expired or revoked
+ * 6. Per-key rate limit: 100 requests per minute per key
+ * 7. Update last_used_at tracking
+ * 8. Attach user_id to request context
  *
  * Security Notes:
+ * - IP-based rate limit prevents unauthenticated flood attacks (H42 Layer 1)
+ * - Per-key rate limit prevents abuse by any single credential
  * - Uses bcrypt for constant-time hash comparison
- * - Rate limits prevent brute force attacks
+ * - API keys default to 1-year TTL; near-expiry (<30 days) is signalled in responses
  * - All requests are logged to audit_log
  * - Keys can be revoked instantly
  */
@@ -25,7 +28,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { verifyApiKey } from '@/lib/api-keys';
 import { extractApiKeyPrefix, isValidApiKeyFormat } from '@styrby/shared';
-import { getClientIp } from '@/lib/rateLimit';
+import { getClientIp, rateLimit as checkRateLimit } from '@/lib/rateLimit';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { getEnv, getHttpsUrlEnv } from '@/lib/env';
@@ -52,6 +55,13 @@ export interface ApiAuthContext {
   userId: string;
   keyId: string;
   scopes: string[];
+  /**
+   * ISO 8601 expiration timestamp for the API key, or null if never expires.
+   * Included so route handlers and CLI clients can detect near-expiry (<30 days)
+   * and prompt the user to rotate before the key stops working.
+   * (H42 Item 2)
+   */
+  keyExpiresAt: string | null;
 }
 
 /**
@@ -61,18 +71,49 @@ export type ApiAuthResult =
   | { success: true; context: ApiAuthContext }
   | { success: false; error: string; status: number };
 
+/**
+ * Per-route rate limit override options for withApiAuthAndRateLimit.
+ */
+export interface RateLimitOptions {
+  /** Time window in milliseconds (default: 60000) */
+  windowMs?: number;
+  /** Maximum requests per window (default: 100) */
+  maxRequests?: number;
+}
+
 // ---------------------------------------------------------------------------
 // Rate Limiting
 // ---------------------------------------------------------------------------
 
 /**
- * Rate limit configuration for API keys.
- * 100 requests per minute per key.
+ * Default per-key rate limit: 100 requests per minute.
+ * Applied after authentication (key-level isolation).
  */
 const API_RATE_LIMIT = {
   windowMs: 60000, // 1 minute
   maxRequests: 100,
 };
+
+/**
+ * Pre-auth IP-based rate limit: 60 requests per minute per IP.
+ *
+ * WHY: Applied before we parse the API key. This stops unauthenticated
+ * floods (e.g., key enumeration or DDoS against the auth layer itself)
+ * from ever reaching the bcrypt verification step.
+ * The limit is intentionally lower than the per-key limit so that a
+ * single IP cannot exhaust per-key capacity even if it spreads across keys.
+ * (H42 Layer 1, SOC2 CC6.6)
+ */
+const IP_RATE_LIMIT = {
+  windowMs: 60000, // 1 minute
+  maxRequests: 60,
+};
+
+/**
+ * Days remaining on an API key before we surface a near-expiry warning hint
+ * in API responses. CLI clients check `keyExpiresAt` and prompt rotation.
+ */
+const KEY_EXPIRY_WARNING_DAYS = 30;
 
 /**
  * Distributed rate limiter for API keys (H-001: replaces in-memory Map).
@@ -197,6 +238,9 @@ function createApiAdminClient() {
 /**
  * Authenticates an API request using the Authorization header.
  *
+ * Runs IP-based pre-auth rate limiting before any key lookup so that
+ * unauthenticated floods cannot drive up bcrypt verification cost.
+ *
  * @param request - The incoming HTTP request
  * @returns Authentication result with user context or error
  *
@@ -205,9 +249,21 @@ function createApiAdminClient() {
  * if (!result.success) {
  *   return NextResponse.json({ error: result.error }, { status: result.status });
  * }
- * const { userId, scopes } = result.context;
+ * const { userId, scopes, keyExpiresAt } = result.context;
  */
 export async function authenticateApiRequest(request: NextRequest): Promise<ApiAuthResult> {
+  // Step 0: IP-based pre-auth rate limit (H42 Layer 1)
+  // WHY: Check before we even parse the key so that key enumeration and
+  // unauthenticated floods are stopped at the cheapest possible checkpoint.
+  const ipRateLimitResult = await checkRateLimit(request, IP_RATE_LIMIT, 'api-v1-ip');
+  if (!ipRateLimitResult.allowed) {
+    return {
+      success: false,
+      error: `Rate limit exceeded. Retry after ${ipRateLimitResult.retryAfter ?? 60} seconds`,
+      status: 429,
+    };
+  }
+
   // Step 1: Extract API key from Authorization header
   const authHeader = request.headers.get('authorization');
 
@@ -293,7 +349,7 @@ export async function authenticateApiRequest(request: NextRequest): Promise<ApiA
     };
   }
 
-  // Step 5: Check expiration
+  // Step 5: Check expiration (H42 Item 2 — TTL enforcement)
   if (matchedKey.expires_at) {
     const expiresAt = new Date(matchedKey.expires_at);
     if (expiresAt < new Date()) {
@@ -305,12 +361,12 @@ export async function authenticateApiRequest(request: NextRequest): Promise<ApiA
     }
   }
 
-  // Step 6: Check rate limit (now distributed via Upstash Redis)
-  const rateLimit = await checkApiRateLimit(matchedKey.id);
-  if (!rateLimit.allowed) {
+  // Step 6: Check per-key rate limit (now distributed via Upstash Redis)
+  const keyRateLimit = await checkApiRateLimit(matchedKey.id);
+  if (!keyRateLimit.allowed) {
     return {
       success: false,
-      error: `Rate limit exceeded. Retry after ${rateLimit.retryAfter} seconds`,
+      error: `Rate limit exceeded. Retry after ${keyRateLimit.retryAfter} seconds`,
       status: 429,
     };
   }
@@ -338,6 +394,9 @@ export async function authenticateApiRequest(request: NextRequest): Promise<ApiA
       userId: matchedKey.user_id,
       keyId: matchedKey.id,
       scopes: matchedKey.scopes,
+      // WHY: Expose expiry so route handlers and CLI clients can surface
+      // near-expiry warnings (<30 days) without a separate API call.
+      keyExpiresAt: matchedKey.expires_at,
     },
   };
 }
@@ -347,18 +406,30 @@ export async function authenticateApiRequest(request: NextRequest): Promise<ApiA
  *
  * @param error - The error message
  * @param status - The HTTP status code
+ * @param extraHeaders - Optional additional response headers (e.g. Retry-After)
  * @returns A NextResponse with the error
  */
-export function apiAuthError(error: string, status: number): NextResponse {
+export function apiAuthError(
+  error: string,
+  status: number,
+  extraHeaders?: Record<string, string>
+): NextResponse {
+  const code =
+    status === 401
+      ? 'UNAUTHORIZED'
+      : status === 429
+        ? 'RATE_LIMITED'
+        : status === 423
+          ? 'LOCKED'
+          : 'ERROR';
+
   return NextResponse.json(
-    {
-      error,
-      code: status === 401 ? 'UNAUTHORIZED' : status === 429 ? 'RATE_LIMITED' : 'ERROR',
-    },
+    { error, code },
     {
       status,
       headers: {
         'Content-Type': 'application/json',
+        ...extraHeaders,
       },
     }
   );
@@ -366,6 +437,9 @@ export function apiAuthError(error: string, status: number): NextResponse {
 
 /**
  * Higher-order function that wraps an API route handler with authentication.
+ *
+ * Includes IP-based pre-auth rate limiting (60 req/min/IP) via
+ * authenticateApiRequest, plus per-key rate limiting (100 req/min/key).
  *
  * @param handler - The route handler to wrap
  * @param requiredScopes - Scopes required for this endpoint (default: ['read'])
@@ -410,17 +484,126 @@ export function withApiAuth(
 }
 
 /**
- * Adds rate limit headers to a response.
+ * Higher-order function that wraps an API route handler with authentication
+ * AND per-route rate limit configuration.
+ *
+ * This is the preferred wrapper for all /api/v1/* route handlers. It provides:
+ * - IP-based pre-auth rate limit (default 60 req/min/IP) via authenticateApiRequest
+ * - Per-key rate limit (default 100 req/min/key) via authenticateApiRequest
+ * - Optional per-route override of the per-key rate limit via `options.rateLimit`
+ *
+ * WHY a separate function (rather than mutating withApiAuth): The per-key
+ * rate limiter is initialized at module load time using the default config.
+ * Overriding per-route requires passing config down through auth, which would
+ * change the authenticateApiRequest signature. Instead we compose: run auth
+ * (which always enforces the IP + default per-key limits), then apply an
+ * additional route-level check when the caller specifies a tighter limit.
+ * For routes that want the defaults this wrapper is a clean alias for withApiAuth.
+ *
+ * @param handler - The route handler to wrap
+ * @param requiredScopes - Scopes required for this endpoint (default: ['read'])
+ * @param options - Optional overrides (e.g. tighter rateLimit for export routes)
+ * @returns A wrapped handler that enforces auth + rate limiting
+ *
+ * @example
+ * // Default: 100 req/min per key + 60 req/min per IP
+ * export const GET = withApiAuthAndRateLimit(handler);
+ *
+ * // Custom: 5 req/min per key (export route)
+ * export const GET = withApiAuthAndRateLimit(handler, ['read'], {
+ *   rateLimit: { windowMs: 60000, maxRequests: 5 },
+ * });
+ */
+export function withApiAuthAndRateLimit(
+  handler: (request: NextRequest, context: ApiAuthContext) => Promise<NextResponse>,
+  requiredScopes: string[] = ['read'],
+  options?: { rateLimit?: RateLimitOptions }
+): (request: NextRequest) => Promise<NextResponse> {
+  return async (request: NextRequest) => {
+    const authResult = await authenticateApiRequest(request);
+
+    if (!authResult.success) {
+      return apiAuthError(authResult.error, authResult.status);
+    }
+
+    // Check required scopes
+    const hasRequiredScopes = requiredScopes.every((scope) =>
+      authResult.context.scopes.includes(scope)
+    );
+
+    if (!hasRequiredScopes) {
+      return apiAuthError(
+        `Insufficient permissions. Required scopes: ${requiredScopes.join(', ')}`,
+        403
+      );
+    }
+
+    // Apply per-route rate limit override when caller requests a tighter window.
+    // WHY: authenticateApiRequest already enforces the default 100 req/min/key.
+    // Some routes (e.g., data export) need stricter limits. We apply an
+    // additional check here using the shared checkRateLimit utility keyed by
+    // key ID so the override is per-credential, not per-IP.
+    if (options?.rateLimit) {
+      const { windowMs = 60000, maxRequests = 100 } = options.rateLimit;
+      const routeLimit = await checkRateLimit(
+        request,
+        { windowMs, maxRequests },
+        `api-v1-route:${authResult.context.keyId}`
+      );
+      if (!routeLimit.allowed) {
+        return apiAuthError(
+          `Rate limit exceeded. Retry after ${routeLimit.retryAfter ?? 60} seconds`,
+          429
+        );
+      }
+    }
+
+    return handler(request, authResult.context);
+  };
+}
+
+/**
+ * Determines if an API key is near expiry (within KEY_EXPIRY_WARNING_DAYS days).
+ *
+ * Used by route handlers to include a hint in API responses so CLI clients
+ * can prompt the user to rotate the key before it stops working.
+ *
+ * @param expiresAt - ISO 8601 expiration timestamp, or null if no expiry
+ * @returns true if the key expires within 30 days, false otherwise
+ *
+ * @example
+ * if (isKeyNearExpiry(context.keyExpiresAt)) {
+ *   response.headers.set('X-Api-Key-Expires-At', context.keyExpiresAt!);
+ *   response.headers.set('X-Api-Key-Expiry-Warning', 'true');
+ * }
+ */
+export function isKeyNearExpiry(expiresAt: string | null): boolean {
+  if (!expiresAt) return false;
+  const msUntilExpiry = new Date(expiresAt).getTime() - Date.now();
+  return msUntilExpiry > 0 && msUntilExpiry < KEY_EXPIRY_WARNING_DAYS * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Adds rate limit headers to a response, and optionally a key-expiry warning.
  *
  * WHY: When using Upstash Redis, the in-memory store may not have the entry.
  * We still set the Limit header so clients know the policy, and best-effort
  * the Remaining/Reset values from the in-memory fallback when available.
  *
+ * If `keyExpiresAt` is supplied and the key is within KEY_EXPIRY_WARNING_DAYS
+ * days of expiry, we set X-Api-Key-Expiry-Warning and X-Api-Key-Expires-At
+ * so CLI clients can surface a rotation prompt. (H42 Item 2)
+ *
  * @param response - The response to add headers to
  * @param keyId - The API key ID for rate limit lookup
- * @returns The response with rate limit headers
+ * @param keyExpiresAt - Optional ISO 8601 expiry timestamp from the auth context
+ * @returns The response with rate limit and optional expiry headers
  */
-export function addRateLimitHeaders(response: NextResponse, keyId: string): NextResponse {
+export function addRateLimitHeaders(
+  response: NextResponse,
+  keyId: string,
+  keyExpiresAt?: string | null
+): NextResponse {
   response.headers.set('X-RateLimit-Limit', String(API_RATE_LIMIT.maxRequests));
 
   const entry = apiRateLimitStore.get(keyId);
@@ -429,6 +612,12 @@ export function addRateLimitHeaders(response: NextResponse, keyId: string): Next
     const resetAt = Math.ceil(entry.resetAt / 1000); // Unix timestamp
     response.headers.set('X-RateLimit-Remaining', String(remaining));
     response.headers.set('X-RateLimit-Reset', String(resetAt));
+  }
+
+  // Near-expiry warning headers for CLI rotation prompt (H42 Item 2)
+  if (keyExpiresAt && isKeyNearExpiry(keyExpiresAt)) {
+    response.headers.set('X-Api-Key-Expires-At', keyExpiresAt);
+    response.headers.set('X-Api-Key-Expiry-Warning', 'true');
   }
 
   return response;

--- a/packages/styrby-web/vercel.json
+++ b/packages/styrby-web/vercel.json
@@ -24,6 +24,10 @@
     {
       "path": "/api/cron/nps-prompt-dispatch",
       "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/cron/idempotency-cleanup",
+      "schedule": "0 8 * * *"
     }
   ]
 }

--- a/supabase/migrations/065_admin_mfa_enforcement.sql
+++ b/supabase/migrations/065_admin_mfa_enforcement.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Migration 065: Admin MFA Enforcement (H42 Layer 1)
+-- ============================================================================
+-- Date:    2026-04-28
+-- Author:  Claude Code (claude-sonnet-4-6)
+-- Branch:  feat/mfa-admin-enforcement-h42
+--
+-- Security references:
+--   OWASP A07:2021  - Identification and Authentication Failures
+--   SOC 2 CC6.1     - Logical access controls; privileged access requires
+--                     phishing-resistant authentication factors
+--   NIST SP 800-63B AAL2 - Multi-factor authentication for privileged accounts
+--
+-- Summary:
+--   Adds `mfa_grace_until` column to `site_admins` with a configurable grace
+--   window so existing admins are not immediately locked out. After the grace
+--   period expires, `assertAdminMfa()` (application layer) enforces that the
+--   admin has at least one active passkey OR a Supabase Auth TOTP factor.
+--
+--   The grace period is purely a migration affordance - it is NOT a persistent
+--   feature. The STYRBY_ADMIN_MFA_GRACE_DAYS environment variable controls the
+--   window (default 7 days). Once all admins have enrolled MFA the column
+--   becomes permanently in the past and the grace branch is never taken.
+--
+-- WHY NOT enforce in Postgres:
+--   MFA factor queries require the `auth.mfa_factors` / Supabase Admin API.
+--   Calling the Admin API from inside a Postgres SECURITY DEFINER function is
+--   not supported without pg_net and introduces a network dependency on every
+--   admin RPC call. Enforcement in the application layer (assertAdminMfa) is
+--   faster, testable, and does not block the Postgres execution path.
+--
+-- Rollback:
+--   ALTER TABLE public.site_admins DROP COLUMN IF EXISTS mfa_grace_until;
+-- ============================================================================
+
+-- Add mfa_grace_until column
+ALTER TABLE public.site_admins
+  ADD COLUMN IF NOT EXISTS mfa_grace_until TIMESTAMPTZ;
+
+-- WHY backfill existing rows with 7-day grace: Any admin already in the table
+-- before this migration has no MFA enrolled (there was no requirement). A hard
+-- cutover (NULL = blocked immediately) would lock them out of the admin console.
+-- The 7-day window matches the default STYRBY_ADMIN_MFA_GRACE_DAYS value, giving
+-- them time to enroll before the gate activates. SOC 2 CC6.1: documented
+-- exception with a defined remediation deadline.
+UPDATE public.site_admins
+  SET mfa_grace_until = now() + INTERVAL '7 days'
+  WHERE mfa_grace_until IS NULL;
+
+-- Column documentation
+COMMENT ON COLUMN public.site_admins.mfa_grace_until IS
+  'Migration-only grace window for MFA enrollment. NULL = no grace (new admins '
+  'added after the MFA policy is enforced). Non-null = admin was present before '
+  'H42 and has until this timestamp to enroll a passkey or TOTP factor. After '
+  'this timestamp, assertAdminMfa() rejects admin actions with ADMIN_MFA_REQUIRED '
+  'unless a factor is enrolled. OWASP A07:2021 / SOC 2 CC6.1.';

--- a/supabase/migrations/066_idempotency_keys.sql
+++ b/supabase/migrations/066_idempotency_keys.sql
@@ -1,0 +1,94 @@
+-- Migration 066: Idempotency Keys
+--
+-- WHY: Per OWASP A04:2021 (Insecure Design) — replay protection for state-
+-- mutating endpoints. The CLI retries POST/PATCH/DELETE on transient network
+-- errors; without server-side deduplication the same operation can fire twice
+-- (e.g. double-charge on checkout retry, double-delete on account wipe).
+--
+-- Design mirrors Stripe's idempotency key pattern + Standard Webhooks spec:
+-- - Key is client-supplied (UUID/ULID/any opaque string)
+-- - Scoped to (key, user_id, route) so the same key cannot collide across users
+--   or be replayed against a different endpoint
+-- - Cached responses live for 24 hours then expire
+-- - Service-role-only access; client code never reads this table directly
+--
+-- References:
+--   Stripe: https://stripe.com/docs/idempotency
+--   OWASP A04:2021: https://owasp.org/Top10/A04_2021-Insecure_Design/
+
+-- ============================================================================
+-- Table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.idempotency_keys (
+  -- Client-supplied idempotency key (UUID, ULID, or any opaque string).
+  -- WHY TEXT not UUID: allows ULID and other non-UUID formats the CLI may
+  -- generate without requiring a conversion step on the client side.
+  key              TEXT        NOT NULL,
+
+  -- User context. Collisions across different users with the same key value
+  -- are prevented by including user_id in the primary key.
+  user_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Normalized route path the key was used against (e.g. '/api/billing/checkout/team').
+  -- WHY: Prevents cross-route replay — a key issued for checkout cannot
+  -- accidentally match a cached response for account delete.
+  route            TEXT        NOT NULL,
+
+  -- sha256(method || ':' || path || ':' || body) — detects body mismatch on replay.
+  -- WHY store body hash not body: avoids storing potentially large request payloads
+  -- in Postgres; the hash is sufficient to detect a different-body replay.
+  request_hash     TEXT        NOT NULL,
+
+  -- HTTP status code of the original response (e.g. 200, 201).
+  -- WHY: Replayed responses must preserve the original status, not always 200.
+  response_status  INTEGER     NOT NULL,
+
+  -- Full JSON response body, returned verbatim on replay.
+  -- WHY JSONB: Next.js route handlers return JSON; storing as JSONB enables
+  -- future queries on response shape if needed, and Postgres validates the JSON.
+  response_body    JSONB       NOT NULL,
+
+  -- Composite primary key: (key, user_id, route).
+  -- Ensures uniqueness per key per user per endpoint.
+  PRIMARY KEY (key, user_id, route),
+
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Auto-expire: 24-hour window matches Stripe's idempotency window.
+  -- The cleanup cron deletes rows where expires_at < NOW().
+  expires_at       TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '24 hours')
+);
+
+-- ============================================================================
+-- Index
+-- ============================================================================
+
+-- Supports the daily cleanup cron: DELETE WHERE expires_at < NOW().
+-- WHY a dedicated index on expires_at: the PK index cannot serve this range
+-- scan efficiently because expires_at is not part of the PK.
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expires
+  ON public.idempotency_keys (expires_at);
+
+-- ============================================================================
+-- Row Level Security
+-- ============================================================================
+
+-- Enable RLS — every access goes through a policy.
+ALTER TABLE public.idempotency_keys ENABLE ROW LEVEL SECURITY;
+
+-- Service-role bypass: RLS is skipped for service-role key connections, which
+-- is how the Next.js API routes access this table (via createAdminClient).
+-- No explicit policy is needed for service-role; the enabled RLS will block
+-- anon/authenticated role access, preventing client SDKs from reading or
+-- writing idempotency records directly.
+
+-- WHY no SELECT/INSERT/UPDATE/DELETE policies for anon or authenticated roles:
+-- This table is internal infrastructure. All access flows through the API layer
+-- (service role). Exposing it to the client would allow users to inspect or
+-- manipulate each other's cached responses if user_id check was ever missed.
+
+COMMENT ON TABLE public.idempotency_keys IS
+  'Server-side idempotency cache for state-mutating API endpoints. '
+  'Service-role access only. Rows expire after 24 hours. '
+  'OWASP A04:2021 replay protection.';

--- a/supabase/migrations/067_api_key_expires_at_ensure.sql
+++ b/supabase/migrations/067_api_key_expires_at_ensure.sql
@@ -1,0 +1,17 @@
+-- Migration 067: Ensure api_keys.expires_at column exists
+--
+-- WHY: The column was defined in 007_api_keys.sql but this migration is
+-- idempotent (ADD COLUMN IF NOT EXISTS) in case a production environment
+-- was provisioned before migration 007 included it or if an older schema
+-- snapshot was restored. Safe to run multiple times.
+--
+-- H42 Item 2 — API Key TTL enforcement.
+
+ALTER TABLE api_keys
+  ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ NULL;
+
+-- Ensure the lookup_api_key RPC still returns expires_at so the middleware
+-- can enforce TTL without a second round-trip. If the function body already
+-- selects it, this is a no-op documentation comment only.
+-- (No DDL change needed — 007_api_keys.sql already includes expires_at in
+-- the lookup_api_key function's SELECT list.)

--- a/supabase/migrations/068_auth_lockout.sql
+++ b/supabase/migrations/068_auth_lockout.sql
@@ -1,0 +1,210 @@
+-- Migration 068: Auth lockout table and helpers
+--
+-- WHY a public table instead of extending auth.users:
+-- Supabase manages the auth.users schema internally; columns added there may
+-- be dropped or cause issues on platform upgrades. A sibling table keyed by
+-- user_id gives us full control and keeps Supabase Auth migration-safe.
+--
+-- H42 Item 3 — Lock out after N failed login attempts.
+--
+-- Policy:
+--   • 5 failed attempts within 1 hour → locked_until = NOW() + 15 minutes
+--   • Lockout responds with 423 Locked + Retry-After header
+--   • Successful auth resets the counter
+--   • Admins are explicitly excluded (see RLS note below)
+--   • failed_login_count is never silently reset — it monotonically increases
+--     within a window so the audit trail is preserved
+--
+-- WHY we exclude admins from lockout: Account lockout on a site-admin account
+-- could result in a denial-of-service against the support/admin surface with
+-- no self-service recovery path. Admins use hardware-backed passkeys or MFA;
+-- the risk-reward tradeoff does not justify auto-lockout. This is documented
+-- rationale, not a security gap. (NIST SP 800-63B §5.2.2 permits this
+-- exception when equivalent compensating controls exist.)
+
+-- ---------------------------------------------------------------------------
+-- Table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.user_lockout (
+  -- The Supabase auth user this record belongs to.
+  user_id         UUID        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Running count of consecutive failed verification attempts.
+  -- Intentionally NOT reset to 0 silently — only reset on successful auth
+  -- so the audit trail shows total cumulative failures in the window.
+  failed_login_count INTEGER    NOT NULL DEFAULT 0,
+
+  -- Timestamp of the most recent failed attempt.
+  -- Used to implement the "5 failures within 1 hour" sliding window.
+  last_failure_at TIMESTAMPTZ NULL,
+
+  -- When non-null and in the future, all login attempts are rejected with
+  -- 423 Locked until this timestamp passes.
+  locked_until    TIMESTAMPTZ NULL,
+
+  -- Audit trail
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ---------------------------------------------------------------------------
+-- Index for fast lockout check by user_id (primary key covers it)
+-- ---------------------------------------------------------------------------
+-- No extra index needed — PK is already on user_id.
+
+-- ---------------------------------------------------------------------------
+-- RLS
+-- ---------------------------------------------------------------------------
+
+-- Enable RLS so users cannot read or write each other's lockout records.
+ALTER TABLE public.user_lockout ENABLE ROW LEVEL SECURITY;
+
+-- Service-role operations (used by the API layer) bypass RLS automatically.
+-- No user-facing RLS policy is needed — users should never read or modify
+-- their own lockout record directly; that would allow self-unlock.
+
+-- ---------------------------------------------------------------------------
+-- Helper function: record_login_failure(p_user_id, p_window_seconds, p_max_failures, p_lockout_seconds)
+-- ---------------------------------------------------------------------------
+-- Called by the Next.js API layer after a passkey verification failure.
+-- Returns the new locked_until timestamp (null if not yet locked).
+--
+-- WHY a stored function: atomic increment + conditional lock in a single
+-- round-trip. Without atomicity, a race condition could let a burst of
+-- parallel requests each see count < threshold and none of them trigger lockout.
+
+CREATE OR REPLACE FUNCTION public.record_login_failure(
+  p_user_id        UUID,
+  p_window_seconds INT  DEFAULT 3600,   -- 1 hour window
+  p_max_failures   INT  DEFAULT 5,      -- lock after 5 failures
+  p_lockout_seconds INT DEFAULT 900     -- 15-minute lockout
+)
+RETURNS TIMESTAMPTZ
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_count        INTEGER;
+  v_locked_until TIMESTAMPTZ;
+  v_window_start TIMESTAMPTZ;
+BEGIN
+  v_window_start := NOW() - (p_window_seconds || ' seconds')::INTERVAL;
+
+  INSERT INTO public.user_lockout (user_id, failed_login_count, last_failure_at, updated_at)
+  VALUES (p_user_id, 1, NOW(), NOW())
+  ON CONFLICT (user_id) DO UPDATE
+    SET
+      -- Reset counter if last failure was outside the window (new window).
+      -- Inside the window: increment.
+      failed_login_count = CASE
+        WHEN user_lockout.last_failure_at < v_window_start THEN 1
+        ELSE user_lockout.failed_login_count + 1
+      END,
+      last_failure_at = NOW(),
+      -- Set lockout if we just hit or exceeded the threshold.
+      -- Once locked, keep the later of existing lock vs new lock so a fresh
+      -- burst while already locked extends the lockout.
+      locked_until = CASE
+        WHEN user_lockout.last_failure_at < v_window_start THEN
+          -- Brand-new window: check if this single failure (count=1) already meets threshold
+          CASE WHEN 1 >= p_max_failures
+            THEN NOW() + (p_lockout_seconds || ' seconds')::INTERVAL
+            ELSE user_lockout.locked_until
+          END
+        WHEN (user_lockout.failed_login_count + 1) >= p_max_failures THEN
+          GREATEST(
+            COALESCE(user_lockout.locked_until, NOW()),
+            NOW() + (p_lockout_seconds || ' seconds')::INTERVAL
+          )
+        ELSE user_lockout.locked_until
+      END,
+      updated_at = NOW()
+  RETURNING failed_login_count, locked_until INTO v_count, v_locked_until;
+
+  RETURN v_locked_until;
+END;
+$$;
+
+-- Grant execute to the service role (used by Next.js API via admin client).
+-- anon / authenticated roles must NOT call this directly.
+REVOKE ALL ON FUNCTION public.record_login_failure FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.record_login_failure FROM anon;
+REVOKE ALL ON FUNCTION public.record_login_failure FROM authenticated;
+-- service_role inherits SECURITY DEFINER access; explicit GRANT not needed.
+
+-- ---------------------------------------------------------------------------
+-- Helper function: reset_login_failures(p_user_id)
+-- ---------------------------------------------------------------------------
+-- Called after a successful authentication to clear the failure counter.
+-- WHY: A successful auth proves the user has the right credential, so prior
+-- failures are no longer evidence of an attack on this account.
+
+CREATE OR REPLACE FUNCTION public.reset_login_failures(p_user_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE public.user_lockout
+  SET
+    failed_login_count = 0,
+    locked_until       = NULL,
+    updated_at         = NOW()
+  WHERE user_id = p_user_id;
+  -- If no row exists, nothing to reset — no-op.
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.reset_login_failures FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.reset_login_failures FROM anon;
+REVOKE ALL ON FUNCTION public.reset_login_failures FROM authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Helper function: check_lockout_status(p_user_id)
+-- ---------------------------------------------------------------------------
+-- Returns (is_locked BOOL, locked_until TIMESTAMPTZ, failed_count INT).
+-- Called at the start of every login attempt to gate further processing.
+
+CREATE OR REPLACE FUNCTION public.check_lockout_status(p_user_id UUID)
+RETURNS TABLE (is_locked BOOL, locked_until TIMESTAMPTZ, failed_count INT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    (ul.locked_until IS NOT NULL AND ul.locked_until > NOW()) AS is_locked,
+    ul.locked_until,
+    ul.failed_login_count
+  FROM public.user_lockout ul
+  WHERE ul.user_id = p_user_id;
+
+  -- If no row: user has no failures — return unlocked defaults.
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT FALSE, NULL::TIMESTAMPTZ, 0::INT;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.check_lockout_status FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.check_lockout_status FROM anon;
+REVOKE ALL ON FUNCTION public.check_lockout_status FROM authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Updated_at trigger
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.user_lockout_set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_user_lockout_updated_at ON public.user_lockout;
+CREATE TRIGGER trg_user_lockout_updated_at
+  BEFORE UPDATE ON public.user_lockout
+  FOR EACH ROW EXECUTE FUNCTION public.user_lockout_set_updated_at();


### PR DESCRIPTION
## Summary

Single integration PR consolidating the 5 H42 hardening sub-PRs (#210, #212, #213, #214, #215) per Pattern B in `~/.claude/standards/CI_VERCEL_COST_OPTIMIZATION.md`. All 5 PRs touch disjoint files — cherry-picked cleanly with no conflicts. Single CI cycle + single Vercel build instead of 5x each.

## What's bundled

| Original | Layer | Title | Migration | Tests |
|---|---|---|---|---|
| #210 | quick-wins | Sourcemap exclude + CSP report endpoint + last SHA pin | — | new endpoint |
| #212 | API/replay | Idempotency-key middleware + cleanup cron + 3 integration points | 066 | 15 |
| #213 | OWASP A04 | Mass-assignment guard via Zod `.strict()` (3 schemas, 6 guard tests) | — | 6 |
| #214 | Auth | MFA enforcement for admin accounts + grace banner UI | 065 | 17 + 61 kept green |
| #215 | API hardening | Default rate limit on `/api/v1/*` + key TTL + auth lockout | 067, 068 | 107 |

**Migrations live in prod (verified):** 065 (admin MFA grace), 066 (idempotency_keys), 067 (api_keys.expires_at idempotent ensure), 068 (auth lockout RPCs).

**Net change:** 52 files, +4554/-117. ~145 new tests.

## Why batched

- All 5 PRs touch disjoint surfaces: route files for #210 (CSP report), middleware for #212 (idempotency), schemas for #213 (account/*), `mfa-gate.ts` for #214, `api-auth.ts` for #215.
- Single CI cycle instead of 5+ via auto-merge thrash.
- Single Vercel prod build instead of 5 sequential.
- Reviewable as one diff covering one cohesive theme (H42 security hardening).

## Real findings

Two of the 5 audits returned **clean bills of health** — the codebase was already mostly hardened:
- **Webhook signature audit** (#211, already merged): only Polar webhook receiver exists and is fully verified. No new HMAC code needed.
- **Mass-assignment audit** (#213): zero exploitable callsites found. PR adds `.strict()` defense-in-depth to 3 schemas; 6 OWASP A04 regression tests pin the contract.

Three substantive changes shipped:
- **Idempotency** (#212): `Idempotency-Key` header support across 3 high-value writes (checkout, account delete, account export). Replay returns cached 2xx; body mismatch returns 409 Conflict.
- **MFA enforcement** (#214): admin actions blocked for admins without passkey/TOTP. 7-day grace period with tiered urgency banner. 12 callsites guarded.
- **API hardening** (#215): default 100/min/key + 60/min/IP rate limit on every `/api/v1/*`. API keys default to 365-day TTL with near-expiry warning headers. Lockout after 5 failed login attempts (15-min cooldown). Admins exempt from lockout (recovery considerations).

## Closes / supersedes

- #210, #212, #213, #214, #215 — all close as superseded once this lands.

## Test plan

- [x] All 5 individual PRs CI-green or near-green individually
- [x] `tsc --noEmit` clean on consolidated branch
- [x] 56/56 in subset of integration-touching tests
- [ ] CI green on full combined diff
- [ ] Post-merge: prod smoke (`/api/v1/sessions` → 401 still clean, MFA banner renders for admins, admin lockout RPC reachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)