### PR TITLE
test(admin+api): repair 19 broken test files (closes #217)

### DIFF
--- a/packages/styrby-web/src/__tests__/billing-ops/churn-save-acceptance.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/churn-save-acceptance.integration.test.ts
@@ -45,7 +45,7 @@
  * @module __tests__/billing-ops/churn-save-acceptance.integration.test
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock, type MockInstance } from 'vitest';
 
 // ============================================================================
 // Mocks
@@ -84,6 +84,24 @@ vi.mock('@/lib/supabase/server', () => ({
   createAdminClient: () => ({ auth: { admin: {} } }),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): every admin action (sendChurnSaveOfferAction)
+// calls assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the integration test env.
+// MFA gate behaviour is covered in src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 // Polar refund helper — not used in churn-save flow; mock to prevent import errors.
 vi.mock('@/lib/billing/polar-refund', () => ({
   createPolarRefund: vi.fn(),
@@ -96,6 +114,8 @@ vi.mock('@/lib/billing/polar-refund', () => ({
     }
   },
 }));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ============================================================================
 // Helpers
@@ -135,7 +155,17 @@ describe('Churn-save lifecycle — send + accept + guards', () => {
 
     const serverModule = await import('@/lib/supabase/server');
     createClient = serverModule.createClient as Mock;
-    createClient.mockResolvedValue({ rpc: mockRpc });
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // admin actions to resolve the acting admin for the MFA gate. The mock must
+    // return a valid admin user so assertAdminMfa (mocked above) receives the ID.
+    createClient.mockResolvedValue({
+      rpc: mockRpc,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
 
     const adminActionsModule = await import(
       '../../app/dashboard/admin/users/[userId]/billing/actions'
@@ -291,7 +321,16 @@ describe('Churn-save lifecycle — send + accept + guards', () => {
     ).rejects.toThrow(/NEXT_REDIRECT/);
 
     vi.clearAllMocks();
-    createClient.mockResolvedValue({ rpc: mockRpc });
+    // WHY include auth.getUser: must be present after clearAllMocks to support
+    // the H42 Layer 1 MFA gate (assertAdminMfa) wired into sendChurnSaveOfferAction.
+    createClient.mockResolvedValue({
+      rpc: mockRpc,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
 
     // Second admin send: RPC returns SQLSTATE 22023 (partial unique index guard).
     // WHY 22023 for duplicate send: admin_send_churn_save_offer raises
@@ -423,5 +462,24 @@ describe('Churn-save lifecycle — send + accept + guards', () => {
     // schema comment in actions.ts.
     const rpcArgs = mockRpc.mock.calls[0]![1] as Record<string, unknown>;
     expect(rpcArgs.p_polar_discount_code).toBeNull();
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves sendChurnSaveOfferAction calls assertAdminMfa before running the
+  // RPC. If the gate throws AdminMfaRequiredError, the action must short-circuit
+  // and return { ok: false, error: 'ADMIN_MFA_REQUIRED' } without calling the RPC.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) sendChurnSaveOfferAction returns ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const result = await sendChurnSaveOfferAction(TARGET_UUID, makeOfferFormData()) as {
+      ok: boolean;
+      error: string;
+    };
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ADMIN_UUID);
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/__tests__/billing-ops/churn-save-acceptance.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/churn-save-acceptance.integration.test.ts
@@ -45,7 +45,7 @@
  * @module __tests__/billing-ops/churn-save-acceptance.integration.test
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach, type Mock, type MockInstance } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 
 // ============================================================================
 // Mocks

--- a/packages/styrby-web/src/__tests__/billing-ops/credit-lifecycle.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/credit-lifecycle.integration.test.ts
@@ -91,6 +91,24 @@ vi.mock('@/lib/supabase/server', () => ({
   }),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): every admin action (issueCreditAction)
+// calls assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the integration test env.
+// MFA gate behaviour is covered in src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 // Polar refund helper — not used in credit flow; mock to prevent import errors.
 vi.mock('@/lib/billing/polar-refund', () => ({
   createPolarRefund: vi.fn(),
@@ -107,6 +125,8 @@ vi.mock('@/lib/billing/polar-refund', () => ({
 // ============================================================================
 // Helpers
 // ============================================================================
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 const ADMIN_UUID  = 'a1b2c3d4-e5f6-7890-abcd-000000000011';
 const TARGET_UUID = 'b2c3d4e5-f6a7-8901-bcde-000000000022';
@@ -148,9 +168,17 @@ describe('Credit lifecycle — issue + revoke + RLS', () => {
     const serverModule = await import('@/lib/supabase/server');
     createClient = serverModule.createClient as Mock;
     // Provide both rpc (for mutation tests) and from (for RLS tests).
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // admin actions to resolve the acting admin for the MFA gate. The mock must
+    // return a valid admin user so assertAdminMfa (mocked above) receives the ID.
     createClient.mockResolvedValue({
       rpc: mockRpc,
       from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
     });
 
     const actionsModule = await import(
@@ -386,5 +414,24 @@ describe('Credit lifecycle — issue + revoke + RLS', () => {
     expect(result.error).toContain('mismatch');
     expect(mockRpc).not.toHaveBeenCalled();
     expect(mockSentryCaptureMessage).toHaveBeenCalledOnce();
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves issueCreditAction calls assertAdminMfa before running the RPC.
+  // If the gate throws AdminMfaRequiredError, the action must short-circuit and
+  // return { ok: false, error: 'ADMIN_MFA_REQUIRED' } without calling the RPC.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) issueCreditAction returns ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const result = await issueCreditAction(
+      TARGET_UUID,
+      makeCreditFormData()
+    ) as { ok: boolean; error: string };
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ADMIN_UUID);
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/__tests__/billing-ops/refund-flow.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/refund-flow.integration.test.ts
@@ -74,6 +74,24 @@ vi.mock('@/lib/supabase/server', () => ({
   }),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): every admin action (issueRefundAction)
+// calls assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the integration test env.
+// MFA gate behaviour is covered in src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 // ── Polar refund helper mock ──────────────────────────────────────────────────
 // WHY mock @/lib/billing/polar-refund (not the Polar SDK directly):
 //   The integration boundary we're testing is actions.ts ↔ the refund helper +
@@ -108,6 +126,8 @@ vi.mock('@/lib/billing/polar-refund', () => ({
 // ============================================================================
 // Helpers
 // ============================================================================
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 const ADMIN_UUID  = 'a1b2c3d4-e5f6-7890-abcd-000000000001';
 const TARGET_UUID = 'b2c3d4e5-f6a7-8901-bcde-000000000002';
@@ -148,6 +168,9 @@ describe('issueRefundAction — end-to-end refund flow', () => {
     // SEC-REFUND-001: client now needs both .rpc (audit RPC) and .from (subscription
     // owner + polar_customer_id lookup before the refund). Default the lookup to a
     // valid row owned by TARGET_UUID so happy-path tests don't re-stub the chain.
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // admin actions to resolve the acting admin for the MFA gate. The mock must
+    // return a valid admin user so assertAdminMfa (mocked above) receives the ID.
     createClient.mockResolvedValue({
       rpc: mockRpc,
       from: vi.fn().mockReturnValue({
@@ -160,6 +183,11 @@ describe('issueRefundAction — end-to-end refund flow', () => {
           }),
         }),
       }),
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
     });
     // SEC-REFUND-001: order resolver — default returns ample refundable balance
     // so amount checks don't trip on the default. Tests that want the resolver
@@ -306,7 +334,8 @@ describe('issueRefundAction — end-to-end refund flow', () => {
     const key1 = (mockCreatePolarRefund.mock.calls[0]![0] as Record<string, unknown>).idempotencyKey as string;
 
     vi.clearAllMocks();
-    // Re-stub the full client shape (rpc + from) since clearAllMocks wiped it.
+    // Re-stub the full client shape (rpc + from + auth) since clearAllMocks wiped it.
+    // WHY include auth.getUser: H42 Layer 1 requires auth.getUser() for the MFA gate.
     createClient.mockResolvedValue({
       rpc: mockRpc,
       from: vi.fn().mockReturnValue({
@@ -319,6 +348,11 @@ describe('issueRefundAction — end-to-end refund flow', () => {
           }),
         }),
       }),
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_UUID, email: 'admin@styrby.test' } },
+        }),
+      },
     });
     mockFindRefundableOrder.mockResolvedValue({
       orderId: 'ord_integration_default',
@@ -445,5 +479,26 @@ describe('issueRefundAction — end-to-end refund flow', () => {
     expect(result.error).toBe('Internal error');
     expect(mockRpc).not.toHaveBeenCalled();
     expect(mockSentryCapture).toHaveBeenCalledOnce();
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves issueRefundAction calls assertAdminMfa before running the Polar
+  // refund or the RPC. If the gate throws AdminMfaRequiredError, the action must
+  // short-circuit and return { ok: false, error: 'ADMIN_MFA_REQUIRED' } without
+  // calling Polar or the audit RPC.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) issueRefundAction returns ADMIN_MFA_REQUIRED and skips Polar + RPC when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const result = await issueRefundAction(
+      TARGET_UUID,
+      makeRefundFormData()
+    ) as { ok: boolean; error: string };
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ADMIN_UUID);
+    expect(mockCreatePolarRefund).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
@@ -118,7 +118,26 @@ vi.mock('@/lib/supabase/server', () => ({
   createAdminClient: vi.fn(),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): requestSupportAccessAction calls
+// assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the integration test env.
+// MFA gate behaviour is covered in src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient } from '@/lib/supabase/server';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 
 // ─── Shared support_tickets mock chain ────────────────────────────────────────
 
@@ -161,6 +180,9 @@ function makeRequestFormData(overrides: Partial<{
   return fd;
 }
 
+// Acting admin ID for MFA gate wiring tests across all describe blocks.
+const ACTING_ADMIN_ID = 'aabbccdd-eeff-0011-2233-445566778899';
+
 // ============================================================================
 // Step 1 — Admin requestSupportAccessAction
 // ============================================================================
@@ -192,8 +214,18 @@ describe('Step 1: Admin requestSupportAccessAction', () => {
     vi.clearAllMocks();
     // WHY include from: the action SELECTs support_tickets to resolve p_user_id
     // server-side before the RPC call (see actions.ts header).
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // the action to resolve the acting admin for the MFA gate.
     mockFrom.mockImplementation(() => makeTicketFromChain());
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, from: mockFrom });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
     // Default: both RPCs succeed.
     configureRpcSequence();
   });
@@ -356,6 +388,27 @@ describe('Step 1: Admin requestSupportAccessAction', () => {
     // Sentry captures the stash failure for ops.
     expect(mockSentryCapture).toHaveBeenCalled();
   });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves requestSupportAccessAction calls assertAdminMfa before running the
+  // admin_request_support_access RPC. If the gate throws AdminMfaRequiredError,
+  // the action must short-circuit and return { ok: false, error: 'ADMIN_MFA_REQUIRED' }
+  // without calling any RPC. OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) requestSupportAccessAction returns ADMIN_MFA_REQUIRED and skips RPCs when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { requestSupportAccessAction } = await import(
+      '../../app/dashboard/admin/support/[id]/actions'
+    );
+
+    const result = await requestSupportAccessAction(TICKET_ID, makeRequestFormData());
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    // Neither RPC must have been called when the gate fires.
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
 });
 
 // ============================================================================
@@ -513,8 +566,17 @@ describe('Audit side effects — RPC is the sole audit channel', () => {
     // WHY include from: mockFrom — Fix 1 adds a server-side SELECT on
     // support_tickets. Without this, requestSupportAccessAction returns
     // { ok: false, error: 'Ticket not found' } before calling the RPC.
+    // WHY include auth.getUser: H42 Layer 1 requires auth.getUser() for MFA gate.
     mockFrom.mockImplementation(() => makeTicketFromChain());
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, from: mockFrom });
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
     mockRpc.mockResolvedValue({ data: null, error: null });
   });
 
@@ -538,9 +600,16 @@ describe('Audit side effects — RPC is the sole audit channel', () => {
       update: mockUpdate,
     }));
 
+    // WHY include auth.getUser: H42 Layer 1 requires auth.getUser() so the action
+    // can resolve the acting admin for the MFA gate (assertAdminMfa).
     (createClient as Mock).mockResolvedValue({
       rpc:  mockRpc,
       from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+        }),
+      },
     });
     // WHY two RPC calls now (post SEC-ADV-001):
     //   1. admin_request_support_access — writes grant row + audit entry

--- a/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
@@ -181,7 +181,7 @@ function makeRequestFormData(overrides: Partial<{
 }
 
 // Acting admin ID for MFA gate wiring tests across all describe blocks.
-const ACTING_ADMIN_ID = 'aabbccdd-eeff-0011-2233-445566778899';
+const ACTING_ADMIN_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
 // ============================================================================
 // Step 1 — Admin requestSupportAccessAction

--- a/packages/styrby-web/src/app/api/admin/audit/verify/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/audit/verify/__tests__/route.test.ts
@@ -38,8 +38,27 @@ vi.mock('@sentry/nextjs', () => ({
   captureException: vi.fn(),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate tries to query the DB via
+// createAdminClient which has no passkeys table in the test environment. Mocking
+// at the public contract level keeps the unit test focused on route logic while
+// the MFA gate's own behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import * as Sentry from '@sentry/nextjs';
 import { GET } from '../route';
 
@@ -270,5 +289,24 @@ describe('GET /api/admin/audit/verify', () => {
         tags: expect.objectContaining({ schema_drift: 'true' }),
       }),
     );
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ─────────────────────────────────────
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — the RPC must never run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips RPC when assertAdminMfa throws', async () => {
+    (isAdmin as Mock).mockResolvedValue(true);
+    mockSupabaseUser({ id: 'admin-1' });
+    (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const res = await GET();
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+    // RPC must not be called when MFA gate fires.
+    // (createClient mock's rpc is not set up in this test path — if the RPC
+    // were called, it would throw, causing a 500 rather than the expected 403.)
   });
 });

--- a/packages/styrby-web/src/app/api/admin/founder-error-histogram/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-error-histogram/__tests__/route.test.ts
@@ -65,6 +65,24 @@ vi.mock('@/lib/rateLimit', () => ({
   ),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { GET } from '../route';
 
 // ============================================================================
@@ -229,5 +247,29 @@ describe('GET /api/admin/founder-error-histogram', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('INTERNAL_ERROR');
+  });
+
+  // --------------------------------------------------------------------------
+  // MFA gate wiring (H42 Layer 1)
+  // --------------------------------------------------------------------------
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — the DB query must never run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips DB query when assertAdminMfa throws', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'admin-1', email: 'admin@styrby.test' } },
+      error: null,
+    });
+    mockIsAdmin.mockResolvedValue(true);
+    (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+    // The admin DB query must not have been triggered.
+    expect(mockAdminFrom).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/app/api/admin/founder-team-metrics/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-team-metrics/__tests__/route.test.ts
@@ -42,9 +42,27 @@ vi.mock('@/lib/rateLimit', () => ({
   },
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { isAdmin } from '@/lib/admin';
 import { rateLimit } from '@/lib/rateLimit';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { GET } from '../route';
 
 // ---------------------------------------------------------------------------
@@ -393,5 +411,24 @@ describe('GET /api/admin/founder-team-metrics — error handling', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('INTERNAL_ERROR');
+  });
+
+  // ── MFA gate wiring (H42 Layer 1) ───────────────────────────────────────────
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — DB queries must not run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips DB queries when assertAdminMfa throws', async () => {
+    mockSupabaseUser({ id: 'admin-1' });
+    (isAdmin as import('vitest').Mock).mockResolvedValue(true);
+    (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const res = await GET(makeRequest() as never);
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+    // The admin DB client must not have been used.
+    expect(createAdminClient).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/app/api/admin/support/[id]/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/__tests__/route.test.ts
@@ -110,6 +110,24 @@ vi.mock('@/lib/rateLimit', () => ({
   ),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { GET, PATCH } from '../route';
 
 // ============================================================================
@@ -614,6 +632,40 @@ describe('PATCH /api/admin/support/[id]', () => {
 
       const body = await response.json();
       expect(body.error).toBe('Failed to update ticket');
+    });
+  });
+
+  // ── MFA gate wiring (H42 Layer 1) ───────────────────────────────────────────
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — DB queries must not run on gate failure.
+  // Applies to both GET and PATCH since the same gate code path is hit for each.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  describe('MFA gate', () => {
+    it('(MFA gate) GET returns 403 ADMIN_MFA_REQUIRED when assertAdminMfa throws', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      mockIsAdmin.mockResolvedValue(true);
+      (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+      const response = await GET(makeGetRequest(), makeContext());
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+      // Ensure no DB call was made — adminFromQueue should still be empty.
+      expect(adminFromQueue).toHaveLength(0);
+    });
+
+    it('(MFA gate) PATCH returns 403 ADMIN_MFA_REQUIRED when assertAdminMfa throws', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      mockIsAdmin.mockResolvedValue(true);
+      (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+      const response = await PATCH(makePatchRequest({ status: 'resolved' }), makeContext());
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe('ADMIN_MFA_REQUIRED');
     });
   });
 });

--- a/packages/styrby-web/src/app/api/admin/support/[id]/reply/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/reply/__tests__/route.test.ts
@@ -112,6 +112,24 @@ vi.mock('@/lib/rateLimit', () => ({
   ),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { POST } from '../route';
 
 // ============================================================================
@@ -536,6 +554,30 @@ describe('POST /api/admin/support/[id]/reply', () => {
 
       const body = await response.json();
       expect(body.error).toBe('Failed to add reply');
+    });
+  });
+
+  // ── MFA gate wiring (H42 Layer 1) ───────────────────────────────────────────
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — DB mutations must not run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  describe('MFA gate', () => {
+    it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips DB mutation when assertAdminMfa throws', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      mockIsAdmin.mockResolvedValue(true);
+      (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+      const response = await POST(
+        makePostRequest({ message: 'Test reply message for gate wiring test.' }),
+        makeContext()
+      );
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+      // The reply insert and audit log must not have been called.
+      expect(mockAuditLogInsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/styrby-web/src/app/api/admin/support/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/support/__tests__/route.test.ts
@@ -92,6 +92,24 @@ vi.mock('@/lib/rateLimit', () => ({
   ),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): the route calls assertAdminMfa(user.id) after
+// the isAdmin check. Without this mock the real gate queries the passkeys table
+// via createAdminClient which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import { GET } from '../route';
 
 // ============================================================================
@@ -404,5 +422,26 @@ describe('GET /api/admin/support', () => {
         expect(response.status).toBe(200);
       }
     );
+  });
+
+  // ── MFA gate wiring (H42 Layer 1) ───────────────────────────────────────────
+
+  // WHY: proves the route calls assertAdminMfa and short-circuits to 403 when
+  // the gate throws AdminMfaRequiredError — DB queries must not run on gate failure.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  describe('MFA gate', () => {
+    it('(MFA gate) returns 403 ADMIN_MFA_REQUIRED and skips DB query when assertAdminMfa throws', async () => {
+      mockAuthenticated(ADMIN_USER);
+      mockIsAdmin.mockResolvedValue(true);
+      (assertAdminMfa as import('vitest').Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+      const response = await GET(makeRequest());
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe('ADMIN_MFA_REQUIRED');
+      // Ensure no DB call was made — adminFromQueue should still be empty.
+      expect(adminFromQueue).toHaveLength(0);
+    });
   });
 });

--- a/packages/styrby-web/src/app/api/v1/costs/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/__tests__/route.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/costs/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/__tests__/route.test.ts
@@ -24,8 +24,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -123,9 +127,13 @@ describe('GET /api/v1/costs', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/costs/breakdown/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/breakdown/__tests__/route.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/costs/breakdown/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/breakdown/__tests__/route.test.ts
@@ -23,8 +23,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -123,9 +127,13 @@ describe('GET /api/v1/costs/breakdown', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
@@ -247,4 +247,28 @@ describe('GET /api/v1/costs/export', () => {
     const res = await GET(makeRequest());
     expect(res.status).toBe(429);
   });
+
+  // --------------------------------------------------------------------------
+  // Auth wiring (H42 Layer 5)
+  // --------------------------------------------------------------------------
+
+  // WHY this test exists: H42 Layer 5 wraps the route with withApiAuthAndRateLimit.
+  // If a future refactor unwraps the route or swaps the middleware, this test
+  // catches it — the handler must NOT execute when the wrapper short-circuits.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('returns 401 when withApiAuthAndRateLimit rejects the request', async () => {
+    const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+    vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
+      return NextResponse.json(
+        { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
+        { status: 401 }
+      );
+    });
+
+    vi.resetModules();
+    const { GET: freshGET } = await import('../route');
+
+    const res = await freshGET(makeRequest());
+    expect(res.status).toBe(401);
+  });
 });

--- a/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/costs/export/__tests__/route.test.ts
@@ -21,8 +21,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),

--- a/packages/styrby-web/src/app/api/v1/machines/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/machines/__tests__/route.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/machines/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/machines/__tests__/route.test.ts
@@ -23,8 +23,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -127,9 +131,13 @@ describe('GET /api/v1/machines', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/__tests__/route.test.ts
@@ -22,8 +22,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -141,9 +145,13 @@ describe('GET /api/v1/sessions/[id]', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/__tests__/route.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
@@ -302,4 +302,31 @@ describe('Session Checkpoints API', () => {
       expect(res.status).toBe(200);
     });
   });
+
+  // --------------------------------------------------------------------------
+  // Auth wiring (H42 Layer 5)
+  // --------------------------------------------------------------------------
+
+  // WHY this test exists: H42 Layer 5 wraps GET, POST, and DELETE with
+  // withApiAuthAndRateLimit. If a future refactor unwraps any of them or swaps
+  // the middleware, this test catches it — the handler must NOT execute when
+  // the wrapper short-circuits. One test covers all three verbs since they
+  // share the same wrapper. OWASP A07:2021, SOC 2 CC6.1.
+  describe('auth wiring', () => {
+    it('returns 401 when withApiAuthAndRateLimit rejects the request', async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
+        return NextResponse.json(
+          { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
+          { status: 401 }
+        );
+      });
+
+      vi.resetModules();
+      const { GET: freshGET } = await import('../route');
+
+      const res = await freshGET(makeRequest('GET', VALID_SESSION_ID));
+      expect(res.status).toBe(401);
+    });
+  });
 });

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
@@ -21,8 +21,12 @@ const mockAuthContext = {
   scopes: ['read', 'write'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/__tests__/route.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 const mockAuthContext = {

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/messages/__tests__/route.test.ts
@@ -23,8 +23,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -139,9 +143,13 @@ describe('GET /api/v1/sessions/[id]/messages', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/api/v1/sessions/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/__tests__/route.test.ts
@@ -13,12 +13,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
 // ============================================================================
-// Mocks — withApiAuth bypass
+// Mocks — withApiAuthAndRateLimit bypass
 // ============================================================================
 
 /**
  * Default auth context injected by the mocked middleware.
- * WHY: v1 routes use API key auth (withApiAuth), not cookie auth.
+ * WHY: v1 routes use API key auth (withApiAuthAndRateLimit), not cookie auth.
  * Mocking the middleware to pass through lets us test the handler logic directly.
  */
 const mockAuthContext = {
@@ -27,8 +27,12 @@ const mockAuthContext = {
   scopes: ['read'],
 };
 
+// WHY withApiAuthAndRateLimit (not withApiAuth): H42 Layer 5 replaced withApiAuth
+// with withApiAuthAndRateLimit on all v1 routes to enforce per-key rate limits
+// in addition to auth. Mock the new export so the module resolution succeeds and
+// the handler is invoked with the test auth context. OWASP A07:2021.
 vi.mock('@/middleware/api-auth', () => ({
-  withApiAuth: vi.fn((handler: Function) => {
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
     return async (request: NextRequest) => handler(request, mockAuthContext);
   }),
   addRateLimitHeaders: vi.fn((response: NextResponse) => response),
@@ -148,11 +152,15 @@ describe('GET /api/v1/sessions', () => {
   // --------------------------------------------------------------------------
 
   describe('authentication', () => {
+    // WHY withApiAuthAndRateLimit wiring test: H42 Layer 5 replaced withApiAuth with
+    // withApiAuthAndRateLimit. This test proves the route is wired to the new
+    // middleware — if a future refactor bypasses it, the gate failure stops firing.
+    // OWASP A07:2021, SOC 2 CC6.1.
     it('returns 401 when auth middleware rejects the request', async () => {
       // WHY: Override the mock to simulate auth failure. This tests that the
-      // withApiAuth wrapper correctly short-circuits before reaching the handler.
-      const { withApiAuth } = await import('@/middleware/api-auth');
-      vi.mocked(withApiAuth).mockImplementationOnce(() => async () => {
+      // withApiAuthAndRateLimit wrapper correctly short-circuits before reaching the handler.
+      const { withApiAuthAndRateLimit } = await import('@/middleware/api-auth');
+      vi.mocked(withApiAuthAndRateLimit).mockImplementationOnce(() => async () => {
         return NextResponse.json(
           { error: 'Missing Authorization header', code: 'UNAUTHORIZED' },
           { status: 401 }

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/__tests__/actions.test.ts
@@ -141,7 +141,7 @@ const VALID_SESSION_ID = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
 const VALID_GRANT_ID = '42';
 const VALID_USER_ID = 'ccccdddd-eeee-ffff-aaaa-bbbbccccdddd';
 /** Acting admin ID returned by auth.getUser() for assertAdminMfa wiring tests. */
-const ACTING_ADMIN_ID = 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb';
+const ACTING_ADMIN_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
 /** Minimal valid form data for happy-path tests. */
 function validFormData(overrides: Record<string, string> = {}): FormData {

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/__tests__/actions.test.ts
@@ -101,7 +101,26 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }));
 
+// WHY mock mfa-gate (H42 Layer 1): requestSupportAccessAction calls
+// assertAdminMfa(actingAdmin.id) after resolving the acting admin via
+// supabase.auth.getUser(). Without this mock the real gate runs createAdminClient
+// to query the passkeys table — which is not set up in the unit test environment.
+// Gate behaviour is covered by src/lib/admin/__tests__/mfa-gate.test.ts.
+// OWASP A07:2021, SOC 2 CC6.1.
+vi.mock('@/lib/admin/mfa-gate', () => ({
+  assertAdminMfa: vi.fn().mockResolvedValue(undefined),
+  AdminMfaRequiredError: class AdminMfaRequiredError extends Error {
+    statusCode = 403 as const;
+    code = 'ADMIN_MFA_REQUIRED' as const;
+    constructor() {
+      super('Admin MFA required');
+      this.name = 'AdminMfaRequiredError';
+    }
+  },
+}));
+
 import { createClient } from '@/lib/supabase/server';
+import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import type { Mock } from 'vitest';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -121,6 +140,8 @@ const VALID_TICKET_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
 const VALID_SESSION_ID = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
 const VALID_GRANT_ID = '42';
 const VALID_USER_ID = 'ccccdddd-eeee-ffff-aaaa-bbbbccccdddd';
+/** Acting admin ID returned by auth.getUser() for assertAdminMfa wiring tests. */
+const ACTING_ADMIN_ID = 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb';
 
 /** Minimal valid form data for happy-path tests. */
 function validFormData(overrides: Record<string, string> = {}): FormData {
@@ -170,7 +191,18 @@ describe('requestSupportAccessAction', () => {
     const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
     mockFrom.mockReturnValue({ select: mockSelect });
 
-    (createClient as Mock).mockResolvedValue({ rpc: mockRpc, from: mockFrom });
+    // WHY include auth.getUser: H42 Layer 1 added auth.getUser() calls inside
+    // admin actions to resolve the acting admin for the MFA gate (assertAdminMfa).
+    // The mock must return a valid admin user so the gate is genuinely exercised.
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      from: mockFrom,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ACTING_ADMIN_ID, email: 'admin@styrby.test' } },
+        }),
+      },
+    });
 
     // Default: both RPCs succeed.
     configureRpc();
@@ -526,5 +558,22 @@ describe('requestSupportAccessAction', () => {
       'admin_request_support_access',
       'admin_stash_grant_token',
     ]);
+  });
+
+  // ── (MFA gate) H42 Layer 1 wiring proof ──────────────────────────────────────
+
+  // WHY: proves requestSupportAccessAction calls assertAdminMfa before running any
+  // RPC. If the gate throws AdminMfaRequiredError, the action must short-circuit
+  // and return { ok: false, error: 'ADMIN_MFA_REQUIRED' } without calling any RPC.
+  // OWASP A07:2021, SOC 2 CC6.1.
+  it('(MFA gate) returns ADMIN_MFA_REQUIRED and skips both RPCs when assertAdminMfa throws', async () => {
+    (assertAdminMfa as Mock).mockRejectedValueOnce(new AdminMfaRequiredError());
+
+    const { requestSupportAccessAction } = await import('../actions');
+    const result = await requestSupportAccessAction(VALID_TICKET_ID, validFormData());
+
+    expect(result).toEqual({ ok: false, error: 'ADMIN_MFA_REQUIRED' });
+    expect(assertAdminMfa).toHaveBeenCalledWith(ACTING_ADMIN_ID);
+    expect(mockRpc).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #217.

This PR is **stacked on #216** — GitHub will auto-retarget to main when #216 merges.

## Summary

Repairs 19 admin/API test files broken by the H42 security cherry-picks:
- **5 admin/integration test files** — MFA gate mock pattern (same as #216)
- **6 admin API route tests** — MFA gate mock + 403 wiring tests
- **8 v1 API route tests** — `withApiAuth` → `withApiAuthAndRateLimit` rename (H42 Layer 5)

## Discipline

- Test-only diff (zero production code touched)
- NO silent bypasses — every gate exercised on happy path + flipped on wiring test
- Mocks honor public contracts; gate internals tested elsewhere
- Every new mock + test cites OWASP A07:2021, SOC 2 CC6.1
- 197/197 test files pass, 3350/3350 tests, `tsc --noEmit` clean

## Test plan

- [x] Local: `pnpm --filter styrby-web test` — 197 pass
- [x] Local: `pnpm --filter styrby-web typecheck` — clean
- [ ] CI passes Web Unit Tests + all other checks
- [ ] Two-stage review (spec compliance + code quality reviewer agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)