### PR TITLE
feat(phase-1): account-switch correctness — clean logout, daemon terminate, auth-mismatch, mobile orphan banner

### DIFF
--- a/packages/styrby-cli/src/auth/__tests__/token-manager.logout.test.ts
+++ b/packages/styrby-cli/src/auth/__tests__/token-manager.logout.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for TokenManager.clearTokens() — logout correctness
+ *
+ * WHY (SOC 2 CC6.1 — auth context lifecycle hygiene): Logout must atomically
+ * destroy all auth context: in-process state, persisted tokens (including
+ * `authenticatedAt`), config entries, and the refresh timer. Subscribers
+ * (daemon, future hooks) must be notified via the 'logout' event so they can
+ * tear down their own session state. A stale `authenticatedAt` surviving
+ * logout could inflate MFA-grace-period windows or mislead "last login"
+ * display in the mobile UI.
+ *
+ * @module auth/__tests__/token-manager.logout
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks — must be declared before imports
+// ============================================================================
+
+/**
+ * WHY: vi.mock() factories are hoisted to the top of the file by vitest.
+ * Variables initialized in the module body are not yet available at hoist
+ * time, causing "Cannot access before initialization" errors. vi.hoisted()
+ * runs its callback at hoist time, making the mock fns available to factories.
+ */
+const { mockSavePersistedData, mockLoadPersistedData, mockSetConfigValue } = vi.hoisted(() => ({
+  mockSavePersistedData: vi.fn(),
+  mockLoadPersistedData: vi.fn(() => ({})),
+  mockSetConfigValue: vi.fn(),
+}));
+
+vi.mock('@/persistence', () => ({
+  loadPersistedData: mockLoadPersistedData,
+  savePersistedData: mockSavePersistedData,
+}));
+
+vi.mock('@/configuration', () => ({
+  setConfigValue: mockSetConfigValue,
+  CONFIG_DIR: '/tmp/.styrby-test',
+  ensureConfigDir: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/env', () => ({
+  config: {
+    supabaseUrl: 'https://test.supabase.co',
+    supabaseAnonKey: 'test-anon-key',
+  },
+}));
+
+// ============================================================================
+// Import after mocks
+// ============================================================================
+
+import { TokenManager } from '../token-manager';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Reset the singleton so each test gets a clean TokenManager instance.
+ *
+ * WHY: TokenManager uses a static singleton. Without resetting between tests,
+ * state (refreshTimer, event listeners, userId) bleeds across test cases,
+ * causing false positives or false negatives.
+ */
+function resetSingleton(): TokenManager {
+  // Access the private static field via bracket notation
+  (TokenManager as unknown as Record<string, unknown>)['instance'] = undefined;
+  return TokenManager.getInstance();
+}
+
+/**
+ * Arm a manager with a realistic authenticated state.
+ */
+function armWithSession(
+  manager: TokenManager,
+  userId = 'user-abc-123'
+): void {
+  manager.setTokens({
+    accessToken: 'at-test',
+    refreshToken: 'rt-test',
+    expiresIn: 3600,
+    userId,
+    userEmail: 'test@example.com',
+  });
+  // Reset call counters so logout assertions are clean
+  mockSavePersistedData.mockClear();
+  mockSetConfigValue.mockClear();
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('TokenManager.clearTokens()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadPersistedData.mockReturnValue({});
+  });
+
+  // --------------------------------------------------------------------------
+  // 1. authenticatedAt is cleared from persistence
+  // --------------------------------------------------------------------------
+  it('clears authenticatedAt from persistence after clearTokens()', () => {
+    const manager = resetSingleton();
+    armWithSession(manager);
+
+    manager.clearTokens();
+
+    const savedPayload = mockSavePersistedData.mock.calls[0]?.[0];
+    expect(savedPayload).toBeDefined();
+    expect(savedPayload).toHaveProperty('authenticatedAt', undefined);
+  });
+
+  // --------------------------------------------------------------------------
+  // 2. Regression guard — existing fields are still cleared
+  // --------------------------------------------------------------------------
+  it('clears accessToken and refreshToken from persistence (regression guard)', () => {
+    const manager = resetSingleton();
+    armWithSession(manager);
+
+    manager.clearTokens();
+
+    const savedPayload = mockSavePersistedData.mock.calls[0]?.[0];
+    expect(savedPayload).toHaveProperty('accessToken', undefined);
+    expect(savedPayload).toHaveProperty('refreshToken', undefined);
+  });
+
+  it('clears authToken and userId from config (regression guard)', () => {
+    const manager = resetSingleton();
+    armWithSession(manager);
+
+    manager.clearTokens();
+
+    const configCalls = mockSetConfigValue.mock.calls;
+    const authTokenCall = configCalls.find(([key]) => key === 'authToken');
+    const userIdCall = configCalls.find(([key]) => key === 'userId');
+
+    expect(authTokenCall).toBeDefined();
+    expect(authTokenCall![1]).toBeUndefined();
+    expect(userIdCall).toBeDefined();
+    expect(userIdCall![1]).toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // 3. 'logout' event is emitted with previous userId
+  // --------------------------------------------------------------------------
+  it("emits 'logout' event with { userId: previousUserId }", () => {
+    const manager = resetSingleton();
+    armWithSession(manager, 'user-xyz-789');
+
+    const listener = vi.fn();
+    manager.on('logout', listener);
+
+    manager.clearTokens();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ userId: 'user-xyz-789' });
+  });
+
+  // --------------------------------------------------------------------------
+  // 4. 'logout' event payload is { userId: null } when already logged out
+  // --------------------------------------------------------------------------
+  it("emits 'logout' event with { userId: null } when already logged out", () => {
+    const manager = resetSingleton();
+    // Do NOT call armWithSession — manager is unauthenticated
+
+    const listener = vi.fn();
+    manager.on('logout', listener);
+
+    manager.clearTokens();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ userId: null });
+  });
+
+  // --------------------------------------------------------------------------
+  // 5. Refresh timer is cancelled (regression guard)
+  // --------------------------------------------------------------------------
+  it('cancels the refresh timer after clearTokens()', () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const manager = resetSingleton();
+
+    // Arm with future-expiring session so scheduleRefresh sets a timer
+    manager.setTokens({
+      accessToken: 'at-test',
+      refreshToken: 'rt-test',
+      expiresIn: 3600,
+      userId: 'user-timer-test',
+    });
+    mockSavePersistedData.mockClear();
+
+    manager.clearTokens();
+
+    // clearTimeout must have been called at least once for the refresh timer
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    clearTimeoutSpy.mockRestore();
+  });
+
+  // --------------------------------------------------------------------------
+  // 6. Event fires AFTER state is cleared — subscriber sees isAuthenticated: false
+  // --------------------------------------------------------------------------
+  it("fires 'logout' event after state is cleared (subscriber sees isAuthenticated: false)", () => {
+    const manager = resetSingleton();
+    armWithSession(manager);
+
+    let stateAtEventTime: boolean | undefined;
+
+    manager.on('logout', () => {
+      stateAtEventTime = manager.getState().isAuthenticated;
+    });
+
+    manager.clearTokens();
+
+    expect(stateAtEventTime).toBe(false);
+  });
+});

--- a/packages/styrby-cli/src/auth/__tests__/token-manager.logout.test.ts
+++ b/packages/styrby-cli/src/auth/__tests__/token-manager.logout.test.ts
@@ -226,4 +226,55 @@ describe('TokenManager.clearTokens()', () => {
 
     expect(stateAtEventTime).toBe(false);
   });
+
+  // --------------------------------------------------------------------------
+  // 7. Double-call idempotency — second clearTokens() emits { userId: null }
+  // --------------------------------------------------------------------------
+  it('double-call idempotency: second clearTokens() emits { userId: null } without crashing', () => {
+    const manager = resetSingleton();
+    armWithSession(manager, 'user-A');
+
+    const listener = vi.fn();
+    manager.on('logout', listener);
+
+    // First call — session was active; payload carries the real userId
+    manager.clearTokens();
+    expect(listener).toHaveBeenNthCalledWith(1, { userId: 'user-A' });
+
+    // Second call — state was already cleared; payload must be { userId: null }
+    manager.clearTokens();
+    expect(listener).toHaveBeenNthCalledWith(2, { userId: null });
+
+    // Both calls must have emitted exactly one event each (2 total)
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  // --------------------------------------------------------------------------
+  // 8. Combined regression: timer cancelled AND logout event fires in one call
+  // --------------------------------------------------------------------------
+  it('clearTokens() cancels refresh timer AND fires logout event in the same call', () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const manager = resetSingleton();
+
+    manager.setTokens({
+      accessToken: 'at-combined',
+      refreshToken: 'rt-combined',
+      expiresIn: 3600,
+      userId: 'user-combined',
+    });
+    mockSavePersistedData.mockClear();
+
+    const listener = vi.fn();
+    manager.on('logout', listener);
+
+    manager.clearTokens();
+
+    // Timer must have been cancelled
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    // Logout event must also have fired — same clearTokens() call
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ userId: 'user-combined' });
+
+    clearTimeoutSpy.mockRestore();
+  });
 });

--- a/packages/styrby-cli/src/auth/token-manager.ts
+++ b/packages/styrby-cli/src/auth/token-manager.ts
@@ -13,6 +13,7 @@
  * @module auth/token-manager
  */
 
+import { EventEmitter } from 'node:events';
 import { createClient, type SupabaseClient, type Session } from '@supabase/supabase-js';
 import { logger } from '@/ui/logger';
 import { loadPersistedData, savePersistedData, type PersistedData } from '@/persistence';
@@ -49,6 +50,28 @@ export interface TokenState {
   userEmail?: string;
   /** Session persistence setting */
   persistence?: SessionPersistence;
+}
+
+/**
+ * Payload emitted with the 'logout' event.
+ *
+ * WHY (SOC 2 CC6.1): The daemon and other subscribers need to know WHOSE
+ * session ended so they can tear down per-user state (active WebSocket,
+ * push token cache, etc.) without querying stale in-process state.
+ */
+export interface LogoutEventPayload {
+  /** The user ID whose session was cleared, or null if none was active */
+  userId: string | null;
+}
+
+/**
+ * Typed event map for TokenManager's EventEmitter interface.
+ *
+ * WHY: Explicit event map provides type-safe `.on('logout', ...)` callers
+ * without casting, and documents the full public event surface of the class.
+ */
+export interface TokenManagerEvents {
+  logout: (payload: LogoutEventPayload) => void;
 }
 
 /**
@@ -92,15 +115,23 @@ const PERSISTENCE_DURATION_MS: Record<SessionPersistence, number> = {
 /**
  * Manages authentication token lifecycle.
  *
+ * Extends EventEmitter to allow the daemon and other internal subscribers
+ * to react to auth lifecycle transitions (e.g., 'logout') without polling.
+ *
+ * WHY (SOC 2 CC6.1): Auth context changes must be propagated synchronously
+ * at the moment they occur so downstream components (WebSocket manager,
+ * push-token cache) never operate with stale session identity.
+ *
  * Singleton pattern - use TokenManager.getInstance()
  */
-export class TokenManager {
+export class TokenManager extends EventEmitter {
   private static instance: TokenManager;
   private supabase: SupabaseClient | null = null;
   private refreshTimer: ReturnType<typeof setTimeout> | null = null;
   private state: TokenState = { isAuthenticated: false };
 
   private constructor() {
+    super();
     // Load persisted tokens on initialization
     this.loadFromPersistence();
   }
@@ -296,13 +327,32 @@ export class TokenManager {
 
   /**
    * Clear all tokens and log out.
+   *
+   * WHY (SOC 2 CC6.1 — auth context lifecycle hygiene): Logout must atomically
+   * destroy all auth context so no stale identity can leak into subsequent
+   * operations. Two additions beyond the base implementation:
+   *
+   * 1. `authenticatedAt: undefined` — If omitted from the savePersistedData
+   *    payload, a stale timestamp survives restart and can inflate MFA-grace
+   *    windows or show a misleading "last login" timestamp in the mobile UI.
+   *
+   * 2. Emit 'logout' event AFTER state reset — the daemon and any future
+   *    subscriber must know whose session ended (previousUserId) so they can
+   *    tear down per-user WebSocket connections, push-token cache entries, etc.
+   *    Emitting after reset guarantees subscribers observe the cleared state
+   *    if they call getState() inside their handler.
    */
   clearTokens(): void {
     this.cancelScheduledRefresh();
 
+    // Capture userId BEFORE state reset so the event payload carries the
+    // identity of the session that just ended (null if already logged out).
+    const previousUserId = this.state.userId ?? null;
+
     this.state = { isAuthenticated: false };
 
-    // Clear from persistence
+    // Clear from persistence — authenticatedAt must be explicitly unset;
+    // omitting it leaves the old timestamp on disk (see WHY above).
     savePersistedData({
       accessToken: undefined,
       refreshToken: undefined,
@@ -313,6 +363,9 @@ export class TokenManager {
     setConfigValue('userId', undefined);
 
     logger.debug('Tokens cleared');
+
+    // Emit after all state is cleared so subscribers see a clean slate.
+    this.emit('logout', { userId: previousUserId } satisfies LogoutEventPayload);
   }
 
   // --------------------------------------------------------------------------

--- a/packages/styrby-cli/src/auth/token-manager.ts
+++ b/packages/styrby-cli/src/auth/token-manager.ts
@@ -132,6 +132,11 @@ export class TokenManager extends EventEmitter {
 
   private constructor() {
     super();
+    // WHY: TokenManager is a long-lived singleton; subscribers (daemon, hooks)
+    // may register/unregister across the process lifetime. Default 10 is too
+    // tight; 20 leaves headroom while still flagging genuine listener leaks
+    // via Node's warning.
+    this.setMaxListeners(20);
     // Load persisted tokens on initialization
     this.loadFromPersistence();
   }

--- a/packages/styrby-cli/src/commands/__tests__/logout.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/logout.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for the logout command.
+ *
+ * Covers the 4 required edge cases per Phase 1 spec:
+ *  1. Happy path: daemon alive, terminate ACK → clearTokens, confirmation, exit 0
+ *  2. No daemon running: terminateDaemon ECONNREFUSED-equivalent (ok: false) → skip,
+ *     clearTokens, exit 0
+ *  3. Daemon terminate timeout (ok: false from live socket) → SIGTERM fallback via
+ *     stopDaemon(), then clearTokens, exit 0
+ *  4. Already logged out: tokenManager.isAuthenticated() === false → "Not logged in.",
+ *     no daemon RPC, no clearTokens, exit 0
+ *
+ * WHY: Logout is a security-critical path (SOC 2 CC6.1 — auth context lifecycle).
+ * Every branch must leave the system in a clean state with no orphaned tokens or
+ * daemon processes. These tests verify correctness at each decision fork.
+ *
+ * OWASP A07:2021 (Identification & Authentication Failures): Incomplete logout
+ * (tokens not cleared, daemon still holds session) is a first-class vulnerability.
+ *
+ * @module commands/__tests__/logout.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Mocks — must be declared before any imports that use them
+// ============================================================================
+
+vi.mock('@/daemon/controlClient', () => ({
+  terminateDaemon: vi.fn(),
+}));
+
+vi.mock('@/daemon/run', () => ({
+  stopDaemon: vi.fn(),
+}));
+
+vi.mock('@/auth/token-manager', () => ({
+  getTokenManager: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('chalk', () => ({
+  default: {
+    green: (s: string) => s,
+    yellow: (s: string) => s,
+    red: (s: string) => s,
+    gray: (s: string) => s,
+    bold: (s: string) => s,
+    cyan: (s: string) => s,
+  },
+}));
+
+// ============================================================================
+// Imports — after mocks
+// ============================================================================
+
+import { terminateDaemon } from '@/daemon/controlClient';
+import { stopDaemon } from '@/daemon/run';
+import { getTokenManager } from '@/auth/token-manager';
+import { handleLogout } from '../logout';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Create a mock TokenManager with a configurable isAuthenticated state.
+ *
+ * @param authenticated - Whether the mock should report an active session
+ * @returns Minimal mock conforming to the TokenManager interface surface used
+ *          by handleLogout
+ */
+function mockTokenManager(authenticated: boolean) {
+  return {
+    isAuthenticated: vi.fn().mockReturnValue(authenticated),
+    clearTokens: vi.fn(),
+  };
+}
+
+// ============================================================================
+// Tests — Edge Case 1: Happy path (daemon alive, terminates cleanly)
+// ============================================================================
+
+describe('handleLogout — happy path (daemon alive, ACK received)', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let tm: ReturnType<typeof mockTokenManager>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    // WHY: process.exit must be intercepted so tests don't actually terminate
+    // the Vitest process. Throwing lets us assert it was called.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      throw new Error(`process.exit(${_code})`);
+    });
+
+    tm = mockTokenManager(true);
+    vi.mocked(getTokenManager).mockReturnValue(tm as never);
+    // Daemon terminates cleanly
+    vi.mocked(terminateDaemon).mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('sends daemon.terminate with 5 second timeout', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(terminateDaemon).toHaveBeenCalledWith(5_000);
+  });
+
+  it('calls clearTokens after daemon terminates', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(tm.clearTokens).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT fall back to stopDaemon when terminate succeeds', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(stopDaemon).not.toHaveBeenCalled();
+  });
+
+  it('prints confirmation message', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toMatch(/logged out/i);
+    expect(output).toMatch(/daemon stopped/i);
+  });
+
+  it('exits with code 0', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});
+
+// ============================================================================
+// Tests — Edge Case 2: No daemon running (ECONNREFUSED / ok: false immediately)
+// ============================================================================
+
+describe('handleLogout — no daemon running (terminateDaemon ok: false)', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let tm: ReturnType<typeof mockTokenManager>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      throw new Error(`process.exit(${_code})`);
+    });
+
+    tm = mockTokenManager(true);
+    vi.mocked(getTokenManager).mockReturnValue(tm as never);
+    // Daemon not reachable — returns ok: false without a live socket
+    vi.mocked(terminateDaemon).mockResolvedValue({ ok: false });
+    // stopDaemon: also called as fallback — returns quickly (no pid file)
+    vi.mocked(stopDaemon).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('still clears tokens even when daemon was not running', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(tm.clearTokens).toHaveBeenCalledOnce();
+  });
+
+  it('attempts SIGTERM fallback via stopDaemon', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    // WHY: When terminateDaemon returns ok:false, we can't distinguish
+    // "not running" from "timed out" — either way we call stopDaemon as
+    // a belt-and-suspenders fallback before clearing tokens.
+    expect(stopDaemon).toHaveBeenCalledOnce();
+  });
+
+  it('exits with code 0', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});
+
+// ============================================================================
+// Tests — Edge Case 3: Daemon terminate timeout (ok: false from slow daemon)
+// ============================================================================
+
+describe('handleLogout — daemon terminate timeout (ok: false, SIGTERM fallback)', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let tm: ReturnType<typeof mockTokenManager>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      throw new Error(`process.exit(${_code})`);
+    });
+
+    tm = mockTokenManager(true);
+    vi.mocked(getTokenManager).mockReturnValue(tm as never);
+    // Daemon exists but terminateDaemon timed out → ok: false
+    vi.mocked(terminateDaemon).mockResolvedValue({ ok: false });
+    vi.mocked(stopDaemon).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    warnSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('calls stopDaemon as SIGTERM fallback', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(stopDaemon).toHaveBeenCalledOnce();
+  });
+
+  it('clears tokens after SIGTERM fallback', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(tm.clearTokens).toHaveBeenCalledOnce();
+  });
+
+  it('prints confirmation message', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toMatch(/logged out/i);
+  });
+
+  it('exits with code 0', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});
+
+// ============================================================================
+// Tests — Edge Case 4: Already logged out (isAuthenticated === false)
+// ============================================================================
+
+describe('handleLogout — already logged out', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let tm: ReturnType<typeof mockTokenManager>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      throw new Error(`process.exit(${_code})`);
+    });
+
+    // Not authenticated — already logged out
+    tm = mockTokenManager(false);
+    vi.mocked(getTokenManager).mockReturnValue(tm as never);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('prints "Not logged in." message', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toMatch(/not logged in/i);
+  });
+
+  it('does not call terminateDaemon', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(terminateDaemon).not.toHaveBeenCalled();
+  });
+
+  it('does not call clearTokens', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(tm.clearTokens).not.toHaveBeenCalled();
+  });
+
+  it('exits with code 0', async () => {
+    await expect(handleLogout([])).rejects.toThrow('process.exit(0)');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});

--- a/packages/styrby-cli/src/commands/__tests__/logout.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/logout.test.ts
@@ -196,14 +196,12 @@ describe('handleLogout — no daemon running (terminateDaemon ok: false)', () =>
 
 describe('handleLogout — daemon terminate timeout (ok: false, SIGTERM fallback)', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
-  let warnSpy: ReturnType<typeof vi.spyOn>;
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let tm: ReturnType<typeof mockTokenManager>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
       throw new Error(`process.exit(${_code})`);
     });
@@ -217,7 +215,6 @@ describe('handleLogout — daemon terminate timeout (ok: false, SIGTERM fallback
 
   afterEach(() => {
     consoleSpy.mockRestore();
-    warnSpy.mockRestore();
     exitSpy.mockRestore();
   });
 

--- a/packages/styrby-cli/src/commands/index.ts
+++ b/packages/styrby-cli/src/commands/index.ts
@@ -9,6 +9,7 @@
 export * from './onboard';
 export * from './interactive';
 export * from './install-agent';
+export * from './logout';
 
 /**
  * Re-export commonly used types

--- a/packages/styrby-cli/src/commands/logout.ts
+++ b/packages/styrby-cli/src/commands/logout.ts
@@ -147,4 +147,3 @@ export async function handleLogout(_args: string[]): Promise<void> {
   process.exit(0);
 }
 
-export default { handleLogout };

--- a/packages/styrby-cli/src/commands/logout.ts
+++ b/packages/styrby-cli/src/commands/logout.ts
@@ -1,0 +1,150 @@
+/**
+ * Logout Command Handler
+ *
+ * Handles the `styrby logout` command, which performs a full, clean teardown
+ * of the user's session:
+ *   1. Send `daemon.terminate` IPC RPC (graceful shutdown, waits up to 5s).
+ *   2. Fall back to SIGTERM via `stopDaemon()` if the RPC didn't ACK.
+ *   3. Call `tokenManager.clearTokens()` to wipe tokens from memory + disk.
+ *   4. Print confirmation and exit 0.
+ *
+ * WHY (SOC 2 CC6.1 — auth context lifecycle): Logout must atomically destroy
+ * all auth context AND the daemon's live session. If the daemon keeps running
+ * after tokens are cleared it retains a live Realtime subscription under the
+ * old identity, which is both a data-integrity and security risk.
+ *
+ * WHY (OWASP A07:2021 — Identification & Authentication Failures): An
+ * incomplete logout that leaves the daemon running or tokens on disk would
+ * allow a subsequent local user (or malicious process) to impersonate the
+ * previous session. Defense-in-depth requires both layers to be cleared.
+ *
+ * @module commands/logout
+ */
+
+import chalk from 'chalk';
+import { terminateDaemon } from '@/daemon/controlClient';
+import { stopDaemon } from '@/daemon/run';
+import { getTokenManager } from '@/auth/token-manager';
+import { logger } from '@/ui/logger';
+
+/**
+ * Maximum milliseconds to wait for the daemon to ACK `daemon.terminate`.
+ *
+ * WHY 5s: Matches the spec requirement. The daemon needs time to persist its
+ * final state snapshot and close the Realtime subscription cleanly. 5s is
+ * generous enough for a local socket operation while not blocking UX visibly.
+ */
+const TERMINATE_TIMEOUT_MS = 5_000;
+
+/**
+ * Handle the `styrby logout` command.
+ *
+ * Performs a full, ordered teardown:
+ *   1. Guard: if not authenticated, short-circuit with "Not logged in."
+ *   2. Send `daemon.terminate` RPC; wait up to 5s for graceful ACK.
+ *   3. If ACK not received (ok: false), fall back to SIGTERM via `stopDaemon()`.
+ *   4. Clear tokens from memory and disk via `tokenManager.clearTokens()`.
+ *   5. Print confirmation and call `process.exit(0)`.
+ *
+ * All branches exit 0 — logout is always a success state from the user's
+ * perspective. Error conditions are logged but do not block token clearance.
+ *
+ * @param _args - Command-line arguments (currently unused by this command)
+ * @returns Promise that resolves when all teardown steps complete (before exit)
+ *
+ * @throws Never — all errors are caught and logged internally
+ *
+ * @example
+ * // Called from CLI entrypoint
+ * case 'logout':
+ *   await handleLogout(args.slice(1));
+ *   break;
+ */
+export async function handleLogout(_args: string[]): Promise<void> {
+  const tokenManager = getTokenManager();
+
+  // ── Guard: already logged out ───────────────────────────────────────────
+  // WHY: isAuthenticated() checks both the in-memory state flag AND whether an
+  // access token exists. This short-circuit prevents spurious daemon RPC calls
+  // and redundant clearTokens() calls when the user has no active session.
+  if (!tokenManager.isAuthenticated()) {
+    console.log(chalk.yellow('Not logged in.'));
+    process.exit(0);
+    return; // unreachable in production; satisfies TypeScript control flow
+  }
+
+  // ── Step 1: Attempt graceful daemon shutdown via IPC ────────────────────
+  // WHY: `daemon.terminate` asks the daemon to persist state, close its
+  // Realtime subscription, and exit cleanly before we wipe tokens.
+  // The 5s window matches the spec and gives the daemon enough time to flush
+  // its final state snapshot (SOC 2 CC7.2 — reliable processing).
+  logger.debug('logout: sending daemon.terminate RPC', { timeoutMs: TERMINATE_TIMEOUT_MS });
+
+  let daemonStoppedCleanly = false;
+  try {
+    const result = await terminateDaemon(TERMINATE_TIMEOUT_MS);
+    daemonStoppedCleanly = result.ok;
+
+    if (result.ok) {
+      logger.debug('logout: daemon terminated gracefully');
+    } else {
+      logger.debug('logout: daemon did not ACK terminate — falling back to SIGTERM');
+    }
+  } catch (err) {
+    // terminateDaemon is documented to never throw (returns { ok: false } on
+    // all error paths). This catch is a defensive belt-and-suspenders layer.
+    logger.warn('logout: unexpected error from terminateDaemon', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // ── Step 2: SIGTERM fallback if RPC didn't ACK ──────────────────────────
+  // WHY: `terminateDaemon` returns `{ ok: false }` for BOTH "daemon not
+  // running" and "daemon timed out". In either case, `stopDaemon()` is safe:
+  //  - Not running: stopDaemon reads no PID file and returns immediately.
+  //  - Timed out: stopDaemon sends SIGTERM, escalates to SIGKILL after 5s.
+  // This guarantees no orphaned daemon process remains after logout.
+  if (!daemonStoppedCleanly) {
+    try {
+      logger.debug('logout: calling stopDaemon() as SIGTERM fallback');
+      await stopDaemon();
+      logger.debug('logout: stopDaemon() completed');
+    } catch (err) {
+      // A SIGTERM failure is non-fatal for the logout flow — tokens must still
+      // be cleared even if we can't kill the daemon (e.g., EPERM).
+      // Log the warning so it shows up in support diagnostics.
+      logger.warn('logout: stopDaemon() fallback failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      console.log(
+        chalk.yellow(
+          'Warning: could not stop daemon. You may need to run `styrby stop` manually.'
+        )
+      );
+    }
+  }
+
+  // ── Step 3: Wipe all auth context ───────────────────────────────────────
+  // WHY: clearTokens() atomically:
+  //  - Resets in-memory state to { isAuthenticated: false }
+  //  - Clears tokens from ~/.styrby/data.json (accessToken, refreshToken,
+  //    authenticatedAt)
+  //  - Clears authToken + userId from the config store
+  //  - Emits 'logout' event with { userId } so any remaining subscribers
+  //    (e.g., push-token cache) can tear down per-user state
+  // Order matters: daemon must be stopped BEFORE clearTokens() so the daemon
+  // cannot issue new Supabase requests with tokens that are about to vanish.
+  tokenManager.clearTokens();
+  logger.debug('logout: tokens cleared');
+
+  // ── Step 4: Confirmation + exit 0 ───────────────────────────────────────
+  console.log(
+    chalk.green(
+      'Logged out. Daemon stopped. Run `styrby login` to sign in again.'
+    )
+  );
+
+  process.exit(0);
+}
+
+export default { handleLogout };

--- a/packages/styrby-cli/src/daemon/__tests__/auth-mismatch.test.ts
+++ b/packages/styrby-cli/src/daemon/__tests__/auth-mismatch.test.ts
@@ -226,7 +226,7 @@ describe('assertAuthContext — auth-context mismatch detection', () => {
     const envelope = makeEnvelope('user-B');
     const result: AuthCheckResult = assertAuthContext(envelope, state);
     // Must tell user what to do next
-    expect(result.message).toMatch(/styrby/i);
+    expect(result.message).toContain('styrby login');
   });
 
   // --------------------------------------------------------------------------
@@ -271,9 +271,9 @@ describe('assertAuthContext — auth-context mismatch detection', () => {
 
   it('AUTH_MISSING message includes styrby login guidance', () => {
     const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 2 });
-    const envelope = makeEnvelope(null as unknown as undefined);
+    const envelope = makeEnvelope(undefined);
     const result: AuthCheckResult = assertAuthContext(envelope, state);
-    expect(result.message).toMatch(/styrby login/i);
+    expect(result.message).toContain('styrby login');
   });
 
   it('AUTH_MISSING fires even if there are active sessions', () => {

--- a/packages/styrby-cli/src/daemon/__tests__/auth-mismatch.test.ts
+++ b/packages/styrby-cli/src/daemon/__tests__/auth-mismatch.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for daemon auth-context mismatch detection.
+ *
+ * Covers the full matrix from Phase 1 spec deliverable #3:
+ *
+ *   | daemon bound | caller now | active sessions | action                  |
+ *   |--------------|------------|-----------------|-------------------------|
+ *   | user A       | user A     | any             | proceed normally        |
+ *   | user A       | user B     | 0               | rebind: terminate + err |
+ *   | user A       | user B     | >0              | refuse AUTH_MISMATCH_ACTIVE_SESSIONS |
+ *   | user A       | none       | any             | refuse AUTH_MISSING     |
+ *
+ * Also covers:
+ *   - `daemon.terminate` and `ping` bypass the check entirely
+ *   - Error response shapes match spec exactly (code + message fields)
+ *
+ * OWASP A07:2021 — Identification and Authentication Failures:
+ *   Verifying that the daemon refuses to execute commands on behalf of a
+ *   caller whose identity differs from the account the daemon was bound to
+ *   prevents privilege-confusion attacks where a newly-logged-in user could
+ *   silently piggyback on another user's active daemon (and their sessions).
+ *
+ * SOC 2 CC6.1 — Logical and Physical Access Controls:
+ *   The daemon is a long-lived background process with privileged access to
+ *   Supabase Realtime channels. Validating caller identity on every mutable
+ *   command ensures the daemon's access scope cannot be widened by an
+ *   account switch without an explicit re-bind cycle.
+ *
+ * @module daemon/__tests__/auth-mismatch
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Hoist: stub process.exit + set STYRBY_DAEMON before any module evaluates
+//
+// WHY vi.hoisted: daemonProcess.ts calls main() at module evaluation time.
+// main() exits with code 1 if STYRBY_DAEMON is not set. vi.hoisted() runs
+// before ALL vi.mock() factories and before the module is imported, so we can
+// safely stub process.exit and set the env flag here to prevent the test worker
+// from being killed before a single test runs.
+// ============================================================================
+
+const { exitStub } = vi.hoisted(() => {
+  // Set the daemon env flag before any module loads. This is the earliest safe
+  // place to do it — hoisted code runs before static imports are resolved.
+  process.env.STYRBY_DAEMON = '1';
+  process.env.SUPABASE_URL = 'https://test.supabase.co';
+  process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+
+  // Replace process.send so the daemon's "ready" signal does not reach the
+  // Vitest host worker IPC channel and cause a deserialization error.
+  (process as NodeJS.Process).send = () => true;
+
+  // Stub process.exit before module evaluation so main()'s process.exit(1)
+  // does not terminate the test worker.
+  const exitStub = vi.spyOn(process, 'exit').mockImplementation((() => {}) as (code?: number | string | null) => never);
+  return { exitStub };
+});
+
+// ============================================================================
+// Mocks — must appear before module imports
+// ============================================================================
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn(() => false),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    readFileSync: vi.fn(() => '{}'),
+    chmodSync: vi.fn(),
+  },
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  readFileSync: vi.fn(() => '{}'),
+  chmodSync: vi.fn(),
+}));
+
+vi.mock('node:net', () => {
+  const serverMock = {
+    on: vi.fn().mockReturnThis(),
+    listen: vi.fn((_path: string, cb: () => void) => { cb?.(); return serverMock; }),
+    close: vi.fn(),
+  };
+  return {
+    default: { createServer: vi.fn(() => serverMock) },
+    createServer: vi.fn(() => serverMock),
+  };
+});
+
+vi.mock('node:os', () => ({
+  default: {
+    homedir: vi.fn(() => '/tmp/styrby-test'),
+    hostname: vi.fn(() => 'test-machine'),
+    networkInterfaces: vi.fn(() => ({})),
+  },
+  homedir: vi.fn(() => '/tmp/styrby-test'),
+  hostname: vi.fn(() => 'test-machine'),
+  networkInterfaces: vi.fn(() => ({})),
+}));
+
+vi.mock('../wakeDetector.js', () => ({
+  WakeDetector: vi.fn().mockImplementation(() => ({
+    on: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('styrby-shared', () => ({
+  createRelayClient: vi.fn(() => ({
+    on: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    getConnectedDevices: vi.fn(() => []),
+    scheduleReconnect: vi.fn(),
+  })),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    channel: vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() })),
+    removeChannel: vi.fn(),
+  })),
+}));
+
+vi.mock('../run.js', () => ({
+  DAEMON_PATHS: {
+    pidFile: '/tmp/styrby-test/daemon.pid',
+    statusFile: '/tmp/styrby-test/daemon.status.json',
+    logFile: '/tmp/styrby-test/daemon.log',
+    socketPath: '/tmp/styrby-test/daemon.sock',
+  },
+  getDaemonStatus: vi.fn(() => ({ running: false })),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// ============================================================================
+// Imports (after mocks)
+// ============================================================================
+
+import { assertAuthContext, type AuthCheckEnvelope, type AuthCheckResult } from '../daemonProcess.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build a minimal mock daemon state for assertAuthContext tests.
+ */
+function makeDaemonState(overrides: { boundUserId?: string | null; activeSessionCount?: number } = {}): {
+  boundUserId: string | null;
+  activeSessionCount: number;
+} {
+  return {
+    boundUserId: overrides.boundUserId !== undefined ? overrides.boundUserId : 'user-A',
+    activeSessionCount: overrides.activeSessionCount !== undefined ? overrides.activeSessionCount : 0,
+  };
+}
+
+/**
+ * Build an IPC envelope for a mutable command.
+ */
+function makeEnvelope(currentUserId: string | null | undefined, commandType = 'list-sessions'): AuthCheckEnvelope {
+  return { type: commandType, currentUserId: currentUserId ?? undefined };
+}
+
+// ============================================================================
+// Global afterEach — restore process.exit stub
+// ============================================================================
+
+afterEach(() => {
+  vi.clearAllMocks();
+  // Keep exitStub installed (don't restore) — daemonProcess.ts's main() may
+  // still be in the microtask queue. Restoring here would re-enable real exit.
+});
+
+// ============================================================================
+// Tests: assertAuthContext — the 4-row matrix
+// ============================================================================
+
+describe('assertAuthContext — auth-context mismatch detection', () => {
+  it('returns { ok: true } when daemon boundUserId matches caller currentUserId (0 sessions)', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 0 });
+    const envelope = makeEnvelope('user-A');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns { ok: true } when daemon boundUserId matches caller currentUserId (N sessions)', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 5 });
+    const envelope = makeEnvelope('user-A');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(true);
+  });
+
+  // --------------------------------------------------------------------------
+  // Row 2: mismatch + 0 active sessions → silently rebind
+  // --------------------------------------------------------------------------
+
+  it('returns AUTH_REBIND_REQUIRED when caller is different user and daemon has 0 active sessions', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 0 });
+    const envelope = makeEnvelope('user-B');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('AUTH_REBIND_REQUIRED');
+    expect(typeof result.message).toBe('string');
+    expect(result.message!.length).toBeGreaterThan(0);
+    // mustTerminate flag tells the dispatcher to trigger daemon.terminate path
+    expect(result.mustTerminate).toBe(true);
+  });
+
+  it('AUTH_REBIND_REQUIRED message is human-readable and actionable', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 0 });
+    const envelope = makeEnvelope('user-B');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    // Must tell user what to do next
+    expect(result.message).toMatch(/styrby/i);
+  });
+
+  // --------------------------------------------------------------------------
+  // Row 3: mismatch + >0 active sessions → refuse
+  // --------------------------------------------------------------------------
+
+  it('returns AUTH_MISMATCH_ACTIVE_SESSIONS when caller is different user and daemon has active sessions', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 3 });
+    const envelope = makeEnvelope('user-B');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('AUTH_MISMATCH_ACTIVE_SESSIONS');
+    expect(result.mustTerminate).toBeFalsy();
+  });
+
+  it('AUTH_MISMATCH_ACTIVE_SESSIONS message includes session count', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 3 });
+    const envelope = makeEnvelope('user-B');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.message).toContain('3');
+  });
+
+  it('AUTH_MISMATCH_ACTIVE_SESSIONS message includes styrby logout guidance', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 1 });
+    const envelope = makeEnvelope('user-B');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.message).toMatch(/styrby logout/i);
+  });
+
+  // --------------------------------------------------------------------------
+  // Row 4: caller is logged out (no currentUserId) → AUTH_MISSING
+  // --------------------------------------------------------------------------
+
+  it('returns AUTH_MISSING when caller has no currentUserId (logged out)', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 0 });
+    const envelope = makeEnvelope(undefined);
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('AUTH_MISSING');
+    expect(result.mustTerminate).toBeFalsy();
+  });
+
+  it('AUTH_MISSING message includes styrby login guidance', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 2 });
+    const envelope = makeEnvelope(null as unknown as undefined);
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.message).toMatch(/styrby login/i);
+  });
+
+  it('AUTH_MISSING fires even if there are active sessions', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 5 });
+    const envelope = makeEnvelope(undefined);
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('AUTH_MISSING');
+  });
+
+  // --------------------------------------------------------------------------
+  // Edge cases
+  // --------------------------------------------------------------------------
+
+  it('treats empty string currentUserId the same as undefined (AUTH_MISSING)', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 0 });
+    const envelope = makeEnvelope('' as unknown as undefined);
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('AUTH_MISSING');
+  });
+
+  it('returns { ok: true } when boundUserId is null (unbound daemon) and any user calls', () => {
+    // WHY: An unbound daemon (e.g., credentials were never written) should
+    // not block callers — the relay connect itself will fail. The auth check
+    // only enforces identity once a boundUserId has been established.
+    const state = makeDaemonState({ boundUserId: null, activeSessionCount: 0 });
+    const envelope = makeEnvelope('user-A');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ============================================================================
+// Tests: exempt commands bypass auth check
+// ============================================================================
+
+describe('assertAuthContext — exempt commands bypass check', () => {
+  it('daemon.terminate: always returns ok=true regardless of userId mismatch', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 5 });
+    // Mismatched user, active sessions — would normally refuse. Exempt because
+    // logout must always be able to stop the daemon.
+    const envelope = makeEnvelope('user-B', 'daemon.terminate');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(true);
+  });
+
+  it('daemon.terminate: bypasses even when caller has no userId', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 3 });
+    const envelope = makeEnvelope(undefined, 'daemon.terminate');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(true);
+  });
+
+  it('ping: always returns ok=true (health check)', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 0 });
+    const envelope = makeEnvelope('user-B', 'ping');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(true);
+  });
+
+  it('status: always returns ok=true (read-only health check)', () => {
+    const state = makeDaemonState({ boundUserId: 'user-A', activeSessionCount: 0 });
+    const envelope = makeEnvelope(undefined, 'status');
+    const result: AuthCheckResult = assertAuthContext(envelope, state);
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ============================================================================
+// Tests: IPC envelope carries currentUserId
+// ============================================================================
+
+describe('IPC envelope — currentUserId field', () => {
+  it('AuthCheckEnvelope accepts currentUserId as optional string', () => {
+    // Type-level test: if this compiles, the type is correct.
+    const withUser: AuthCheckEnvelope = { type: 'list-sessions', currentUserId: 'user-A' };
+    const withoutUser: AuthCheckEnvelope = { type: 'list-sessions' };
+    expect(withUser.currentUserId).toBe('user-A');
+    expect(withoutUser.currentUserId).toBeUndefined();
+  });
+});

--- a/packages/styrby-cli/src/daemon/__tests__/terminate.test.ts
+++ b/packages/styrby-cli/src/daemon/__tests__/terminate.test.ts
@@ -1,0 +1,534 @@
+/**
+ * Tests for daemon terminate RPC — daemon-side handler + client-side method.
+ *
+ * TDD: these tests are written BEFORE the implementation. They describe the
+ * exact contract the `daemon.terminate` IPC command and `terminateDaemon()`
+ * client method must satisfy.
+ *
+ * Covers (daemon-side handler):
+ * - Closes the Realtime subscription cleanly (relay.disconnect() is called)
+ * - Persists a final state snapshot before exiting
+ * - Closes the IPC server
+ * - Calls process.exit(0)
+ *
+ * Covers (client-side terminateDaemon):
+ * - Returns { ok: true } when daemon exits within timeout
+ * - Returns { ok: false } on IPC timeout (daemon did not respond)
+ *
+ * WHY process.exit is tested via mock:
+ *   process.exit(0) would terminate the test runner. We spy on it with
+ *   vi.spyOn(process, 'exit') and restore after each test.
+ *
+ * WHY isolated module + vi.mock:
+ *   daemonProcess.ts runs main() at module evaluation time. We cannot import
+ *   it directly in tests without triggering the daemon loop. Instead we test
+ *   the exported handleTerminate function (the extracted handler), plus the
+ *   gracefulShutdown flow through a thin integration test of the IPC handler
+ *   dispatch. See the implementation plan: handleTerminate is extracted from
+ *   the IPC switch statement into a testable function.
+ *
+ * @module daemon/__tests__/terminate
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as net from 'node:net';
+
+// ============================================================================
+// Mocks — must appear before module imports
+// ============================================================================
+
+vi.mock('node:net', () => {
+  const serverMock = {
+    on: vi.fn().mockReturnThis(),
+    listen: vi.fn((_path: string, cb: () => void) => { cb?.(); return serverMock; }),
+    close: vi.fn(),
+  };
+  const createConnection = vi.fn();
+  const createServer = vi.fn(() => serverMock);
+  return { default: { createConnection, createServer }, createConnection, createServer };
+});
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn(() => false),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    readFileSync: vi.fn(() => '{}'),
+    chmodSync: vi.fn(),
+  },
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  readFileSync: vi.fn(() => '{}'),
+  chmodSync: vi.fn(),
+}));
+
+vi.mock('node:os', () => ({
+  default: {
+    homedir: vi.fn(() => '/tmp/styrby-test'),
+    hostname: vi.fn(() => 'test-machine'),
+    networkInterfaces: vi.fn(() => ({})),
+  },
+  homedir: vi.fn(() => '/tmp/styrby-test'),
+  hostname: vi.fn(() => 'test-machine'),
+  networkInterfaces: vi.fn(() => ({})),
+}));
+
+vi.mock('../wakeDetector.js', () => ({
+  WakeDetector: vi.fn().mockImplementation(() => ({
+    on: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('styrby-shared', () => ({
+  createRelayClient: vi.fn(() => ({
+    on: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    getConnectedDevices: vi.fn(() => []),
+    scheduleReconnect: vi.fn(),
+  })),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    channel: vi.fn(() => ({ on: vi.fn().mockReturnThis(), subscribe: vi.fn() })),
+    removeChannel: vi.fn(),
+  })),
+}));
+
+vi.mock('../run.js', () => ({
+  DAEMON_PATHS: {
+    pidFile: '/tmp/styrby-test/daemon.pid',
+    statusFile: '/tmp/styrby-test/daemon.status.json',
+    logFile: '/tmp/styrby-test/daemon.log',
+    socketPath: '/tmp/styrby-test/daemon.sock',
+  },
+  getDaemonStatus: vi.fn(() => ({ running: false })),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// ============================================================================
+// Imports (after mocks)
+// ============================================================================
+
+import { terminateDaemon } from '../controlClient.js';
+
+// ============================================================================
+// Setup for handleTerminate tests
+// ============================================================================
+
+// WHY: daemonProcess.ts calls main() at module load time and main() calls
+// process.send({ type: 'ready' }). Vitest workers use process.send for their
+// own IPC channel. If the daemon's message reaches the Vitest host it causes
+// a deserialization error that crashes the test worker. Stubbing process.send
+// before the dynamic import silently swallows the ready signal.
+// _origProcessSend / _processSendStub are declared inside the describe block
+// that uses them (handleTerminate tests) to limit scope.
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Tracks the last socket created by net.createConnection mock. */
+let _lastSocket: ReturnType<typeof buildSocketMock> | null = null;
+
+/**
+ * Build a mock Socket that immediately responds with the given JSON line
+ * when `write` is called — simulates a fast daemon ACK.
+ */
+function buildSocketMock(responseJson: object) {
+  const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  const socket = {
+    write: vi.fn<[string], boolean>((msg: string) => {
+      void msg;
+      Promise.resolve().then(() => {
+        const line = JSON.stringify(responseJson) + '\n';
+        for (const h of handlers['data'] ?? []) h(Buffer.from(line));
+        for (const h of handlers['close'] ?? []) h();
+      });
+      return true;
+    }),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers[event] = [...(handlers[event] ?? []), handler];
+      return socket as unknown as net.Socket;
+    }),
+    setTimeout: vi.fn(() => socket as unknown as net.Socket),
+    destroy: vi.fn(),
+  };
+  return socket;
+}
+
+/**
+ * Build a socket mock that fires a timeout event after handlers are registered,
+ * simulating a daemon that never responds (e.g., hung or crashed mid-shutdown).
+ */
+function buildTimeoutSocketMock() {
+  const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  const socket = {
+    write: vi.fn<[string], boolean>(() => true),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers[event] = [...(handlers[event] ?? []), handler];
+      return socket as unknown as net.Socket;
+    }),
+    // Trigger the timeout event immediately after setTimeout is called
+    setTimeout: vi.fn(() => {
+      Promise.resolve().then(() => {
+        for (const h of handlers['timeout'] ?? []) h();
+      });
+      return socket as unknown as net.Socket;
+    }),
+    destroy: vi.fn(),
+  };
+  return socket;
+}
+
+/**
+ * Build a socket mock that fires ECONNREFUSED — simulates daemon not running.
+ */
+function buildErrorSocketMock(code: string = 'ECONNREFUSED') {
+  const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  const socket = {
+    write: vi.fn(),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers[event] = [...(handlers[event] ?? []), handler];
+      return socket as unknown as net.Socket;
+    }),
+    setTimeout: vi.fn(() => {
+      // WHY setTimeout(_, 0): defers the error to the next microtask so the
+      // caller's await completes first, preventing a race between socket
+      // creation and the error handler being registered via .on('error', ...).
+      Promise.resolve().then(() => {
+        const err = Object.assign(new Error(`connect ${code}`), { code });
+        for (const h of handlers['error'] ?? []) h(err);
+      });
+      return socket as unknown as net.Socket;
+    }),
+    destroy: vi.fn(),
+  };
+  return socket;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('terminateDaemon (controlClient)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _lastSocket = null;
+
+    // Wire the createConnection mock to use _lastSocket
+    vi.mocked(net.createConnection).mockImplementation(
+      (_opts: unknown, cb?: () => void) => {
+        Promise.resolve().then(() => cb?.());
+        return _lastSocket as unknown as net.Socket;
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // Happy path: daemon terminates within timeout
+  // --------------------------------------------------------------------------
+
+  it('sends { type: "daemon.terminate" } over IPC', async () => {
+    _lastSocket = buildSocketMock({ success: true, data: { terminating: true } });
+
+    await terminateDaemon(5000);
+
+    const written = JSON.parse(
+      (_lastSocket.write as ReturnType<typeof vi.fn>).mock.calls[0][0].trimEnd()
+    ) as { type: string };
+    expect(written.type).toBe('daemon.terminate');
+  });
+
+  it('returns { ok: true } when daemon ACKs the terminate command', async () => {
+    _lastSocket = buildSocketMock({ success: true, data: { terminating: true } });
+
+    const result = await terminateDaemon(5000);
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  // --------------------------------------------------------------------------
+  // Timeout path: daemon does not respond in time
+  // --------------------------------------------------------------------------
+
+  it('returns { ok: false } when daemon does not respond within timeoutMs', async () => {
+    _lastSocket = buildTimeoutSocketMock();
+
+    const result = await terminateDaemon(100);
+
+    expect(result).toEqual({ ok: false });
+  });
+
+  // --------------------------------------------------------------------------
+  // Socket error path: daemon not running
+  // --------------------------------------------------------------------------
+
+  it('returns { ok: false } when socket is unreachable (daemon not running)', async () => {
+    _lastSocket = buildErrorSocketMock('ECONNREFUSED');
+
+    const result = await terminateDaemon(5000);
+
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('returns { ok: false } when daemon returns success: false', async () => {
+    _lastSocket = buildSocketMock({ success: false, error: 'already shutting down' });
+
+    const result = await terminateDaemon(5000);
+
+    // A non-successful response still means the daemon received the command but
+    // was in a state where it could not ACK gracefully. We treat this as !ok.
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+// ============================================================================
+// Handler unit tests — test handleTerminate() in isolation
+// ============================================================================
+
+describe('handleTerminate (daemon IPC handler)', () => {
+  // WHY module-scoped stubs are kept inside this describe block:
+  // _origProcessSend and _processSendStub are only needed here; keeping them
+  // at describe scope (not module scope) prevents accidental leakage into the
+  // terminateDaemon describe block above.
+  const _origProcessSend = process.send;
+  const _processSendStub = vi.fn(() => true);
+
+  /** Spy on process.exit to prevent test runner termination. */
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  /** Mock relay — captures disconnect() calls. */
+  let mockRelay: { disconnect: ReturnType<typeof vi.fn> };
+  /** Mock IPC server — captures close() calls. */
+  let mockIpcServer: { close: ReturnType<typeof vi.fn> };
+  /** Mock stateSnapshot — captures persist calls. */
+  let mockStateSnapshot: { persistNow: ReturnType<typeof vi.fn>; clearOnExit: ReturnType<typeof vi.fn> };
+  /** Mock socket connection passed into the handler. */
+  let mockConn: { write: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null | undefined) => {
+      // Prevent actual exit — just capture the call
+      return undefined as never;
+    });
+
+    // Stub process.send to prevent daemon's "ready" signal from crashing the
+    // Vitest worker's IPC channel. See WHY comment above.
+    (process as NodeJS.Process).send = _processSendStub;
+
+    // Set env flags so main() inside daemonProcess runs its startup path
+    process.env.STYRBY_DAEMON = '1';
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+
+    mockRelay = { disconnect: vi.fn().mockResolvedValue(undefined) };
+    mockIpcServer = { close: vi.fn() };
+    mockStateSnapshot = {
+      persistNow: vi.fn(),
+      clearOnExit: vi.fn(),
+    };
+    mockConn = { write: vi.fn() };
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    (process as NodeJS.Process).send = _origProcessSend;
+    delete process.env.STYRBY_DAEMON;
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_ANON_KEY;
+    vi.restoreAllMocks();
+  });
+
+  it('is exported as handleTerminate from daemonProcess module', async () => {
+    // WHY: The handler must be exported so tests (and the auth-mismatch tests)
+    // can invoke it directly without spinning up the full daemon loop.
+    const mod = await import('../daemonProcess.js');
+    expect(typeof (mod as Record<string, unknown>)['handleTerminate']).toBe('function');
+  });
+
+  it('calls relay.disconnect() to close Realtime subscription cleanly', async () => {
+    const { handleTerminate } = await import('../daemonProcess.js') as {
+      handleTerminate: (
+        relay: typeof mockRelay | null,
+        ipcServer: typeof mockIpcServer | null,
+        snapshot: typeof mockStateSnapshot,
+        conn: typeof mockConn
+      ) => Promise<void>;
+    };
+
+    await handleTerminate(mockRelay, mockIpcServer, mockStateSnapshot, mockConn);
+
+    expect(mockRelay.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('calls snapshot.persistNow() before exit (final state flush)', async () => {
+    const { handleTerminate } = await import('../daemonProcess.js') as {
+      handleTerminate: (
+        relay: typeof mockRelay | null,
+        ipcServer: typeof mockIpcServer | null,
+        snapshot: typeof mockStateSnapshot,
+        conn: typeof mockConn
+      ) => Promise<void>;
+    };
+
+    await handleTerminate(mockRelay, mockIpcServer, mockStateSnapshot, mockConn);
+
+    expect(mockStateSnapshot.persistNow).toHaveBeenCalledOnce();
+  });
+
+  it('calls ipcServer.close() before exit', async () => {
+    const { handleTerminate } = await import('../daemonProcess.js') as {
+      handleTerminate: (
+        relay: typeof mockRelay | null,
+        ipcServer: typeof mockIpcServer | null,
+        snapshot: typeof mockStateSnapshot,
+        conn: typeof mockConn
+      ) => Promise<void>;
+    };
+
+    await handleTerminate(mockRelay, mockIpcServer, mockStateSnapshot, mockConn);
+
+    expect(mockIpcServer.close).toHaveBeenCalledOnce();
+  });
+
+  it('calls process.exit(0) as the final action', async () => {
+    const { handleTerminate } = await import('../daemonProcess.js') as {
+      handleTerminate: (
+        relay: typeof mockRelay | null,
+        ipcServer: typeof mockIpcServer | null,
+        snapshot: typeof mockStateSnapshot,
+        conn: typeof mockConn
+      ) => Promise<void>;
+    };
+
+    await handleTerminate(mockRelay, mockIpcServer, mockStateSnapshot, mockConn);
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('writes ACK to socket before shutdown sequence begins', async () => {
+    const { handleTerminate } = await import('../daemonProcess.js') as {
+      handleTerminate: (
+        relay: typeof mockRelay | null,
+        ipcServer: typeof mockIpcServer | null,
+        snapshot: typeof mockStateSnapshot,
+        conn: typeof mockConn
+      ) => Promise<void>;
+    };
+
+    await handleTerminate(mockRelay, mockIpcServer, mockStateSnapshot, mockConn);
+
+    // The first write must be the ACK, before relay disconnects
+    expect(mockConn.write).toHaveBeenCalledOnce();
+    const ackJson = JSON.parse(
+      (mockConn.write as ReturnType<typeof vi.fn>).mock.calls[0][0].trimEnd()
+    ) as { success: boolean };
+    expect(ackJson.success).toBe(true);
+
+    // Verify strict invocation order: ACK → relay.disconnect → ipcServer.close → process.exit
+    const connWriteMock = mockConn.write as ReturnType<typeof vi.fn>;
+    const relayDisconnectMock = mockRelay.disconnect as ReturnType<typeof vi.fn>;
+    const ipcServerCloseMock = mockIpcServer.close as ReturnType<typeof vi.fn>;
+
+    expect(connWriteMock.mock.invocationCallOrder[0]).toBeLessThan(
+      relayDisconnectMock.mock.invocationCallOrder[0]
+    );
+    expect(relayDisconnectMock.mock.invocationCallOrder[0]).toBeLessThan(
+      ipcServerCloseMock.mock.invocationCallOrder[0]
+    );
+    expect(ipcServerCloseMock.mock.invocationCallOrder[0]).toBeLessThan(
+      exitSpy.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('still ACKs and proceeds through full shutdown even if persistNow() throws', async () => {
+    // WHY: persistNow() failure (e.g., disk full, FS permission error) must
+    // never halt the shutdown sequence. The daemon must still disconnect
+    // Realtime, close the IPC server, and exit — leaving orphaned state is
+    // better than leaving an orphaned daemon process.
+    mockStateSnapshot.persistNow.mockImplementation(() => {
+      throw new Error('ENOSPC: no space left on device');
+    });
+
+    const { handleTerminate } = await import('../daemonProcess.js') as {
+      handleTerminate: (
+        relay: typeof mockRelay | null,
+        ipcServer: typeof mockIpcServer | null,
+        snapshot: typeof mockStateSnapshot,
+        conn: typeof mockConn
+      ) => Promise<void>;
+    };
+
+    await handleTerminate(mockRelay, mockIpcServer, mockStateSnapshot, mockConn);
+
+    // Caller must still receive the ACK despite the persistNow error
+    expect(mockConn.write).toHaveBeenCalledOnce();
+    const ackJson = JSON.parse(
+      (mockConn.write as ReturnType<typeof vi.fn>).mock.calls[0][0].trimEnd()
+    ) as { success: boolean };
+    expect(ackJson.success).toBe(true);
+
+    // Full shutdown sequence must still execute
+    expect(mockRelay.disconnect).toHaveBeenCalledOnce();
+    expect(mockIpcServer.close).toHaveBeenCalledOnce();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('works when relay is null (daemon never connected to Realtime)', async () => {
+    const { handleTerminate } = await import('../daemonProcess.js') as {
+      handleTerminate: (
+        relay: null,
+        ipcServer: typeof mockIpcServer | null,
+        snapshot: typeof mockStateSnapshot,
+        conn: typeof mockConn
+      ) => Promise<void>;
+    };
+
+    // Should not throw — relay disconnect is skipped gracefully
+    await expect(
+      handleTerminate(null, mockIpcServer, mockStateSnapshot, mockConn)
+    ).resolves.not.toThrow();
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('closes IPC server even if relay.disconnect() rejects', async () => {
+    mockRelay.disconnect.mockRejectedValue(new Error('relay already closed'));
+
+    const { handleTerminate } = await import('../daemonProcess.js') as {
+      handleTerminate: (
+        relay: typeof mockRelay | null,
+        ipcServer: typeof mockIpcServer | null,
+        snapshot: typeof mockStateSnapshot,
+        conn: typeof mockConn
+      ) => Promise<void>;
+    };
+
+    await handleTerminate(mockRelay, mockIpcServer, mockStateSnapshot, mockConn);
+
+    // IPC must close even after relay error
+    expect(mockIpcServer.close).toHaveBeenCalledOnce();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});

--- a/packages/styrby-cli/src/daemon/controlClient.ts
+++ b/packages/styrby-cli/src/daemon/controlClient.ts
@@ -34,7 +34,21 @@ export type DaemonCommand =
    * The daemon updates `sessions.status = 'running'` and `last_seen_at = now()`.
    * Does NOT spawn a new agent process — relay-reconnect only.
    */
-  | { type: 'attach-relay'; sessionId: string };
+  | { type: 'attach-relay'; sessionId: string }
+  /**
+   * Terminate the daemon process cleanly.
+   *
+   * The daemon will:
+   * 1. ACK this command
+   * 2. Persist a final state snapshot
+   * 3. Close the Realtime subscription
+   * 4. Close the IPC server
+   * 5. Call process.exit(0)
+   *
+   * Used by `styrby logout` to tear down the daemon before clearing tokens.
+   * SOC 2 CC7.2: Ensures no orphaned Realtime subscriptions on logout.
+   */
+  | { type: 'daemon.terminate' };
 
 /**
  * Response received from the daemon via IPC.
@@ -198,7 +212,107 @@ export async function attachRelaySession(sessionId: string): Promise<boolean> {
   }
 }
 
+/**
+ * Send `daemon.terminate` and wait for the daemon to shut down cleanly.
+ *
+ * Behavior:
+ * 1. Sends `{ type: 'daemon.terminate' }` over IPC.
+ * 2. If the daemon ACKs (success: true) within `timeoutMs`, returns `{ ok: true }`.
+ * 3. If no ACK arrives within `timeoutMs`, or the socket is unreachable,
+ *    returns `{ ok: false }`.
+ *
+ * WHY this function doesn't reuse `sendDaemonCommand`:
+ *   `sendDaemonCommand` resolves/rejects based on the JSON response and always
+ *   throws on timeout. `terminateDaemon` needs a different success shape
+ *   (`{ ok: boolean }` not `DaemonResponse`), never throws (callers rely on the
+ *   `ok` flag to decide between graceful shutdown and SIGTERM fallback), and
+ *   uses a caller-supplied timeout rather than the fixed `IPC_TIMEOUT_MS`.
+ *   Fitting all three into `sendDaemonCommand` would have required a brittle
+ *   options bag with three overloads — a separate function is cleaner.
+ *
+ * WHY `{ ok: boolean }` instead of throwing on timeout:
+ *   `styrby logout` needs to distinguish a graceful shutdown from a timeout so
+ *   it can fall back to SIGTERM via PID file. Throwing would conflate both cases
+ *   and force the caller to catch + inspect error messages.
+ *
+ * WHY we use the standard IPC_TIMEOUT_MS from sendDaemonCommand for the socket
+ * read, but `timeoutMs` controls whether we treat that as a timeout result:
+ *   The socket-level timeout is a separate concern (prevents the connection
+ *   from hanging forever). The `timeoutMs` parameter lets callers specify how
+ *   long they are willing to wait for the daemon ACK — distinct from whether
+ *   the socket itself is alive.
+ *
+ * SOC 2 CC7.2: Reliable processing requires that the caller knows whether the
+ * daemon stopped cleanly, so it can apply fallback (SIGTERM) rather than
+ * leaving the daemon running while tokens are wiped.
+ *
+ * @param timeoutMs - Max milliseconds to wait for the daemon to ACK (default 5000)
+ * @returns `{ ok: true }` on graceful shutdown, `{ ok: false }` on timeout or error
+ */
+export async function terminateDaemon(timeoutMs: number = 5_000): Promise<{ ok: boolean }> {
+  const socketPath = DAEMON_PATHS.socketPath;
+
+  return new Promise<{ ok: boolean }>((resolve) => {
+    let buffer = '';
+    let settled = false;
+
+    const settle = (ok: boolean): void => {
+      if (settled) return;
+      settled = true;
+      resolve({ ok });
+    };
+
+    const socket = net.createConnection({ path: socketPath }, () => {
+      socket.write(JSON.stringify({ type: 'daemon.terminate' }) + '\n');
+    });
+
+    // WHY custom timeout here instead of reusing IPC_TIMEOUT_MS:
+    // The caller-supplied timeoutMs governs how long the logout command will wait.
+    // The default socket timeout (IPC_TIMEOUT_MS = 3s) is the inner bound;
+    // terminateDaemon's timeout is the outer bound from the caller's perspective.
+    socket.setTimeout(timeoutMs);
+
+    socket.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex !== -1) {
+        const responseLine = buffer.substring(0, newlineIndex).trim();
+        if (responseLine) {
+          socket.destroy();
+          try {
+            const resp = JSON.parse(responseLine) as { success: boolean };
+            settle(resp.success === true);
+          } catch {
+            settle(false);
+          }
+        }
+      }
+    });
+
+    socket.on('timeout', () => {
+      socket.destroy();
+      settle(false);
+    });
+
+    socket.on('error', (err: NodeJS.ErrnoException) => {
+      const code = err.code;
+      if (code === 'ECONNREFUSED' || code === 'ENOENT') {
+        // Daemon not running — treat as ok=false (nothing to terminate)
+        logger.debug('terminateDaemon: daemon not running', { code });
+      }
+      settle(false);
+    });
+
+    socket.on('close', () => {
+      // Socket closed without a response line (e.g., daemon closed it right
+      // after sending the ACK but before our data handler fired). Treat as ok
+      // only if we already settled — otherwise the ACK was lost.
+      if (!settled) settle(false);
+    });
+  });
+}
+
 export default {
   sendDaemonCommand, canConnectToDaemon, getDaemonStatusViaIpc,
-  requestDaemonStop, listConnectedDevices, attachRelaySession,
+  requestDaemonStop, listConnectedDevices, attachRelaySession, terminateDaemon,
 };

--- a/packages/styrby-cli/src/daemon/controlClient.ts
+++ b/packages/styrby-cli/src/daemon/controlClient.ts
@@ -18,23 +18,53 @@ import { logger } from '@/ui/logger';
 import { DAEMON_PATHS, type DaemonState } from './run';
 
 /**
+ * Base fields present on every IPC command envelope.
+ *
+ * currentUserId carries the caller's authenticated identity so the daemon
+ * can enforce account-context isolation on every mutable command.
+ *
+ * OWASP A07:2021 — Identification and Authentication Failures:
+ *   The caller is responsible for supplying its current userId. The daemon
+ *   validates it against the account it was bound to at startup.
+ *
+ * SOC 2 CC6.1 — Logical and Physical Access Controls:
+ *   Identity must travel with the command — not assumed from socket ownership —
+ *   so the daemon can distinguish a legitimate same-account call from an
+ *   account-switch scenario that requires a rebind or refusal.
+ *
+ * WHY optional (not required):
+ *   Read-only health-check commands (ping, status) and the terminate command
+ *   are exempt from the auth check. Callers MAY omit currentUserId for those
+ *   command types. The daemon's assertAuthContext skips validation for exempt
+ *   types, so a missing field is harmless for them.
+ */
+interface DaemonCommandBase {
+  /**
+   * The userId of the account currently logged into the CLI on the calling machine.
+   * Populated by TokenManager.getCurrentUserId() before sending any mutable command.
+   * Absent / omitted for exempt commands (daemon.terminate, ping, status).
+   */
+  currentUserId?: string;
+}
+
+/**
  * Commands that can be sent to the daemon via IPC.
  */
 export type DaemonCommand =
-  | { type: 'status' }
-  | { type: 'ping' }
-  | { type: 'stop' }
-  | { type: 'list-sessions' }
-  | { type: 'start-session'; agentType: string; projectPath: string }
-  | { type: 'stop-session'; sessionId: string }
-  | { type: 'send-message'; sessionId: string; message: string }
-  | { type: 'shutdown' }
+  | (DaemonCommandBase & { type: 'status' })
+  | (DaemonCommandBase & { type: 'ping' })
+  | (DaemonCommandBase & { type: 'stop' })
+  | (DaemonCommandBase & { type: 'list-sessions' })
+  | (DaemonCommandBase & { type: 'start-session'; agentType: string; projectPath: string })
+  | (DaemonCommandBase & { type: 'stop-session'; sessionId: string })
+  | (DaemonCommandBase & { type: 'send-message'; sessionId: string; message: string })
+  | (DaemonCommandBase & { type: 'shutdown' })
   /**
    * Re-attach the daemon's RelayClient to an existing session's Realtime channel.
    * The daemon updates `sessions.status = 'running'` and `last_seen_at = now()`.
    * Does NOT spawn a new agent process — relay-reconnect only.
    */
-  | { type: 'attach-relay'; sessionId: string }
+  | (DaemonCommandBase & { type: 'attach-relay'; sessionId: string })
   /**
    * Terminate the daemon process cleanly.
    *
@@ -47,8 +77,10 @@ export type DaemonCommand =
    *
    * Used by `styrby logout` to tear down the daemon before clearing tokens.
    * SOC 2 CC7.2: Ensures no orphaned Realtime subscriptions on logout.
+   * WHY no currentUserId required: daemon.terminate is exempt from auth check —
+   * logout must always be able to stop the daemon regardless of identity state.
    */
-  | { type: 'daemon.terminate' };
+  | (DaemonCommandBase & { type: 'daemon.terminate' });
 
 /**
  * Response received from the daemon via IPC.

--- a/packages/styrby-cli/src/daemon/daemonProcess.ts
+++ b/packages/styrby-cli/src/daemon/daemonProcess.ts
@@ -518,12 +518,12 @@ function handleIpcCommand(rawMessage: string, conn: net.Socket): void {
     const activeSessionCount = relay ? relay.getConnectedDevices().length : 0;
     const authResult = assertAuthContext(command, { boundUserId, activeSessionCount });
 
-    if (!authResult.ok) {
-      // Narrow: authResult.ok === false discriminant ensures these fields exist.
-      const failResult = authResult as Extract<AuthCheckResult, { ok: false }>;
-
+    if (authResult.ok === false) {
+      // WHY === false: strict equality narrows the discriminated union so TypeScript
+      // resolves `authResult.code`, `.message`, and `.mustTerminate` without a cast.
+      // `!authResult.ok` does not narrow discriminated unions in tsc strict mode.
       structuredLog.warn('daemon.ipc_auth_mismatch', {
-        code: failResult.code,
+        code: authResult.code,
         commandType: command.type,
         hasCallerUserId: Boolean(command.currentUserId),
         activeSessionCount,
@@ -532,11 +532,11 @@ function handleIpcCommand(rawMessage: string, conn: net.Socket): void {
       const refusalResponse = {
         success: false,
         ok: false,
-        code: failResult.code,
-        message: failResult.message,
+        code: authResult.code,
+        message: authResult.message,
       };
 
-      if (failResult.mustTerminate) {
+      if (authResult.mustTerminate) {
         // Silently rebind: respond to caller THEN trigger daemon termination.
         // WHY respond first: the conn write must happen before handleTerminate
         // closes the IPC server; after close() no new writes are accepted.

--- a/packages/styrby-cli/src/daemon/daemonProcess.ts
+++ b/packages/styrby-cli/src/daemon/daemonProcess.ts
@@ -97,6 +97,57 @@ const DAEMON_FILES = {
 };
 
 // ============================================================================
+// Auth-Context Types
+// ============================================================================
+
+/**
+ * Minimal shape of an IPC envelope that carries the caller's identity.
+ *
+ * WHY optional currentUserId:
+ *   Commands predating the auth-check feature (e.g. `daemon.terminate`, `ping`,
+ *   `status`) are sent without currentUserId. The `assertAuthContext` helper
+ *   treats a missing field identically to the caller being logged-out (AUTH_MISSING),
+ *   EXCEPT for the explicitly-exempt command types which bypass the check entirely.
+ *
+ * OWASP A07:2021 — Identification and Authentication Failures:
+ *   The envelope must carry caller identity so the daemon can detect account
+ *   switches without relying on the filesystem or a shared auth state that could
+ *   be manipulated outside the IPC channel.
+ *
+ * SOC 2 CC6.1 — Logical and Physical Access Controls:
+ *   Every mutable IPC command is gated on caller identity to ensure the
+ *   daemon's privileged Realtime subscription is only exercised by the
+ *   account it was bound to at startup.
+ */
+export interface AuthCheckEnvelope {
+  /** IPC command type (e.g. 'list-sessions', 'attach-relay') */
+  type: string;
+  /**
+   * The userId of the account currently logged in on the calling machine.
+   * Populated by the CLI from TokenManager before sending the IPC command.
+   * Absent for exempt commands (daemon.terminate, ping, status).
+   */
+  currentUserId?: string;
+}
+
+/**
+ * Result returned by assertAuthContext.
+ *
+ * ok === true  → proceed normally
+ * ok === false → respond to caller with `code` + `message`; if mustTerminate is
+ *                true, also trigger daemon termination after responding.
+ */
+export type AuthCheckResult =
+  | { ok: true }
+  | {
+      ok: false;
+      code: 'AUTH_MISSING' | 'AUTH_MISMATCH_ACTIVE_SESSIONS' | 'AUTH_REBIND_REQUIRED';
+      message: string;
+      /** When true the dispatcher must trigger handleTerminate() after responding. */
+      mustTerminate?: boolean;
+    };
+
+// ============================================================================
 // State
 // ============================================================================
 
@@ -108,6 +159,17 @@ const startedAt = new Date().toISOString();
 let connectionState: 'connected' | 'connecting' | 'disconnected' | 'reconnecting' | 'error' = 'disconnected';
 let errorMessage: string | undefined;
 let shuttingDown = false;
+
+/**
+ * The userId read from data.json when the daemon started.
+ *
+ * WHY module-level: set once in connectToRelay() (synchronous read from data.json
+ * before the async Supabase connect). All subsequent IPC commands compare their
+ * caller-supplied currentUserId against this value. Null means the daemon never
+ * successfully read credentials (e.g., onboarding incomplete) — in that case
+ * auth check is skipped so the daemon can still accept health-check commands.
+ */
+let boundUserId: string | null = null;
 
 // ============================================================================
 // Entry Point
@@ -186,6 +248,13 @@ async function connectToRelay(): Promise<void> {
       log('Cannot connect: no credentials found');
       return;
     }
+
+    // WHY capture here (not in main): data.json is read once at the top of
+    // connectToRelay — this is the earliest point where we know which account
+    // the daemon is serving. Storing it in the module-level boundUserId lets
+    // assertAuthContext enforce identity on every subsequent IPC command without
+    // re-reading the filesystem on each call.
+    boundUserId = data.userId;
 
     // Precedence: env vars → ~/.styrby/config.json → error with actionable message.
     //
@@ -268,6 +337,120 @@ async function connectToRelay(): Promise<void> {
 }
 
 // ============================================================================
+// Auth-Context Helper
+// ============================================================================
+
+/**
+ * Commands that are always allowed regardless of caller identity.
+ *
+ * WHY exempt instead of checked:
+ *   - `daemon.terminate` — logout must always be able to stop the daemon,
+ *     even when the caller has already cleared their token (currentUserId absent).
+ *     Blocking terminate on identity would create a deadlock: user can't log out
+ *     because the daemon refuses commands, but can't kill the daemon another way
+ *     without escalating to SIGTERM (which bypasses clean Realtime disconnect).
+ *   - `ping` / `status` — read-only health checks. Blocking them on identity
+ *     would prevent `styrby status` from working when users switch accounts,
+ *     which is exactly when they need to know the daemon is still running.
+ */
+const EXEMPT_COMMAND_TYPES = new Set(['daemon.terminate', 'ping', 'status']);
+
+/**
+ * Assert that the IPC caller's identity matches the account the daemon is
+ * bound to, and determine the appropriate action for a mismatch.
+ *
+ * Decision matrix:
+ *
+ *   | daemon.boundUserId | caller.currentUserId | activeSessions | result                         |
+ *   |--------------------|--------------------- |----------------|--------------------------------|
+ *   | user A             | user A               | any            | { ok: true }                   |
+ *   | null (unbound)     | any                  | any            | { ok: true } — skip check      |
+ *   | user A             | absent / empty       | any            | AUTH_MISSING                   |
+ *   | user A             | user B               | 0              | AUTH_REBIND_REQUIRED (terminate)|
+ *   | user A             | user B               | >0             | AUTH_MISMATCH_ACTIVE_SESSIONS  |
+ *
+ * Exempt commands (daemon.terminate, ping, status) always return { ok: true }.
+ *
+ * OWASP A07:2021 — Identification and Authentication Failures:
+ *   This function is the single enforcement point for account-bound identity
+ *   on every mutable IPC command, preventing a newly-switched-in caller from
+ *   piggy-backing on a daemon bound to a different user's Supabase channels.
+ *
+ * SOC 2 CC6.1 — Logical and Physical Access Controls:
+ *   Access to the daemon's Realtime subscription is controlled by binding the
+ *   daemon to one userId at startup. This function enforces that binding on
+ *   every subsequent IPC command.
+ *
+ * @param envelope        - The incoming IPC command envelope (type + optional currentUserId)
+ * @param daemonState     - Current daemon runtime state (boundUserId + activeSessionCount)
+ * @returns AuthCheckResult — { ok: true } to proceed, or refusal payload with code + message
+ *
+ * @example
+ * const check = assertAuthContext(envelope, { boundUserId, activeSessionCount });
+ * if (!check.ok) {
+ *   conn.write(JSON.stringify({ success: false, ...check }) + '\n');
+ *   if (check.mustTerminate) void handleTerminate(relay, ipcServer, stateSnapshot, conn);
+ *   return;
+ * }
+ */
+export function assertAuthContext(
+  envelope: AuthCheckEnvelope,
+  daemonState: { boundUserId: string | null; activeSessionCount: number },
+): AuthCheckResult {
+  // Exempt commands bypass identity check entirely.
+  if (EXEMPT_COMMAND_TYPES.has(envelope.type)) {
+    return { ok: true };
+  }
+
+  // If the daemon was never bound to a userId (onboarding incomplete or
+  // credentials missing), skip the check — the relay connect will fail
+  // independently and report an appropriate error to the user.
+  if (!daemonState.boundUserId) {
+    return { ok: true };
+  }
+
+  const callerId = envelope.currentUserId;
+
+  // Caller has no current user (logged out or pre-auth).
+  if (!callerId) {
+    return {
+      ok: false,
+      code: 'AUTH_MISSING',
+      message: 'Not logged in. Run `styrby login`.',
+    };
+  }
+
+  // Identity matches — proceed normally.
+  if (callerId === daemonState.boundUserId) {
+    return { ok: true };
+  }
+
+  // Mismatch: different user is calling.
+  if (daemonState.activeSessionCount === 0) {
+    // No active sessions — safe to rebind. The daemon will terminate so the
+    // next invocation starts fresh bound to the new user's credentials.
+    return {
+      ok: false,
+      code: 'AUTH_REBIND_REQUIRED',
+      message:
+        'Daemon is bound to a different account with no active sessions. ' +
+        'Run `styrby login` to start a new daemon session.',
+      mustTerminate: true,
+    };
+  }
+
+  // Active sessions exist — refuse to let a different caller interfere.
+  return {
+    ok: false,
+    code: 'AUTH_MISMATCH_ACTIVE_SESSIONS',
+    message:
+      `Daemon is bound to a different account with ${daemonState.activeSessionCount} active session` +
+      `${daemonState.activeSessionCount === 1 ? '' : 's'}. ` +
+      'Run `styrby logout` first or wait for sessions to end.',
+  };
+}
+
+// ============================================================================
 // IPC Server (Unix Domain Socket)
 // ============================================================================
 
@@ -305,12 +488,68 @@ function startIpcServer(): void {
 /**
  * Handle an incoming IPC command from a CLI client.
  *
+ * Auth-context check is applied at the top of dispatch via `assertAuthContext`.
+ * Exempt commands (daemon.terminate, ping, status) bypass the check.
+ * All other commands must present a matching `currentUserId` in their envelope.
+ *
+ * OWASP A07:2021 — Identification and Authentication Failures:
+ *   Centralising the auth check here (rather than per-handler) ensures no
+ *   new command variant can accidentally skip the identity enforcement step.
+ *
+ * SOC 2 CC6.1 — Logical and Physical Access Controls:
+ *   assertAuthContext enforces that only the account bound at daemon startup
+ *   can issue mutable IPC commands to this daemon instance.
+ *
  * @param rawMessage - Raw JSON string from the client
  * @param conn - The socket connection to respond on
  */
 function handleIpcCommand(rawMessage: string, conn: net.Socket): void {
   try {
-    const command = JSON.parse(rawMessage) as { type: string };
+    const command = JSON.parse(rawMessage) as AuthCheckEnvelope & Record<string, unknown>;
+
+    // ── Auth-context check ─────────────────────────────────────────────────
+    // WHY activeSessionCount from relay.getConnectedDevices():
+    //   The daemon does not maintain a separate session registry; connected
+    //   devices (presence entries on Supabase Realtime) serve as the proxy for
+    //   active sessions. A count of 0 means no mobile-side consumers are live,
+    //   making a silent rebind safe. This is a best-effort approximation — if
+    //   the relay is disconnected, the count falls back to 0 (safe-side: allows
+    //   rebind even though sessions may exist on the Supabase side).
+    const activeSessionCount = relay ? relay.getConnectedDevices().length : 0;
+    const authResult = assertAuthContext(command, { boundUserId, activeSessionCount });
+
+    if (!authResult.ok) {
+      // Narrow: authResult.ok === false discriminant ensures these fields exist.
+      const failResult = authResult as Extract<AuthCheckResult, { ok: false }>;
+
+      structuredLog.warn('daemon.ipc_auth_mismatch', {
+        code: failResult.code,
+        commandType: command.type,
+        hasCallerUserId: Boolean(command.currentUserId),
+        activeSessionCount,
+      });
+
+      const refusalResponse = {
+        success: false,
+        ok: false,
+        code: failResult.code,
+        message: failResult.message,
+      };
+
+      if (failResult.mustTerminate) {
+        // Silently rebind: respond to caller THEN trigger daemon termination.
+        // WHY respond first: the conn write must happen before handleTerminate
+        // closes the IPC server; after close() no new writes are accepted.
+        conn.write(JSON.stringify(refusalResponse) + '\n', () => {
+          void handleTerminate(relay, ipcServer, stateSnapshot, conn);
+        });
+      } else {
+        conn.write(JSON.stringify(refusalResponse) + '\n');
+      }
+      return;
+    }
+    // ── End auth-context check ─────────────────────────────────────────────
+
     let response: Record<string, unknown>;
 
     switch (command.type) {

--- a/packages/styrby-cli/src/daemon/daemonProcess.ts
+++ b/packages/styrby-cli/src/daemon/daemonProcess.ts
@@ -335,6 +335,17 @@ function handleIpcCommand(rawMessage: string, conn: net.Socket): void {
         conn.write(JSON.stringify(response) + '\n', () => gracefulShutdown('IPC stop command'));
         return;
 
+      case 'daemon.terminate':
+        // WHY: handleTerminate is extracted into a named, exported function so
+        // tests can inject mocks for relay, ipcServer, and stateSnapshot without
+        // triggering the daemon's full startup sequence. The IPC switch delegates
+        // to it with the live module-level references.
+        //
+        // SOC 2 CC7.2: Controlled shutdown path ensures Realtime subscription is
+        // closed before exit, preventing orphaned Supabase Realtime channels.
+        void handleTerminate(relay, ipcServer, stateSnapshot, conn);
+        return;
+
       case 'list-sessions':
         response = { success: true, data: { devices: relay ? relay.getConnectedDevices() : [] } };
         break;
@@ -512,6 +523,91 @@ async function gracefulShutdown(reason: string): Promise<void> {
   }
 
   log('Daemon shut down cleanly');
+  process.exit(0);
+}
+
+// ============================================================================
+// Terminate Handler (exported for unit testing)
+// ============================================================================
+
+/**
+ * Handle the `daemon.terminate` IPC command.
+ *
+ * Performs a controlled, ordered shutdown sequence:
+ * 1. ACK the caller so `terminateDaemon()` on the client side receives a
+ *    response before the socket closes (otherwise the client gets ECONNRESET
+ *    and cannot distinguish a clean shutdown from a crash).
+ * 2. Persist a final state snapshot — so the NEXT daemon start has sane
+ *    recovery state even if the user re-authenticates as the same account.
+ * 3. Disconnect the Supabase Realtime subscription — prevents orphaned
+ *    presence entries on the Realtime server.
+ * 4. Close the IPC server so no further commands are accepted.
+ * 5. Call process.exit(0).
+ *
+ * WHY pass relay/ipcServer/snapshot as parameters instead of closing over
+ * module-level vars directly:
+ *   The IPC switch statement calls this with the live module-level references,
+ *   but tests inject mocks. Dependency-injection keeps this function testable
+ *   without a full daemon startup. This is a deliberate design choice — not
+ *   over-engineering — required by the TDD mandate in CLAUDE.md.
+ *
+ * WHY disconnect relay AFTER ACK but BEFORE exit:
+ *   If we disconnect before writing the ACK the socket may be destroyed by the
+ *   server close, and the client receives no response (silent timeout). ACKing
+ *   first ensures the client's Promise resolves to { ok: true }.
+ *
+ * WHY persist snapshot on terminate (not clearOnExit):
+ *   This is account-switch logout. The NEXT daemon start (for the same or a
+ *   new account) should NOT restore the old session. We persist with
+ *   sessionStatus: 'idle' (already the default) so the snapshot is present
+ *   but non-restorable, then let normal gracefulShutdown call clearOnExit.
+ *   The snapshot record gives the observability pipeline a clean audit trail.
+ *
+ * SOC 2 CC7.2: Reliable processing integrity requires controlled shutdown that
+ * leaves no orphaned subscriptions or stale lock files.
+ *
+ * @param relay        - Live RelayClient (or null if never connected)
+ * @param ipcServer    - Live IPC net.Server (or null)
+ * @param snapshot     - StateSnapshotManager singleton
+ * @param conn         - The socket connection that sent the terminate command
+ */
+export async function handleTerminate(
+  relay: { disconnect: () => Promise<void> } | null,
+  ipcServer: { close: () => void } | null,
+  snapshot: { persistNow: () => void; clearOnExit: () => void },
+  conn: { write: (data: string, cb?: () => void) => void }
+): Promise<void> {
+  // Step 1 — ACK the caller immediately (before any async work)
+  const ack = JSON.stringify({ success: true, data: { terminating: true } }) + '\n';
+  conn.write(ack);
+
+  structuredLog.info('daemon.terminate', { reason: 'daemon.terminate RPC' });
+
+  // Step 2 — Persist final snapshot (sessionStatus is already 'idle' on a
+  // clean terminate; this captures the final lastSeenAt timestamp).
+  try {
+    snapshot.persistNow();
+  } catch (err) {
+    structuredLog.error('daemon.terminate.snapshot_fail', {}, err instanceof Error ? err : new Error(String(err)));
+  }
+
+  // Step 3 — Disconnect Realtime subscription cleanly
+  if (relay) {
+    try {
+      await relay.disconnect();
+    } catch (err) {
+      // Non-fatal: relay may already be closed. Log and proceed.
+      structuredLog.error('daemon.terminate.relay_disconnect_fail', {}, err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  // Step 4 — Close IPC server (no new commands accepted after this)
+  if (ipcServer) {
+    ipcServer.close();
+  }
+
+  // Step 5 — Exit cleanly
+  log('Daemon terminated via daemon.terminate RPC');
   process.exit(0);
 }
 

--- a/packages/styrby-cli/src/daemon/stateSnapshot.ts
+++ b/packages/styrby-cli/src/daemon/stateSnapshot.ts
@@ -234,6 +234,24 @@ export class StateSnapshotManager extends EventEmitter {
   }
 
   /**
+   * Flush the current snapshot to disk immediately (one-shot, outside the interval).
+   *
+   * WHY: Called from `handleTerminate` before process.exit(0). The periodic
+   * interval may not fire in time between receiving the terminate command and
+   * the process exiting. Calling persistNow() guarantees the final session
+   * state (e.g., sessionStatus: 'idle') is on disk before exit, so the next
+   * daemon start has correct state to reason about.
+   *
+   * SOC 2 CC7.2: Reliable processing requires that clean shutdown leaves
+   * recoverable, consistent state on disk — not a stale 30-second-old snapshot.
+   */
+  persistNow(): void {
+    if (!this.currentSnapshot) return;
+    this.currentSnapshot.lastSeenAt = new Date().toISOString();
+    this._write();
+  }
+
+  /**
    * Return the current in-memory snapshot (for tests).
    */
   getCurrent(): DaemonStateSnapshot | null {

--- a/packages/styrby-mobile/app/(tabs)/sessions.tsx
+++ b/packages/styrby-mobile/app/(tabs)/sessions.tsx
@@ -37,6 +37,7 @@ import {
   SessionsLoadingState,
   SessionsErrorState,
   SessionsEmptyState,
+  SessionOrphanedBanner,
   groupSessionsByDate,
 } from '../../src/components/sessions';
 import type { AgentType } from 'styrby-shared';
@@ -322,14 +323,28 @@ export default function SessionsScreen() {
         sections={sections}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <SessionCard
-            session={item}
-            onPress={handleSessionPress}
-            isBookmarked={bookmarkedIds.has(item.id)}
-            isTogglingBookmark={togglingIds.has(item.id)}
-            bookmarkError={toggleErrors.get(item.id)}
-            onBookmarkPress={toggleBookmark}
-          />
+          <>
+            {/*
+              WHY: Render the orphaned-session banner immediately above the card
+              for the sessions that are still marked active but whose CLI heartbeat
+              has gone cold. This placement keeps the warning contextually paired
+              with the specific session card without disrupting the rest of the list.
+              The banner self-manages visibility (renders null when not orphaned).
+            */}
+            <SessionOrphanedBanner
+              sessionId={item.id}
+              status={item.status}
+              lastHeartbeatAt={item.last_heartbeat_at ?? null}
+            />
+            <SessionCard
+              session={item}
+              onPress={handleSessionPress}
+              isBookmarked={bookmarkedIds.has(item.id)}
+              isTogglingBookmark={togglingIds.has(item.id)}
+              bookmarkError={toggleErrors.get(item.id)}
+              onBookmarkPress={toggleBookmark}
+            />
+          </>
         )}
         renderSectionHeader={({ section }) => (
           <View

--- a/packages/styrby-mobile/src/components/sessions/SessionOrphanedBanner.tsx
+++ b/packages/styrby-mobile/src/components/sessions/SessionOrphanedBanner.tsx
@@ -1,0 +1,385 @@
+/**
+ * SessionOrphanedBanner
+ *
+ * Renders an amber warning banner when a session appears "orphaned" —
+ * meaning the CLI that owned it was logged out or lost connectivity long
+ * enough that its heartbeat has gone cold while the session is still marked
+ * active in Supabase.
+ *
+ * WHY "orphaned" instead of "stale":
+ *   The root cause is not generic staleness — it's specifically that the CLI
+ *   process that owned the session disconnected without cleanly terminating the
+ *   session. "Orphaned" communicates the causal relationship to developers and
+ *   aligns with Phase 1 spec language (account-switch-correctness).
+ *
+ * WHY 90s heartbeat threshold:
+ *   The CLI daemon emits heartbeats every 30s. Three missed heartbeats (90s)
+ *   signals the daemon is definitively gone rather than briefly busy. Shorter
+ *   thresholds cause false positives during transient network blips. This value
+ *   must stay in sync with the CLI daemon's heartbeat interval and the
+ *   `isOrphaned` check in the Supabase RLS / cron cleanup job.
+ *
+ * WHY amber / yellow instead of red:
+ *   Per spec: "this is a recoverable state, not a fatal error." Red implies
+ *   immediate action is required. Amber communicates "something changed;
+ *   you have a decision to make." The user can dismiss and keep the session
+ *   record, or end it — neither path causes data loss.
+ *
+ * Security citations:
+ * - OWASP A07:2021 (Identification and Authentication Failures): account-switch
+ *   scenarios can leave sessions bound to a different identity. This banner
+ *   surfaces the evidence so the user can take corrective action.
+ * - SOC 2 CC6.1 (Logical Access Controls): users retain control over session
+ *   lifecycle; the "End Session" action enforces the principle of least-privilege
+ *   by terminating a session no longer under the expected user's control.
+ * - GDPR Art. 17 (Right to Erasure) / Art. 7 (Right to Withdraw Consent):
+ *   "End Session" gives the data subject a direct path to terminate an active
+ *   processing session from their own device.
+ *
+ * @module components/sessions/SessionOrphanedBanner
+ */
+
+import React, { useState, useCallback } from 'react';
+import { View, Text, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
+import { supabase } from '../../lib/supabase';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * A session is considered orphaned if its last heartbeat is older than this.
+ *
+ * WHY 90_000ms: CLI heartbeat interval is 30s. Three missed beats (3 × 30s = 90s)
+ * provides a reliable signal that the daemon process is gone rather than
+ * transiently slow. See `daemonProcess.ts` HEARTBEAT_INTERVAL_MS.
+ */
+const ORPHAN_HEARTBEAT_THRESHOLD_MS = 90_000;
+
+/**
+ * Session statuses that can produce an orphaned session.
+ * Only active-lifecycle statuses can become orphaned — terminal statuses
+ * like 'stopped' or 'expired' are already ended and need no banner.
+ *
+ * WHY: 'completed' and 'ended' are not valid SessionStatus values in this
+ * codebase (see styrby-shared/src/types.ts). Active statuses are the set
+ * defined by the shared type: starting, running, idle, paused.
+ */
+const ACTIVE_STATUSES = new Set(['starting', 'running', 'idle', 'paused']);
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Props for the SessionOrphanedBanner component.
+ */
+export interface SessionOrphanedBannerProps {
+  /**
+   * The session's Supabase UUID, used as the predicate when calling
+   * `supabase.from('sessions').update(...).eq('id', sessionId)`.
+   */
+  sessionId: string;
+
+  /**
+   * Current lifecycle status of the session.
+   * The banner only renders when this is an active status (starting, running,
+   * idle, paused) AND lastHeartbeatAt is stale.
+   */
+  status: string;
+
+  /**
+   * ISO 8601 timestamp of the most recent CLI heartbeat for this session,
+   * or null if no heartbeat has ever been recorded.
+   *
+   * WHY nullable: Sessions created before the heartbeat feature shipped
+   * will have null. We treat null as "never received a heartbeat", which
+   * means we cannot conclusively determine orphan state — so we don't show
+   * the banner. Better to miss a true orphan than to show false positives.
+   */
+  lastHeartbeatAt: string | null;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Determines whether a session should be treated as orphaned.
+ *
+ * A session is orphaned when:
+ *   1. Its status is an active lifecycle status (not a terminal status).
+ *   2. Its last heartbeat timestamp is older than ORPHAN_HEARTBEAT_THRESHOLD_MS.
+ *
+ * Returns false if lastHeartbeatAt is null (cannot determine state).
+ *
+ * @param status - Session lifecycle status string
+ * @param lastHeartbeatAt - ISO 8601 timestamp or null
+ * @returns true if the session appears orphaned
+ */
+function isSessionOrphaned(status: string, lastHeartbeatAt: string | null): boolean {
+  if (!ACTIVE_STATUSES.has(status)) return false;
+  if (!lastHeartbeatAt) return false;
+
+  const staleDeltaMs = Date.now() - new Date(lastHeartbeatAt).getTime();
+  return staleDeltaMs > ORPHAN_HEARTBEAT_THRESHOLD_MS;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Warning banner for sessions whose CLI has gone offline unexpectedly.
+ *
+ * Renders only when both conditions are met:
+ *   - `status` is an active lifecycle status (starting/running/idle/paused)
+ *   - `lastHeartbeatAt` is more than 90s in the past
+ *
+ * Two user actions:
+ *   - **Dismiss**: Hides the banner locally. Does not call Supabase.
+ *     Appropriate when the user knows what happened and just wants the
+ *     banner out of the way.
+ *   - **End Session**: Sets `status='stopped'` via Supabase. This is the
+ *     same logical operation as `DELETE /api/v1/sessions/[id]` as
+ *     described in the spec — the mobile app's data layer goes through
+ *     Supabase directly rather than a REST layer.
+ *
+ * CONCERN (i18n): All strings are hardcoded in English. If the app adds
+ * i18n in a future sprint, this component should be updated to use the
+ * same translation system as the rest of the app.
+ *
+ * @param props - SessionOrphanedBannerProps
+ * @returns React element or null
+ *
+ * @example
+ * <SessionOrphanedBanner
+ *   sessionId={session.id}
+ *   status={session.status}
+ *   lastHeartbeatAt={session.last_heartbeat_at}
+ * />
+ */
+export function SessionOrphanedBanner({
+  sessionId,
+  status,
+  lastHeartbeatAt,
+}: SessionOrphanedBannerProps): React.ReactElement | null {
+  /**
+   * When true the user has dismissed the banner locally.
+   * Resets on next mount (e.g., navigating away and back).
+   */
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  /** True while the "End Session" Supabase update is in flight. */
+  const [isEnding, setIsEnding] = useState(false);
+
+  /**
+   * Error message from a failed "End Session" call. Cleared on retry
+   * and on successful completion.
+   */
+  const [endError, setEndError] = useState<string | null>(null);
+
+  // --- Orphan detection ---
+  const orphaned = isSessionOrphaned(status, lastHeartbeatAt);
+
+  // If not orphaned or dismissed, render nothing.
+  if (!orphaned || isDismissed) return null;
+
+  /**
+   * Local dismiss: hides the banner without touching Supabase.
+   *
+   * WHY no server call: "Dismiss" is purely a UX affordance. The session
+   * state in Supabase is unchanged. The user has acknowledged the banner
+   * and chosen to leave the session record as-is.
+   */
+  const handleDismiss = () => {
+    setIsDismissed(true);
+  };
+
+  /**
+   * End Session: sets `status='stopped'` in Supabase, then hides the banner.
+   *
+   * WHY update status to 'stopped' rather than a soft-delete:
+   *   The sessions table uses soft-delete (deleted_at timestamp). However,
+   *   the appropriate user action here is to mark the session as cleanly
+   *   stopped — not to erase it. The user may want to review the session
+   *   history after the CLI was forcefully disconnected. 'stopped' matches
+   *   the terminal status used by the CLI when it shuts down normally.
+   *
+   * SECURITY: SOC 2 CC6.1 — the update is scoped to a single row by id,
+   * and Supabase RLS ensures only the session owner can update it.
+   * GDPR Art. 7 — user-initiated termination of an active processing session.
+   */
+  const handleEndSession = async () => {
+    setIsEnding(true);
+    setEndError(null);
+
+    try {
+      const { error } = await supabase
+        .from('sessions')
+        .update({ status: 'stopped', ended_at: new Date().toISOString() })
+        .eq('id', sessionId);
+
+      if (error) {
+        setEndError(`Failed to end session: ${error.message}`);
+      } else {
+        // Success — hide the banner. Supabase Realtime will propagate the
+        // status change to any other listeners (e.g., the session list).
+        setIsDismissed(true);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      setEndError(`Failed to end session: ${msg}`);
+    } finally {
+      setIsEnding(false);
+    }
+  };
+
+  return (
+    <View
+      testID="orphaned-banner"
+      style={styles.container}
+      // WHY 'none': React Native's AccessibilityRole enum does not include
+      // 'status'. Using 'none' suppresses the default role announcement;
+      // accessibilityLabel + accessibilityLiveRegion carry the message.
+      accessibilityRole="none"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel="Warning: This session's CLI was logged out. You can dismiss this warning or end the session."
+    >
+      {/* Warning icon dot — amber, matches ConnectionStateBadge palette */}
+      <View style={styles.dotRow}>
+        <View style={styles.dot} />
+        <Text style={styles.title} numberOfLines={2}>
+          {"This session's CLI was logged out. Tap to dismiss or end the session."}
+        </Text>
+      </View>
+
+      {/* Error message (only rendered after a failed End Session call) */}
+      {endError && (
+        <Text style={styles.errorText} testID="end-session-error" numberOfLines={2}>
+          {endError}
+        </Text>
+      )}
+
+      {/* Action buttons */}
+      <View style={styles.buttonRow}>
+        {/* Dismiss — local state only */}
+        <Pressable
+          testID="dismiss-button"
+          onPress={handleDismiss}
+          style={styles.dismissButton}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss warning"
+        >
+          <Text style={styles.dismissLabel}>Dismiss</Text>
+        </Pressable>
+
+        {/* End Session — calls Supabase */}
+        <Pressable
+          testID="end-session-button"
+          onPress={handleEndSession}
+          disabled={isEnding}
+          style={[styles.endButton, isEnding && styles.endButtonDisabled]}
+          accessibilityRole="button"
+          accessibilityLabel="End session"
+          accessibilityState={{ disabled: isEnding }}
+        >
+          {isEnding ? (
+            <ActivityIndicator
+              testID="end-session-loading"
+              size="small"
+              color="#92400e"
+            />
+          ) : (
+            <Text style={styles.endLabel}>End Session</Text>
+          )}
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+// ============================================================================
+// Styles
+// ============================================================================
+
+/**
+ * WHY StyleSheet.create and not NativeWind className here:
+ *   NativeWind className processing requires the metro transformer. In the
+ *   Jest test environment (node) NativeWind is fully mocked and className
+ *   props are stripped. StyleSheet.create produces style objects that the
+ *   react-native mock in jest.setup.js returns as-is, so style assertions
+ *   in tests work correctly. ConnectionStateBadge uses the same pattern.
+ */
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 12,
+    marginVertical: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: 'rgba(251,191,36,0.15)',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: 'rgba(245,158,11,0.4)',
+    gap: 8,
+  },
+  dotRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#f59e0b',
+    marginTop: 3,
+    flexShrink: 0,
+  },
+  title: {
+    flex: 1,
+    fontSize: 13,
+    color: '#92400e',
+    fontWeight: '500',
+    lineHeight: 18,
+  },
+  errorText: {
+    fontSize: 12,
+    color: '#b45309',
+    fontStyle: 'italic',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 10,
+    marginTop: 2,
+  },
+  dismissButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: 'rgba(245,158,11,0.5)',
+  },
+  dismissLabel: {
+    fontSize: 12,
+    color: '#92400e',
+    fontWeight: '500',
+  },
+  endButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 6,
+    backgroundColor: 'rgba(245,158,11,0.25)',
+    minWidth: 90,
+    alignItems: 'center',
+  },
+  endButtonDisabled: {
+    opacity: 0.55,
+  },
+  endLabel: {
+    fontSize: 12,
+    color: '#92400e',
+    fontWeight: '600',
+  },
+});

--- a/packages/styrby-mobile/src/components/sessions/SessionOrphanedBanner.tsx
+++ b/packages/styrby-mobile/src/components/sessions/SessionOrphanedBanner.tsx
@@ -42,6 +42,7 @@
 import React, { useState, useCallback } from 'react';
 import { View, Text, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
 import { supabase } from '../../lib/supabase';
+import type { SessionStatus } from 'styrby-shared';
 
 // ============================================================================
 // Constants
@@ -63,9 +64,12 @@ const ORPHAN_HEARTBEAT_THRESHOLD_MS = 90_000;
  *
  * WHY: 'completed' and 'ended' are not valid SessionStatus values in this
  * codebase (see styrby-shared/src/types.ts). Active statuses are the set
- * defined by the shared type: starting, running, idle, paused.
+ * defined by the shared type: starting, running, idle.
+ * WHY 'paused' is excluded: SessionStatus = 'starting' | 'running' | 'idle' |
+ * 'stopped' | 'error'. 'paused' is not in the union; including it would be
+ * dead code that TypeScript cannot guard against at the Set boundary.
  */
-const ACTIVE_STATUSES = new Set(['starting', 'running', 'idle', 'paused']);
+const ACTIVE_STATUSES = new Set<SessionStatus>(['starting', 'running', 'idle']);
 
 // ============================================================================
 // Types
@@ -84,9 +88,11 @@ export interface SessionOrphanedBannerProps {
   /**
    * Current lifecycle status of the session.
    * The banner only renders when this is an active status (starting, running,
-   * idle, paused) AND lastHeartbeatAt is stale.
+   * idle) AND lastHeartbeatAt is stale.
+   * Typed as SessionStatus so TypeScript catches any future invalid values
+   * at compile time — the same guard that was missing when 'paused' slipped in.
    */
-  status: string;
+  status: SessionStatus;
 
   /**
    * ISO 8601 timestamp of the most recent CLI heartbeat for this session,
@@ -98,6 +104,27 @@ export interface SessionOrphanedBannerProps {
    * the banner. Better to miss a true orphan than to show false positives.
    */
   lastHeartbeatAt: string | null;
+
+  /**
+   * Optional clock provider for deterministic time control in tests.
+   * Defaults to () => Date.now() in production.
+   *
+   * WHY: Injecting the clock as a prop eliminates real-clock dependency in
+   * boundary tests. Without this, 89s-vs-90s threshold tests pass a
+   * real-clock-relative offset that can drift on slow CI runners and produce
+   * intermittent failures. Injecting a fixed timestamp makes the test
+   * deterministic regardless of test runner speed.
+   *
+   * @example
+   * // In a test:
+   * const fixedNow = 1_700_000_000_000;
+   * <SessionOrphanedBanner
+   *   timeProvider={() => fixedNow}
+   *   lastHeartbeatAt={new Date(fixedNow - 91_000).toISOString()}
+   *   ...
+   * />
+   */
+  timeProvider?: () => number;
 }
 
 // ============================================================================
@@ -113,15 +140,20 @@ export interface SessionOrphanedBannerProps {
  *
  * Returns false if lastHeartbeatAt is null (cannot determine state).
  *
- * @param status - Session lifecycle status string
+ * @param status - Session lifecycle status (must be a valid SessionStatus)
  * @param lastHeartbeatAt - ISO 8601 timestamp or null
+ * @param now - Current epoch ms; injected so tests can control the clock deterministically
  * @returns true if the session appears orphaned
  */
-function isSessionOrphaned(status: string, lastHeartbeatAt: string | null): boolean {
+function isSessionOrphaned(
+  status: SessionStatus,
+  lastHeartbeatAt: string | null,
+  now: number,
+): boolean {
   if (!ACTIVE_STATUSES.has(status)) return false;
   if (!lastHeartbeatAt) return false;
 
-  const staleDeltaMs = Date.now() - new Date(lastHeartbeatAt).getTime();
+  const staleDeltaMs = now - new Date(lastHeartbeatAt).getTime();
   return staleDeltaMs > ORPHAN_HEARTBEAT_THRESHOLD_MS;
 }
 
@@ -163,6 +195,7 @@ export function SessionOrphanedBanner({
   sessionId,
   status,
   lastHeartbeatAt,
+  timeProvider = () => Date.now(),
 }: SessionOrphanedBannerProps): React.ReactElement | null {
   /**
    * When true the user has dismissed the banner locally.
@@ -180,7 +213,7 @@ export function SessionOrphanedBanner({
   const [endError, setEndError] = useState<string | null>(null);
 
   // --- Orphan detection ---
-  const orphaned = isSessionOrphaned(status, lastHeartbeatAt);
+  const orphaned = isSessionOrphaned(status, lastHeartbeatAt, timeProvider());
 
   // If not orphaned or dismissed, render nothing.
   if (!orphaned || isDismissed) return null;

--- a/packages/styrby-mobile/src/components/sessions/__tests__/SessionOrphanedBanner.integration.test.tsx
+++ b/packages/styrby-mobile/src/components/sessions/__tests__/SessionOrphanedBanner.integration.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Integration test: SessionOrphanedBanner wired into sessions list.
+ *
+ * Validates that the `last_heartbeat_at` field flows correctly from the
+ * `SessionRow` type through the sessions screen's `renderItem` callback to the
+ * `SessionOrphanedBanner` component, and that the banner renders (or is absent)
+ * based on the staleness of the heartbeat.
+ *
+ * WHY a separate integration file instead of extending the unit tests:
+ *   The unit tests for `SessionOrphanedBanner` (SessionOrphanedBanner.test.tsx)
+ *   verify the component in isolation with direct prop injection. This file
+ *   verifies the wiring: that the sessions screen passes the correct field
+ *   (`last_heartbeat_at`) and that the banner lifecycle (orphaned vs fresh)
+ *   behaves as expected when rendered through a real SessionRow shape.
+ *
+ * Spec: docs/planning/phase-1-account-switch-correctness-spec.md — Task 6 (T6)
+ *
+ * @module components/sessions/__tests__/SessionOrphanedBanner.integration
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SessionOrphanedBanner } from '../SessionOrphanedBanner';
+import type { SessionRow } from '../../../hooks/useSessions';
+import type { SessionOrphanedBannerProps } from '../SessionOrphanedBanner';
+
+// ============================================================================
+// Supabase mock
+// (mirrors the pattern from SessionOrphanedBanner.test.tsx)
+// ============================================================================
+
+jest.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({
+      update: () => ({
+        eq: () => Promise.resolve({ error: null }),
+      }),
+    }),
+  },
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build a minimal SessionRow for testing the banner wiring.
+ * All fields carry valid defaults; override only what the test needs.
+ *
+ * @param overrides - Partial SessionRow fields to override
+ * @returns A complete SessionRow suitable for passing into SessionOrphanedBanner props
+ */
+function buildSessionRow(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: 'integration-session-id',
+    user_id: 'user-abc',
+    machine_id: 'machine-xyz',
+    agent_type: 'claude',
+    status: 'running',
+    title: 'My Session',
+    summary: null,
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+    total_cost_usd: 0,
+    started_at: new Date(Date.now() - 600_000).toISOString(),
+    ended_at: null,
+    tags: [],
+    updated_at: new Date().toISOString(),
+    message_count: 0,
+    team_id: null,
+    last_heartbeat_at: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Simulate the props the sessions screen passes to SessionOrphanedBanner
+ * based on a SessionRow — this mirrors the exact wiring in app/(tabs)/sessions.tsx.
+ *
+ * @param session - A SessionRow as loaded by useSessions
+ * @returns Props ready to pass to <SessionOrphanedBanner />
+ */
+function bannerPropsFromRow(
+  session: SessionRow,
+  timeProvider?: () => number,
+): SessionOrphanedBannerProps {
+  const props: SessionOrphanedBannerProps = {
+    sessionId: session.id,
+    status: session.status,
+    lastHeartbeatAt: session.last_heartbeat_at ?? null,
+  };
+  if (timeProvider) props.timeProvider = timeProvider;
+  return props;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SessionOrphanedBanner — wiring integration (T6)', () => {
+  // --------------------------------------------------------------------------
+  // 1. last_heartbeat_at: null — no banner (cannot determine orphan state)
+  // --------------------------------------------------------------------------
+
+  it('renders nothing when last_heartbeat_at is null (no heartbeat ever received)', () => {
+    const session = buildSessionRow({ status: 'running', last_heartbeat_at: null });
+    const { queryByTestId } = render(
+      <SessionOrphanedBanner {...bannerPropsFromRow(session)} />,
+    );
+
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // 2. Fresh heartbeat — no banner
+  // --------------------------------------------------------------------------
+
+  it('renders nothing when last_heartbeat_at is within 90s (fresh session)', () => {
+    const fixedNow = 1_700_000_000_000;
+    const session = buildSessionRow({
+      status: 'running',
+      last_heartbeat_at: new Date(fixedNow - 30_000).toISOString(), // 30s ago
+    });
+
+    const { queryByTestId } = render(
+      <SessionOrphanedBanner
+        {...bannerPropsFromRow(session, () => fixedNow)}
+      />,
+    );
+
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // 3. Stale heartbeat + active status — banner renders
+  // --------------------------------------------------------------------------
+
+  it('renders orphaned banner when last_heartbeat_at > 90s ago and status is active', () => {
+    const fixedNow = 1_700_000_000_000;
+    const session = buildSessionRow({
+      status: 'running',
+      last_heartbeat_at: new Date(fixedNow - 120_000).toISOString(), // 120s ago
+    });
+
+    const { getByTestId, getByText } = render(
+      <SessionOrphanedBanner
+        {...bannerPropsFromRow(session, () => fixedNow)}
+      />,
+    );
+
+    expect(getByTestId('orphaned-banner')).toBeTruthy();
+    expect(getByText(/This session's CLI was logged out/i)).toBeTruthy();
+  });
+
+  // --------------------------------------------------------------------------
+  // 4. Stale heartbeat + non-active status — no banner
+  // --------------------------------------------------------------------------
+
+  it('renders nothing when last_heartbeat_at is stale but status is stopped', () => {
+    const fixedNow = 1_700_000_000_000;
+    const session = buildSessionRow({
+      status: 'stopped',
+      last_heartbeat_at: new Date(fixedNow - 120_000).toISOString(),
+    });
+
+    const { queryByTestId } = render(
+      <SessionOrphanedBanner
+        {...bannerPropsFromRow(session, () => fixedNow)}
+      />,
+    );
+
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // 5. All active statuses with stale heartbeat — banner renders in each case
+  // --------------------------------------------------------------------------
+
+  it('renders banner for all active statuses (starting, running, idle) when heartbeat is stale', () => {
+    const fixedNow = 1_700_000_000_000;
+    const staleTs = new Date(fixedNow - 120_000).toISOString();
+    const activeStatuses: Array<SessionRow['status']> = ['starting', 'running', 'idle'];
+
+    for (const status of activeStatuses) {
+      const session = buildSessionRow({ status, last_heartbeat_at: staleTs });
+      const { getByTestId, unmount } = render(
+        <SessionOrphanedBanner
+          {...bannerPropsFromRow(session, () => fixedNow)}
+        />,
+      );
+      expect(getByTestId('orphaned-banner')).toBeTruthy();
+      unmount();
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // 6. SessionRow.last_heartbeat_at field exists and is forwarded correctly
+  // --------------------------------------------------------------------------
+
+  it('correctly maps session.last_heartbeat_at ?? null to the lastHeartbeatAt prop', () => {
+    /**
+     * WHY: Validates the wiring expression `item.last_heartbeat_at ?? null`
+     * used in app/(tabs)/sessions.tsx. This test specifically exercises the
+     * nullish-coalesce path where the field is undefined (old Realtime events
+     * that predate the column addition will lack it).
+     */
+    const fixedNow = 1_700_000_000_000;
+    // Simulate a row where last_heartbeat_at is undefined (not in payload)
+    const session = buildSessionRow({ status: 'running' });
+    // Force undefined to simulate pre-column rows
+    (session as unknown as Record<string, unknown>).last_heartbeat_at = undefined;
+
+    const props = bannerPropsFromRow(session, () => fixedNow);
+    // Should coerce undefined to null, resulting in no banner
+    expect(props.lastHeartbeatAt).toBeNull();
+
+    const { queryByTestId } = render(<SessionOrphanedBanner {...props} />);
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+  });
+});

--- a/packages/styrby-mobile/src/components/sessions/__tests__/SessionOrphanedBanner.test.tsx
+++ b/packages/styrby-mobile/src/components/sessions/__tests__/SessionOrphanedBanner.test.tsx
@@ -133,6 +133,36 @@ describe('SessionOrphanedBanner', () => {
     expect(queryByTestId('orphaned-banner')).toBeNull();
   });
 
+  it('timeProvider: deterministically shows banner at 90001ms and hides it at 89999ms', () => {
+    /**
+     * WHY: Without timeProvider injection, 89s/90s boundary tests rely on
+     * real-clock offsets that can drift on slow CI runners. By pinning both
+     * "now" (via timeProvider) and lastHeartbeatAt to fixed epoch values we
+     * make the threshold check 100% deterministic regardless of runner speed.
+     */
+    const fixedNow = 1_700_000_000_000; // arbitrary fixed epoch
+
+    // 90001ms delta — just over threshold, banner MUST appear
+    const staleFixed = new Date(fixedNow - 90_001).toISOString();
+    const { queryByTestId: queryStale } = render(
+      <SessionOrphanedBanner
+        {...buildProps({ lastHeartbeatAt: staleFixed, status: 'running' })}
+        timeProvider={() => fixedNow}
+      />,
+    );
+    expect(queryStale('orphaned-banner')).toBeTruthy();
+
+    // 89999ms delta — just under threshold, banner MUST NOT appear
+    const freshFixed = new Date(fixedNow - 89_999).toISOString();
+    const { queryByTestId: queryFresh } = render(
+      <SessionOrphanedBanner
+        {...buildProps({ lastHeartbeatAt: freshFixed, status: 'running' })}
+        timeProvider={() => fixedNow}
+      />,
+    );
+    expect(queryFresh('orphaned-banner')).toBeNull();
+  });
+
   // --------------------------------------------------------------------------
   // Case 2: Stale heartbeat + active status — renders banner
   // --------------------------------------------------------------------------
@@ -146,8 +176,10 @@ describe('SessionOrphanedBanner', () => {
     expect(getByText(/This session's CLI was logged out/i)).toBeTruthy();
   });
 
-  it('renders banner for all active statuses (starting, running, idle, paused)', () => {
-    const activeStatuses = ['starting', 'running', 'idle', 'paused'] as const;
+  it('renders banner for all active statuses (starting, running, idle)', () => {
+    // WHY 'paused' removed: SessionStatus = 'starting' | 'running' | 'idle' |
+    // 'stopped' | 'error'. 'paused' is not in the union; it was dead code.
+    const activeStatuses = ['starting', 'running', 'idle'] as const;
 
     for (const status of activeStatuses) {
       const { getByTestId, unmount } = render(
@@ -170,9 +202,13 @@ describe('SessionOrphanedBanner', () => {
     expect(queryByTestId('orphaned-banner')).toBeNull();
   });
 
-  it('renders nothing when status is expired', () => {
+  it('renders nothing when status is not a recognised active status (e.g. a legacy value)', () => {
+    // WHY cast: 'expired' is not in SessionStatus. The cast simulates a value
+    // arriving from an older Supabase row before a migration cleaned up legacy
+    // status strings. The component must safely return null in this case.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { queryByTestId } = render(
-      <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: staleHeartbeat(), status: 'expired' })} />,
+      <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: staleHeartbeat(), status: 'expired' as any })} />,
     );
 
     expect(queryByTestId('orphaned-banner')).toBeNull();

--- a/packages/styrby-mobile/src/components/sessions/__tests__/SessionOrphanedBanner.test.tsx
+++ b/packages/styrby-mobile/src/components/sessions/__tests__/SessionOrphanedBanner.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * Tests for SessionOrphanedBanner component.
+ *
+ * Covers all 7 required cases from Phase 1 Task 5 spec:
+ *  1. Renders nothing when session is fresh (heartbeat within 90s, status active)
+ *  2. Renders banner when session is stale (heartbeat > 90s ago AND status active)
+ *  3. Renders nothing when session status is 'stopped' or 'expired' (non-active)
+ *  4. Dismiss button hides banner via local state
+ *  5. End Session button calls Supabase UPDATE with status='stopped' for correct id
+ *  6. Loading state during End Session call (button shows loading indicator)
+ *  7. Error state if API call fails (banner remains visible with error message)
+ *
+ * WHY mock supabase at module level:
+ *   The real supabase client connects to a live server and uses expo-secure-store.
+ *   Mocking at module level isolates the component from all IO, keeping tests
+ *   fast and deterministic. Test cases override the mock return values per-test
+ *   to simulate success/failure.
+ *
+ * WHY renderHook / render from @testing-library/react-native:
+ *   The component uses React hooks internally. @testing-library/react-native
+ *   renders into a simulated React Native host compatible with our Jest config.
+ *
+ * @module components/sessions/__tests__/SessionOrphanedBanner
+ */
+
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+import { SessionOrphanedBanner } from '../SessionOrphanedBanner';
+import type { SessionOrphanedBannerProps } from '../SessionOrphanedBanner';
+
+// ============================================================================
+// Supabase mock
+// ============================================================================
+
+/**
+ * WHY mockSupabaseUpdateFn prefix:
+ *   jest.mock() factories are hoisted above imports. Variables used inside the
+ *   factory must be prefixed with "mock" to pass Babel's hoisting safety check.
+ */
+/**
+ * Extended jest.fn type that carries a `__nextResult` field for controlling
+ * the return value of the chained `.eq()` call in tests.
+ *
+ * WHY extend rather than cast at each use-site: The pattern repeats across
+ * multiple tests. Centralising the type here avoids repeated `as` casts and
+ * keeps each test focused on the assertion rather than the type gymnastics.
+ */
+interface MockUpdateFn extends jest.Mock {
+  __nextResult?: unknown;
+}
+
+const mockSupabaseUpdateFn: MockUpdateFn = jest.fn() as MockUpdateFn;
+const mockSupabaseEqFn = jest.fn();
+const mockSupabaseFromFn = jest.fn();
+
+jest.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: (table: string) => {
+      mockSupabaseFromFn(table);
+      return {
+        update: (data: Record<string, unknown>) => {
+          mockSupabaseUpdateFn(data);
+          return {
+            eq: (col: string, val: string) => {
+              mockSupabaseEqFn(col, val);
+              return mockSupabaseUpdateFn.__nextResult ?? { error: null };
+            },
+          };
+        },
+      };
+    },
+  },
+}));
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+/** ISO timestamp for 'fresh' — 30s ago (well within 90s threshold). */
+function freshHeartbeat(): string {
+  return new Date(Date.now() - 30_000).toISOString();
+}
+
+/** ISO timestamp for 'stale' — 120s ago (beyond 90s threshold). */
+function staleHeartbeat(): string {
+  return new Date(Date.now() - 120_000).toISOString();
+}
+
+/** Build default props for easy overriding. */
+function buildProps(overrides: Partial<SessionOrphanedBannerProps> = {}): SessionOrphanedBannerProps {
+  return {
+    sessionId: 'session-abc-123',
+    status: 'running',
+    lastHeartbeatAt: staleHeartbeat(),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SessionOrphanedBanner', () => {
+  beforeEach(() => {
+    // Reset supabase mock state before each test
+    mockSupabaseFromFn.mockClear();
+    mockSupabaseUpdateFn.mockClear();
+    mockSupabaseEqFn.mockClear();
+    // Default: successful update
+    mockSupabaseUpdateFn.__nextResult = { error: null };
+  });
+
+  // --------------------------------------------------------------------------
+  // Case 1: Fresh session — renders nothing
+  // --------------------------------------------------------------------------
+
+  it('renders nothing when heartbeat is within 90s and status is active', () => {
+    const { queryByTestId, queryByText } = render(
+      <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: freshHeartbeat(), status: 'running' })} />,
+    );
+
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+    expect(queryByText(/session's CLI/i)).toBeNull();
+  });
+
+  it('renders nothing when heartbeat is exactly at 90s boundary (not yet stale)', () => {
+    // 89s ago — should NOT trigger the banner
+    const justUnderThreshold = new Date(Date.now() - 89_000).toISOString();
+    const { queryByTestId } = render(
+      <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: justUnderThreshold, status: 'running' })} />,
+    );
+
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // Case 2: Stale heartbeat + active status — renders banner
+  // --------------------------------------------------------------------------
+
+  it('renders banner when heartbeat > 90s ago and status is active', () => {
+    const { getByTestId, getByText } = render(
+      <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: staleHeartbeat(), status: 'running' })} />,
+    );
+
+    expect(getByTestId('orphaned-banner')).toBeTruthy();
+    expect(getByText(/This session's CLI was logged out/i)).toBeTruthy();
+  });
+
+  it('renders banner for all active statuses (starting, running, idle, paused)', () => {
+    const activeStatuses = ['starting', 'running', 'idle', 'paused'] as const;
+
+    for (const status of activeStatuses) {
+      const { getByTestId, unmount } = render(
+        <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: staleHeartbeat(), status })} />,
+      );
+      expect(getByTestId('orphaned-banner')).toBeTruthy();
+      unmount();
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // Case 3: Non-active status — renders nothing even if heartbeat is stale
+  // --------------------------------------------------------------------------
+
+  it('renders nothing when status is stopped (even with stale heartbeat)', () => {
+    const { queryByTestId } = render(
+      <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: staleHeartbeat(), status: 'stopped' })} />,
+    );
+
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+  });
+
+  it('renders nothing when status is expired', () => {
+    const { queryByTestId } = render(
+      <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: staleHeartbeat(), status: 'expired' })} />,
+    );
+
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+  });
+
+  it('renders nothing when status is error', () => {
+    const { queryByTestId } = render(
+      <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: staleHeartbeat(), status: 'error' })} />,
+    );
+
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // Case 4: Dismiss button hides banner via local state
+  // --------------------------------------------------------------------------
+
+  it('dismiss button hides the banner without calling any API', async () => {
+    const { getByTestId, queryByTestId } = render(
+      <SessionOrphanedBanner {...buildProps()} />,
+    );
+
+    expect(getByTestId('orphaned-banner')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('dismiss-button'));
+    });
+
+    // Banner should be gone from the tree
+    expect(queryByTestId('orphaned-banner')).toBeNull();
+
+    // Supabase must NOT have been called
+    expect(mockSupabaseFromFn).not.toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // Case 5: End Session calls Supabase update with correct sessionId
+  // --------------------------------------------------------------------------
+
+  it('End Session calls supabase.from("sessions").update({status:"stopped"}).eq("id", sessionId)', async () => {
+    const sessionId = 'test-session-xyz-789';
+    const { getByTestId } = render(
+      <SessionOrphanedBanner {...buildProps({ sessionId })} />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('end-session-button'));
+    });
+
+    await waitFor(() => {
+      expect(mockSupabaseFromFn).toHaveBeenCalledWith('sessions');
+      expect(mockSupabaseUpdateFn).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'stopped' }),
+      );
+      expect(mockSupabaseEqFn).toHaveBeenCalledWith('id', sessionId);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Case 6: Loading state during End Session call
+  // --------------------------------------------------------------------------
+
+  it('shows loading state and disables End Session button while API call is in flight', async () => {
+    // Make the supabase call hang indefinitely via a promise that never resolves
+    let resolveUpdate: ((val: unknown) => void) | undefined;
+    mockSupabaseUpdateFn.__nextResult =
+      new Promise((resolve) => { resolveUpdate = resolve; });
+
+    const { getByTestId } = render(
+      <SessionOrphanedBanner {...buildProps()} />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('end-session-button'));
+    });
+
+    // While pending: loading indicator should be present and button should be disabled
+    expect(getByTestId('end-session-loading')).toBeTruthy();
+    const btn = getByTestId('end-session-button');
+    // Pressable accessibilityState.disabled should be true during loading
+    expect(btn.props.accessibilityState?.disabled).toBe(true);
+
+    // Resolve to prevent open handles
+    await act(async () => {
+      resolveUpdate?.({ error: null });
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Case 7: Error state if API call fails — banner remains, error message shown
+  // --------------------------------------------------------------------------
+
+  it('shows error message when End Session API call fails and keeps banner visible', async () => {
+    mockSupabaseUpdateFn.__nextResult = {
+      error: { message: 'Network error' },
+    };
+
+    const { getByTestId, getByText, queryByTestId } = render(
+      <SessionOrphanedBanner {...buildProps()} />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('end-session-button'));
+    });
+
+    await waitFor(() => {
+      // Banner must still be visible
+      expect(queryByTestId('orphaned-banner')).toBeTruthy();
+      // Error message should be displayed
+      expect(getByText(/failed to end session/i)).toBeTruthy();
+    });
+  });
+
+  it('clears error state and hides banner on successful retry after previous failure', async () => {
+    // First call: fail
+    mockSupabaseUpdateFn.__nextResult = {
+      error: { message: 'timeout' },
+    };
+
+    const { getByTestId, queryByText, queryByTestId } = render(
+      <SessionOrphanedBanner {...buildProps()} />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('end-session-button'));
+    });
+
+    await waitFor(() => {
+      expect(queryByText(/failed to end session/i)).toBeTruthy();
+    });
+
+    // Second call: succeed
+    mockSupabaseUpdateFn.__nextResult = { error: null };
+
+    await act(async () => {
+      fireEvent.press(getByTestId('end-session-button'));
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId('orphaned-banner')).toBeNull();
+    });
+  });
+});

--- a/packages/styrby-mobile/src/components/sessions/index.ts
+++ b/packages/styrby-mobile/src/components/sessions/index.ts
@@ -33,3 +33,5 @@ export {
 } from './constants';
 export { ConnectionStateBadge } from './ConnectionStateBadge';
 export type { ConnectionStateBadgeProps } from './ConnectionStateBadge';
+export { SessionOrphanedBanner } from './SessionOrphanedBanner';
+export type { SessionOrphanedBannerProps } from './SessionOrphanedBanner';

--- a/packages/styrby-mobile/src/hooks/useSessions.ts
+++ b/packages/styrby-mobile/src/hooks/useSessions.ts
@@ -75,6 +75,17 @@ export interface SessionRow {
   message_count: number;
   /** Team ID if this is a team session (null for personal sessions, optional if not selected) */
   team_id?: string | null;
+  /**
+   * ISO 8601 timestamp of the most recent CLI heartbeat for this session.
+   * Null if no heartbeat has ever been emitted (pre-heartbeat sessions).
+   *
+   * WHY: The CLI daemon emits a heartbeat every 30s. When the daemon stops
+   * abnormally (e.g. forced logout, crash) the heartbeat ceases but the session
+   * status remains 'running' in Supabase. The SessionOrphanedBanner compares
+   * this timestamp against Date.now() and shows a warning if the delta exceeds
+   * 90s (three missed heartbeats).
+   */
+  last_heartbeat_at: string | null;
 }
 
 /**
@@ -228,7 +239,8 @@ export function useSessions(): UseSessionsReturn {
         .select(
           'id, user_id, machine_id, agent_type, status, title, summary, ' +
           'total_input_tokens, total_output_tokens, total_cost_usd, ' +
-          'started_at, ended_at, tags, updated_at, message_count, team_id',
+          'started_at, ended_at, tags, updated_at, message_count, team_id, ' +
+          'last_heartbeat_at',
         )
         .is('deleted_at', null)
         .order('updated_at', { ascending: false })

--- a/packages/styrby-mobile/src/lib/schemas.ts
+++ b/packages/styrby-mobile/src/lib/schemas.ts
@@ -133,6 +133,13 @@ export const SessionSchema = z.object({
   message_count: z.number(),
   /** Team ID if this is a team session, null for personal */
   team_id: z.string().nullable().optional(),
+  /**
+   * ISO 8601 timestamp of the most recent CLI heartbeat for this session.
+   * Null if no heartbeat has ever been emitted (pre-heartbeat sessions).
+   * Optional to allow forward-compatibility: rows selected without this column
+   * (e.g. in Realtime events before the payload includes it) will default to null.
+   */
+  last_heartbeat_at: z.string().nullable().optional(),
 });
 
 /** Inferred TypeScript type for a validated session row. */


### PR DESCRIPTION
## Phase 1 — Account-Switch Correctness

Implements the spec at `docs/planning/phase-1-account-switch-correctness-spec.md`.

**Built via `/subagent-dev` two-stage review pipeline. Final integration review verdict: SHIP.**

## Problem solved

When a user re-authenticates the CLI as a different account, the running daemon held the old user's Realtime subscription and session ownership — mobile saw ghost sessions; the new account saw nothing. There was no `logout()` flow that tore the daemon down, and no way to detect cross-account contamination.

## What ships

| # | Task | Commit | Tests |
|---|---|---|---|
| 1 | Daemon `terminate` IPC RPC + final-snapshot persistence | 43ed150 | 14 |
| 2 | TokenManager extends EventEmitter, emits `'logout'` event | be34e35 + a5a604e | 9 |
| 3 | `styrby logout` command (4 edge cases handled) | 3be61a6 + a7e82b3 | 16 |
| 4 | Daemon auth-context mismatch detection (4-row matrix) | c24da95 + 25f8c3b | 17 |
| 5 | Mobile `SessionOrphanedBanner` component | 452e6dd + 8cebb9e | 13 |
| 6 | Wiring (`SessionRow`/`useSessions`/`(tabs)/sessions.tsx`) + spec close-out | 60ba0bd | 6 |

**Total: ~75 new tests, 9 commits, 0 regressions.**

## Integration story

```
TokenManager 'logout' event (T2)
   ↓
styrby logout command (T3)
   ↓ calls terminateDaemon()
Daemon `daemon.terminate` IPC handler (T1) → ACK → snapshot → realtime close → exit(0)
   ↓
Auth-context check on every non-exempt IPC command (T4) — silent rebind / refuse-with-error matrix
   ↓ (mobile side, via Realtime)
SessionOrphanedBanner appears on stale sessions (T5)
   ↓
Wired into (tabs)/sessions.tsx, SessionRow extended with last_heartbeat_at (T6)
```

## Spec-vs-reality mismatches surfaced and resolved

The spec was authored against architectural assumptions that didn't fully hold. These were resolved during implementation:

1. **`useSessionConnectionState` was the wrong hook** — it tracks relay reconnect telemetry (attempt count, lastAttemptAt), NOT per-session heartbeat age. Used direct date math against `session.last_heartbeat_at` instead. Mobile-side test added a `timeProvider` injection seam for deterministic boundary testing.
2. **No REST client in mobile** — mobile talks to data exclusively via Supabase. The spec's `DELETE /api/v1/sessions/[id]` is fulfilled by `supabase.from('sessions').update({ status: 'stopped' })`, consistent with the existing pattern.
3. **Screen path** — mobile uses `app/(tabs)/sessions.tsx` (expo-router), not `screens/Sessions/index.tsx`.

## Locked design decisions (from pre-execution)

- **Always-kill daemon on logout** — no `--keep-daemon` flag (one lifecycle path; auditable; defer rebind variant to Phase 2)
- **Atomic mobile banner** — ships in same PR as CLI changes; no split (avoids the "logout works but ghosts persist" deployment window)

## Discipline summary

- ✅ Test-only deviations from spec all PASS-validated by spec-compliance reviewer
- ✅ Every reviewer finding addressed or explicitly deferred with rationale
- ✅ No silent bypasses; every security gate is exercised on happy path AND wiring-failure path
- ✅ JSDoc + WHY-comments + OWASP/SOC 2/GDPR citations on all new code
- ✅ TypeScript strict mode clean; SessionStatus type tightened to catch dead-branch bugs at compile time

## Tracked follow-ups (intentionally deferred)

- **Daemon supervisor stop-flag** — currently benign (supervisor lives in CLI invocation that started the daemon, not the logout process) but if supervision migrates to a long-lived host, a stop-flag file or exit-code convention will be needed. **Surfaced by final integration reviewer.**
- i18n: `SessionOrphanedBanner` strings hardcoded English (codebase-wide pattern; not Phase 1 scope)
- Console.log/logger consistency: `commands/logout.ts` matches existing `commands/stop.ts` convention; project-wide cleanup deserves its own task
- `useCallback` wraps on banner handlers (cosmetic)
- Design-token color literals on banner (matches `ConnectionStateBadge` precedent)
- Integration test rendering: uses `bannerPropsFromRow` mirror rather than full screen render — TypeScript already catches wiring drift at compile time, mirror catches logic bugs

## Phase 2 (deferred)

- Multi-account support (keep both accounts logged in, switch between them) — separate spec, separate PR
- "Log out remotely" mobile UX

## Verification

- `pnpm --filter styrby-cli typecheck` ✅
- `pnpm --filter styrby-cli test` — 2496 pass / 2 fail (both pre-existing startup-perf-budget; not regressions)
- `pnpm --filter styrby-mobile typecheck` ✅
- `pnpm --filter styrby-mobile test` — 1614 pass / 1 fail (pre-existing login-passkey snapshot from earlier Google OAuth work; not regression)

## Test plan

- [ ] Manual repro: log in as A, start session, log out, log in as B → no ghost session, no error spam
- [ ] Manual repro: log in as A, start session, attempt to invoke daemon as B without logout → clear `AUTH_MISMATCH_ACTIVE_SESSIONS` error
- [ ] Manual repro: log in as A, kill the laptop's wifi, kill terminal, reboot → mobile shows SessionOrphanedBanner on stale session
- [ ] Code review by human

🤖 Built via /subagent-dev — 18 sub-agent dispatches across 6 tasks (6 implementer + 6 spec-compliance reviewer + 6 quality reviewer + final opus integration review)