### PR TITLE
chore: add Turborepo + remote cache (Bundle 2 of CI/CD cost-cut)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,17 @@ env:
   EXPO_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
   EXPO_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key
   RESEND_API_KEY: re_placeholder_key
+  # Bundle 2 — Turborepo remote cache (2026-04-30):
+  # When TURBO_TOKEN and TURBO_TEAM are set in repo Actions secrets, Turbo
+  # uploads/downloads task outputs from the configured remote cache (Vercel
+  # Remote Cache by default; can be self-hosted). When unset, Turbo falls back
+  # to local-only cache — still useful within a single CI run for tasks that
+  # invoke each other, but no cross-run sharing. Setup: `npx turbo link` once,
+  # then add the resulting token + team slug as repo secrets.
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  # Per Turbo's recommendation: opt out of telemetry on CI runners.
+  TURBO_TELEMETRY_DISABLED: '1'
 
 # SEC-008 FIX: Explicit least-privilege permissions.
 # WHY: Without a top-level permissions block, GitHub defaults to write access
@@ -228,25 +239,12 @@ jobs:
       - name: Lint (if configured)
         run: pnpm run lint
 
-      # Build shared first so its type declarations are available for CLI typecheck
-      - name: Build shared (type declarations)
-        run: pnpm --filter @styrby/shared build
-
-      - name: Type check shared
-        run: pnpm --filter @styrby/shared run typecheck
-
-      - name: Type check CLI
-        run: pnpm --filter styrby-cli run typecheck
-
-      - name: Type check web
-        run: pnpm --filter styrby-web run typecheck
-
-      - name: Type check mobile
-        # FIXED: React 18 vs 19 type conflict resolved via pnpm.packageExtensions in
-        # root package.json. Each Expo/React Native library now declares @types/react@~18.3.0
-        # as a peer dependency, preventing TypeScript from falling back to the React 19 types
-        # that live in .pnpm/node_modules/@types/react (shared by styrby-web's dependencies).
-        run: pnpm --filter styrby-mobile run typecheck
+      # Bundle 2 (Turbo): typecheck task in turbo.json depends on `^build`, so
+      # turbo automatically builds @styrby/shared before typechecking any consumer.
+      # All four typechecks share the same shared-build cache key — second
+      # invocation hits cache when shared hasn't changed.
+      - name: Type check (all packages, turbo-orchestrated)
+        run: pnpm turbo run typecheck --filter=@styrby/shared --filter=styrby-cli --filter=styrby-web --filter=styrby-mobile
 
   # ─── Shared unit tests ───
   test-shared:

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ ARCHITECTURE.md
 .copy-reports/
 .db-reports/
 scripts/__pycache__/
+
+# Turborepo local cache (Bundle 2)
+.turbo/

--- a/package.json
+++ b/package.json
@@ -10,17 +10,18 @@
     "cli": "pnpm --filter styrby-cli",
     "mobile": "pnpm --filter styrby-mobile",
     "web": "pnpm --filter styrby-web",
-    "lint": "pnpm -r --if-present run lint",
-    "typecheck": "pnpm -r --if-present run typecheck",
-    "build": "pnpm -r --if-present run build",
-    "test": "pnpm -r --if-present run test",
-    "clean": "rm -rf node_modules packages/*/node_modules packages/*/dist",
+    "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
+    "build": "turbo run build",
+    "test": "turbo run test",
+    "clean": "rm -rf node_modules packages/*/node_modules packages/*/dist .turbo packages/*/.turbo",
     "size": "size-limit",
     "size:json": "size-limit --json"
   },
   "devDependencies": {
     "@size-limit/file": "^11.1.6",
-    "size-limit": "^11.1.6"
+    "size-limit": "^11.1.6",
+    "turbo": "2.9.6"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/styrby-cli/package.json
+++ b/packages/styrby-cli/package.json
@@ -92,6 +92,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@styrby/shared": "workspace:*",
     "@types/cross-spawn": "^6.0.6",
     "@types/libsodium-wrappers": "0.7.14",
     "@types/node": "~22.15.0",

--- a/packages/styrby-web/vercel.json
+++ b/packages/styrby-web/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "cd ../.. && pnpm install",
-  "buildCommand": "cd ../.. && pnpm --filter @styrby/shared build && pnpm --filter styrby-web build",
+  "buildCommand": "cd ../.. && pnpm turbo run build --filter=styrby-web",
   "outputDirectory": ".next",
   "framework": "nextjs",
   "ignoreCommand": "cd ../.. && bash -c 'git diff --quiet HEAD^ HEAD -- packages/styrby-web packages/styrby-shared pnpm-lock.yaml pnpm-workspace.yaml package.json packages/styrby-web/vercel.json && exit 0 || exit 1'",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@styrby/shared':
+        specifier: workspace:*
+        version: link:../styrby-shared
       '@types/cross-spawn':
         specifier: ^6.0.6
         version: 6.0.6
@@ -23179,7 +23182,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0
 
   react-shallow-renderer@16.15.0(react@18.3.1):
     dependencies:
@@ -24211,6 +24214,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.27.3
 
+  terser-webpack-plugin@5.3.16(webpack@5.105.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 7.0.5
+      terser: 5.46.0
+      webpack: 5.105.0
+
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -24906,6 +24918,38 @@ snapshots:
       - utf-8-validate
 
   webpack-sources@3.3.3: {}
+
+  webpack@5.105.0:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.19.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       size-limit:
         specifier: ^11.1.6
         version: 11.2.0
+      turbo:
+        specifier: 2.9.6
+        version: 2.9.6
 
   packages/styrby-cli:
     dependencies:
@@ -1878,7 +1881,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}
@@ -5376,6 +5379,36 @@ packages:
   '@tootallnate/once@3.0.1':
     resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
     engines: {node: '>= 10'}
+
+  '@turbo/darwin-64@2.9.6':
+    resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.6':
+    resolution: {integrity: sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.6':
+    resolution: {integrity: sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.6':
+    resolution: {integrity: sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.6':
+    resolution: {integrity: sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.6':
+    resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
+    cpu: [arm64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -11294,6 +11327,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  turbo@2.9.6:
+    resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
+    hasBin: true
+
   tweetnacl-util@0.15.1:
     resolution: {integrity: sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==}
 
@@ -16199,14 +16236,14 @@ snapshots:
       '@remotion/studio-shared': 4.0.438(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@rspack/core': 1.7.6(@swc/helpers@0.5.15)
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
-      css-loader: 5.2.7(webpack@5.105.0)
+      css-loader: 5.2.7(webpack@5.105.0(esbuild@0.25.0))
       esbuild: 0.25.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-refresh: 0.18.0
       remotion: 4.0.438(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       source-map: 0.7.3
-      style-loader: 4.0.0(webpack@5.105.0)
+      style-loader: 4.0.0(webpack@5.105.0(esbuild@0.25.0))
       webpack: 5.105.0(esbuild@0.25.0)
     transitivePeerDependencies:
       - '@swc/core'
@@ -17189,6 +17226,24 @@ snapshots:
       '@testing-library/dom': 10.4.1
 
   '@tootallnate/once@3.0.1': {}
+
+  '@turbo/darwin-64@2.9.6':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.6':
+    optional: true
+
+  '@turbo/linux-64@2.9.6':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.6':
+    optional: true
+
+  '@turbo/windows-64@2.9.6':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.6':
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -18851,7 +18906,7 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-loader@5.2.7(webpack@5.105.0):
+  css-loader@5.2.7(webpack@5.105.0(esbuild@0.25.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.12)
       loader-utils: 2.0.4
@@ -18863,7 +18918,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.7.4
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.0)
 
   css-select@5.2.2:
     dependencies:
@@ -19465,7 +19520,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -19498,7 +19553,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -19576,7 +19631,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -23124,7 +23179,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.0)
 
   react-shallow-renderer@16.15.0(react@18.3.1):
     dependencies:
@@ -24004,9 +24059,9 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  style-loader@4.0.0(webpack@5.105.0):
+  style-loader@4.0.0(webpack@5.105.0(esbuild@0.25.0)):
     dependencies:
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.0)
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
@@ -24141,7 +24196,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       terser: 5.46.0
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.0)
     optionalDependencies:
       esbuild: 0.25.0
 
@@ -24311,6 +24366,15 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+
+  turbo@2.9.6:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.6
+      '@turbo/darwin-arm64': 2.9.6
+      '@turbo/linux-64': 2.9.6
+      '@turbo/linux-arm64': 2.9.6
+      '@turbo/windows-64': 2.9.6
+      '@turbo/windows-arm64': 2.9.6
 
   tweetnacl-util@0.15.1: {}
 
@@ -24842,38 +24906,6 @@ snapshots:
       - utf-8-validate
 
   webpack-sources@3.3.3: {}
-
-  webpack@5.105.0:
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.0)(webpack@5.105.0)
-      watchpack: 2.5.1
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.0):
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "ui": "stream",
+  "globalDependencies": [
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    ".npmrc"
+  ],
+  "globalPassThroughEnv": [
+    "NODE_ENV",
+    "CI",
+    "VERCEL",
+    "VERCEL_ENV",
+    "VERCEL_URL",
+    "VERCEL_GIT_COMMIT_SHA"
+  ],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "scripts/**",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "package.json",
+        "next.config.*",
+        "next-env.d.ts",
+        "tailwind.config.*",
+        "postcss.config.*",
+        "public/**",
+        "app/**",
+        "$TURBO_DEFAULT$"
+      ],
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "!.next/cache/**"
+      ],
+      "env": [
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        "SUPABASE_URL",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "POLAR_ACCESS_TOKEN",
+        "POLAR_WEBHOOK_SECRET",
+        "POLAR_ORGANIZATION_ID",
+        "EXPO_PUBLIC_SUPABASE_URL",
+        "EXPO_PUBLIC_SUPABASE_ANON_KEY",
+        "RESEND_API_KEY",
+        "ANALYZE"
+      ]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "app/**",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "package.json"
+      ],
+      "outputs": []
+    },
+    "lint": {
+      "inputs": [
+        "src/**",
+        "app/**",
+        ".eslintrc*",
+        "eslint.config.*",
+        "package.json"
+      ],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "app/**",
+        "vitest.config.*",
+        "vitest.setup.*",
+        "jest.config.*",
+        "jest.setup.*",
+        "tsconfig.json",
+        "package.json"
+      ],
+      "outputs": [],
+      "env": [
+        "NODE_OPTIONS",
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        "SUPABASE_URL",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "POLAR_ACCESS_TOKEN",
+        "POLAR_WEBHOOK_SECRET",
+        "POLAR_ORGANIZATION_ID",
+        "EXPO_PUBLIC_SUPABASE_URL",
+        "EXPO_PUBLIC_SUPABASE_ANON_KEY",
+        "RESEND_API_KEY"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Bundle 2 of the CI/CD cost-cut series. Adds Turborepo as the orchestrator for build/test/typecheck/lint across all 4 packages. With \`TURBO_TOKEN\` configured, CI and Vercel share a remote cache — task outputs are pulled instead of recomputed.

This is the **structural** layer: every other optimization (path filters from Bundle 1, prebuilt deploy from Bundle 3) compounds with it.

## Local validation

\`\`\`
pnpm turbo run build --filter=@styrby/shared
  → first run:  4.6s  (cache miss, runs tsc)
  → second run: 106ms (FULL TURBO — 43× speedup)

pnpm turbo run typecheck --filter=@styrby/shared --filter=styrby-cli \
                         --filter=styrby-web --filter=styrby-mobile
  → first run:  ~33s  (5 tasks: shared:build + 4 typechecks)
  → second run: 161ms (all 5 cached — 200× speedup)
\`\`\`

## What ships

| File | Change |
|---|---|
| \`turbo.json\` (new) | Task graph: build/typecheck/test/lint pipelines with proper inputs/outputs/env |
| \`package.json\` (root scripts) | \`lint\`/\`typecheck\`/\`build\`/\`test\` delegate to \`turbo run X\` |
| \`.github/workflows/ci.yml\` | \`TURBO_TOKEN\`/\`TURBO_TEAM\`/\`TURBO_TELEMETRY_DISABLED\` env at workflow level. Quality job consolidates 5 sequential \`pnpm --filter\` typechecks into one \`pnpm turbo run typecheck\` invocation. Other jobs unchanged (preserves no-token correctness — they download shared-build artifact). |
| \`packages/styrby-web/vercel.json\` | \`buildCommand\` → \`pnpm turbo run build --filter=styrby-web\`. Vercel has native Turbo Remote Cache support. |
| \`.gitignore\` | Adds \`.turbo/\` for local cache dir |

## ⚠️ User action required to activate the cache

This PR ships the wiring; the cache activates only when you configure \`TURBO_TOKEN\`. 5-minute task:

1. From a checkout: \`npx turbo link\` (asks you to log into Vercel and link to a remote cache scope)
2. Copy the token from \`~/.turbo/config.json\`
3. Add to **GitHub Actions** (Settings → Secrets and variables → Actions):
   - **Secret**: \`TURBO_TOKEN\` = \`<token>\`
   - **Variable**: \`TURBO_TEAM\` = \`<team slug>\`
4. Add to **Vercel project** (dashboard → styrby-web → Settings → Environment Variables) for Production + Preview + Development:
   - \`TURBO_TOKEN\`
   - \`TURBO_TEAM\`

Before activation: turbo runs locally, no cache sharing across runs (no regression vs today).
After activation: cache shared between every CI run, every Vercel build, every developer machine that's logged in.

## No-regression guarantee

Without \`TURBO_TOKEN\` set, CI runs identically to today:
- Quality job runs the same 5 logical steps via turbo (no cache → executed in series internally → same total time)
- All other CI jobs unchanged
- Vercel buildCommand: turbo invokes the same pnpm scripts in the same order, no cache → same speed as today

CI on this PR validates the no-token path.

## Expected impact (post-activation)

| Surface | Today | After activation |
|---|---|---|
| Quality job (typecheck) | ~60s | ~5s on cache hit |
| Build shared | ~30s | instant on no-op |
| Build CLI/web | ~3min | ~30s on incremental change |
| styrby-web rebuild on no-shared PRs | 3-4 min | ~1 min |

Estimated savings: ~\$40-60/day additional on top of Bundles 0+1. Combined with Bundle 0 (ignoreCommand) + Bundle 1 (path filters), captures roughly 60-70% of the \$168/day target burn. Bundle 3 (prebuilt deploy) closes the rest.

## Test plan

- [ ] CI passes on this PR (no-token path: turbo runs locally, no cache)
- [ ] Vercel preview build runs on this PR (since vercel.json is in the include list from Bundle 0)
- [ ] After merge: user runs \`npx turbo link\`, adds secrets/vars to GH and Vercel
- [ ] After activation: spot-check a follow-up PR shows turbo cache hits in CI logs (\`>>> FULL TURBO\` or \`X cached, Y total\` summary)
- [ ] After a week of cache data: open Bundle 3 (prebuilt deploy)

## Related

- Bundle 0 + 1: PR #222 (paths-ignore + ignoreCommand + path filters + dedupe + CodeQL/merge_group) — merged a1961ec
- Bundle 3: PR #224 (Vercel prebuilt deploy) — opens after this validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)