### PR TITLE
feat(cli): StyrbyApiClient — typed HTTP wrapper for /api/v1 (H41 Phase 3)

### DIFF
--- a/packages/styrby-cli/src/api/__tests__/styrbyApiClient.test.ts
+++ b/packages/styrby-cli/src/api/__tests__/styrbyApiClient.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Unit tests for StyrbyApiClient (Strategy C — Phase 3).
+ *
+ * WHY fetchImpl injection (not global vi.fn() of fetch): the client accepts
+ * a `fetchImpl` config field exactly so tests can substitute a deterministic
+ * mock without leaking into other suites that might use real fetch.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_BASE_URL,
+  StyrbyApiClient,
+  StyrbyApiError,
+} from '../styrbyApiClient.js';
+
+// Sentry is initialised in src/index.ts on the real CLI path. Tests should
+// never reach a real Sentry transport; mock the entire module to assert
+// breadcrumbs without network traffic.
+vi.mock('@sentry/node', () => ({
+  addBreadcrumb: vi.fn(),
+}));
+
+import * as Sentry from '@sentry/node';
+
+// Helpers ---------------------------------------------------------------------
+
+interface MockResponseInit {
+  status?: number;
+  body?: unknown;
+  text?: string;
+  headers?: Record<string, string>;
+}
+
+function mockJson(init: MockResponseInit = {}): Response {
+  const status = init.status ?? 200;
+  const body = init.body !== undefined ? JSON.stringify(init.body) : init.text ?? '';
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'application/json', ...(init.headers ?? {}) },
+  });
+}
+
+function makeFetch(responses: Array<MockResponseInit | Error>): {
+  fetch: typeof fetch;
+  calls: Array<{ url: string; init: RequestInit }>;
+} {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  let i = 0;
+  const fakeFetch = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    calls.push({ url, init });
+    const next = responses[i++];
+    if (next === undefined) {
+      throw new Error(`makeFetch: no more responses queued at call ${i}`);
+    }
+    if (next instanceof Error) {
+      throw next;
+    }
+    return mockJson(next);
+  }) as typeof fetch;
+  return { fetch: fakeFetch, calls };
+}
+
+// Tests -----------------------------------------------------------------------
+
+describe('StyrbyApiClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('constructor + URL handling', () => {
+    it('defaults to production base URL', () => {
+      const client = new StyrbyApiClient({ apiKey: 'sk_test' });
+      // Indirect: a request goes to the prod URL.
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { ok: true } }]);
+      // Need a fresh client wired with the fake fetch to inspect URL.
+      const c2 = new StyrbyApiClient({ apiKey: 'sk_test', fetchImpl: fakeFetch });
+      return c2.otpSend({ email: 'a@b.com' }).then(() => {
+        expect(calls[0].url.startsWith(DEFAULT_BASE_URL)).toBe(true);
+        // Quiets unused warning on first client.
+        expect(client).toBeInstanceOf(StyrbyApiClient);
+      });
+    });
+
+    it('strips trailing slash from baseUrl', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { ok: true } }]);
+      const c = new StyrbyApiClient({ baseUrl: 'https://example.com/', fetchImpl: fakeFetch });
+      await c.otpSend({ email: 'a@b.com' });
+      expect(calls[0].url).toBe('https://example.com/api/v1/auth/otp/send');
+    });
+
+    it('encodes path segments with special characters', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { session: {} } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk_test', fetchImpl: fakeFetch });
+      await c.getSession('id with space/and-slash');
+      expect(calls[0].url).toContain('id%20with%20space%2Fand-slash');
+    });
+
+    it('appends defined query params and skips undefined ones', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { sessions: [], pagination: { total: 0, limit: 20, offset: 0, hasMore: false } } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk_test', fetchImpl: fakeFetch });
+      await c.listSessions({ limit: 50, status: 'running' });
+      const url = new URL(calls[0].url);
+      expect(url.searchParams.get('limit')).toBe('50');
+      expect(url.searchParams.get('status')).toBe('running');
+      expect(url.searchParams.has('agent_type')).toBe(false);
+      expect(url.searchParams.has('archived')).toBe(false);
+    });
+  });
+
+  describe('headers', () => {
+    it('attaches Authorization on authenticated calls', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { count: 0, machines: [] } }]);
+      const c = new StyrbyApiClient({ apiKey: 'styrby_abc', fetchImpl: fakeFetch });
+      await c.listMachines();
+      const headers = calls[0].init.headers as Headers;
+      expect(headers.get('Authorization')).toBe('Bearer styrby_abc');
+    });
+
+    it('throws clearly when an authenticated call has no apiKey', async () => {
+      const c = new StyrbyApiClient({ fetchImpl: makeFetch([]).fetch });
+      await expect(c.listMachines()).rejects.toThrow(/apiKey is required/);
+    });
+
+    it('omits Authorization on auth bootstrap calls', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { ok: true } }]);
+      const c = new StyrbyApiClient({ fetchImpl: fakeFetch });
+      await c.otpSend({ email: 'a@b.com' });
+      const headers = calls[0].init.headers as Headers;
+      expect(headers.has('Authorization')).toBe(false);
+    });
+
+    it('attaches Idempotency-Key when supplied', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 201, body: { id: 't1', name: 'n', created_at: 't' } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      await c.createTemplate({ name: 'n', content: 'c' }, { idempotencyKey: 'key-123' });
+      const headers = calls[0].init.headers as Headers;
+      expect(headers.get('Idempotency-Key')).toBe('key-123');
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws StyrbyApiError with status + parsed message on 4xx', async () => {
+      const { fetch: fakeFetch } = makeFetch([{ status: 400, body: { error: 'name is required' } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch, maxAttempts: 1 });
+      const err = await c.createTemplate({ name: '', content: 'c' }).catch((e) => e);
+      expect(err).toBeInstanceOf(StyrbyApiError);
+      expect(err.status).toBe(400);
+      expect(err.message).toBe('name is required');
+      expect(err.code).toBeUndefined();
+    });
+
+    it('parses { error: CODE, message: text } shape into code + message', async () => {
+      const { fetch: fakeFetch } = makeFetch([
+        { status: 400, body: { error: 'VALIDATION_ERROR', message: 'provider must be github or google' } },
+      ]);
+      const c = new StyrbyApiClient({ fetchImpl: fakeFetch, maxAttempts: 1 });
+      const err = await c.oauthStart({ provider: 'github', redirect_to: 'http://x' }).catch((e) => e);
+      expect(err.code).toBe('VALIDATION_ERROR');
+      expect(err.message).toBe('provider must be github or google');
+    });
+
+    it('treats short ALL_CAPS error as code when no message field present', async () => {
+      const { fetch: fakeFetch } = makeFetch([{ status: 401, body: { error: 'AUTH_FAILED' } }]);
+      const c = new StyrbyApiClient({ fetchImpl: fakeFetch, maxAttempts: 1 });
+      const err = await c.otpVerify({ email: 'a@b.com', otp: '000000' }).catch((e) => e);
+      expect(err.code).toBe('AUTH_FAILED');
+      expect(err.status).toBe(401);
+    });
+
+    it('uses status 0 for transport failures', async () => {
+      const { fetch: fakeFetch } = makeFetch([new TypeError('fetch failed')]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch, maxAttempts: 1 });
+      const err = await c.listMachines().catch((e) => e);
+      expect(err).toBeInstanceOf(StyrbyApiError);
+      expect(err.status).toBe(0);
+    });
+  });
+
+  describe('retry policy', () => {
+    it('retries 5xx on retryable verbs and eventually returns success', async () => {
+      const { fetch: fakeFetch } = makeFetch([
+        { status: 503, body: { error: 'Service Unavailable' } },
+        { status: 503, body: { error: 'Service Unavailable' } },
+        { status: 200, body: { count: 0, machines: [] } },
+      ]);
+      const c = new StyrbyApiClient({
+        apiKey: 'sk',
+        fetchImpl: fakeFetch,
+        maxAttempts: 3,
+        // Speed up backoff so the test stays fast.
+        timeoutMs: 5_000,
+      });
+      // Force backoff to ~0ms by patching sleep via setTimeout shim.
+      vi.useFakeTimers();
+      const promise = c.listMachines();
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      expect(result.count).toBe(0);
+    });
+
+    it('does NOT retry single-use auth verbs (oauthCallback)', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([
+        { status: 503, body: { error: 'INTERNAL_ERROR' } },
+      ]);
+      const c = new StyrbyApiClient({ fetchImpl: fakeFetch, maxAttempts: 3 });
+      await expect(c.oauthCallback({ code: 'x', state: 'y' })).rejects.toBeInstanceOf(StyrbyApiError);
+      expect(calls).toHaveLength(1);
+    });
+
+    it('does NOT retry POST without Idempotency-Key', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([
+        { status: 503, body: { error: 'transient' } },
+      ]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch, maxAttempts: 3 });
+      await expect(c.writeAuditEvent({ action: 'x' })).rejects.toBeInstanceOf(StyrbyApiError);
+      expect(calls).toHaveLength(1);
+    });
+
+    it('DOES retry POST when Idempotency-Key is provided', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([
+        { status: 503, body: { error: 'transient' } },
+        { status: 201, body: { id: 'a', created_at: 't' } },
+      ]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch, maxAttempts: 3 });
+      vi.useFakeTimers();
+      const promise = c.writeAuditEvent({ action: 'x' }, { idempotencyKey: 'k1' });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      expect(calls).toHaveLength(2);
+      expect(result.id).toBe('a');
+    });
+
+    it('does NOT retry 4xx (client errors are not transient)', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([
+        { status: 400, body: { error: 'name is required' } },
+      ]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch, maxAttempts: 3 });
+      await expect(c.listMachines()).rejects.toBeInstanceOf(StyrbyApiError);
+      expect(calls).toHaveLength(1);
+    });
+  });
+
+  describe('upsertContext', () => {
+    it('reports inserted=true on 201, false on 200', async () => {
+      const { fetch: fakeFetch } = makeFetch([
+        { status: 201, body: { id: 'x', session_group_id: 'g', version: 1, created_at: 't', updated_at: 't' } },
+      ]);
+      const c1 = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r1 = await c1.upsertContext({ session_group_id: 'g', summary_markdown: 'm' });
+      expect(r1.inserted).toBe(true);
+      expect(r1.version).toBe(1);
+
+      const { fetch: fakeFetch2 } = makeFetch([
+        { status: 200, body: { id: 'x', session_group_id: 'g', version: 2, created_at: 't', updated_at: 't' } },
+      ]);
+      const c2 = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch2 });
+      const r2 = await c2.upsertContext({ session_group_id: 'g', summary_markdown: 'm' });
+      expect(r2.inserted).toBe(false);
+      expect(r2.version).toBe(2);
+    });
+  });
+
+  describe('exportCostsCsv', () => {
+    it('returns CSV body as text', async () => {
+      const csv = 'date,cost\n2026-04-30,1.23\n';
+      const fakeFetch = (async () => new Response(csv, { status: 200, headers: { 'content-type': 'text/csv' } })) as typeof fetch;
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const result = await c.exportCostsCsv({ period: 'month' });
+      expect(result).toBe(csv);
+    });
+  });
+
+  describe('withApiKey', () => {
+    it('returns a new client carrying the new key but same baseUrl/fetchImpl', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { count: 0, machines: [] } }]);
+      const original = new StyrbyApiClient({ baseUrl: 'https://x.test', fetchImpl: fakeFetch });
+      const upgraded = original.withApiKey('styrby_minted');
+      await upgraded.listMachines();
+      expect(calls[0].url.startsWith('https://x.test')).toBe(true);
+      expect((calls[0].init.headers as Headers).get('Authorization')).toBe('Bearer styrby_minted');
+    });
+  });
+
+  describe('observability', () => {
+    it('emits a Sentry breadcrumb on success with status + outcome', async () => {
+      const { fetch: fakeFetch } = makeFetch([{ status: 200, body: { count: 0, machines: [] } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      await c.listMachines();
+      expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'styrby-api',
+          message: 'GET /api/v1/machines',
+          level: 'info',
+          data: expect.objectContaining({ status: 200, outcome: 'ok', attempt: 1 }),
+        }),
+      );
+    });
+
+    it('emits a warning breadcrumb on error', async () => {
+      const { fetch: fakeFetch } = makeFetch([{ status: 401, body: { error: 'AUTH_FAILED' } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch, maxAttempts: 1 });
+      await c.listMachines().catch(() => undefined);
+      expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: 'warning',
+          data: expect.objectContaining({ outcome: 'error', status: 401 }),
+        }),
+      );
+    });
+  });
+
+  describe('deleteSessionCheckpoint', () => {
+    it('throws synchronously when neither name nor checkpointId is provided', async () => {
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: makeFetch([]).fetch });
+      await expect(c.deleteSessionCheckpoint('s1', {})).rejects.toThrow(/name or checkpointId/);
+    });
+
+    it('passes the selector as a query param', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { deleted: true } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      await c.deleteSessionCheckpoint('s1', { name: 'before-merge' });
+      const url = new URL(calls[0].url);
+      expect(url.searchParams.get('name')).toBe('before-merge');
+      expect(calls[0].init.method).toBe('DELETE');
+    });
+  });
+});

--- a/packages/styrby-cli/src/api/styrbyApiClient.ts
+++ b/packages/styrby-cli/src/api/styrbyApiClient.ts
@@ -1,0 +1,849 @@
+/**
+ * Styrby API Client (Strategy C — Phase 3)
+ *
+ * Typed HTTP client for `/api/v1/*` endpoints. The CLI uses this in place of
+ * direct Supabase Postgres access. Auth is per-user `styrby_*` API key in the
+ * `Authorization: Bearer` header — no project anon key embedded.
+ *
+ * WHY a class wrapper (not raw fetch in callsites):
+ *  - Single retry/backoff policy applied uniformly across idempotent verbs
+ *  - Single `apiKey` source — no chance of leaking via misplaced fetch calls
+ *  - Single error type (`StyrbyApiError`) so callers do one catch shape
+ *  - Single observability hook — every call leaves a Sentry breadcrumb
+ *  - Type-safe per-method signatures matching the route contracts
+ *
+ * Auth methods (`oauthStart`, `oauthCallback`, `otpSend`, `otpVerify`) are the
+ * bootstrap path — they do NOT require an API key. Every other method does.
+ *
+ * @module api/styrbyApiClient
+ */
+
+import * as Sentry from '@sentry/node';
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * Production base URL for `/api/v1/*`. Callers override via constructor for
+ * sandbox / local-dev. Trailing slash is intentionally absent — paths are
+ * appended with a leading slash.
+ */
+export const DEFAULT_BASE_URL = 'https://styrbyapp.com';
+
+/**
+ * Maximum retry attempts for retryable errors (5xx, network). The first call
+ * counts as attempt 1; total retries = MAX_ATTEMPTS - 1. WHY 3: covers a single
+ * transient blip without amplifying load on a degraded server.
+ */
+const MAX_ATTEMPTS = 3;
+
+/**
+ * Base backoff in milliseconds. Each retry waits `BASE_BACKOFF_MS * 2^(attempt-1)`
+ * — 250ms, 500ms, 1000ms — capped at MAX_BACKOFF_MS.
+ */
+const BASE_BACKOFF_MS = 250;
+const MAX_BACKOFF_MS = 5_000;
+
+/**
+ * Per-request timeout. Beyond this, the AbortController fires and we treat the
+ * call as a network failure. WHY 30s: matches typical Vercel function timeout
+ * for /api/v1 routes; covers cold starts without holding the daemon indefinitely.
+ */
+const REQUEST_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by every `StyrbyApiClient` method on non-2xx responses or transport
+ * failures. Carries the HTTP status (0 for network/timeout) plus the parsed
+ * error payload so callers can branch on `status` and `code`.
+ */
+export class StyrbyApiError extends Error {
+  /**
+   * HTTP status. `0` indicates a transport-level failure (network, timeout,
+   * abort) where no response was received. WHY 0: lets callers `if (err.status === 0)`
+   * to distinguish "server said no" from "we never reached the server".
+   */
+  readonly status: number;
+
+  /**
+   * Server-provided error code when present (e.g. `'AUTH_FAILED'`,
+   * `'RATE_LIMITED'`, `'VALIDATION_ERROR'`). Undefined for transport failures
+   * or endpoints that return only `{ error: string }`.
+   */
+  readonly code?: string;
+
+  /**
+   * Optional `retryAfter` seconds from the server, surfaced verbatim from
+   * 429 responses. Callers can use this to schedule a respectful retry.
+   */
+  readonly retryAfter?: number;
+
+  /** Raw response body for debugging. Never logged automatically. */
+  readonly body?: unknown;
+
+  constructor(status: number, message: string, opts?: { code?: string; retryAfter?: number; body?: unknown }) {
+    super(message);
+    this.name = 'StyrbyApiError';
+    this.status = status;
+    this.code = opts?.code;
+    this.retryAfter = opts?.retryAfter;
+    this.body = opts?.body;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public response types — mirror /api/v1 route contracts
+// ---------------------------------------------------------------------------
+
+export interface AuthOAuthStartResponse {
+  authorization_url: string;
+  state: string;
+}
+
+export interface AuthCredentialResponse {
+  styrby_api_key: string;
+  expires_at: string;
+}
+
+export interface AccountResponse {
+  user_id: string;
+  email: string;
+  tier: string;
+  created_at: string;
+  mfa_enrolled: boolean;
+  key_expires_at: string | null;
+}
+
+export interface AuditEventInput {
+  action: string;
+  resource_type?: string;
+  resource_id?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuditEventResponse {
+  id: string;
+  created_at: string;
+}
+
+export interface BroadcastInput {
+  channel: string;
+  event: string;
+  payload: Record<string, unknown>;
+}
+
+export interface BroadcastResponse {
+  delivered: boolean;
+}
+
+export interface ContextFileRef {
+  path: string;
+  lastTouchedAt: string;
+  relevance: number;
+}
+
+export interface ContextRecentMessage {
+  role: string;
+  preview: string;
+}
+
+export interface ContextUpsertInput {
+  session_group_id: string;
+  summary_markdown: string;
+  file_refs?: ContextFileRef[];
+  recent_messages?: ContextRecentMessage[];
+  token_budget?: number;
+}
+
+export interface ContextUpsertResponse {
+  id: string;
+  session_group_id: string;
+  version: number;
+  created_at: string;
+  updated_at: string;
+  /** True when the upsert created a new row (HTTP 201), false on update (HTTP 200). */
+  inserted: boolean;
+}
+
+export interface TemplateVariable {
+  name: string;
+  description?: string;
+  defaultValue?: string;
+}
+
+export interface TemplateCreateInput {
+  name: string;
+  content: string;
+  description?: string;
+  variables?: TemplateVariable[];
+  is_default?: boolean;
+}
+
+export interface TemplateCreateResponse {
+  id: string;
+  name: string;
+  created_at: string;
+}
+
+export interface MachineSummary {
+  id: string;
+  name: string;
+  platform: string;
+  platformVersion: string;
+  architecture: string;
+  hostname: string;
+  cliVersion: string;
+  isOnline: boolean;
+  lastSeenAt: string;
+  createdAt: string;
+}
+
+export interface MachinesResponse {
+  machines: MachineSummary[];
+  count: number;
+}
+
+export type SessionStatus = 'starting' | 'running' | 'idle' | 'paused' | 'stopped' | 'error' | 'expired';
+
+export interface SessionListQuery {
+  limit?: number;
+  offset?: number;
+  status?: SessionStatus;
+  agent_type?: string;
+  archived?: boolean;
+}
+
+export interface SessionSummary {
+  id: string;
+  agent_type: string;
+  model: string | null;
+  title: string | null;
+  summary: string | null;
+  project_path: string | null;
+  git_branch: string | null;
+  tags: string[] | null;
+  is_archived: boolean;
+  status: SessionStatus;
+  started_at: string | null;
+  ended_at: string | null;
+  last_activity_at: string | null;
+  total_cost_usd: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_tokens: number;
+  message_count: number;
+  created_at: string;
+}
+
+export interface Pagination {
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+export interface SessionListResponse {
+  sessions: SessionSummary[];
+  pagination: Pagination;
+}
+
+export interface SessionCheckpoint {
+  id: string;
+  session_id: string;
+  name: string;
+  message_index: number;
+  notes?: string | null;
+  created_at: string;
+}
+
+export interface CostsSummaryResponse {
+  summary: {
+    period: string;
+    totalCostUsd: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalCacheTokens: number;
+    sessionCount: number;
+  };
+  breakdown: Array<{
+    date: string;
+    costUsd: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheTokens: number;
+  }>;
+}
+
+export interface CostsBreakdownResponse {
+  breakdown: Array<{
+    agentType: string;
+    costUsd: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheTokens: number;
+    sessionCount: number;
+    percentage: number;
+  }>;
+  total: {
+    costUsd: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheTokens: number;
+    sessionCount: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Client config + internal types
+// ---------------------------------------------------------------------------
+
+/**
+ * Constructor options for `StyrbyApiClient`.
+ *
+ * `apiKey` is optional so the client can be used for the bootstrap auth flow
+ * (oauthStart, otpSend, etc) before a key has been minted. After bootstrap,
+ * pass the minted `styrby_*` key to a new client (or call `withApiKey`).
+ */
+export interface StyrbyApiClientConfig {
+  /** Per-user `styrby_*` API key. Required for every method except auth bootstrap. */
+  apiKey?: string;
+  /** Override the base URL. Defaults to production `https://styrbyapp.com`. */
+  baseUrl?: string;
+  /** Inject an alternative fetch implementation (used in tests). Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Override the default request timeout (ms). */
+  timeoutMs?: number;
+  /** Override the default max retry attempts. */
+  maxAttempts?: number;
+}
+
+/**
+ * Internal request descriptor. Verbs that mutate state (`POST`/`PATCH`/`DELETE`)
+ * default to `retryable: false` unless the call is idempotency-keyed. Reads are
+ * always retryable. Each method passes the right value explicitly.
+ */
+interface InternalRequest {
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  path: string;
+  body?: unknown;
+  query?: Record<string, string | number | boolean | undefined>;
+  /**
+   * Whether transient failures (5xx, network) should be retried with backoff.
+   * Strict default: only set to true for verbs that are server-side idempotent.
+   */
+  retryable: boolean;
+  /** When true, omits the Authorization header (auth bootstrap calls). */
+  unauthenticated?: boolean;
+  /**
+   * Optional Idempotency-Key value forwarded to the server. The server caches
+   * the response for 24h, so retries return the same row without duplicating writes.
+   */
+  idempotencyKey?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed HTTP client for the Styrby v1 API. Construct one per `apiKey` and
+ * reuse across calls — instances are cheap, hold no sockets, and are safe
+ * to share across the daemon's request lifetime.
+ */
+export class StyrbyApiClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string | undefined;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly maxAttempts: number;
+
+  constructor(config: StyrbyApiClientConfig = {}) {
+    this.baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+    this.apiKey = config.apiKey;
+    this.fetchImpl = config.fetchImpl ?? globalThis.fetch.bind(globalThis);
+    this.timeoutMs = config.timeoutMs ?? REQUEST_TIMEOUT_MS;
+    this.maxAttempts = config.maxAttempts ?? MAX_ATTEMPTS;
+  }
+
+  /**
+   * Returns a new client with the given API key, preserving baseUrl/fetchImpl.
+   * WHY a fresh instance (not a setter): the apiKey is `readonly` to stop
+   * a leaked client from being mutated post-creation. The bootstrap flow uses
+   * this to upgrade an unauthenticated client into an authenticated one.
+   */
+  withApiKey(apiKey: string): StyrbyApiClient {
+    return new StyrbyApiClient({
+      apiKey,
+      baseUrl: this.baseUrl,
+      fetchImpl: this.fetchImpl,
+      timeoutMs: this.timeoutMs,
+      maxAttempts: this.maxAttempts,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Auth bootstrap (no API key required)
+  // -------------------------------------------------------------------------
+
+  oauthStart(input: { provider: 'github' | 'google'; redirect_to: string }): Promise<AuthOAuthStartResponse> {
+    return this.request<AuthOAuthStartResponse>({
+      method: 'POST',
+      path: '/api/v1/auth/oauth/start',
+      body: input,
+      retryable: true,
+      unauthenticated: true,
+    });
+  }
+
+  oauthCallback(input: { code: string; state: string }): Promise<AuthCredentialResponse> {
+    return this.request<AuthCredentialResponse>({
+      method: 'POST',
+      path: '/api/v1/auth/oauth/callback',
+      body: input,
+      // WHY not retryable: OAuth `code` is single-use. A retry after a 5xx that
+      // actually consumed the code would 401 with AUTH_FAILED. Caller must
+      // re-run the full flow on transient failures.
+      retryable: false,
+      unauthenticated: true,
+    });
+  }
+
+  otpSend(input: { email: string }): Promise<{ ok: true }> {
+    return this.request<{ ok: true }>({
+      method: 'POST',
+      path: '/api/v1/auth/otp/send',
+      body: input,
+      retryable: true,
+      unauthenticated: true,
+    });
+  }
+
+  otpVerify(input: { email: string; otp: string }): Promise<AuthCredentialResponse> {
+    return this.request<AuthCredentialResponse>({
+      method: 'POST',
+      path: '/api/v1/auth/otp/verify',
+      body: input,
+      // WHY not retryable: OTP codes are single-use, like OAuth codes above.
+      retryable: false,
+      unauthenticated: true,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Account
+  // -------------------------------------------------------------------------
+
+  getAccount(): Promise<AccountResponse> {
+    return this.request<AccountResponse>({
+      method: 'GET',
+      path: '/api/v1/account',
+      retryable: true,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Audit log (high-volume; idempotency-keyed for safe retry)
+  // -------------------------------------------------------------------------
+
+  writeAuditEvent(event: AuditEventInput, opts?: { idempotencyKey?: string }): Promise<AuditEventResponse> {
+    return this.request<AuditEventResponse>({
+      method: 'POST',
+      path: '/api/v1/audit',
+      body: event,
+      // WHY retryable=true only when an Idempotency-Key is supplied: without
+      // the key, a retry after a 5xx that succeeded server-side would write
+      // a duplicate row. With the key, the server replays the cached response.
+      retryable: Boolean(opts?.idempotencyKey),
+      idempotencyKey: opts?.idempotencyKey,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Broadcast (best-effort; never retried)
+  // -------------------------------------------------------------------------
+
+  broadcast(input: BroadcastInput): Promise<BroadcastResponse> {
+    return this.request<BroadcastResponse>({
+      method: 'POST',
+      path: '/api/v1/broadcast',
+      body: input,
+      // WHY retryable=false: the server documents broadcast as best-effort.
+      // delivered:false on a soft failure is NOT a 5xx — it's a successful
+      // 200 response with the boolean flag. Real 5xx here means our process
+      // failed, but mobile will catch up via poll, so retrying just adds load.
+      retryable: false,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Context memory (idempotency-keyed; upsert returns 200 vs 201)
+  // -------------------------------------------------------------------------
+
+  async upsertContext(
+    input: ContextUpsertInput,
+    opts?: { idempotencyKey?: string },
+  ): Promise<ContextUpsertResponse> {
+    const { status, body } = await this.requestRaw<Omit<ContextUpsertResponse, 'inserted'>>({
+      method: 'POST',
+      path: '/api/v1/contexts',
+      body: input,
+      retryable: Boolean(opts?.idempotencyKey),
+      idempotencyKey: opts?.idempotencyKey,
+    });
+    return { ...body, inserted: status === 201 };
+  }
+
+  // -------------------------------------------------------------------------
+  // Templates
+  // -------------------------------------------------------------------------
+
+  createTemplate(
+    input: TemplateCreateInput,
+    opts?: { idempotencyKey?: string },
+  ): Promise<TemplateCreateResponse> {
+    return this.request<TemplateCreateResponse>({
+      method: 'POST',
+      path: '/api/v1/templates',
+      body: input,
+      retryable: Boolean(opts?.idempotencyKey),
+      idempotencyKey: opts?.idempotencyKey,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Machines
+  // -------------------------------------------------------------------------
+
+  listMachines(): Promise<MachinesResponse> {
+    return this.request<MachinesResponse>({
+      method: 'GET',
+      path: '/api/v1/machines',
+      retryable: true,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Sessions
+  // -------------------------------------------------------------------------
+
+  listSessions(query: SessionListQuery = {}): Promise<SessionListResponse> {
+    return this.request<SessionListResponse>({
+      method: 'GET',
+      path: '/api/v1/sessions',
+      query: {
+        limit: query.limit,
+        offset: query.offset,
+        status: query.status,
+        agent_type: query.agent_type,
+        archived: query.archived === undefined ? undefined : String(query.archived),
+      },
+      retryable: true,
+    });
+  }
+
+  getSession(sessionId: string): Promise<{ session: SessionSummary }> {
+    return this.request<{ session: SessionSummary }>({
+      method: 'GET',
+      path: `/api/v1/sessions/${encodeURIComponent(sessionId)}`,
+      retryable: true,
+    });
+  }
+
+  listSessionMessages(sessionId: string, query: { limit?: number; offset?: number } = {}): Promise<unknown> {
+    return this.request<unknown>({
+      method: 'GET',
+      path: `/api/v1/sessions/${encodeURIComponent(sessionId)}/messages`,
+      query: { limit: query.limit, offset: query.offset },
+      retryable: true,
+    });
+  }
+
+  listSessionCheckpoints(sessionId: string): Promise<{ checkpoints: SessionCheckpoint[] }> {
+    return this.request<{ checkpoints: SessionCheckpoint[] }>({
+      method: 'GET',
+      path: `/api/v1/sessions/${encodeURIComponent(sessionId)}/checkpoints`,
+      retryable: true,
+    });
+  }
+
+  createSessionCheckpoint(
+    sessionId: string,
+    input: { name: string; message_index: number; notes?: string },
+    opts?: { idempotencyKey?: string },
+  ): Promise<{ checkpoint: SessionCheckpoint }> {
+    return this.request<{ checkpoint: SessionCheckpoint }>({
+      method: 'POST',
+      path: `/api/v1/sessions/${encodeURIComponent(sessionId)}/checkpoints`,
+      body: input,
+      retryable: Boolean(opts?.idempotencyKey),
+      idempotencyKey: opts?.idempotencyKey,
+    });
+  }
+
+  async deleteSessionCheckpoint(
+    sessionId: string,
+    selector: { name?: string; checkpointId?: string },
+  ): Promise<{ deleted: true }> {
+    if (!selector.name && !selector.checkpointId) {
+      // WHY async-rejected (not sync throw): the method is typed Promise<...>;
+      // callers expect to handle errors via .catch / try/await. A sync throw
+      // would force them to wrap the call site in a separate try, splitting
+      // the error path. Single uniform rejection.
+      throw new Error('deleteSessionCheckpoint requires either name or checkpointId');
+    }
+    return this.request<{ deleted: true }>({
+      method: 'DELETE',
+      path: `/api/v1/sessions/${encodeURIComponent(sessionId)}/checkpoints`,
+      query: { name: selector.name, checkpointId: selector.checkpointId },
+      // WHY retryable=true: DELETE is idempotent — second delete returns the
+      // same outcome (already-gone counts as success at this layer).
+      retryable: true,
+    });
+  }
+
+  deleteSessionGroup(groupId: string): Promise<{ deleted: boolean; id: string }> {
+    return this.request<{ deleted: boolean; id: string }>({
+      method: 'DELETE',
+      path: `/api/v1/sessions/groups/${encodeURIComponent(groupId)}`,
+      retryable: true,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Costs
+  // -------------------------------------------------------------------------
+
+  getCostsSummary(query: { period?: string } = {}): Promise<CostsSummaryResponse> {
+    return this.request<CostsSummaryResponse>({
+      method: 'GET',
+      path: '/api/v1/costs',
+      query: { period: query.period },
+      retryable: true,
+    });
+  }
+
+  getCostsBreakdown(query: { period?: string } = {}): Promise<CostsBreakdownResponse> {
+    return this.request<CostsBreakdownResponse>({
+      method: 'GET',
+      path: '/api/v1/costs/breakdown',
+      query: { period: query.period },
+      retryable: true,
+    });
+  }
+
+  /**
+   * Costs export returns CSV text (not JSON). Caller writes the string to disk
+   * or pipes to stdout. Other endpoints all return JSON via `request`.
+   */
+  async exportCostsCsv(query: { period?: string } = {}): Promise<string> {
+    const url = this.buildUrl('/api/v1/costs/export', { period: query.period });
+    const response = await this.fetchWithTimeout(url, {
+      method: 'GET',
+      headers: this.buildHeaders({ unauthenticated: false, contentType: false }),
+    });
+    if (!response.ok) {
+      const body = await this.safeReadJson(response);
+      throw this.errorFromResponse(response.status, body);
+    }
+    Sentry.addBreadcrumb({
+      category: 'styrby-api',
+      level: 'info',
+      message: 'GET /api/v1/costs/export',
+      data: { status: response.status },
+    });
+    return await response.text();
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private buildUrl(path: string, query?: Record<string, string | number | boolean | undefined>): string {
+    const url = new URL(this.baseUrl + path);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value === undefined || value === null) continue;
+        url.searchParams.set(key, String(value));
+      }
+    }
+    return url.toString();
+  }
+
+  private buildHeaders(opts: { unauthenticated?: boolean; contentType?: boolean; idempotencyKey?: string }): Headers {
+    const headers = new Headers();
+    headers.set('Accept', 'application/json');
+    if (opts.contentType !== false) {
+      headers.set('Content-Type', 'application/json');
+    }
+    if (!opts.unauthenticated) {
+      // WHY throw here (not earlier): auth-bootstrap methods explicitly pass
+      // unauthenticated=true. Any other path that lacks an apiKey is a coding
+      // bug we want surfaced loudly rather than silently 401'd.
+      if (!this.apiKey) {
+        throw new Error('StyrbyApiClient: apiKey is required for this endpoint');
+      }
+      headers.set('Authorization', `Bearer ${this.apiKey}`);
+    }
+    if (opts.idempotencyKey) {
+      headers.set('Idempotency-Key', opts.idempotencyKey);
+    }
+    return headers;
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async safeReadJson(response: Response): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Construct a `StyrbyApiError` from a non-2xx response. Server contract
+   * across v1 routes is a JSON object with `error` (string or code) and
+   * occasionally `message` and `retryAfter`. We accept both shapes.
+   */
+  private errorFromResponse(status: number, body: unknown): StyrbyApiError {
+    let message = `Styrby API request failed with status ${status}`;
+    let code: string | undefined;
+    let retryAfter: number | undefined;
+
+    if (body && typeof body === 'object') {
+      const obj = body as Record<string, unknown>;
+      if (typeof obj.error === 'string') {
+        // Some routes return `{ error: 'CODE_NAME', message: 'human text' }`.
+        // Others return `{ error: 'human text' }`. Treat short ALL_CAPS as code.
+        if (typeof obj.message === 'string') {
+          code = obj.error;
+          message = obj.message;
+        } else if (/^[A-Z_][A-Z0-9_]+$/.test(obj.error)) {
+          code = obj.error;
+          message = obj.error;
+        } else {
+          message = obj.error;
+        }
+      }
+      if (typeof obj.retryAfter === 'number') {
+        retryAfter = obj.retryAfter;
+      }
+    }
+
+    return new StyrbyApiError(status, message, { code, retryAfter, body });
+  }
+
+  /** Whether a status code or transport error should be retried. */
+  private isRetryableStatus(status: number): boolean {
+    return status === 0 || status === 429 || (status >= 500 && status < 600);
+  }
+
+  /** Backoff delay (ms) for the given attempt number (1-based). Honours `Retry-After` when present. */
+  private backoffMs(attempt: number, retryAfter: number | undefined): number {
+    if (retryAfter !== undefined && retryAfter > 0) {
+      // Server's hint is in seconds; cap so a misbehaving server can't pin us indefinitely.
+      return Math.min(retryAfter * 1000, MAX_BACKOFF_MS);
+    }
+    const exp = BASE_BACKOFF_MS * Math.pow(2, attempt - 1);
+    // Add up-to-25% jitter so concurrent clients don't synchronise their retries.
+    const jitter = Math.random() * exp * 0.25;
+    return Math.min(exp + jitter, MAX_BACKOFF_MS);
+  }
+
+  /**
+   * JSON request helper used by every typed method. Returns the parsed body,
+   * discarding the status code. Use `requestRaw` when status matters (e.g. 200 vs 201).
+   */
+  private async request<T>(req: InternalRequest): Promise<T> {
+    const { body } = await this.requestRaw<T>(req);
+    return body;
+  }
+
+  /**
+   * Same as `request` but exposes the HTTP status alongside the body. Used by
+   * `upsertContext` to distinguish first-insert (201) from update (200).
+   */
+  private async requestRaw<T>(req: InternalRequest): Promise<{ status: number; body: T }> {
+    const url = this.buildUrl(req.path, req.query);
+    const init: RequestInit = {
+      method: req.method,
+      headers: this.buildHeaders({
+        unauthenticated: req.unauthenticated,
+        idempotencyKey: req.idempotencyKey,
+      }),
+    };
+    if (req.body !== undefined) {
+      init.body = JSON.stringify(req.body);
+    }
+
+    let lastError: StyrbyApiError | undefined;
+
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
+      let response: Response;
+      try {
+        response = await this.fetchWithTimeout(url, init);
+      } catch (err) {
+        // Network / timeout / abort — treat as status 0.
+        lastError = new StyrbyApiError(0, err instanceof Error ? err.message : 'Network error', { body: err });
+        if (!req.retryable || attempt === this.maxAttempts) {
+          this.breadcrumb(req, 0, attempt, 'transport-error');
+          throw lastError;
+        }
+        await this.sleep(this.backoffMs(attempt, undefined));
+        continue;
+      }
+
+      if (response.ok) {
+        const json = (await this.safeReadJson(response)) as T;
+        this.breadcrumb(req, response.status, attempt, 'ok');
+        return { status: response.status, body: json };
+      }
+
+      const errBody = await this.safeReadJson(response);
+      const apiError = this.errorFromResponse(response.status, errBody);
+      lastError = apiError;
+
+      if (!req.retryable || !this.isRetryableStatus(response.status) || attempt === this.maxAttempts) {
+        this.breadcrumb(req, response.status, attempt, 'error');
+        throw apiError;
+      }
+
+      await this.sleep(this.backoffMs(attempt, apiError.retryAfter));
+    }
+
+    // Unreachable — the loop returns or throws on every path. This satisfies TS.
+    throw lastError ?? new StyrbyApiError(0, 'StyrbyApiClient: exhausted retries with no error');
+  }
+
+  private breadcrumb(req: InternalRequest, status: number, attempt: number, outcome: 'ok' | 'error' | 'transport-error'): void {
+    Sentry.addBreadcrumb({
+      category: 'styrby-api',
+      level: outcome === 'ok' ? 'info' : 'warning',
+      message: `${req.method} ${req.path}`,
+      data: {
+        status,
+        attempt,
+        outcome,
+        // WHY only path (not query/body): values may include user identifiers,
+        // OTPs, or session group IDs. Sentry breadcrumbs are auto-attached to
+        // every error; minimise PII exposure. GDPR Art 5(1)(c) data minimisation.
+      },
+    });
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}


### PR DESCRIPTION
## Summary
- Strategy C Phase 3 — adds a single typed HTTP client (`StyrbyApiClient`) the CLI will use in place of direct Supabase Postgres calls in subsequent phases.
- One method per `/api/v1` endpoint shipped in PR #221, plus the four auth bootstrap routes (oauthStart, oauthCallback, otpSend, otpVerify).
- Single error type (`StyrbyApiError`), retry policy with exponential backoff + jitter applied selectively, Sentry breadcrumbs on every call (PII-safe).
- 24 unit tests via injected `fetchImpl` — no global fetch mocking, deterministic + isolated.

## Why this is purely additive
- No `@supabase/*` imports added or removed in this PR.
- No CLI callsite swaps — the client is exported but not yet consumed.
- Phase 4 (replacing the ~22 Category-A callsites) will land as its own PR series once this is in.

## Retry policy at a glance
| Verb | Retryable? | Why |
|---|---|---|
| GET (all) | ✅ | Idempotent reads |
| DELETE (all) | ✅ | Server-side idempotent (already-gone = success) |
| `otpSend` | ✅ | Send-OTP is idempotent on email |
| `oauthStart` | ✅ | New state token each call |
| `oauthCallback`, `otpVerify` | ❌ | Single-use codes — retry after 5xx would 401 |
| `broadcast` | ❌ | Best-effort per spec; mobile catches up via poll |
| `audit`, `contexts`, `templates`, `checkpoint create` | Conditional | Retry only when caller supplies `Idempotency-Key`; the server replays the cached response so no duplicate write |

## Observability
Every call leaves a Sentry breadcrumb with `{ status, attempt, outcome }`. Query strings, bodies, and headers are intentionally omitted from breadcrumb data — they may include user IDs, OTPs, or session group IDs. GDPR Art 5(1)(c) data minimisation.

## Test plan
- [x] `pnpm test src/api/__tests__/styrbyApiClient.test.ts` — 24/24 pass in 39ms
- [x] `pnpm typecheck` — clean
- [ ] CI green (Lint+Type Check, CLI Unit Tests)
- [ ] Reviewer reads `docs/planning/styrby-cli-strategy-c-plan.md` Phase 3 spec to confirm scope match

## Refs
- `docs/planning/styrby-cli-strategy-c-plan.md` — Phase 3 spec
- PR #221 — the 10 server-side endpoints this client wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)