### PR TITLE
fix(cli/mcp): repair approvalHandler audit_log schema drift (H41 Phase 3.5)

### DIFF
--- a/packages/styrby-cli/src/mcp/__tests__/approvalHandler.test.ts
+++ b/packages/styrby-cli/src/mcp/__tests__/approvalHandler.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression tests for createSupabaseApprovalHandler (Phase 3.5).
+ *
+ * WHY this exists: prior to this PR the handler wrote `event_type`/`severity`/
+ * `machine_id` columns that don't exist on audit_log. The bug was latent —
+ * never caught because the unit-test surface only tested the MCP server, not
+ * the handler itself. These tests pin the column names + enum values.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSupabaseApprovalHandler } from '../approvalHandler.js';
+import type { RequestApprovalInput } from '../tools.js';
+
+// Helper: build a deeply-mocked SupabaseClient stub. Each `from(table)` call
+// returns a fluent chain; `insert` and `select` resolve to the values pushed
+// into the queues on construction.
+function buildStubSupabase(opts: {
+  insertResult?: { error: { message: string } | null };
+  selectRows?: Array<{ data: unknown[] | null; error: { message: string } | null }>;
+}) {
+  const inserts: Array<{ table: string; payload: Record<string, unknown> }> = [];
+  let selectIdx = 0;
+  const selectQueue = opts.selectRows ?? [];
+
+  const stub = {
+    from(table: string) {
+      return {
+        insert(payload: Record<string, unknown>) {
+          inserts.push({ table, payload });
+          return Promise.resolve(opts.insertResult ?? { error: null });
+        },
+        select() {
+          // chainable: .eq().eq().eq().order().limit() → resolves to row set
+          const chain = {
+            eq() {
+              return chain;
+            },
+            order() {
+              return chain;
+            },
+            limit() {
+              const next = selectQueue[selectIdx++] ?? { data: [], error: null };
+              return Promise.resolve(next);
+            },
+          };
+          return chain;
+        },
+      };
+    },
+  } as unknown as Parameters<typeof createSupabaseApprovalHandler>[0];
+
+  return { stub, inserts };
+}
+
+const SAMPLE_INPUT: RequestApprovalInput = {
+  action: 'bash',
+  reason: 'Run npm install',
+  risk: 'medium',
+  context: { command: 'npm install' },
+};
+
+describe('createSupabaseApprovalHandler', () => {
+  it('writes request row with real audit_log columns (no event_type/severity)', async () => {
+    const { stub, inserts } = buildStubSupabase({
+      // Decision row arrives on the first poll cycle.
+      selectRows: [
+        {
+          data: [
+            {
+              metadata: { approval_id: 'placeholder', decision: 'approved', user_message: 'ok' },
+              created_at: '2026-04-30T00:00:00Z',
+            },
+          ],
+          error: null,
+        },
+      ],
+    });
+
+    const handler = createSupabaseApprovalHandler(stub, 'user-1', 'machine-1');
+    // Patch matcher: the test stub returns the same row regardless of resource_id
+    // filtering; that's fine because we're verifying the request-INSERT shape.
+    await handler.request(SAMPLE_INPUT, 5_000).catch(() => undefined);
+
+    expect(inserts.length).toBeGreaterThanOrEqual(1);
+    const requestInsert = inserts[0];
+    expect(requestInsert.table).toBe('audit_log');
+
+    const payload = requestInsert.payload;
+    // Real columns present
+    expect(payload).toHaveProperty('user_id', 'user-1');
+    expect(payload).toHaveProperty('action', 'mcp_approval_requested');
+    expect(payload).toHaveProperty('resource_type', 'mcp_approval');
+    expect(payload).toHaveProperty('resource_id');
+    expect(payload).toHaveProperty('metadata');
+    // Drift columns absent
+    expect(payload).not.toHaveProperty('event_type');
+    expect(payload).not.toHaveProperty('severity');
+    expect(payload).not.toHaveProperty('machine_id');
+    // machine_id moved into metadata
+    expect((payload.metadata as { machine_id: string }).machine_id).toBe('machine-1');
+    // requested_action holds the original input.action (no name collision with column `action`)
+    expect((payload.metadata as { requested_action: string }).requested_action).toBe('bash');
+  });
+
+  it('writes timeout row with mcp_approval_timeout action when no decision arrives', async () => {
+    const { stub, inserts } = buildStubSupabase({
+      // All select cycles return empty — decision never arrives, handler times out.
+      selectRows: Array.from({ length: 100 }, () => ({ data: [], error: null })),
+    });
+
+    const handler = createSupabaseApprovalHandler(stub, 'user-1', 'machine-1');
+
+    // Use a very short timeout so the test doesn't sit waiting. The poll
+    // interval is 1s by default; we accept a 1s wait + a few hundred ms of
+    // jitter in test environment.
+    const result = await handler.request(SAMPLE_INPUT, 50);
+    expect(result.decision).toBe('denied');
+
+    // Two inserts: the request, and the timeout.
+    const timeoutInsert = inserts.find((i) => i.payload.action === 'mcp_approval_timeout');
+    expect(timeoutInsert).toBeDefined();
+    expect(timeoutInsert!.payload).toHaveProperty('resource_id');
+    expect(timeoutInsert!.payload).not.toHaveProperty('event_type');
+    expect((timeoutInsert!.payload.metadata as { machine_id: string }).machine_id).toBe('machine-1');
+  });
+
+  it('returns the decision when a matching row arrives', async () => {
+    const { stub } = buildStubSupabase({
+      selectRows: [
+        {
+          data: [
+            {
+              metadata: {
+                approval_id: 'will-match', // resource_id filter handles correctness in real DB
+                decision: 'approved',
+                user_message: 'go ahead',
+              },
+              created_at: '2026-04-30T00:00:00Z',
+            },
+          ],
+          error: null,
+        },
+      ],
+    });
+
+    const handler = createSupabaseApprovalHandler(stub, 'user-1', 'machine-1');
+    const result = await handler.request(SAMPLE_INPUT, 5_000);
+
+    expect(result.decision).toBe('approved');
+    expect(result.reason).toBe('go ahead');
+  });
+
+  it('throws on insert error rather than swallowing', async () => {
+    const { stub } = buildStubSupabase({
+      insertResult: { error: { message: 'permission denied for table audit_log' } },
+    });
+
+    const handler = createSupabaseApprovalHandler(stub, 'user-1', 'machine-1');
+    await expect(handler.request(SAMPLE_INPUT, 5_000)).rejects.toThrow(
+      /permission denied for table audit_log/,
+    );
+  });
+});

--- a/packages/styrby-cli/src/mcp/approvalHandler.ts
+++ b/packages/styrby-cli/src/mcp/approvalHandler.ts
@@ -50,12 +50,20 @@ import type { RequestApprovalInput, RequestApprovalOutput } from './tools.js';
 const POLL_INTERVAL_MS = 1000;
 
 /**
- * Audit-log event names.
- * Stable identifiers used for both writes and reads — changing these
- * breaks the poll loop's lookup, so they live as named constants.
+ * Audit-log action values.
+ *
+ * Stable identifiers used for both writes and reads — changing these breaks
+ * the poll loop's lookup, so they live as named constants.
+ *
+ * WHY enum-friendly snake_case (not dotted): `audit_log.action` is typed
+ * `audit_action` (a Postgres ENUM); enum values cannot contain dots. The
+ * three values below are added by migration 069. Prior versions of this file
+ * wrote `'mcp.approval_requested'` to a non-existent `event_type` column —
+ * see migration 069's preamble for the full backstory.
  */
-const AUDIT_EVENT_REQUESTED = 'mcp.approval_requested';
-const AUDIT_EVENT_DECIDED = 'mcp.approval_decided';
+const AUDIT_ACTION_REQUESTED = 'mcp_approval_requested';
+const AUDIT_ACTION_DECIDED = 'mcp_approval_decided';
+const AUDIT_ACTION_TIMEOUT = 'mcp_approval_timeout';
 
 // ============================================================================
 // Approval row shape
@@ -64,12 +72,31 @@ const AUDIT_EVENT_DECIDED = 'mcp.approval_decided';
 /**
  * Metadata persisted in the audit_log.metadata JSONB column.
  * Keep keys snake_case to match the existing column convention.
+ *
+ * WHY `requested_action` (not `action`): the audit_log row's top-level `action`
+ * column is the lifecycle event (`mcp_approval_requested`/`_decided`/`_timeout`).
+ * The MCP tool's action being approved (e.g. `bash`, `edit`) lives inside
+ * metadata to avoid name collision. Without renaming, the JSONB shape would
+ * shadow the column and confuse readers.
+ *
+ * WHY `machine_id` lives here (not as a column): audit_log has no machine_id
+ * column. Storing it inside metadata preserves the per-machine attribution
+ * for forensics without requiring a schema change.
+ *
+ * WHY `risk` retained as metadata field: the original code passed
+ * `severity` as a top-level column (which doesn't exist). Risk level is more
+ * semantically meaningful here than a fixed `info`/`warning` severity, and
+ * it's exposed to downstream consumers (push trigger, mobile UI) via the
+ * JSONB blob.
  */
 interface ApprovalMetadata {
   approval_id: string;
-  action: string;
+  /** The MCP tool action being approved (e.g. `bash`, `edit`). NOT the audit action. */
+  requested_action: string;
   reason: string;
   risk: string;
+  /** CLI machine that requested approval. Was previously a non-existent top-level column. */
+  machine_id: string;
   context?: Record<string, unknown>;
 }
 
@@ -112,21 +139,22 @@ export function createSupabaseApprovalHandler(
 
       // 1. Insert the request audit row. The push trigger configured in
       //    migration 017 fires on inserts to audit_log with the
-      //    'mcp.approval_requested' event_type and delivers a push to the
+      //    'mcp_approval_requested' action and delivers a push to the
       //    user's device tokens.
       const requestMetadata: ApprovalMetadata = {
         approval_id: approvalId,
-        action: input.action,
+        requested_action: input.action,
         reason: input.reason,
         risk: input.risk,
+        machine_id: machineId,
         context: input.context,
       };
 
       const { error: insertError } = await supabase.from('audit_log').insert({
         user_id: userId,
-        machine_id: machineId,
-        event_type: AUDIT_EVENT_REQUESTED,
-        severity: input.risk === 'high' ? 'warning' : 'info',
+        action: AUDIT_ACTION_REQUESTED,
+        resource_type: 'mcp_approval',
+        resource_id: approvalId,
         metadata: requestMetadata,
       });
 
@@ -138,25 +166,27 @@ export function createSupabaseApprovalHandler(
       // WHY poll instead of realtime: see module comment. Phase 4 swaps
       // this for a `supabase.channel(...).on('postgres_changes', ...)`
       // subscription on the dedicated mcp_approvals table.
+      // WHY filter by both action and resource_id: action='mcp_approval_decided'
+      // catches every decision; resource_id pins the specific approval. The
+      // pre-PR code matched on metadata.approval_id post-fetch, which scaled
+      // poorly and was racy on concurrent approvals. Filtering server-side
+      // by resource_id returns at most one row per cycle and is index-friendly.
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
         const { data, error } = await supabase
           .from('audit_log')
           .select('metadata, created_at')
           .eq('user_id', userId)
-          .eq('event_type', AUDIT_EVENT_DECIDED)
+          .eq('action', AUDIT_ACTION_DECIDED)
+          .eq('resource_id', approvalId)
           .order('created_at', { ascending: false })
-          .limit(50);
+          .limit(1);
 
         if (error) {
           throw new Error(`Failed to poll for decision: ${error.message}`);
         }
 
-        const matched = (data ?? []).find((row) => {
-          const meta = row.metadata as DecisionMetadata | null;
-          return meta?.approval_id === approvalId;
-        });
-
+        const matched = data?.[0];
         if (matched) {
           const meta = matched.metadata as DecisionMetadata;
           return {
@@ -169,8 +199,10 @@ export function createSupabaseApprovalHandler(
         await sleep(POLL_INTERVAL_MS);
       }
 
-      // 3. Timeout — record the timeout as a denial in the audit log so
-      //    the trail is complete, then return denied to the agent.
+      // 3. Timeout — record the timeout in audit_log with the dedicated
+      //    'mcp_approval_timeout' action so forensics can distinguish a
+      //    user-issued denial from a no-response timeout. Return denied to
+      //    the agent regardless (fail-closed).
       const timeoutAt = new Date().toISOString();
       const timeoutMetadata: DecisionMetadata = {
         approval_id: approvalId,
@@ -179,10 +211,10 @@ export function createSupabaseApprovalHandler(
       };
       await supabase.from('audit_log').insert({
         user_id: userId,
-        machine_id: machineId,
-        event_type: AUDIT_EVENT_DECIDED,
-        severity: 'info',
-        metadata: timeoutMetadata,
+        action: AUDIT_ACTION_TIMEOUT,
+        resource_type: 'mcp_approval',
+        resource_id: approvalId,
+        metadata: { ...timeoutMetadata, machine_id: machineId },
       });
 
       return {

--- a/supabase/migrations/069_mcp_approval_audit_actions.sql
+++ b/supabase/migrations/069_mcp_approval_audit_actions.sql
@@ -1,0 +1,33 @@
+-- Migration 069: MCP approval lifecycle audit_action enum values
+--
+-- WHY: packages/styrby-cli/src/mcp/approvalHandler.ts records the lifecycle of
+-- MCP tool-call approvals (the wedge that records request → decision → timeout
+-- in audit_log instead of a dedicated mcp_approvals table). The current code
+-- writes columns `event_type` / `severity` / `machine_id` which DO NOT EXIST on
+-- audit_log (initial schema 001 defines: user_id, action, resource_type,
+-- resource_id, metadata, created_at). Every call has been silently failing
+-- with "column does not exist" since the wedge shipped — a latent bug that
+-- only surfaces when MCP approval flow is exercised against the real DB.
+--
+-- This migration adds the three enum values so the CLI can write the correct
+-- `action` column with semantically-distinct identifiers. Naming follows the
+-- snake_case enum convention already established by team_command_approved /
+-- team_command_denied / team_command_timeout (migration 032), with `mcp_`
+-- prefix so it's easy to grep for MCP-specific approvals separately from
+-- team-tier command approvals.
+--
+-- WHY no data migration: no rows exist with these values today (the broken
+-- INSERTs never landed any rows). Adding enum values is forward-only.
+--
+-- WHY no rollback: ENUM values cannot be removed in PostgreSQL without
+-- recreating the type and rewriting every dependent column — a heavyweight
+-- operation. The CLI swap to use these values lands in the same PR; if the
+-- migration applies but the CLI rolls back, no harm (the values are simply
+-- unused).
+--
+-- @security SOC 2 CC7.2 (System Monitoring) — restores audit-log integrity
+--   for MCP approval lifecycle events.
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'mcp_approval_requested';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'mcp_approval_decided';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'mcp_approval_timeout';


### PR DESCRIPTION
## What this fixes

A pre-existing latent bug discovered while scoping H41 Phase 4: `packages/styrby-cli/src/mcp/approvalHandler.ts` has been writing `audit_log` rows with three columns that **don't exist** on the table — \`event_type\`, \`severity\`, \`machine_id\`. Every \`createSupabaseApprovalHandler#request()\` call has been silently failing with "column does not exist" since the MCP wedge shipped.

The bug stayed hidden because the unit-test surface only covered the MCP server's tool registration, not the handler implementation.

## Changes

| File | Change |
|---|---|
| \`supabase/migrations/069_mcp_approval_audit_actions.sql\` (new) | ADD VALUE to \`audit_action\` enum: \`mcp_approval_requested\`, \`mcp_approval_decided\`, \`mcp_approval_timeout\` |
| \`packages/styrby-cli/src/mcp/approvalHandler.ts\` | Replace non-column writes with real columns: \`action\`, \`resource_type='mcp_approval'\`, \`resource_id=approvalId\`, \`metadata\` (machine_id moved here). Server-side filtering by \`resource_id\` replaces the racy fetch-50-and-find-in-memory pattern. Timeout uses dedicated \`mcp_approval_timeout\` action. |
| \`packages/styrby-cli/src/mcp/__tests__/approvalHandler.test.ts\` (new) | 4 regression tests pinning column shape — verifies real columns present, drift columns absent, correct values for request and timeout paths, error propagation on insert failure |

## Why before Phase 4

H41 Phase 4 swaps these inserts to \`apiClient.writeAuditEvent()\`. That endpoint expects \`{action, resource_type, resource_id, metadata}\`. Swapping a file that's been writing the wrong columns to a typed client that enforces the right columns would just relocate the bug. Fix the schema first, swap second.

## Migration safety

- **Forward-only**: PostgreSQL doesn't allow removing enum values without recreating the type. Additive change, no data migration.
- **Rollback-safe**: if the CLI rolls back without the migration, the new constants are simply unused — no broken state.
- **No existing rows affected**: the broken INSERTs never landed any data, so there's nothing to migrate.

## Test plan
- [x] \`pnpm exec vitest run src/mcp/\` — 13/13 pass (4 new + 9 existing)
- [x] \`pnpm typecheck\` — clean
- [ ] CI green
- [ ] Migration applies cleanly to scratch DB (Postgres Migrations workflow)
- [ ] Reviewer confirms the metadata.requested_action rename doesn't break any downstream consumer (mobile push trigger, MCP tool callers)

## Refs
- \`styrby-backlog.md\` — H41 phase ladder + full inventory of /api/v1 endpoints needed for Phase 4
- \`docs/planning/styrby-cli-strategy-c-plan.md\` — Phase 4 prereq context

🤖 Generated with [Claude Code](https://claude.com/claude-code)