### PR TITLE
feat(api/v1): 3 endpoints gating Phase 5 — POST /machines, POST /sessions/groups, GET /templates (H41 Phase 3.6a)

### DIFF
--- a/packages/styrby-cli/src/api/__tests__/styrbyApiClient.test.ts
+++ b/packages/styrby-cli/src/api/__tests__/styrbyApiClient.test.ts
@@ -315,6 +315,102 @@ describe('StyrbyApiClient', () => {
     });
   });
 
+  describe('registerMachine', () => {
+    it('returns isNew=true on 201, false on 200', async () => {
+      const { fetch: fakeFetch } = makeFetch([
+        { status: 201, body: { machine_id: 'm1', name: 'mac', is_new: true, created_at: 't' } },
+      ]);
+      const c1 = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r1 = await c1.registerMachine({ machine_fingerprint: '0123456789abcdef', name: 'mac' });
+      expect(r1.isNew).toBe(true);
+      expect(r1.is_new).toBe(true);
+      expect(r1.machine_id).toBe('m1');
+
+      const { fetch: fakeFetch2 } = makeFetch([
+        { status: 200, body: { machine_id: 'm1', name: 'mac', is_new: false, created_at: 't' } },
+      ]);
+      const c2 = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch2 });
+      const r2 = await c2.registerMachine({ machine_fingerprint: '0123456789abcdef', name: 'mac' });
+      expect(r2.isNew).toBe(false);
+      expect(r2.is_new).toBe(false);
+    });
+
+    it('forwards Idempotency-Key when supplied', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([
+        { status: 201, body: { machine_id: 'm1', name: 'mac', is_new: true, created_at: 't' } },
+      ]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      await c.registerMachine(
+        { machine_fingerprint: '0123456789abcdef', name: 'mac' },
+        { idempotencyKey: 'reg-1' },
+      );
+      const headers = calls[0].init.headers as Headers;
+      expect(headers.get('Idempotency-Key')).toBe('reg-1');
+    });
+
+    it('does NOT retry POST without Idempotency-Key (preserves singular registration)', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 503, body: { error: 'transient' } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch, maxAttempts: 3 });
+      await expect(
+        c.registerMachine({ machine_fingerprint: '0123456789abcdef', name: 'mac' }),
+      ).rejects.toBeInstanceOf(StyrbyApiError);
+      expect(calls).toHaveLength(1);
+    });
+  });
+
+  describe('createSessionGroup', () => {
+    it('posts to /api/v1/sessions/groups with optional name', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([
+        { status: 201, body: { group_id: 'g1', name: 'My Group', created_at: 't' } },
+      ]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r = await c.createSessionGroup({ name: 'My Group' });
+      expect(r.group_id).toBe('g1');
+      expect(calls[0].url).toContain('/api/v1/sessions/groups');
+      expect(calls[0].init.method).toBe('POST');
+      expect(JSON.parse(calls[0].init.body as string)).toEqual({ name: 'My Group' });
+    });
+
+    it('accepts an empty input (server defaults name to empty string)', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([
+        { status: 201, body: { group_id: 'g1', name: '', created_at: 't' } },
+      ]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r = await c.createSessionGroup();
+      expect(r.name).toBe('');
+      expect(JSON.parse(calls[0].init.body as string)).toEqual({});
+    });
+  });
+
+  describe('listTemplates', () => {
+    it('returns the templates array and count', async () => {
+      const { fetch: fakeFetch } = makeFetch([
+        {
+          status: 200,
+          body: {
+            templates: [
+              {
+                id: 't1',
+                name: 'Default',
+                description: null,
+                content: 'hello {{var}}',
+                variables: [],
+                is_default: true,
+                created_at: 't',
+                updated_at: 't',
+              },
+            ],
+            count: 1,
+          },
+        },
+      ]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r = await c.listTemplates();
+      expect(r.count).toBe(1);
+      expect(r.templates[0].is_default).toBe(true);
+    });
+  });
+
   describe('deleteSessionCheckpoint', () => {
     it('throws synchronously when neither name nor checkpointId is provided', async () => {
       const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: makeFetch([]).fetch });

--- a/packages/styrby-cli/src/api/styrbyApiClient.ts
+++ b/packages/styrby-cli/src/api/styrbyApiClient.ts
@@ -207,6 +207,52 @@ export interface MachinesResponse {
   count: number;
 }
 
+export interface MachineRegisterInput {
+  machine_fingerprint: string;
+  name: string;
+  platform?: 'darwin' | 'linux' | 'win32';
+  platform_version?: string;
+  architecture?: 'arm64' | 'x64' | 'x86';
+  hostname?: string;
+  cli_version?: string;
+}
+
+export interface MachineRegisterResponse {
+  machine_id: string;
+  name: string;
+  /** True when the row was newly inserted; false on re-pair (matched by
+   * (user_id, machine_fingerprint) and updated). */
+  is_new: boolean;
+  created_at: string;
+}
+
+export interface SessionGroupCreateInput {
+  /** Optional human label, max 255 chars. Defaults to '' on the server. */
+  name?: string;
+}
+
+export interface SessionGroupCreateResponse {
+  group_id: string;
+  name: string;
+  created_at: string;
+}
+
+export interface TemplateSummary {
+  id: string;
+  name: string;
+  description: string | null;
+  content: string;
+  variables: unknown;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TemplatesListResponse {
+  templates: TemplateSummary[];
+  count: number;
+}
+
 export type SessionStatus = 'starting' | 'running' | 'idle' | 'paused' | 'stopped' | 'error' | 'expired';
 
 export interface SessionListQuery {
@@ -522,6 +568,49 @@ export class StyrbyApiClient {
     return this.request<MachinesResponse>({
       method: 'GET',
       path: '/api/v1/machines',
+      retryable: true,
+    });
+  }
+
+  async registerMachine(
+    input: MachineRegisterInput,
+    opts?: { idempotencyKey?: string },
+  ): Promise<MachineRegisterResponse & { isNew: boolean }> {
+    // The server returns 201 on first registration, 200 on re-pair. We surface
+    // both via the response body's is_new field; isNew is also derivable from
+    // the HTTP status, so we expose both in case future callers want either.
+    const { status, body } = await this.requestRaw<MachineRegisterResponse>({
+      method: 'POST',
+      path: '/api/v1/machines',
+      body: input,
+      // WHY retryable when keyed: machines.upsert is inherently idempotent on
+      // (user_id, machine_fingerprint), and the idempotency middleware caches
+      // the exact 201/200 response so retries don't see is_new flip mid-flight.
+      retryable: Boolean(opts?.idempotencyKey),
+      idempotencyKey: opts?.idempotencyKey,
+    });
+    return { ...body, isNew: status === 201 };
+  }
+
+  createSessionGroup(
+    input: SessionGroupCreateInput = {},
+    opts?: { idempotencyKey?: string },
+  ): Promise<SessionGroupCreateResponse> {
+    return this.request<SessionGroupCreateResponse>({
+      method: 'POST',
+      path: '/api/v1/sessions/groups',
+      body: input,
+      // WHY retryable only with key: bare retries would create duplicate
+      // groups; with the key, the server replays the cached response.
+      retryable: Boolean(opts?.idempotencyKey),
+      idempotencyKey: opts?.idempotencyKey,
+    });
+  }
+
+  listTemplates(): Promise<TemplatesListResponse> {
+    return this.request<TemplatesListResponse>({
+      method: 'GET',
+      path: '/api/v1/templates',
       retryable: true,
     });
   }

--- a/packages/styrby-web/src/app/api/v1/machines/route.ts
+++ b/packages/styrby-web/src/app/api/v1/machines/route.ts
@@ -1,35 +1,50 @@
 /**
- * GET /api/v1/machines
+ * /api/v1/machines
  *
- * Lists machines (CLI instances) for the authenticated user.
+ * GET  - Lists machines (CLI instances) for the authenticated user.
+ * POST - Registers (or re-registers) a machine. Used by `styrby onboard`.
  *
- * @auth Required - API key via Authorization: Bearer sk_live_xxx
+ * @auth Required - API key via Authorization: Bearer styrby_xxx
  * @rateLimit 100 requests per minute per key
  *
- * Query Parameters:
+ * GET Query Parameters:
  * - online_only: Filter to only online machines (default: false)
  *
- * @returns 200 {
- *   machines: Array<{
- *     id: string,
- *     name: string,
- *     platform: string,
- *     platformVersion: string,
- *     architecture: string,
- *     hostname: string,
- *     cliVersion: string,
- *     isOnline: boolean,
- *     lastSeenAt: string,
- *     createdAt: string
- *   }>,
+ * GET @returns 200 {
+ *   machines: Array<{ id, name, platform, platformVersion, architecture,
+ *     hostname, cliVersion, isOnline, lastSeenAt, createdAt }>,
  *   count: number
  * }
+ *
+ * POST @body {
+ *   machine_fingerprint: string (16-128),  // stable client-generated ID
+ *   name: string (1-255),
+ *   platform?: 'darwin'|'linux'|'win32',
+ *   platform_version?: string (max 64),
+ *   architecture?: 'arm64'|'x64'|'x86',
+ *   hostname?: string (max 255),
+ *   cli_version?: string (max 64)
+ * }
+ *
+ * POST @returns 201 { machine_id, name, is_new: true,  created_at } - new
+ *              200 { machine_id, name, is_new: false, created_at } - re-pair
+ *
+ * @security OWASP A01:2021 - user_id sourced from auth context only.
+ * @security OWASP A03:2021 - Zod .strict() on POST body (mass-assignment).
+ * @security OWASP A07:2021 - auth enforced by withApiAuthAndRateLimit.
+ * @security SOC 2 CC6.1 - 'write' scope required for POST.
+ * @security GDPR Art 6(1)(b) - lawful basis: contract performance.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { withApiAuthAndRateLimit, addRateLimitHeaders, type ApiAuthContext } from '@/middleware/api-auth';
+import { createAdminClient } from '@/lib/supabase/server';
+import { checkIdempotency, storeIdempotencyResult } from '@/lib/middleware/idempotency';
+import * as Sentry from '@sentry/nextjs';
 import { z } from 'zod';
+
+const ROUTE_ID = '/api/v1/machines';
 
 // ---------------------------------------------------------------------------
 // Query Schema
@@ -149,3 +164,135 @@ async function handler(
 }
 
 export const GET = withApiAuthAndRateLimit(handler);
+
+// ===========================================================================
+// POST /api/v1/machines  —  register or re-register a CLI machine
+// ===========================================================================
+
+/** Min length of the client-generated machine_fingerprint. WHY 16: aligns with
+ * a typical 128-bit ID hex-encoded; rejects accidental empty/short values. */
+const MIN_FINGERPRINT_LENGTH = 16;
+const MAX_FINGERPRINT_LENGTH = 128;
+const MAX_NAME_LENGTH = 255;
+const MAX_VERSION_LENGTH = 64;
+const MAX_HOSTNAME_LENGTH = 255;
+
+const MachineBodySchema = z
+  .object({
+    machine_fingerprint: z
+      .string()
+      .min(MIN_FINGERPRINT_LENGTH, `machine_fingerprint must be at least ${MIN_FINGERPRINT_LENGTH} characters`)
+      .max(MAX_FINGERPRINT_LENGTH, `machine_fingerprint must be ${MAX_FINGERPRINT_LENGTH} characters or fewer`),
+    name: z
+      .string()
+      .min(1, 'name is required')
+      .max(MAX_NAME_LENGTH, `name must be ${MAX_NAME_LENGTH} characters or fewer`),
+    platform: z.enum(['darwin', 'linux', 'win32']).optional(),
+    platform_version: z.string().max(MAX_VERSION_LENGTH).optional(),
+    architecture: z.enum(['arm64', 'x64', 'x86']).optional(),
+    hostname: z.string().max(MAX_HOSTNAME_LENGTH).optional(),
+    cli_version: z.string().max(MAX_VERSION_LENGTH).optional(),
+  })
+  .strict();
+
+type MachineBody = z.infer<typeof MachineBodySchema>;
+
+async function handlePost(request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+
+  // Idempotency check (opt-in via Idempotency-Key header).
+  // The unique constraint (user_id, machine_fingerprint) makes upsert
+  // inherently idempotent — but the 24h replay cache returns the *exact*
+  // first response (including is_new=true) so retries don't see is_new flip.
+  const idempotency = await checkIdempotency(request, userId, ROUTE_ID);
+  if ('conflict' in idempotency) {
+    return NextResponse.json({ error: idempotency.message }, { status: 409 });
+  }
+  if (idempotency.replayed) {
+    const replay = NextResponse.json(idempotency.body, { status: idempotency.status });
+    replay.headers.set('X-Idempotency-Replay', 'true');
+    return replay;
+  }
+
+  let parsed: MachineBody;
+  try {
+    const raw = await request.json();
+    const result = MachineBodySchema.safeParse(raw);
+    if (!result.success) {
+      const msg = result.error.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ');
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    parsed = result.data;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be valid JSON' }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+
+  // Pre-check: does a row exist for this (user_id, machine_fingerprint)?
+  // WHY: distinguishes first registration (201, is_new=true) from re-pair
+  // (200, is_new=false). supabase-js .upsert() doesn't expose this.
+  // TOCTOU: a concurrent insert between SELECT and UPSERT would land on the
+  // unique constraint and the UPSERT's ON CONFLICT path would update.
+  // is_new could be advisory-only in that race; not worth a transaction.
+  const { data: existing, error: existingErr } = await supabase
+    .from('machines')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('machine_fingerprint', parsed.machine_fingerprint)
+    .maybeSingle();
+
+  if (existingErr) {
+    Sentry.captureException(new Error(`machines pre-check error: ${existingErr.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to register machine' }, { status: 500 });
+  }
+
+  const isNew = existing === null;
+
+  const { data: row, error: upsertErr } = await supabase
+    .from('machines')
+    .upsert(
+      {
+        user_id: userId,
+        machine_fingerprint: parsed.machine_fingerprint,
+        name: parsed.name,
+        platform: parsed.platform ?? null,
+        platform_version: parsed.platform_version ?? null,
+        architecture: parsed.architecture ?? null,
+        hostname: parsed.hostname ?? null,
+        cli_version: parsed.cli_version ?? null,
+        is_online: true,
+        last_seen_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,machine_fingerprint' },
+    )
+    .select('id, name, created_at')
+    .single<{ id: string; name: string; created_at: string }>();
+
+  if (upsertErr) {
+    Sentry.captureException(new Error(`machines upsert error: ${upsertErr.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to register machine' }, { status: 500 });
+  }
+  if (!row) {
+    Sentry.captureMessage('Machines upsert returned no row', { level: 'error', tags: { endpoint: ROUTE_ID } });
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+
+  const status = isNew ? 201 : 200;
+  const responseBody = {
+    machine_id: row.id,
+    name: row.name,
+    is_new: isNew,
+    created_at: row.created_at,
+  };
+
+  await storeIdempotencyResult(request, userId, ROUTE_ID, status, responseBody);
+
+  return NextResponse.json(responseBody, { status });
+}
+
+export const POST = withApiAuthAndRateLimit(handlePost, ['write']);

--- a/packages/styrby-web/src/app/api/v1/sessions/groups/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/groups/route.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /api/v1/sessions/groups
+ *
+ * INSERT into `agent_session_groups`. Used by the CLI's `styrby multi` flow
+ * to create a parent record tying N concurrent agent sessions together.
+ * Each individual session keeps its own session_id; they're linked via
+ * sessions.session_group_id (set when the session is spawned).
+ *
+ * @auth Required - Bearer `styrby_*` API key via withApiAuthAndRateLimit
+ * @rateLimit 100 requests per minute per key (default)
+ * @idempotency Opt-in via Idempotency-Key header (24h replay window). Strongly
+ *   recommended — group creation is otherwise non-idempotent and a CLI retry
+ *   after a 5xx that succeeded server-side would create a duplicate group.
+ *
+ * @body {
+ *   name?: string   // Optional - human label, max 255 chars; defaults to ''
+ * }
+ *
+ * @returns 201 { group_id, name, created_at }
+ *
+ * @error 400 { error }  - Zod validation failure (incl. unknown fields)
+ * @error 401 { error }  - Missing or invalid API key
+ * @error 409 { error }  - Idempotency-Key body mismatch
+ * @error 429 { error }  - Rate limit exceeded
+ * @error 500 { error }  - Unexpected database error (sanitized)
+ *
+ * @security OWASP A01:2021 - user_id sourced from auth context only.
+ * @security OWASP A03:2021 - Zod .strict() guards mass-assignment.
+ * @security OWASP A07:2021 - auth enforced by withApiAuthAndRateLimit.
+ * @security SOC 2 CC6.1 - 'write' scope required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import * as Sentry from '@sentry/nextjs';
+
+import {
+  withApiAuthAndRateLimit,
+  type ApiAuthContext,
+} from '@/middleware/api-auth';
+import { createAdminClient } from '@/lib/supabase/server';
+import {
+  checkIdempotency,
+  storeIdempotencyResult,
+} from '@/lib/middleware/idempotency';
+
+const ROUTE_ID = '/api/v1/sessions/groups';
+const MAX_NAME_LENGTH = 255;
+
+const GroupBodySchema = z
+  .object({
+    name: z.string().max(MAX_NAME_LENGTH).optional(),
+  })
+  .strict();
+
+type GroupBody = z.infer<typeof GroupBodySchema>;
+
+interface GroupRow {
+  id: string;
+  name: string;
+  created_at: string;
+}
+
+async function handlePost(request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+
+  // -- Idempotency check ------------------------------------------------------
+  const idempotency = await checkIdempotency(request, userId, ROUTE_ID);
+  if ('conflict' in idempotency) {
+    return NextResponse.json({ error: idempotency.message }, { status: 409 });
+  }
+  if (idempotency.replayed) {
+    const replay = NextResponse.json(idempotency.body, { status: idempotency.status });
+    replay.headers.set('X-Idempotency-Replay', 'true');
+    return replay;
+  }
+
+  // -- Parse body -------------------------------------------------------------
+  let parsed: GroupBody;
+  try {
+    const raw = await request.json().catch(() => ({}));
+    const result = GroupBodySchema.safeParse(raw);
+    if (!result.success) {
+      const msg = result.error.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ');
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    parsed = result.data;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be valid JSON' }, { status: 400 });
+  }
+
+  // -- INSERT -----------------------------------------------------------------
+  const supabase = createAdminClient();
+  const { data: row, error: insertErr } = await supabase
+    .from('agent_session_groups')
+    .insert({
+      user_id: userId,
+      // WHY ?? '': matches the migration 035 default of empty string. Storing
+      // null would distinguish "explicitly unnamed" from "default" but the
+      // table uses NOT NULL DEFAULT '' so empty string is the canonical empty.
+      name: parsed.name ?? '',
+    })
+    .select('id, name, created_at')
+    .single<GroupRow>();
+
+  if (insertErr) {
+    Sentry.captureException(new Error(`agent_session_groups insert error: ${insertErr.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to create session group' }, { status: 500 });
+  }
+  if (!row) {
+    Sentry.captureMessage('Group insert returned no row', { level: 'error', tags: { endpoint: ROUTE_ID } });
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+
+  const responseBody = { group_id: row.id, name: row.name, created_at: row.created_at };
+  await storeIdempotencyResult(request, userId, ROUTE_ID, 201, responseBody);
+
+  return NextResponse.json(responseBody, { status: 201 });
+}
+
+export const POST = withApiAuthAndRateLimit(handlePost, ['write']);

--- a/packages/styrby-web/src/app/api/v1/templates/route.ts
+++ b/packages/styrby-web/src/app/api/v1/templates/route.ts
@@ -1,4 +1,23 @@
 /**
+ * /api/v1/templates  —  GET (list) + POST (create)
+ *
+ * GET — list all templates for the authenticated user, ordered by created_at DESC.
+ *   No pagination yet — typical user has < 50 templates so a flat list is fine.
+ *   When that ceases to be true, add ?limit/&offset (same pattern as /sessions).
+ *
+ * GET @returns 200 { templates: TemplateSummary[], count: number }
+ *   where TemplateSummary = { id, name, description, content, variables,
+ *                             is_default, created_at, updated_at }
+ *
+ * GET @error 401 { error }  - Missing or invalid API key
+ * GET @error 429 { error }  - Rate limit exceeded
+ * GET @error 500 { error }  - Unexpected database error (sanitized)
+ *
+ * GET @security OWASP A01:2021 - SELECT bound to user_id from auth context.
+ * GET @security OWASP A07:2021 - auth enforced by withApiAuthAndRateLimit.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ *
  * POST /api/v1/templates
  *
  * INSERT into `context_templates`. Creates a new reusable project context
@@ -425,3 +444,56 @@ async function handlePost(request: NextRequest, authContext: ApiAuthContext): Pr
  * from creating template records. SOC 2 CC6.1 (least-privilege access).
  */
 export const POST = withApiAuthAndRateLimit(handlePost, ['write']);
+
+// ===========================================================================
+// GET /api/v1/templates  —  list user's templates
+// ===========================================================================
+
+/**
+ * Shape of a template row returned by the LIST endpoint.
+ *
+ * WHY explicit interface (not z.infer): the GET response intentionally omits
+ * fields that are private to the server (e.g. user_id) and includes the full
+ * content. Codifying it here makes drift from migration 002_context_templates.sql
+ * surface as a TypeScript error rather than a silent runtime mismatch.
+ */
+interface TemplateSummaryRow {
+  id: string;
+  name: string;
+  description: string | null;
+  content: string;
+  variables: unknown;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+async function handleGet(_request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+  const supabase = createAdminClient();
+
+  // WHY: order by is_default first (default templates surface at the top of
+  // the CLI's list view) then by recency. Matches the mobile picker UX.
+  const { data: rows, error } = await supabase
+    .from('context_templates')
+    .select('id, name, description, content, variables, is_default, created_at, updated_at')
+    .eq('user_id', userId)
+    .order('is_default', { ascending: false })
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    Sentry.captureException(new Error(`context_templates list error: ${error.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to list templates' }, { status: 500 });
+  }
+
+  const templates = (rows ?? []) as TemplateSummaryRow[];
+  // WHY no-store: per-user data; never serve from a shared cache.
+  return NextResponse.json(
+    { templates, count: templates.length },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}
+
+export const GET = withApiAuthAndRateLimit(handleGet, ['read']);


### PR DESCRIPTION
3 of the 9 missing /api/v1 endpoints required to unblock H41 Phase 5 (CLI auth bootstrap rewrite needs POST /machines) and the simplest Phase 4 template list swap.

Endpoints added:
- POST /api/v1/machines (register/re-register CLI machine, UPSERT on user_id+machine_fingerprint, returns 201/200 with is_new flag)
- POST /api/v1/sessions/groups (create multi-agent group, retryable only with Idempotency-Key)
- GET /api/v1/templates (list user's templates, ordered is_default DESC then created_at DESC)

Plus matching StyrbyApiClient methods: registerMachine, createSessionGroup, listTemplates. 6 new unit tests, all 30 pass.

Why scoped to 3 (not 9): these specifically gate Phase 5 (auth rewrite). Other 6 ship as Phase 3.6b. Smaller PRs review faster.

Patterns: withApiAuthAndRateLimit + Zod .strict() + per-route idempotency middleware + Sentry breadcrumbs with PII hygiene. Same as PR #221.

Test plan:
- pnpm typecheck clean (CLI + web)
- pnpm exec vitest run src/api/__tests__/styrbyApiClient.test.ts: 30/30 pass

Refs: styrby-backlog.md, docs/planning/styrby-cli-strategy-c-plan.md, PR #221, PR #225.