### PR TITLE
feat(api/v1): 6 remaining endpoints for CLI Phase 4 swaps (H41 Phase 3.6b)

### DIFF
--- a/packages/styrby-cli/src/api/__tests__/styrbyApiClient.test.ts
+++ b/packages/styrby-cli/src/api/__tests__/styrbyApiClient.test.ts
@@ -411,6 +411,106 @@ describe('StyrbyApiClient', () => {
     });
   });
 
+  describe('getTemplate / updateTemplate / deleteTemplate', () => {
+    it('GET /api/v1/templates/[id] returns the row', async () => {
+      const row = {
+        id: 't1', name: 'n', description: null, content: 'c',
+        variables: [], is_default: false, created_at: 'ts', updated_at: 'ts',
+      };
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { template: row } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r = await c.getTemplate('t1');
+      expect(r.template.id).toBe('t1');
+      expect(calls[0].url).toContain('/api/v1/templates/t1');
+      expect(calls[0].init.method).toBe('GET');
+    });
+
+    it('PATCH sends only the supplied fields and forwards Idempotency-Key', async () => {
+      const updated = { id: 't1', name: 'new', description: null, content: 'c', variables: [], is_default: false, created_at: 'ts', updated_at: 'ts2' };
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { template: updated } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r = await c.updateTemplate('t1', { name: 'new' }, { idempotencyKey: 'patch-1' });
+      expect(r.template.name).toBe('new');
+      expect(calls[0].init.method).toBe('PATCH');
+      expect(JSON.parse(calls[0].init.body as string)).toEqual({ name: 'new' });
+      expect((calls[0].init.headers as Headers).get('Idempotency-Key')).toBe('patch-1');
+    });
+
+    it('DELETE returns deleted+id', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { deleted: true, id: 't1' } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r = await c.deleteTemplate('t1');
+      expect(r.deleted).toBe(true);
+      expect(r.id).toBe('t1');
+      expect(calls[0].init.method).toBe('DELETE');
+    });
+
+    it('GET /api/v1/templates/[id] surfaces 404 as StyrbyApiError', async () => {
+      const { fetch: fakeFetch } = makeFetch([{ status: 404, body: { error: 'Not found' } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch, maxAttempts: 1 });
+      const err = await c.getTemplate('t-missing').catch((e) => e);
+      expect(err).toBeInstanceOf(StyrbyApiError);
+      expect(err.status).toBe(404);
+    });
+  });
+
+  describe('getContext', () => {
+    it('GET /api/v1/contexts/[group] returns the row', async () => {
+      const row = {
+        id: 'c1', session_group_id: 'g1', summary_markdown: '...', file_refs: [],
+        recent_messages: [], token_budget: 4000, version: 1, created_at: 'ts', updated_at: 'ts',
+      };
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { context: row } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r = await c.getContext('g1');
+      expect(r.context.version).toBe(1);
+      expect(calls[0].url).toContain('/api/v1/contexts/g1');
+    });
+  });
+
+  describe('listSessionGroups', () => {
+    it('GET /api/v1/sessions/groups returns groups + count', async () => {
+      const groups = [
+        { id: 'g1', name: 'A', active_agent_session_id: null, created_at: 't', updated_at: 't' },
+      ];
+      const { fetch: fakeFetch } = makeFetch([{ status: 200, body: { groups, count: 1 } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r = await c.listSessionGroups();
+      expect(r.count).toBe(1);
+      expect(r.groups[0].id).toBe('g1');
+    });
+  });
+
+  describe('searchAuditLog', () => {
+    it('forwards filters as query params', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([{ status: 200, body: { events: [], count: 0 } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      await c.searchAuditLog({
+        action: 'mcp_approval_decided',
+        resource_id: '00000000-0000-0000-0000-000000000001',
+        limit: 10,
+      });
+      const url = new URL(calls[0].url);
+      expect(url.searchParams.get('action')).toBe('mcp_approval_decided');
+      expect(url.searchParams.get('resource_id')).toBe('00000000-0000-0000-0000-000000000001');
+      expect(url.searchParams.get('limit')).toBe('10');
+      expect(url.searchParams.has('resource_type')).toBe(false);
+      expect(url.searchParams.has('since')).toBe(false);
+    });
+
+    it('returns events array', async () => {
+      const events = [
+        { id: 'e1', action: 'mcp_approval_decided', resource_type: 'mcp_approval',
+          resource_id: 'a1', metadata: {}, created_at: 't' },
+      ];
+      const { fetch: fakeFetch } = makeFetch([{ status: 200, body: { events, count: 1 } }]);
+      const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: fakeFetch });
+      const r = await c.searchAuditLog({ action: 'mcp_approval_decided' });
+      expect(r.count).toBe(1);
+      expect(r.events[0].id).toBe('e1');
+    });
+  });
+
   describe('deleteSessionCheckpoint', () => {
     it('throws synchronously when neither name nor checkpointId is provided', async () => {
       const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: makeFetch([]).fetch });

--- a/packages/styrby-cli/src/api/styrbyApiClient.ts
+++ b/packages/styrby-cli/src/api/styrbyApiClient.ts
@@ -253,6 +253,76 @@ export interface TemplatesListResponse {
   count: number;
 }
 
+export interface TemplateRow {
+  id: string;
+  name: string;
+  description: string | null;
+  content: string;
+  variables: unknown;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TemplateUpdateInput {
+  name?: string;
+  content?: string;
+  /** null clears, undefined leaves alone. */
+  description?: string | null;
+  variables?: TemplateVariable[];
+  is_default?: boolean;
+}
+
+export interface ContextRow {
+  id: string;
+  session_group_id: string;
+  summary_markdown: string;
+  file_refs: unknown;
+  recent_messages: unknown;
+  token_budget: number;
+  version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SessionGroupSummary {
+  id: string;
+  name: string;
+  active_agent_session_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SessionGroupsListResponse {
+  groups: SessionGroupSummary[];
+  count: number;
+}
+
+export interface AuditSearchQuery {
+  /** Required — single audit_action enum value to filter on. */
+  action: string;
+  resource_id?: string;
+  resource_type?: string;
+  /** 1-100, default 50. */
+  limit?: number;
+  /** ISO 8601 timestamp; only rows after this. */
+  since?: string;
+}
+
+export interface AuditEventRow {
+  id: string;
+  action: string;
+  resource_type: string | null;
+  resource_id: string | null;
+  metadata: unknown;
+  created_at: string;
+}
+
+export interface AuditSearchResponse {
+  events: AuditEventRow[];
+  count: number;
+}
+
 export type SessionStatus = 'starting' | 'running' | 'idle' | 'paused' | 'stopped' | 'error' | 'expired';
 
 export interface SessionListQuery {
@@ -611,6 +681,73 @@ export class StyrbyApiClient {
     return this.request<TemplatesListResponse>({
       method: 'GET',
       path: '/api/v1/templates',
+      retryable: true,
+    });
+  }
+
+  getTemplate(id: string): Promise<{ template: TemplateRow }> {
+    return this.request<{ template: TemplateRow }>({
+      method: 'GET',
+      path: `/api/v1/templates/${encodeURIComponent(id)}`,
+      retryable: true,
+    });
+  }
+
+  updateTemplate(
+    id: string,
+    input: TemplateUpdateInput,
+    opts?: { idempotencyKey?: string },
+  ): Promise<{ template: TemplateRow }> {
+    return this.request<{ template: TemplateRow }>({
+      method: 'PATCH',
+      path: `/api/v1/templates/${encodeURIComponent(id)}`,
+      body: input,
+      // WHY retryable only with key: PATCH is logically idempotent (same body =
+      // same result), but a network retry between client and server might race
+      // with another caller's PATCH. Idempotency-Key replays the cached response.
+      retryable: Boolean(opts?.idempotencyKey),
+      idempotencyKey: opts?.idempotencyKey,
+    });
+  }
+
+  deleteTemplate(id: string): Promise<{ deleted: true; id: string }> {
+    return this.request<{ deleted: true; id: string }>({
+      method: 'DELETE',
+      path: `/api/v1/templates/${encodeURIComponent(id)}`,
+      // WHY retryable=true: DELETE is idempotent at the server (already-gone
+      // returns 404, which the caller can treat as success-equivalent if they
+      // want — but we don't auto-retry 404s, only 5xx).
+      retryable: true,
+    });
+  }
+
+  getContext(groupId: string): Promise<{ context: ContextRow }> {
+    return this.request<{ context: ContextRow }>({
+      method: 'GET',
+      path: `/api/v1/contexts/${encodeURIComponent(groupId)}`,
+      retryable: true,
+    });
+  }
+
+  listSessionGroups(): Promise<SessionGroupsListResponse> {
+    return this.request<SessionGroupsListResponse>({
+      method: 'GET',
+      path: '/api/v1/sessions/groups',
+      retryable: true,
+    });
+  }
+
+  searchAuditLog(query: AuditSearchQuery): Promise<AuditSearchResponse> {
+    return this.request<AuditSearchResponse>({
+      method: 'GET',
+      path: '/api/v1/audit',
+      query: {
+        action: query.action,
+        resource_id: query.resource_id,
+        resource_type: query.resource_type,
+        limit: query.limit,
+        since: query.since,
+      },
       retryable: true,
     });
   }

--- a/packages/styrby-web/src/app/api/v1/audit/route.ts
+++ b/packages/styrby-web/src/app/api/v1/audit/route.ts
@@ -278,3 +278,113 @@ async function handlePost(request: NextRequest, context: ApiAuthContext): Promis
 export const POST = withApiAuthAndRateLimit(handlePost, ['write'], {
   rateLimit: AUDIT_RATE_LIMIT,
 });
+
+// ===========================================================================
+// GET /api/v1/audit  —  search audit log
+// ===========================================================================
+
+/**
+ * Used primarily by the CLI's MCP approval handler to poll for decision rows,
+ * and by founder/admin tooling that needs to inspect a user's audit trail.
+ *
+ * Filtering by `action` is required — we don't expose a raw "give me everything"
+ * read because that would amplify exfiltration risk if a write-scoped key were
+ * compromised (audit_log can carry sensitive metadata).
+ *
+ * @auth Required - Bearer `styrby_*` API key via withApiAuthAndRateLimit
+ * @rateLimit 1000 req/min/key (matches the POST high-volume cap — approval
+ *   polling fires once per second per active approval).
+ *
+ * Query Parameters:
+ * - action: REQUIRED — single audit_action enum value to filter on
+ * - resource_id?: filter by resource_id (e.g. an approval UUID)
+ * - resource_type?: filter by resource_type
+ * - limit?: 1-100, default 50
+ * - since?: ISO 8601 timestamp; only rows created after this
+ *
+ * @returns 200 { events: AuditEventRow[], count }
+ *
+ * @error 400 { error }  - Missing required `action` or invalid query
+ * @error 401 { error }  - Missing or invalid API key
+ * @error 429 { error }  - Rate limit exceeded
+ * @error 500 { error }  - Unexpected database error (sanitized)
+ *
+ * @security OWASP A01:2021 - results scoped to user_id from auth context.
+ * @security OWASP A07:2021 - auth enforced by withApiAuthAndRateLimit.
+ * @security GDPR Art 5(1)(c) - data minimisation: required `action` filter
+ *   prevents wholesale audit-log slurping.
+ * @security SOC 2 CC6.1 - 'read' scope sufficient (no mutation).
+ */
+
+const AuditQuerySchema = z.object({
+  action: z.string().min(1, 'action filter is required').max(100),
+  resource_id: z.string().max(255).optional(),
+  resource_type: z.string().max(100).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  since: z.string().datetime({ offset: true }).optional(),
+});
+
+interface AuditEventRow {
+  id: string;
+  action: string;
+  resource_type: string | null;
+  resource_id: string | null;
+  metadata: unknown;
+  created_at: string;
+}
+
+async function handleGet(request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+
+  const url = new URL(request.url);
+  const rawQuery = {
+    action: url.searchParams.get('action') ?? undefined,
+    resource_id: url.searchParams.get('resource_id') ?? undefined,
+    resource_type: url.searchParams.get('resource_type') ?? undefined,
+    limit: url.searchParams.get('limit') ?? undefined,
+    since: url.searchParams.get('since') ?? undefined,
+  };
+
+  const parseResult = AuditQuerySchema.safeParse(rawQuery);
+  if (!parseResult.success) {
+    const msg = parseResult.error.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ');
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+  const q = parseResult.data;
+
+  const supabase = createAdminClient();
+
+  // WHY: chain filters server-side to minimize result set. The action filter is
+  // load-bearing for both the index strategy (idx_audit_log_action exists per
+  // migration 001) and for the data-minimisation guarantee.
+  let query = supabase
+    .from('audit_log')
+    .select('id, action, resource_type, resource_id, metadata, created_at')
+    .eq('user_id', userId)
+    .eq('action', q.action)
+    .order('created_at', { ascending: false })
+    .limit(q.limit);
+
+  if (q.resource_id) query = query.eq('resource_id', q.resource_id);
+  if (q.resource_type) query = query.eq('resource_type', q.resource_type);
+  if (q.since) query = query.gte('created_at', q.since);
+
+  const { data: rows, error } = await query;
+
+  if (error) {
+    Sentry.captureException(new Error(`audit_log search error: ${error.message}`), {
+      extra: { route: ROUTE_ID, action: q.action },
+    });
+    return NextResponse.json({ error: 'Failed to search audit log' }, { status: 500 });
+  }
+
+  const events = (rows ?? []) as AuditEventRow[];
+  return NextResponse.json(
+    { events, count: events.length },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}
+
+export const GET = withApiAuthAndRateLimit(handleGet, ['read'], {
+  rateLimit: AUDIT_RATE_LIMIT,
+});

--- a/packages/styrby-web/src/app/api/v1/contexts/[group_id]/route.ts
+++ b/packages/styrby-web/src/app/api/v1/contexts/[group_id]/route.ts
@@ -1,0 +1,115 @@
+/**
+ * GET /api/v1/contexts/[group_id]
+ *
+ * Fetches the current `agent_context_memory` row for a session group. Used
+ * by the CLI's `styrby context show` flow + the optimistic-locking pre-check
+ * inside `commands/context.ts` (which currently selects directly from
+ * Supabase; Phase 4 swaps it to this endpoint).
+ *
+ * @auth Required - Bearer `styrby_*` API key via withApiAuthAndRateLimit
+ * @rateLimit 100 requests per minute per key (default)
+ *
+ * @returns 200 { context: ContextRow }  - row exists for this group + user
+ * @returns 404 { error: 'Not found' }    - no row OR group belongs to another user
+ *
+ * @error 401 { error }  - Missing or invalid API key
+ * @error 429 { error }  - Rate limit exceeded
+ * @error 500 { error }  - Unexpected database error (sanitized)
+ *
+ * @security OWASP A01:2021 - ownership enforced via JOIN through
+ *   agent_session_groups; consistent 404 on cross-user / missing.
+ * @security OWASP A07:2021 - auth enforced by withApiAuthAndRateLimit.
+ * @security SOC 2 CC6.1 - 'read' scope required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+
+import {
+  withApiAuthAndRateLimit,
+  type ApiAuthContext,
+} from '@/middleware/api-auth';
+import { createAdminClient } from '@/lib/supabase/server';
+
+const ROUTE_ID = '/api/v1/contexts/[group_id]';
+
+interface ContextRow {
+  id: string;
+  session_group_id: string;
+  summary_markdown: string;
+  file_refs: unknown;
+  recent_messages: unknown;
+  token_budget: number;
+  version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Extract `group_id` from URL pathname. See templates/[id]/route.ts for the
+ * rationale on manual parsing + UUID validation.
+ */
+function extractGroupId(request: NextRequest): { ok: true; id: string } | { ok: false; error: string } {
+  const segments = new URL(request.url).pathname.split('/').filter(Boolean);
+  const id = segments[segments.length - 1];
+  if (!id) return { ok: false, error: 'Missing group id' };
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!uuidRegex.test(id)) return { ok: false, error: 'Invalid group id format' };
+  return { ok: true, id };
+}
+
+async function handleGet(request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+  const idResult = extractGroupId(request);
+  if (!idResult.ok) return NextResponse.json({ error: idResult.error }, { status: 400 });
+
+  const supabase = createAdminClient();
+
+  // -- Step 1: ownership check on agent_session_groups -----------------------
+  // WHY this check (not RLS): auth.uid() is null for API-key-authenticated
+  // requests. Service role client bypasses RLS — we must enforce ownership
+  // explicitly. Same pattern as POST /api/v1/contexts (route.ts).
+  const { data: groupRow, error: groupErr } = await supabase
+    .from('agent_session_groups')
+    .select('user_id')
+    .eq('id', idResult.id)
+    .maybeSingle<{ user_id: string }>();
+
+  if (groupErr) {
+    Sentry.captureException(new Error(`agent_session_groups fetch error: ${groupErr.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to fetch context' }, { status: 500 });
+  }
+  if (!groupRow || groupRow.user_id !== userId) {
+    // 404 on both "no group" and "wrong owner" (IDOR defense, OWASP A01:2021).
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  // -- Step 2: fetch the context row -----------------------------------------
+  // WHY separate query (not a join): the schema has agent_context_memory with
+  // a UNIQUE constraint on session_group_id, so 0 or 1 row guaranteed. The
+  // separate fetch is simpler than a left-join + null-handling, and the perf
+  // cost is negligible (one extra round-trip on a UUID-keyed lookup).
+  const { data: contextRow, error: ctxErr } = await supabase
+    .from('agent_context_memory')
+    .select('id, session_group_id, summary_markdown, file_refs, recent_messages, token_budget, version, created_at, updated_at')
+    .eq('session_group_id', idResult.id)
+    .maybeSingle<ContextRow>();
+
+  if (ctxErr) {
+    Sentry.captureException(new Error(`agent_context_memory fetch error: ${ctxErr.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to fetch context' }, { status: 500 });
+  }
+  if (!contextRow) {
+    // Group exists + owned, but no context_memory row yet (CLI hasn't synced).
+    // 404 is correct — the resource being requested (the context) doesn't exist.
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ context: contextRow }, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export const GET = withApiAuthAndRateLimit(handleGet, ['read']);

--- a/packages/styrby-web/src/app/api/v1/sessions/groups/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/groups/route.ts
@@ -121,3 +121,49 @@ async function handlePost(request: NextRequest, authContext: ApiAuthContext): Pr
 }
 
 export const POST = withApiAuthAndRateLimit(handlePost, ['write']);
+
+// ===========================================================================
+// GET /api/v1/sessions/groups  —  list user's session groups
+// ===========================================================================
+
+/**
+ * Shape of a session group row in the list response.
+ *
+ * Includes active_agent_session_id so the CLI / mobile UI can determine which
+ * member session is currently focused without a follow-up query.
+ */
+interface SessionGroupSummary {
+  id: string;
+  name: string;
+  active_agent_session_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+async function handleGet(_request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+  const supabase = createAdminClient();
+
+  // WHY ORDER BY created_at DESC: matches the multi-agent session picker UX —
+  // most recent group surfaces first. Most users have < 20 groups, no pagination.
+  const { data: rows, error } = await supabase
+    .from('agent_session_groups')
+    .select('id, name, active_agent_session_id, created_at, updated_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    Sentry.captureException(new Error(`agent_session_groups list error: ${error.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to list session groups' }, { status: 500 });
+  }
+
+  const groups = (rows ?? []) as SessionGroupSummary[];
+  return NextResponse.json(
+    { groups, count: groups.length },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}
+
+export const GET = withApiAuthAndRateLimit(handleGet, ['read']);

--- a/packages/styrby-web/src/app/api/v1/templates/[id]/route.ts
+++ b/packages/styrby-web/src/app/api/v1/templates/[id]/route.ts
@@ -1,0 +1,264 @@
+/**
+ * /api/v1/templates/[id]  —  GET (fetch one) + PATCH (update) + DELETE
+ *
+ * Per-template operations bound to the authenticated user. The [id] segment
+ * is the template UUID (matches context_templates.id). Ownership is enforced
+ * server-side via WHERE user_id = auth context — RLS-equivalent at the app
+ * layer because /api/v1 routes use the service-role client.
+ *
+ * @auth Required - Bearer `styrby_*` API key via withApiAuthAndRateLimit
+ * @rateLimit 100 requests per minute per key (default)
+ *
+ * GET @returns 200 { template: TemplateRow } | 404 { error: 'Not found' }
+ *
+ * PATCH @body {
+ *   name?: string,           // 1-255
+ *   content?: string,        // 1-50000
+ *   description?: string,    // max 1000, set to null to clear
+ *   variables?: Variable[],
+ *   is_default?: boolean
+ * }
+ * PATCH @returns 200 { template: TemplateRow } | 404 | 400
+ *
+ * DELETE @returns 200 { deleted: true, id }  |  404
+ *
+ * @error 401 { error }  - Missing or invalid API key
+ * @error 404 { error }  - Template not found OR belongs to another user
+ *                        (consistent 404 prevents IDOR enumeration)
+ * @error 429 { error }  - Rate limit exceeded
+ * @error 500 { error }  - Unexpected database error (sanitized)
+ *
+ * @security OWASP A01:2021 - 404 on cross-user lookup (no existence leak).
+ * @security OWASP A03:2021 - PATCH body uses Zod .strict() (mass-assignment).
+ * @security OWASP A07:2021 - auth enforced by withApiAuthAndRateLimit.
+ * @security SOC 2 CC6.1 - 'read' for GET, 'write' for PATCH/DELETE.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import * as Sentry from '@sentry/nextjs';
+
+import {
+  withApiAuthAndRateLimit,
+  type ApiAuthContext,
+} from '@/middleware/api-auth';
+import { createAdminClient } from '@/lib/supabase/server';
+
+// ---------------------------------------------------------------------------
+// Constants — mirror /api/v1/templates POST handler (route.ts)
+// ---------------------------------------------------------------------------
+
+const ROUTE_ID = '/api/v1/templates/[id]';
+const MAX_NAME_LENGTH = 255;
+const MAX_CONTENT_LENGTH = 50_000;
+const MAX_DESCRIPTION_LENGTH = 1_000;
+const MAX_VARIABLE_FIELD_LENGTH = 255;
+const MAX_VARIABLE_DEFAULT_LENGTH = 1_000;
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+const VariableSchema = z
+  .object({
+    name: z.string().min(1, 'variable name must not be empty').max(MAX_VARIABLE_FIELD_LENGTH),
+    description: z.string().max(MAX_VARIABLE_FIELD_LENGTH).optional(),
+    defaultValue: z.string().max(MAX_VARIABLE_DEFAULT_LENGTH).optional(),
+  })
+  .strict();
+
+/**
+ * PATCH body — every field optional. WHY .strict(): even on PATCH, unknown
+ * fields are mass-assignment vectors (e.g. injecting user_id, created_at).
+ *
+ * WHY description allows null (not just optional): empty description is a
+ * legitimate state ("clear the description"); .nullable().optional() distinguishes
+ * "leave alone" (omit) from "explicitly clear" (null). The handler treats both
+ * the same in the UPDATE — but the API contract is honest about the difference.
+ */
+const PatchBodySchema = z
+  .object({
+    name: z.string().min(1).max(MAX_NAME_LENGTH).optional(),
+    content: z.string().min(1).max(MAX_CONTENT_LENGTH).optional(),
+    description: z.string().max(MAX_DESCRIPTION_LENGTH).nullable().optional(),
+    variables: z.array(VariableSchema).optional(),
+    is_default: z.boolean().optional(),
+  })
+  .strict()
+  .refine(
+    (data) => Object.keys(data).length > 0,
+    { message: 'PATCH body must include at least one field to update' },
+  );
+
+type PatchBody = z.infer<typeof PatchBodySchema>;
+
+// ---------------------------------------------------------------------------
+// Row interface
+// ---------------------------------------------------------------------------
+
+interface TemplateRow {
+  id: string;
+  name: string;
+  description: string | null;
+  content: string;
+  variables: unknown;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helper — dynamic route param extractor
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract `id` from the URL pathname. WHY this manual extraction (not the
+ * Next.js `{ params }` second arg): the withApiAuthAndRateLimit wrapper
+ * doesn't pass route params through — only `(request, authContext)`. Parsing
+ * the pathname keeps the wrapper signature stable across all routes.
+ *
+ * WHY validate as UUID: bare strings would happily reach the DB and produce
+ * a cryptic "invalid input syntax for type uuid" 500. Failing fast at the
+ * route boundary gives a clean 400 with a helpful message.
+ */
+function extractTemplateId(request: NextRequest): { ok: true; id: string } | { ok: false; error: string } {
+  const segments = new URL(request.url).pathname.split('/').filter(Boolean);
+  // Path: /api/v1/templates/[id]  →  segments = ['api','v1','templates','[id]']
+  const id = segments[segments.length - 1];
+  if (!id) return { ok: false, error: 'Missing template id' };
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!uuidRegex.test(id)) return { ok: false, error: 'Invalid template id format' };
+  return { ok: true, id };
+}
+
+// ===========================================================================
+// GET handler
+// ===========================================================================
+
+async function handleGet(request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+  const idResult = extractTemplateId(request);
+  if (!idResult.ok) return NextResponse.json({ error: idResult.error }, { status: 400 });
+
+  const supabase = createAdminClient();
+  const { data: row, error } = await supabase
+    .from('context_templates')
+    .select('id, name, description, content, variables, is_default, created_at, updated_at')
+    .eq('id', idResult.id)
+    .eq('user_id', userId)
+    .maybeSingle<TemplateRow>();
+
+  if (error) {
+    Sentry.captureException(new Error(`context_templates fetch error: ${error.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to fetch template' }, { status: 500 });
+  }
+  if (!row) {
+    // WHY 404 (not 403) on cross-user: consistent IDOR defense — same response
+    // as "not found". OWASP A01:2021. Don't reveal that the template exists.
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ template: row }, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+// ===========================================================================
+// PATCH handler
+// ===========================================================================
+
+async function handlePatch(request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+  const idResult = extractTemplateId(request);
+  if (!idResult.ok) return NextResponse.json({ error: idResult.error }, { status: 400 });
+
+  let parsed: PatchBody;
+  try {
+    const raw = await request.json();
+    const result = PatchBodySchema.safeParse(raw);
+    if (!result.success) {
+      const msg = result.error.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ');
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    parsed = result.data;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be valid JSON' }, { status: 400 });
+  }
+
+  // Build update payload — only include fields the caller supplied. supabase-js
+  // .update() with a sparse object emits an UPDATE that touches only those columns.
+  // WHY explicit object construction (not spread): spread would forward Zod's
+  // unknown-key errors silently. Explicit picks force compile-time discipline.
+  const update: Partial<TemplateRow> = {};
+  if (parsed.name !== undefined) update.name = parsed.name;
+  if (parsed.content !== undefined) update.content = parsed.content;
+  if (parsed.description !== undefined) update.description = parsed.description; // null clears
+  if (parsed.variables !== undefined) update.variables = parsed.variables;
+  if (parsed.is_default !== undefined) update.is_default = parsed.is_default;
+
+  const supabase = createAdminClient();
+  // WHY user_id in WHERE: cross-user UPDATEs would silently match 0 rows; we
+  // make that explicit by filtering. Combined with the .single() expectation,
+  // a missing match returns no row and we surface 404.
+  const { data: row, error } = await supabase
+    .from('context_templates')
+    .update(update)
+    .eq('id', idResult.id)
+    .eq('user_id', userId)
+    .select('id, name, description, content, variables, is_default, created_at, updated_at')
+    .maybeSingle<TemplateRow>();
+
+  if (error) {
+    Sentry.captureException(new Error(`context_templates update error: ${error.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to update template' }, { status: 500 });
+  }
+  if (!row) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ template: row });
+}
+
+// ===========================================================================
+// DELETE handler
+// ===========================================================================
+
+async function handleDelete(request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+  const idResult = extractTemplateId(request);
+  if (!idResult.ok) return NextResponse.json({ error: idResult.error }, { status: 400 });
+
+  const supabase = createAdminClient();
+  // WHY .select() after .delete(): supabase-js returns the deleted row when
+  // .select() is chained, letting us distinguish "deleted" from "didn't exist".
+  // A bare .delete() would succeed even if 0 rows matched, masking IDOR misses.
+  const { data: row, error } = await supabase
+    .from('context_templates')
+    .delete()
+    .eq('id', idResult.id)
+    .eq('user_id', userId)
+    .select('id')
+    .maybeSingle<{ id: string }>();
+
+  if (error) {
+    Sentry.captureException(new Error(`context_templates delete error: ${error.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to delete template' }, { status: 500 });
+  }
+  if (!row) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ deleted: true, id: row.id });
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export const GET = withApiAuthAndRateLimit(handleGet, ['read']);
+export const PATCH = withApiAuthAndRateLimit(handlePatch, ['write']);
+export const DELETE = withApiAuthAndRateLimit(handleDelete, ['write']);


### PR DESCRIPTION
6 of the remaining /api/v1 endpoints needed for H41 Phase 4 callsite swaps. With 3.6a (PR #227) + this, all 19 CLI callsites have endpoints to swap to.

Endpoints:
- GET /api/v1/templates/[id] — fetch by UUID, 404 cross-user (IDOR defense)
- PATCH /api/v1/templates/[id] — Zod .strict() with .refine() requiring at least one field
- DELETE /api/v1/templates/[id] — uses .select() to disambiguate deleted vs not-found
- GET /api/v1/contexts/[group_id] — two-step ownership check, 404 on mismatch
- GET /api/v1/sessions/groups — list with active_agent_session_id included
- GET /api/v1/audit — required action filter (data-minimisation), 1000 req/min cap

Plus StyrbyApiClient: getTemplate, updateTemplate, deleteTemplate, getContext, listSessionGroups, searchAuditLog. 8 new tests, total 38 pass.

Same security posture as PR #221: withApiAuthAndRateLimit + Zod .strict() + 404 cross-user + Sentry PII hygiene + service-role with explicit owner check.

Test plan:
- pnpm typecheck clean (CLI + web)
- pnpm exec vitest run src/api/__tests__/styrbyApiClient.test.ts: 38/38 pass

Refs: styrby-backlog.md, PR #221, PR #225, PR #227.