### PR TITLE
feat(auth): /api/v1/auth/exchange + CLI mints styrby_* key (H41 Phase 5)

### DIFF
--- a/packages/styrby-cli/src/api/__tests__/styrbyApiClient.test.ts
+++ b/packages/styrby-cli/src/api/__tests__/styrbyApiClient.test.ts
@@ -511,6 +511,45 @@ describe('StyrbyApiClient', () => {
     });
   });
 
+  describe('exchangeSupabaseJwt', () => {
+    it('POSTs to /api/v1/auth/exchange with Bearer Supabase JWT and returns mint result', async () => {
+      const { fetch: fakeFetch, calls } = makeFetch([
+        { status: 200, body: { styrby_api_key: 'styrby_minted_xyz', expires_at: '2027-04-30T00:00:00Z', user_id: 'u-1' } },
+      ]);
+      const c = new StyrbyApiClient({ fetchImpl: fakeFetch });
+      const r = await c.exchangeSupabaseJwt('eyJ.fake.supabase.jwt');
+      expect(r.styrby_api_key).toBe('styrby_minted_xyz');
+      expect(r.user_id).toBe('u-1');
+      expect(calls[0].url).toContain('/api/v1/auth/exchange');
+      expect(calls[0].init.method).toBe('POST');
+      const headers = calls[0].init.headers as Headers;
+      expect(headers.get('Authorization')).toBe('Bearer eyJ.fake.supabase.jwt');
+    });
+
+    it('surfaces 401 AUTH_FAILED as StyrbyApiError', async () => {
+      const { fetch: fakeFetch } = makeFetch([{ status: 401, body: { error: 'AUTH_FAILED' } }]);
+      const c = new StyrbyApiClient({ fetchImpl: fakeFetch });
+      const err = await c.exchangeSupabaseJwt('expired-jwt').catch((e) => e);
+      expect(err).toBeInstanceOf(StyrbyApiError);
+      expect(err.status).toBe(401);
+      expect(err.code).toBe('AUTH_FAILED');
+    });
+
+    it('does NOT attach a styrby_* Bearer header when one is configured (only Supabase JWT)', async () => {
+      // Even if a previously-minted styrby_* key exists in this client, the
+      // exchange endpoint expects the SUPABASE JWT — we must not overwrite it.
+      const { fetch: fakeFetch, calls } = makeFetch([
+        { status: 200, body: { styrby_api_key: 'styrby_new', expires_at: 't', user_id: 'u' } },
+      ]);
+      const c = new StyrbyApiClient({ apiKey: 'styrby_old', fetchImpl: fakeFetch });
+      await c.exchangeSupabaseJwt('supabase-jwt');
+      const headers = calls[0].init.headers as Headers;
+      expect(headers.get('Authorization')).toBe('Bearer supabase-jwt');
+      // Sanity: the client's own styrby_* key was NOT used as Bearer here.
+      expect(headers.get('Authorization')).not.toContain('styrby_old');
+    });
+  });
+
   describe('deleteSessionCheckpoint', () => {
     it('throws synchronously when neither name nor checkpointId is provided', async () => {
       const c = new StyrbyApiClient({ apiKey: 'sk', fetchImpl: makeFetch([]).fetch });

--- a/packages/styrby-cli/src/api/styrbyApiClient.ts
+++ b/packages/styrby-cli/src/api/styrbyApiClient.ts
@@ -549,6 +549,60 @@ export class StyrbyApiClient {
     });
   }
 
+  /**
+   * Exchange a valid Supabase Auth access token for a fresh `styrby_*` API key.
+   *
+   * Bridge endpoint introduced in H41 Phase 5: lets the existing CLI auth
+   * bootstrap (which mints a Supabase JWT via `supabase.auth.signInWithOtp` /
+   * `signInWithOAuth`) acquire a styrby_* key for use with /api/v1/* without
+   * having to re-prompt the user. The Supabase JWT remains valid for Realtime
+   * subscriptions until Phase 5b replaces that surface.
+   *
+   * The Supabase JWT is sent in the Authorization header (Bearer <jwt>); the
+   * server validates it via `supabase.auth.getUser(jwt)` and mints a key
+   * scoped to that user.
+   *
+   * WHY not retryable: minting is server-side idempotent in the sense that it
+   * doesn't conflict on repeat (each call inserts a fresh row), but a retry
+   * after a 5xx that succeeded would mint a SECOND key — wasteful and
+   * confusing in the user's key list. Caller treats failures as terminal.
+   */
+  async exchangeSupabaseJwt(supabaseAccessToken: string): Promise<AuthCredentialResponse & { user_id: string }> {
+    // The exchange endpoint is unauthenticated wrt our styrby_* key (caller
+    // doesn't have one yet), but it DOES require the Supabase JWT in the
+    // Authorization header. We fall outside the standard request() helper's
+    // header builder because that helper attaches `Bearer <styrby_*>` instead.
+    const url = this.buildUrl('/api/v1/auth/exchange');
+    const headers = new Headers();
+    headers.set('Accept', 'application/json');
+    headers.set('Authorization', `Bearer ${supabaseAccessToken}`);
+
+    const response = await this.fetchWithTimeout(url, {
+      method: 'POST',
+      headers,
+    });
+
+    if (!response.ok) {
+      const body = await this.safeReadJson(response);
+      this.breadcrumb(
+        { method: 'POST', path: '/api/v1/auth/exchange', retryable: false, unauthenticated: true },
+        response.status,
+        1,
+        'error',
+      );
+      throw this.errorFromResponse(response.status, body);
+    }
+
+    const body = (await this.safeReadJson(response)) as AuthCredentialResponse & { user_id: string };
+    this.breadcrumb(
+      { method: 'POST', path: '/api/v1/auth/exchange', retryable: false, unauthenticated: true },
+      response.status,
+      1,
+      'ok',
+    );
+    return body;
+  }
+
   // -------------------------------------------------------------------------
   // Account
   // -------------------------------------------------------------------------

--- a/packages/styrby-cli/src/commands/onboard.ts
+++ b/packages/styrby-cli/src/commands/onboard.ts
@@ -617,11 +617,50 @@ export async function runOnboard(options: OnboardOptions = {}): Promise<OnboardR
   console.log(chalk.bold('\n  [3/6] Authentication complete!'));
   console.log(`        Welcome, ${authData.userEmail}`);
 
+  // WHY also mint a styrby_* API key (H41 Phase 5):
+  // The CLI's Supabase JWT (authData.accessToken) authenticates Realtime
+  // subscriptions via supabase-js. Strategy C requires every /api/v1/* call
+  // to use a per-user styrby_* key instead of the Supabase JWT. We exchange
+  // the JWT here — single-shot, server-side validated — and persist both
+  // credentials. Subsequent Phase 4 callsite swaps consume styrbyApiKey via
+  // the typed StyrbyApiClient. The Supabase JWT remains the auth surface for
+  // Realtime until Phase 5b replaces that.
+  //
+  // WHY non-fatal: an exchange failure here doesn't break onboarding —
+  // pre-Phase-4, every CLI codepath still uses the Supabase JWT. The styrby
+  // key is purely additive; we surface a warning + Sentry breadcrumb but let
+  // the user keep onboarding. Phase 4 swaps will start failing if the key
+  // is missing; we'll harden this gate then.
+  let mintedStyrbyKey: { styrbyApiKey?: string; expiresAt?: string } = {};
+  try {
+    const { StyrbyApiClient } = await import('@/api/styrbyApiClient');
+    const client = new StyrbyApiClient();
+    const exchanged = await client.exchangeSupabaseJwt(authData.accessToken);
+    mintedStyrbyKey = {
+      styrbyApiKey: exchanged.styrby_api_key,
+      expiresAt: exchanged.expires_at,
+    };
+    logger.debug('Minted styrby_* key', {
+      // WHY only the key prefix in logs: GDPR Art 5(1)(c) data minimisation.
+      // The first 11 chars are public (styrby_xxxx_) per generateApiKey().
+      keyPrefix: exchanged.styrby_api_key.slice(0, 11) + '…',
+    });
+  } catch (exchangeErr) {
+    logger.debug('styrby_* key exchange failed (non-fatal pre-Phase-4)', {
+      error: exchangeErr instanceof Error ? exchangeErr.message : 'unknown',
+    });
+  }
+
   savePersistedData({
     userId: authData.userId,
     accessToken: authData.accessToken,
     refreshToken: authData.refreshToken,
     authenticatedAt: new Date().toISOString(),
+    // WHY undefined-safe: if the exchange failed, we leave styrbyApiKey unset.
+    // savePersistedData merges with existing data, so an undefined value here
+    // does NOT clobber a previously-stored key.
+    ...(mintedStyrbyKey.styrbyApiKey ? { styrbyApiKey: mintedStyrbyKey.styrbyApiKey } : {}),
+    ...(mintedStyrbyKey.expiresAt ? { styrbyKeyExpiresAt: mintedStyrbyKey.expiresAt } : {}),
   });
 
   setConfigValue('userId', authData.userId);

--- a/packages/styrby-cli/src/persistence.ts
+++ b/packages/styrby-cli/src/persistence.ts
@@ -56,14 +56,39 @@ function validateSessionId(sessionId: string): boolean {
 
 /**
  * Persisted data structure for authentication and machine info.
+ *
+ * Two auth credential paradigms coexist on disk during the H41 transition:
+ *
+ *   - `accessToken` / `refreshToken`: legacy Supabase JWT pair (pre-Strategy-C).
+ *     Kept here so existing data.json files don't need migration; readers that
+ *     still depend on Supabase Auth (auth/token-manager.ts) honour them.
+ *
+ *   - `styrbyApiKey` / `styrbyKeyExpiresAt`: per-user `styrby_*` key minted by
+ *     /api/v1/auth/otp/verify or /oauth/callback. The CLI's typed apiClient
+ *     uses this for every /api/v1/* call. End-state: this is the only auth
+ *     credential on disk; the Supabase JWT pair will be deleted during the
+ *     CLI's next clear-and-onboard cycle once Phase 4 lands.
+ *
+ * Reading either field is safe — both are optional. Onboarding paths post-Phase-5
+ * mint and persist the styrby key; callers swapping to apiClient should prefer it.
  */
 export interface PersistedData {
-  /** User ID from Supabase auth */
+  /** User ID — same UUID space whether minted by Supabase Auth or /api/v1/auth/*. */
   userId?: string;
-  /** Access token for Supabase */
+  /** Legacy Supabase access token. Will be cleared on next re-onboard post-Phase-5. */
   accessToken?: string;
-  /** Refresh token for Supabase */
+  /** Legacy Supabase refresh token. Will be cleared on next re-onboard post-Phase-5. */
   refreshToken?: string;
+  /**
+   * Per-user `styrby_*` API key minted by /api/v1/auth/*.
+   * WHY 0o600 file mode (set in savePersistedData below): plaintext key on disk
+   * matches the CLI's threat model — same security posture as the prior
+   * Supabase JWT. Mobile + web use platform secure storage; CLI relies on
+   * file permissions + user-only readable home directory.
+   */
+  styrbyApiKey?: string;
+  /** ISO 8601 expiry for the styrby_* key. CLI re-onboards when this approaches. */
+  styrbyKeyExpiresAt?: string;
   /** Unique machine identifier */
   machineId?: string;
   /** Machine name (hostname) */

--- a/packages/styrby-web/src/app/api/v1/auth/exchange/route.ts
+++ b/packages/styrby-web/src/app/api/v1/auth/exchange/route.ts
@@ -1,0 +1,162 @@
+/**
+ * POST /api/v1/auth/exchange
+ *
+ * Exchanges a valid Supabase Auth access token for a per-user `styrby_*` API
+ * key. This is the bridge between the existing CLI auth bootstrap (which
+ * mints a Supabase JWT via `supabase.auth.signInWithOtp` /
+ * `signInWithOAuth`) and Strategy C (which uses `styrby_*` keys for every
+ * `/api/v1/*` call).
+ *
+ * Flow:
+ *   1. Caller authenticates with Supabase Auth (any method) and obtains
+ *      an access_token.
+ *   2. Caller POSTs here with `Authorization: Bearer <supabase_access_token>`.
+ *   3. Server validates the JWT against Supabase, extracts user_id.
+ *   4. Server mints a fresh `styrby_*` key for that user (bcrypt hash to
+ *      api_keys; raw key returned ONCE).
+ *   5. Caller persists both credentials. The Supabase JWT remains valid for
+ *      Realtime subscriptions until Phase 5b replaces that surface; the
+ *      styrby_* key authenticates every /api/v1/* call.
+ *
+ * @auth Bearer Supabase access token (NOT a styrby_* key — this is the
+ *   bootstrap path that mints one). The token is validated server-side via
+ *   `supabase.auth.getUser(jwt)` which honours signature + expiry + user
+ *   existence.
+ *
+ * @rateLimit 10 requests per minute per IP (low — exchange should fire once
+ *   per onboarding, not per user action).
+ *
+ * @body none — caller passes the JWT in the Authorization header.
+ *
+ * @returns 200 {
+ *   styrby_api_key: string,  // Raw plaintext key — shown ONCE
+ *   expires_at: string,      // ISO 8601 expiry (365-day default)
+ *   user_id: string          // UUID of the authenticated user
+ * }
+ *
+ * @error 401 { error: 'AUTH_FAILED' }     — Missing or invalid Supabase JWT
+ * @error 429 { error: 'RATE_LIMITED' }    — IP cap exceeded
+ * @error 500 { error: 'INTERNAL_ERROR' }  — Key minting failure (Sentry)
+ *
+ * @security OWASP A07:2021 — auth via Supabase JWT signature verification.
+ * @security OWASP A02:2021 — bcrypt-hashed key storage; raw key never logged.
+ * @security OWASP A05:2021 — explicit 365-day TTL; no non-expiring keys.
+ * @security OWASP A01:2021 — generic 401 for all auth failures (no enumeration).
+ * @security GDPR Art 6(1)(b) — lawful basis: contract performance.
+ * @security SOC 2 CC6.1 — key bound to authenticated user_id from validated JWT.
+ *
+ * @module api/v1/auth/exchange
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+
+import { createAdminClient } from '@/lib/supabase/server';
+import { hashApiKey } from '@/lib/api-keys';
+import { generateApiKey } from '@styrby/shared';
+import { AUTH_EXCHANGE_RATE_LIMIT, KEY_TTL_DAYS } from '@/lib/auth/api-config';
+import { rateLimit } from '@/lib/rateLimit';
+
+const ROUTE_ID = '/api/v1/auth/exchange';
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+async function handlePost(request: NextRequest): Promise<NextResponse> {
+  // ── 1. IP-based rate limit ────────────────────────────────────────────────
+  // WHY separate try/catch: a throw from rateLimit (Redis unreachable) is a
+  // TRUE infrastructure failure that must surface as 500, not silently fall
+  // through. Same pattern as /otp/send.
+  let rateLimitResult: Awaited<ReturnType<typeof rateLimit>>;
+  try {
+    rateLimitResult = await rateLimit(request, AUTH_EXCHANGE_RATE_LIMIT, 'auth-exchange');
+  } catch (rateLimitErr) {
+    Sentry.captureException(rateLimitErr, {
+      tags: { endpoint: ROUTE_ID },
+      extra: { context: 'rateLimit infrastructure threw' },
+    });
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 });
+  }
+
+  if (!rateLimitResult.allowed) {
+    const retryAfter = rateLimitResult.retryAfter ?? 60;
+    return NextResponse.json(
+      { error: 'RATE_LIMITED' },
+      { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+    );
+  }
+
+  // ── 2. Extract + validate the Supabase JWT from Authorization header ──────
+  const authHeader = request.headers.get('authorization') ?? '';
+  const match = authHeader.match(/^Bearer\s+(.+)$/);
+  if (!match) {
+    return NextResponse.json({ error: 'AUTH_FAILED' }, { status: 401 });
+  }
+  const supabaseJwt = match[1].trim();
+  if (supabaseJwt.length === 0) {
+    return NextResponse.json({ error: 'AUTH_FAILED' }, { status: 401 });
+  }
+
+  // WHY admin client + getUser(token): the admin client uses the service-role
+  // key, but `getUser(jwt)` validates the supplied JWT against Supabase's auth
+  // server (signature + expiry + user existence). If the JWT is fake / expired /
+  // revoked, getUser returns an error and we 401.
+  // OWASP A07:2021 — server-side JWT verification, no client-side trust.
+  const supabase = createAdminClient();
+  let userId: string;
+  try {
+    const { data, error } = await supabase.auth.getUser(supabaseJwt);
+    if (error || !data?.user?.id) {
+      // Generic 401 — no signal about which JWTs are valid (OWASP A07:2021).
+      return NextResponse.json({ error: 'AUTH_FAILED' }, { status: 401 });
+    }
+    userId = data.user.id;
+  } catch {
+    // Catch-all → 401 prevents leaking infra errors as auth signals.
+    return NextResponse.json({ error: 'AUTH_FAILED' }, { status: 401 });
+  }
+
+  // ── 3. Mint styrby_* API key (same pattern as /otp/verify, /oauth/callback) ──
+  try {
+    const { key: plaintextKey, prefix } = generateApiKey();
+    const keyHash = await hashApiKey(plaintextKey);
+
+    const expDate = new Date();
+    expDate.setDate(expDate.getDate() + KEY_TTL_DAYS);
+    const expiresAt = expDate.toISOString();
+
+    const { error: insertError } = await supabase
+      .from('api_keys')
+      .insert({
+        user_id: userId,
+        // 'CLI Bootstrap Exchange' distinguishes this key from /otp and /oauth
+        // mints in the user's API key listing UI.
+        name: 'CLI Bootstrap Exchange',
+        key_prefix: prefix,
+        key_hash: keyHash,
+        scopes: ['read', 'write'],
+        expires_at: expiresAt,
+      });
+
+    if (insertError) {
+      Sentry.captureException(new Error(`api_keys insert failed: ${insertError.message}`), {
+        tags: { endpoint: ROUTE_ID, user_id: userId },
+      });
+      return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 });
+    }
+
+    // SECURITY: plaintextKey returned ONCE; never logged anywhere.
+    return NextResponse.json(
+      { styrby_api_key: plaintextKey, expires_at: expiresAt, user_id: userId },
+      { status: 200 },
+    );
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { endpoint: ROUTE_ID, user_id: userId },
+    });
+    return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 });
+  }
+}
+
+export const POST = handlePost;

--- a/packages/styrby-web/src/lib/auth/api-config.ts
+++ b/packages/styrby-web/src/lib/auth/api-config.ts
@@ -61,6 +61,16 @@ export const OTP_SEND_RATE_LIMIT = { windowMs: 60_000, maxRequests: 3 };
  */
 export const OTP_VERIFY_RATE_LIMIT = { windowMs: 60_000, maxRequests: 10 };
 
+/**
+ * Rate limit for /api/v1/auth/exchange (Supabase JWT → styrby_* key).
+ *
+ * WHY 10/min/IP: exchange should fire ONCE per onboarding (not per user
+ * action). 10/min covers retry-after-network-blip without enabling brute-force
+ * JWT testing. Mirrors OTP_VERIFY's cap since both consume an existing trust
+ * artefact (a Supabase JWT in this case) to mint a key.
+ */
+export const AUTH_EXCHANGE_RATE_LIMIT = { windowMs: 60_000, maxRequests: 10 };
+
 // ============================================================================
 // Key TTL
 // ============================================================================


### PR DESCRIPTION
Bridge between existing Supabase Auth bootstrap and Strategy C's per-user styrby_* keys.

## Server side
- New POST /api/v1/auth/exchange — takes Supabase JWT in Authorization header, validates server-side via supabase.auth.getUser(jwt), mints a styrby_* key bound to the user.
- Same minting pattern as /otp/verify and /oauth/callback (generateApiKey, hashApiKey, KEY_TTL_DAYS, rateLimit).
- 10/min/IP rate limit, generic 401 for all auth failures (no enumeration), bcrypt hash stored.

## CLI side
- PersistedData extended with styrbyApiKey + styrbyKeyExpiresAt (optional, coexists with legacy accessToken).
- StyrbyApiClient.exchangeSupabaseJwt(supabaseToken) — uses Supabase JWT as Bearer (not the client's own apiKey).
- commands/onboard.ts step 3 exchanges Supabase JWT for styrby_* key after auth completes. Non-fatal on failure (pre-Phase-4 the CLI still uses Supabase JWT exclusively).

## Why this approach (not full bootstrap rewrite)
- Existing Supabase Auth flow keeps working — onboarding doesn't break.
- Realtime pairing still uses Supabase JWT (Phase 5b will replace).
- Phase 4 callsite swaps now have a key to authenticate with.
- Smaller surgical PR.

## Tests
- 3 new unit tests covering 200 response, 401 AUTH_FAILED, Authorization header correctness.
- 33/33 client tests pass.
- pnpm typecheck clean (CLI + web).

## Refs
- styrby-backlog.md (H41 phase ladder)
- PR #221 (auth endpoints + minting pattern)
- PR #225 (StyrbyApiClient base)
- PR #227 (Phase 3.6a)
- PR #228 (Phase 3.6b)