### PR TITLE
test(billing): fix ChurnSaveOfferCard act() warning + flake (LAUNCH-2 + close LAUNCH-3 stale)

### DIFF
--- a/packages/styrby-web/src/components/billing/__tests__/ChurnSaveOfferCard.test.tsx
+++ b/packages/styrby-web/src/components/billing/__tests__/ChurnSaveOfferCard.test.tsx
@@ -29,7 +29,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import React from 'react';
 import { ChurnSaveOfferCard } from '../ChurnSaveOfferCard';
 import type { AcceptOfferActionResult } from '@/app/billing/offer/[offerId]/actions';
@@ -169,7 +169,15 @@ describe('ChurnSaveOfferCard', () => {
       expect(screen.getByText(/Accepting\.\.\./i)).toBeTruthy();
     });
 
-    resolveAction({ ok: true });
+    // WHY act() + microtask flush: resolveAction() triggers React's startTransition
+    // to flip the pending state back to ready. Without act(), the test exits while
+    // React is mid-transition, causing the "wrap in act()" warning intermittently
+    // and a flaky "(f) was hanging on prior render" failure under CI load.
+    // Awaiting a microtask after resolveAction lets React commit the resolved state.
+    await act(async () => {
+      resolveAction({ ok: true });
+      await Promise.resolve();
+    });
   });
 
   // ── (g) Error banner ───────────────────────────────────────────────────────


### PR DESCRIPTION
LAUNCH-2: ChurnSaveOfferCard pending-state test was emitting a React 19 'wrap in act(...)' warning + intermittently flaking under CI load. Root cause: resolveAction() outside act() commits resolved state after test exits, racing with cleanup. Fix wraps the resolve in act() with a microtask flush.

Verified: 15/15 pass in 557ms (down from 915ms — the warning capture overhead is gone). Stable on re-runs.

LAUNCH-3 (SEC-ENV-001): closed as stale — packages/styrby-web/.env.example already documents NEXT_PUBLIC_STYRBY_SENTRY_MUTED + NEXT_PUBLIC_ENTERPRISE_CALENDAR_URL.

Test plan:
- pnpm exec vitest run src/components/billing/__tests__/ChurnSaveOfferCard.test.tsx (15/15 pass)
- No production code changes; test-only fix.

Refs: styrby-backlog.md