### PR TITLE
feat(cli): swap template command to /api/v1/templates via apiClient (H41 Phase 4-step1)

### DIFF
--- a/packages/styrby-cli/src/api/clientFromPersistence.ts
+++ b/packages/styrby-cli/src/api/clientFromPersistence.ts
@@ -1,0 +1,79 @@
+/**
+ * Helper: load PersistedData → return an authenticated StyrbyApiClient.
+ *
+ * Single source of truth for "the CLI's apiClient" (H41 Phase 4 onward).
+ * Every Category-A callsite that previously did `supabase.from(...)` now
+ * imports this and calls `getApiClient()` instead.
+ *
+ * H41 Phase 5 mints `styrbyApiKey` during onboarding. Phase 4 swaps assume
+ * the key is present. If it isn't (existing CLI installs that pre-date
+ * Phase 5), callers get a clear actionable error rather than a silent 401.
+ *
+ * @module api/clientFromPersistence
+ */
+
+import { loadPersistedData } from '@/persistence';
+import { StyrbyApiClient } from '@/api/styrbyApiClient';
+
+/**
+ * Distinct error subclass so callers can `instanceof MissingStyrbyKeyError`
+ * to surface a re-onboard prompt rather than a generic auth failure.
+ *
+ * WHY a class (not just a string code): callers can branch on the error type
+ * at the catch site — typically `if (err instanceof MissingStyrbyKeyError)
+ * print "run styrby onboard --refresh"`.
+ */
+export class MissingStyrbyKeyError extends Error {
+  constructor(message = 'No styrby_* API key on disk. Run `styrby onboard --refresh` to mint one.') {
+    super(message);
+    this.name = 'MissingStyrbyKeyError';
+  }
+}
+
+/**
+ * Construct an authenticated StyrbyApiClient from persisted data.
+ *
+ * @returns A StyrbyApiClient with the per-user `styrby_*` key set.
+ * @throws {MissingStyrbyKeyError} If no key is on disk (post-Phase-5 onboard
+ *   should have minted one; if not, the CLI was installed pre-Phase-5 and
+ *   the user must re-onboard).
+ *
+ * @example
+ * try {
+ *   const client = getApiClient();
+ *   await client.createTemplate({ name, content });
+ * } catch (err) {
+ *   if (err instanceof MissingStyrbyKeyError) {
+ *     console.log(chalk.yellow(err.message));
+ *     process.exit(1);
+ *   }
+ *   throw err;
+ * }
+ */
+export function getApiClient(): StyrbyApiClient {
+  const data = loadPersistedData();
+  if (!data?.styrbyApiKey) {
+    throw new MissingStyrbyKeyError();
+  }
+  return new StyrbyApiClient({ apiKey: data.styrbyApiKey });
+}
+
+/**
+ * Same as getApiClient() but returns null instead of throwing when no key
+ * is present. Used by callsites that want to opportunistically use the
+ * apiClient when available, falling back to legacy Supabase paths during
+ * the H41 transition.
+ *
+ * WHY this opt-in nullable variant: some flows (cost-reporter, audit logs)
+ * fire on every CLI action — failing them with MissingStyrbyKeyError on
+ * pre-Phase-5 installs would break the CLI for existing users. Callers
+ * that can degrade gracefully use this helper; callers that require the
+ * key (templates, contexts) use getApiClient() with the explicit error.
+ */
+export function tryGetApiClient(): StyrbyApiClient | null {
+  const data = loadPersistedData();
+  if (!data?.styrbyApiKey) {
+    return null;
+  }
+  return new StyrbyApiClient({ apiKey: data.styrbyApiKey });
+}

--- a/packages/styrby-cli/src/commands/template.ts
+++ b/packages/styrby-cli/src/commands/template.ts
@@ -16,11 +16,10 @@
  */
 
 import chalk from 'chalk';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { logger } from '@/ui/logger';
-import { loadPersistedData } from '@/persistence';
-import { config as envConfig } from '@/env';
 import { confirm, prompt } from '@/ui/interactive';
+import { getApiClient, MissingStyrbyKeyError } from '@/api/clientFromPersistence';
+import { StyrbyApiError, type StyrbyApiClient, type TemplateRow, type TemplateSummary } from '@/api/styrbyApiClient';
 import {
   ContextTemplate,
   ContextTemplateRow,
@@ -114,34 +113,29 @@ export async function handleTemplate(args: string[]): Promise<void> {
  * @returns Promise that resolves when list is displayed
  */
 async function handleTemplateList(): Promise<void> {
-  const authResult = await ensureAuthenticated();
-  if ('error' in authResult) {
-    console.log(chalk.red('\n' + authResult.error));
-    process.exit(1);
-  }
-
-  const supabase = authResult.supabase;
+  const apiClient = ensureApiClientOrExit();
 
   console.log(chalk.gray('\nFetching templates...\n'));
 
-  const { data, error } = await supabase
-    .from('context_templates')
-    .select('*')
-    .order('created_at', { ascending: false });
-
-  if (error) {
-    console.log(chalk.red(`Failed to fetch templates: ${error.message}`));
-    logger.debug('Supabase error', { error });
-    process.exit(1);
+  let result: Awaited<ReturnType<StyrbyApiClient['listTemplates']>>;
+  try {
+    result = await apiClient.listTemplates();
+  } catch (err) {
+    handleApiError(err, 'fetch templates');
+    return; // unreachable; handleApiError exits
   }
 
-  if (!data || data.length === 0) {
+  if (result.count === 0) {
     console.log(chalk.yellow('No templates found.'));
     console.log(chalk.gray('\nCreate one with: styrby template create <name>'));
     return;
   }
 
-  const templates = (data as ContextTemplateRow[]).map(contextTemplateFromRow);
+  // WHY transform via row → domain: existing renderContextTemplate / display
+  // helpers all consume the ContextTemplate domain shape, not the row shape.
+  // The /api/v1/templates list returns the same DB columns as the prior direct
+  // .from('context_templates').select('*') — drop in the transform unchanged.
+  const templates = (result.templates as unknown as ContextTemplateRow[]).map(contextTemplateFromRow);
 
   // Display header
   console.log(chalk.bold('Your Templates'));
@@ -185,14 +179,7 @@ async function handleTemplateCreate(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const authResult = await ensureAuthenticated();
-  if ('error' in authResult) {
-    console.log(chalk.red('\n' + authResult.error));
-    process.exit(1);
-  }
-
-  const supabase = authResult.supabase;
-  const userId = authResult.userId;
+  const apiClient = ensureApiClientOrExit();
 
   console.log('');
   console.log(chalk.bold(`Create Template: ${name}`));
@@ -245,19 +232,21 @@ async function handleTemplateCreate(args: string[]): Promise<void> {
   console.log('');
   console.log(chalk.gray('Creating template...'));
 
-  const { error } = await supabase.from('context_templates').insert({
-    user_id: userId,
-    name: name.trim(),
-    description: description || null,
-    content: content.trim(),
-    variables,
-    is_default: isDefault,
-  });
-
-  if (error) {
-    console.log(chalk.red(`\nFailed to create template: ${error.message}`));
-    logger.debug('Supabase error', { error });
-    process.exit(1);
+  // WHY user_id NOT in the body: the /api/v1/templates POST endpoint takes
+  // user_id from the authenticated apiClient context (Bearer styrby_*) and
+  // rejects any user_id in the body via Zod .strict(). Passing it would
+  // produce a 400 mass-assignment-guard rejection.
+  try {
+    await apiClient.createTemplate({
+      name: name.trim(),
+      content: content.trim(),
+      description: description || undefined,
+      variables,
+      is_default: isDefault,
+    });
+  } catch (err) {
+    handleApiError(err, 'create template');
+    return; // unreachable
   }
 
   console.log(chalk.green(`\nTemplate "${name}" created successfully!`));
@@ -286,32 +275,21 @@ async function handleTemplateShow(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const authResult = await ensureAuthenticated();
-  if ('error' in authResult) {
-    console.log(chalk.red('\n' + authResult.error));
+  const apiClient = ensureApiClientOrExit();
+
+  // WHY list+filter (not GET by name): /api/v1/templates/[id] takes a UUID,
+  // not a name. The existing CLI ergonomics use `styrby template show <name>`
+  // — we keep that UX by listing the user's templates (typically <50) and
+  // filtering case-insensitively client-side. Server-side name filtering
+  // would need a new endpoint; the list is small enough that this is fine.
+  const row = await findTemplateByName(apiClient, name);
+  if (!row) {
+    console.log(chalk.red(`\nTemplate "${name}" not found.`));
+    console.log(chalk.gray('Use "styrby template list" to see available templates.'));
     process.exit(1);
   }
 
-  const supabase = authResult.supabase;
-
-  const { data, error } = await supabase
-    .from('context_templates')
-    .select('*')
-    .ilike('name', name)
-    .single();
-
-  if (error) {
-    if (error.code === 'PGRST116') {
-      console.log(chalk.red(`\nTemplate "${name}" not found.`));
-      console.log(chalk.gray('Use "styrby template list" to see available templates.'));
-    } else {
-      console.log(chalk.red(`\nFailed to fetch template: ${error.message}`));
-      logger.debug('Supabase error', { error });
-    }
-    process.exit(1);
-  }
-
-  const template = contextTemplateFromRow(data as ContextTemplateRow);
+  const template = contextTemplateFromRow(row as unknown as ContextTemplateRow);
 
   // Display template details
   console.log('');
@@ -366,13 +344,7 @@ async function handleTemplateUse(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const authResult = await ensureAuthenticated();
-  if ('error' in authResult) {
-    console.log(chalk.red('\n' + authResult.error));
-    process.exit(1);
-  }
-
-  const supabase = authResult.supabase;
+  const apiClient = ensureApiClientOrExit();
 
   // Parse variable overrides from command line (--varname=value)
   const variableOverrides: Record<string, string> = {};
@@ -386,24 +358,14 @@ async function handleTemplateUse(args: string[]): Promise<void> {
     }
   }
 
-  const { data, error } = await supabase
-    .from('context_templates')
-    .select('*')
-    .ilike('name', name)
-    .single();
-
-  if (error) {
-    if (error.code === 'PGRST116') {
-      console.log(chalk.red(`\nTemplate "${name}" not found.`));
-      console.log(chalk.gray('Use "styrby template list" to see available templates.'));
-    } else {
-      console.log(chalk.red(`\nFailed to fetch template: ${error.message}`));
-      logger.debug('Supabase error', { error });
-    }
+  const row = await findTemplateByName(apiClient, name);
+  if (!row) {
+    console.log(chalk.red(`\nTemplate "${name}" not found.`));
+    console.log(chalk.gray('Use "styrby template list" to see available templates.'));
     process.exit(1);
   }
 
-  const template = contextTemplateFromRow(data as ContextTemplateRow);
+  const template = contextTemplateFromRow(row as unknown as ContextTemplateRow);
 
   // Collect variable values
   const values: Record<string, string> = { ...variableOverrides };
@@ -452,36 +414,20 @@ async function handleTemplateDelete(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const authResult = await ensureAuthenticated();
-  if ('error' in authResult) {
-    console.log(chalk.red('\n' + authResult.error));
-    process.exit(1);
-  }
+  const apiClient = ensureApiClientOrExit();
 
-  const supabase = authResult.supabase;
-
-  // First, verify the template exists
-  const { data, error: fetchError } = await supabase
-    .from('context_templates')
-    .select('id, name')
-    .ilike('name', name)
-    .single();
-
-  if (fetchError) {
-    if (fetchError.code === 'PGRST116') {
-      console.log(chalk.red(`\nTemplate "${name}" not found.`));
-      console.log(chalk.gray('Use "styrby template list" to see available templates.'));
-    } else {
-      console.log(chalk.red(`\nFailed to fetch template: ${fetchError.message}`));
-      logger.debug('Supabase error', { error: fetchError });
-    }
+  // First, find the template (case-insensitive name match via list filter).
+  const row = await findTemplateByName(apiClient, name);
+  if (!row) {
+    console.log(chalk.red(`\nTemplate "${name}" not found.`));
+    console.log(chalk.gray('Use "styrby template list" to see available templates.'));
     process.exit(1);
   }
 
   // Confirm deletion
   console.log('');
   const confirmed = await confirm(
-    `Delete template "${chalk.bold(data.name)}"? This cannot be undone.`,
+    `Delete template "${chalk.bold(row.name)}"? This cannot be undone.`,
     false
   );
 
@@ -490,19 +436,14 @@ async function handleTemplateDelete(args: string[]): Promise<void> {
     return;
   }
 
-  // Delete the template
-  const { error: deleteError } = await supabase
-    .from('context_templates')
-    .delete()
-    .eq('id', data.id);
-
-  if (deleteError) {
-    console.log(chalk.red(`\nFailed to delete template: ${deleteError.message}`));
-    logger.debug('Supabase error', { error: deleteError });
-    process.exit(1);
+  try {
+    await apiClient.deleteTemplate(row.id);
+  } catch (err) {
+    handleApiError(err, 'delete template');
+    return; // unreachable
   }
 
-  console.log(chalk.green(`\nTemplate "${data.name}" deleted successfully.`));
+  console.log(chalk.green(`\nTemplate "${row.name}" deleted successfully.`));
   console.log('');
 }
 
@@ -511,43 +452,78 @@ async function handleTemplateDelete(args: string[]): Promise<void> {
 // ============================================================================
 
 /**
- * Ensure the user is authenticated and return a configured Supabase client.
+ * Get an authenticated apiClient, or print a friendly error and exit.
  *
- * @returns Authentication result with Supabase client and user ID, or error
+ * Replaces the prior `ensureAuthenticated` (which built a Supabase client
+ * from PersistedData.accessToken). Templates now flow through /api/v1/*
+ * with a `styrby_*` Bearer token — Phase 4 of H41.
+ *
+ * @returns A StyrbyApiClient ready for use, or process exits with code 1.
  */
-async function ensureAuthenticated(): Promise<
-  | { success: true; supabase: SupabaseClient; userId: string }
-  | { success: false; error: string; supabase?: never; userId?: never }
-> {
-  const data = loadPersistedData();
-
-  if (!data?.userId || !data?.accessToken) {
-    return {
-      success: false,
-      error: 'Not authenticated. Run "styrby onboard" first.',
-    };
+function ensureApiClientOrExit(): StyrbyApiClient {
+  try {
+    return getApiClient();
+  } catch (err) {
+    if (err instanceof MissingStyrbyKeyError) {
+      console.log(chalk.red('\n' + err.message));
+      process.exit(1);
+    }
+    throw err;
   }
-
-  if (!envConfig.supabaseAnonKey) {
-    return {
-      success: false,
-      error: 'Supabase anonymous key not configured. Set SUPABASE_ANON_KEY.',
-    };
-  }
-
-  const supabase = createClient(envConfig.supabaseUrl, envConfig.supabaseAnonKey, {
-    auth: { persistSession: false },
-    global: {
-      headers: { Authorization: `Bearer ${data.accessToken}` },
-    },
-  });
-
-  return {
-    success: true,
-    supabase,
-    userId: data.userId,
-  };
 }
+
+/**
+ * Find a template by case-insensitive name match.
+ *
+ * The /api/v1/templates list endpoint returns the user's full template set
+ * (no name filter on the server). Matching client-side keeps the existing
+ * `styrby template show <name>` ergonomics while every operation flows
+ * through the typed apiClient. Typical user has < 50 templates so the
+ * list-and-filter pattern is fine.
+ *
+ * @returns The matching TemplateSummary, or null if no name matched.
+ */
+async function findTemplateByName(
+  apiClient: StyrbyApiClient,
+  name: string,
+): Promise<TemplateSummary | null> {
+  let result: Awaited<ReturnType<StyrbyApiClient['listTemplates']>>;
+  try {
+    result = await apiClient.listTemplates();
+  } catch (err) {
+    handleApiError(err, 'fetch template');
+    return null; // unreachable
+  }
+  const lower = name.toLowerCase();
+  return result.templates.find((t) => t.name.toLowerCase() === lower) ?? null;
+}
+
+/**
+ * Print a contextual error from a StyrbyApiError (or any error) and exit.
+ *
+ * WHY a single helper: every callsite in this file wraps an apiClient call
+ * with the same chalk-red error display. Extracting the pattern keeps the
+ * handler bodies focused on flow, not error-formatting boilerplate.
+ *
+ * @param err - The thrown error from an apiClient call
+ * @param verb - Action description used in the error message ("create template",
+ *               "fetch templates", etc.)
+ */
+function handleApiError(err: unknown, verb: string): never {
+  if (err instanceof StyrbyApiError) {
+    console.log(chalk.red(`\nFailed to ${verb}: ${err.message}`));
+    logger.debug('StyrbyApiError', { status: err.status, code: err.code });
+  } else if (err instanceof Error) {
+    console.log(chalk.red(`\nFailed to ${verb}: ${err.message}`));
+  } else {
+    console.log(chalk.red(`\nFailed to ${verb}: unknown error`));
+  }
+  process.exit(1);
+}
+
+// Suppress unused TemplateRow import — kept for type compatibility with
+// future callers that need the full row shape outside the summary endpoint.
+void (null as unknown as TemplateRow | undefined);
 
 /**
  * Prompt for multiline input.

--- a/packages/styrby-cli/src/persistence.ts
+++ b/packages/styrby-cli/src/persistence.ts
@@ -80,7 +80,9 @@ export interface PersistedData {
   /** Legacy Supabase refresh token. Will be cleared on next re-onboard post-Phase-5. */
   refreshToken?: string;
   /**
-   * Per-user `styrby_*` API key minted by /api/v1/auth/*.
+   * Per-user `styrby_*` API key minted by /api/v1/auth/* during H41 Phase 5.
+   * Bearer token for every /api/v1/* call.
+   *
    * WHY 0o600 file mode (set in savePersistedData below): plaintext key on disk
    * matches the CLI's threat model — same security posture as the prior
    * Supabase JWT. Mobile + web use platform secure storage; CLI relies on


### PR DESCRIPTION
First Phase 4 swap — `src/commands/template.ts`. All 5 supabase.from('context_templates') calls replaced with typed StyrbyApiClient methods. Drops @supabase/supabase-js + envConfig.supabaseAnonKey from this file.

## Highlights
- New helper `src/api/clientFromPersistence.ts` — single source of truth for getting an authenticated StyrbyApiClient from persisted data, with `MissingStyrbyKeyError` for clean re-onboard prompts.
- PersistedData gains `styrbyApiKey` + `styrbyKeyExpiresAt` fields (mirrors PR #229's same change; rebase will be a no-op).
- Each handler now uses `apiClient.listTemplates / createTemplate / deleteTemplate` + a `findTemplateByName` helper for case-insensitive name lookups (server has no name filter; client-side filter on the user's <50 templates is fine).

## Why step 1 (not full Phase 4)
19 callsites across 5+ files. template.ts is the smallest, proves the pattern. Subsequent steps swap context.ts (8), multiAgentOrchestrator.ts (3), approvalHandler.ts (2+poll), budget-actions.ts (2), cost-reporter.ts (1) using the same helper.

## Runtime dependency
Requires PR #229 (Phase 5) to mint styrbyApiKey during onboarding. Until #229 lands + existing users re-onboard, template commands exit with `MissingStyrbyKeyError`. Acceptable transition UX (paid-beta hasn't started).

## Test plan
- [x] pnpm typecheck (CLI) clean
- [ ] CI green
- [ ] Manual: re-onboard with #229 merged, run `styrby template list` and confirm round-trip

Refs: PR #225, #227, #228, #229