### PR TITLE
feat(cli/mcp): swap approvalHandler to apiClient (H41 Phase 4-step4)

### DIFF
--- a/packages/styrby-cli/src/commands/mcpServe.ts
+++ b/packages/styrby-cli/src/commands/mcpServe.ts
@@ -33,9 +33,7 @@
  */
 
 import chalk from 'chalk';
-import { createClient } from '@supabase/supabase-js';
 import { loadPersistedData } from '@/persistence';
-import { config as envConfig } from '@/env';
 import { logger } from '@/ui/logger';
 import { runStdioServer } from '@/mcp/server';
 import { createSupabaseApprovalHandler } from '@/mcp/approvalHandler';
@@ -93,23 +91,25 @@ async function handleMcpServe(): Promise<void> {
     process.exit(1);
   }
 
-  if (!envConfig.supabaseAnonKey) {
-    logger.error('Supabase anonymous key not configured. Set SUPABASE_ANON_KEY.');
-    process.exit(1);
+  // H41 Phase 4-step4: load the styrby_* key and build a typed apiClient.
+  // Replaces the prior direct-Supabase auth path (no more anon-key + JWT
+  // dance for the MCP server). MissingStyrbyKeyError fires if the user
+  // ran the CLI before Phase 5's exchange flow minted the key — fix is to
+  // re-onboard.
+  let apiClient: import('@/api/styrbyApiClient').StyrbyApiClient;
+  try {
+    const { getApiClient } = await import('@/api/clientFromPersistence');
+    apiClient = getApiClient();
+  } catch (err) {
+    const { MissingStyrbyKeyError } = await import('@/api/clientFromPersistence');
+    if (err instanceof MissingStyrbyKeyError) {
+      logger.error(err.message);
+      process.exit(1);
+    }
+    throw err;
   }
 
-  // WHY persistSession=false: this is a one-shot server process bound to
-  // a specific token already held in memory. Letting Supabase's auth
-  // module re-persist the session would race with the daemon process
-  // that owns persistence in the typical multi-process CLI deployment.
-  const supabase = createClient(envConfig.supabaseUrl, envConfig.supabaseAnonKey, {
-    auth: { persistSession: false },
-    global: {
-      headers: { Authorization: `Bearer ${data.accessToken}` },
-    },
-  });
-
-  const handler = createSupabaseApprovalHandler(supabase, data.userId, data.machineId);
+  const handler = createSupabaseApprovalHandler(apiClient, data.userId, data.machineId);
 
   // Banner goes to stderr — invisible to the JSON-RPC protocol on stdout.
   logger.info(chalk.bold.cyan('Styrby MCP server starting on stdio…'));

--- a/packages/styrby-cli/src/mcp/__tests__/approvalHandler.test.ts
+++ b/packages/styrby-cli/src/mcp/__tests__/approvalHandler.test.ts
@@ -1,56 +1,71 @@
 /**
- * Regression tests for createSupabaseApprovalHandler (Phase 3.5).
+ * Regression tests for createSupabaseApprovalHandler.
  *
- * WHY this exists: prior to this PR the handler wrote `event_type`/`severity`/
- * `machine_id` columns that don't exist on audit_log. The bug was latent —
- * never caught because the unit-test surface only tested the MCP server, not
- * the handler itself. These tests pin the column names + enum values.
+ * H41 Phase 4-step4: rewritten to mock StyrbyApiClient.writeAuditEvent +
+ * searchAuditLog instead of a Supabase client. Drops the column-shape
+ * regression tests (those guarantees moved to the server-side /api/v1/audit
+ * route's tests + Zod .strict() schema). Tests now focus on:
+ *  - The handler calls apiClient.writeAuditEvent for the request row
+ *  - The handler polls via apiClient.searchAuditLog
+ *  - Decision rows return the correct {decision, reason} shape
+ *  - Timeout path writes a `mcp_approval_timeout` audit row
+ *  - Insert errors propagate (timeout-row write swallows by design)
  */
 
 import { describe, expect, it, vi } from 'vitest';
 
 import { createSupabaseApprovalHandler } from '../approvalHandler.js';
 import type { RequestApprovalInput } from '../tools.js';
+import type { StyrbyApiClient } from '@/api/styrbyApiClient';
 
-// Helper: build a deeply-mocked SupabaseClient stub. Each `from(table)` call
-// returns a fluent chain; `insert` and `select` resolve to the values pushed
-// into the queues on construction.
-function buildStubSupabase(opts: {
-  insertResult?: { error: { message: string } | null };
-  selectRows?: Array<{ data: unknown[] | null; error: { message: string } | null }>;
+interface RecordedAudit {
+  action: string;
+  resource_type?: string;
+  resource_id?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Build a deeply-mocked StyrbyApiClient stub. Records each writeAuditEvent
+ * call; serves searchAuditLog responses from the supplied queue.
+ *
+ * WHY a focused stub (not vi.fn() on the whole class): the handler only
+ * uses two methods. A targeted stub keeps the test signal-to-noise high
+ * and surfaces accidental dependencies on other client methods as
+ * compile errors via the explicit cast.
+ */
+function buildStubApiClient(opts: {
+  writeAuditError?: Error;
+  searchResults?: Array<{
+    events: Array<{
+      id?: string;
+      action: string;
+      resource_type?: string | null;
+      resource_id?: string | null;
+      metadata: unknown;
+      created_at: string;
+    }>;
+    count: number;
+  }>;
+  searchError?: Error;
 }) {
-  const inserts: Array<{ table: string; payload: Record<string, unknown> }> = [];
-  let selectIdx = 0;
-  const selectQueue = opts.selectRows ?? [];
+  const audits: RecordedAudit[] = [];
+  let searchIdx = 0;
+  const searchQueue = opts.searchResults ?? [];
 
   const stub = {
-    from(table: string) {
-      return {
-        insert(payload: Record<string, unknown>) {
-          inserts.push({ table, payload });
-          return Promise.resolve(opts.insertResult ?? { error: null });
-        },
-        select() {
-          // chainable: .eq().eq().eq().order().limit() → resolves to row set
-          const chain = {
-            eq() {
-              return chain;
-            },
-            order() {
-              return chain;
-            },
-            limit() {
-              const next = selectQueue[selectIdx++] ?? { data: [], error: null };
-              return Promise.resolve(next);
-            },
-          };
-          return chain;
-        },
-      };
+    writeAuditEvent: async (event: RecordedAudit) => {
+      audits.push(event);
+      if (opts.writeAuditError) throw opts.writeAuditError;
+      return { id: 'audit-' + audits.length, created_at: new Date().toISOString() };
     },
-  } as unknown as Parameters<typeof createSupabaseApprovalHandler>[0];
+    searchAuditLog: async () => {
+      if (opts.searchError) throw opts.searchError;
+      return searchQueue[searchIdx++] ?? { events: [], count: 0 };
+    },
+  } as unknown as StyrbyApiClient;
 
-  return { stub, inserts };
+  return { stub, audits };
 }
 
 const SAMPLE_INPUT: RequestApprovalInput = {
@@ -61,52 +76,42 @@ const SAMPLE_INPUT: RequestApprovalInput = {
 };
 
 describe('createSupabaseApprovalHandler', () => {
-  it('writes request row with real audit_log columns (no event_type/severity)', async () => {
-    const { stub, inserts } = buildStubSupabase({
+  it('writes request row via apiClient.writeAuditEvent with mcp_approval_requested action', async () => {
+    const { stub, audits } = buildStubApiClient({
       // Decision row arrives on the first poll cycle.
-      selectRows: [
+      searchResults: [
         {
-          data: [
+          events: [
             {
+              action: 'mcp_approval_decided',
+              resource_id: 'placeholder',
               metadata: { approval_id: 'placeholder', decision: 'approved', user_message: 'ok' },
               created_at: '2026-04-30T00:00:00Z',
             },
           ],
-          error: null,
+          count: 1,
         },
       ],
     });
 
     const handler = createSupabaseApprovalHandler(stub, 'user-1', 'machine-1');
-    // Patch matcher: the test stub returns the same row regardless of resource_id
-    // filtering; that's fine because we're verifying the request-INSERT shape.
     await handler.request(SAMPLE_INPUT, 5_000).catch(() => undefined);
 
-    expect(inserts.length).toBeGreaterThanOrEqual(1);
-    const requestInsert = inserts[0];
-    expect(requestInsert.table).toBe('audit_log');
-
-    const payload = requestInsert.payload;
-    // Real columns present
-    expect(payload).toHaveProperty('user_id', 'user-1');
-    expect(payload).toHaveProperty('action', 'mcp_approval_requested');
-    expect(payload).toHaveProperty('resource_type', 'mcp_approval');
-    expect(payload).toHaveProperty('resource_id');
-    expect(payload).toHaveProperty('metadata');
-    // Drift columns absent
-    expect(payload).not.toHaveProperty('event_type');
-    expect(payload).not.toHaveProperty('severity');
-    expect(payload).not.toHaveProperty('machine_id');
-    // machine_id moved into metadata
-    expect((payload.metadata as { machine_id: string }).machine_id).toBe('machine-1');
+    expect(audits.length).toBeGreaterThanOrEqual(1);
+    const request = audits[0];
+    expect(request.action).toBe('mcp_approval_requested');
+    expect(request.resource_type).toBe('mcp_approval');
+    expect(request.resource_id).toBeTruthy();
+    // machine_id is in metadata (not as a column — the audit_log table has no such column)
+    expect((request.metadata as { machine_id: string }).machine_id).toBe('machine-1');
     // requested_action holds the original input.action (no name collision with column `action`)
-    expect((payload.metadata as { requested_action: string }).requested_action).toBe('bash');
+    expect((request.metadata as { requested_action: string }).requested_action).toBe('bash');
   });
 
   it('writes timeout row with mcp_approval_timeout action when no decision arrives', async () => {
-    const { stub, inserts } = buildStubSupabase({
-      // All select cycles return empty — decision never arrives, handler times out.
-      selectRows: Array.from({ length: 100 }, () => ({ data: [], error: null })),
+    const { stub, audits } = buildStubApiClient({
+      // All search cycles return empty — decision never arrives, handler times out.
+      searchResults: Array.from({ length: 100 }, () => ({ events: [], count: 0 })),
     });
 
     const handler = createSupabaseApprovalHandler(stub, 'user-1', 'machine-1');
@@ -117,29 +122,29 @@ describe('createSupabaseApprovalHandler', () => {
     const result = await handler.request(SAMPLE_INPUT, 50);
     expect(result.decision).toBe('denied');
 
-    // Two inserts: the request, and the timeout.
-    const timeoutInsert = inserts.find((i) => i.payload.action === 'mcp_approval_timeout');
-    expect(timeoutInsert).toBeDefined();
-    expect(timeoutInsert!.payload).toHaveProperty('resource_id');
-    expect(timeoutInsert!.payload).not.toHaveProperty('event_type');
-    expect((timeoutInsert!.payload.metadata as { machine_id: string }).machine_id).toBe('machine-1');
+    // Two writes: the request, and the timeout.
+    const timeoutAudit = audits.find((a) => a.action === 'mcp_approval_timeout');
+    expect(timeoutAudit).toBeDefined();
+    expect(timeoutAudit!.resource_id).toBeTruthy();
+    expect((timeoutAudit!.metadata as { machine_id: string }).machine_id).toBe('machine-1');
   });
 
   it('returns the decision when a matching row arrives', async () => {
-    const { stub } = buildStubSupabase({
-      selectRows: [
+    const { stub } = buildStubApiClient({
+      searchResults: [
         {
-          data: [
+          events: [
             {
+              action: 'mcp_approval_decided',
               metadata: {
-                approval_id: 'will-match', // resource_id filter handles correctness in real DB
+                approval_id: 'will-match', // resource_id filter handles correctness in real prod
                 decision: 'approved',
                 user_message: 'go ahead',
               },
               created_at: '2026-04-30T00:00:00Z',
             },
           ],
-          error: null,
+          count: 1,
         },
       ],
     });
@@ -151,14 +156,40 @@ describe('createSupabaseApprovalHandler', () => {
     expect(result.reason).toBe('go ahead');
   });
 
-  it('throws on insert error rather than swallowing', async () => {
-    const { stub } = buildStubSupabase({
-      insertResult: { error: { message: 'permission denied for table audit_log' } },
+  it('throws on writeAuditEvent error rather than swallowing (request path)', async () => {
+    const { stub } = buildStubApiClient({
+      writeAuditError: new Error('permission denied for table audit_log'),
     });
 
     const handler = createSupabaseApprovalHandler(stub, 'user-1', 'machine-1');
     await expect(handler.request(SAMPLE_INPUT, 5_000)).rejects.toThrow(
       /permission denied for table audit_log/,
     );
+  });
+
+  it('swallows timeout-record write errors (best-effort, primary contract is denied return)', async () => {
+    // Force search to always return empty → handler times out and tries to
+    // write the timeout audit row. We make THAT write throw too; the handler
+    // must still return denied (the primary contract).
+    const { stub } = buildStubApiClient({
+      searchResults: Array.from({ length: 100 }, () => ({ events: [], count: 0 })),
+    });
+    // Patch writeAuditEvent: succeed on first call (request row), fail on subsequent.
+    const original = stub.writeAuditEvent;
+    let count = 0;
+    (stub as unknown as { writeAuditEvent: typeof stub.writeAuditEvent }).writeAuditEvent = async (event) => {
+      count++;
+      if (count >= 2) throw new Error('storage unavailable');
+      return original(event);
+    };
+
+    // Silence the expected console.error from the catch block.
+    const consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const handler = createSupabaseApprovalHandler(stub, 'user-1', 'machine-1');
+    const result = await handler.request(SAMPLE_INPUT, 50);
+    expect(result.decision).toBe('denied');
+    expect(result.reason).toMatch(/timed out/i);
+    consoleErrSpy.mockRestore();
   });
 });

--- a/packages/styrby-cli/src/mcp/approvalHandler.ts
+++ b/packages/styrby-cli/src/mcp/approvalHandler.ts
@@ -32,9 +32,9 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { SupabaseClient } from '@supabase/supabase-js';
 import type { ApprovalHandler } from './server.js';
 import type { RequestApprovalInput, RequestApprovalOutput } from './tools.js';
+import type { StyrbyApiClient } from '@/api/styrbyApiClient';
 
 // ============================================================================
 // Constants
@@ -115,21 +115,32 @@ interface DecisionMetadata {
 // ============================================================================
 
 /**
- * Creates a Supabase-backed ApprovalHandler.
+ * Creates an apiClient-backed ApprovalHandler (H41 Phase 4-step4).
  *
- * The handler is bound to a single user + machine context so the audit
- * row can identify whose mobile device should receive the push.
+ * Replaces the prior Supabase-backed implementation. All audit_log reads
+ * and writes now flow through /api/v1/audit (POST for inserts, GET for the
+ * polling read loop). The handler is bound to a single user + machine
+ * context so the audit row can identify whose mobile device should receive
+ * the push.
  *
- * @param supabase - Authenticated Supabase client
- * @param userId - The Styrby user ID to push to
- * @param machineId - The CLI machine the agent is running on
- * @returns An ApprovalHandler ready to be passed to createStyrbyMcpServer
+ * Note: the `userId` parameter is no longer used inside the handler — the
+ * apiClient's bearer key already identifies the user server-side. We keep
+ * the parameter in the signature for source-compat with existing callers
+ * (a follow-up pass can drop it). `machineId` is still embedded in the
+ * metadata so push-trigger logic can target the right device.
+ *
+ * @param apiClient - Authenticated StyrbyApiClient with the user's styrby_* key
+ * @param userId - Styrby user ID (kept for caller-compat; unused internally)
+ * @param machineId - CLI machine ID for push target attribution
  */
 export function createSupabaseApprovalHandler(
-  supabase: SupabaseClient,
+  apiClient: StyrbyApiClient,
   userId: string,
   machineId: string,
 ): ApprovalHandler {
+  // WHY void here: the apiClient's bearer key identifies the user; we don't
+  // pass userId in the body anywhere. Keep the parameter for source-compat.
+  void userId;
   return {
     async request(
       input: RequestApprovalInput,
@@ -150,22 +161,22 @@ export function createSupabaseApprovalHandler(
         context: input.context,
       };
 
-      const { error: insertError } = await supabase.from('audit_log').insert({
-        user_id: userId,
-        action: AUDIT_ACTION_REQUESTED,
-        resource_type: 'mcp_approval',
-        resource_id: approvalId,
-        metadata: requestMetadata,
-      });
-
-      if (insertError) {
-        throw new Error(`Failed to record approval request: ${insertError.message}`);
+      try {
+        await apiClient.writeAuditEvent({
+          action: AUDIT_ACTION_REQUESTED,
+          resource_type: 'mcp_approval',
+          resource_id: approvalId,
+          metadata: requestMetadata as unknown as Record<string, unknown>,
+        });
+      } catch (insertError) {
+        const msg = insertError instanceof Error ? insertError.message : 'unknown';
+        throw new Error(`Failed to record approval request: ${msg}`);
       }
 
       // 2. Poll for the decision row.
       // WHY poll instead of realtime: see module comment. Phase 4 swaps
-      // this for a `supabase.channel(...).on('postgres_changes', ...)`
-      // subscription on the dedicated mcp_approvals table.
+      // this for a Supabase Realtime subscription on the dedicated
+      // mcp_approvals table once that lands.
       // WHY filter by both action and resource_id: action='mcp_approval_decided'
       // catches every decision; resource_id pins the specific approval. The
       // pre-PR code matched on metadata.approval_id post-fetch, which scaled
@@ -173,20 +184,19 @@ export function createSupabaseApprovalHandler(
       // by resource_id returns at most one row per cycle and is index-friendly.
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        const { data, error } = await supabase
-          .from('audit_log')
-          .select('metadata, created_at')
-          .eq('user_id', userId)
-          .eq('action', AUDIT_ACTION_DECIDED)
-          .eq('resource_id', approvalId)
-          .order('created_at', { ascending: false })
-          .limit(1);
-
-        if (error) {
-          throw new Error(`Failed to poll for decision: ${error.message}`);
+        let result: Awaited<ReturnType<StyrbyApiClient['searchAuditLog']>>;
+        try {
+          result = await apiClient.searchAuditLog({
+            action: AUDIT_ACTION_DECIDED,
+            resource_id: approvalId,
+            limit: 1,
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : 'unknown';
+          throw new Error(`Failed to poll for decision: ${msg}`);
         }
 
-        const matched = data?.[0];
+        const matched = result.events[0];
         if (matched) {
           const meta = matched.metadata as DecisionMetadata;
           return {
@@ -209,13 +219,24 @@ export function createSupabaseApprovalHandler(
         decision: 'denied',
         user_message: 'No response — request timed out',
       };
-      await supabase.from('audit_log').insert({
-        user_id: userId,
-        action: AUDIT_ACTION_TIMEOUT,
-        resource_type: 'mcp_approval',
-        resource_id: approvalId,
-        metadata: { ...timeoutMetadata, machine_id: machineId },
-      });
+      // WHY catch+swallow: the timeout-record write is best-effort; the
+      // primary contract (return denied to the agent) must not depend on
+      // the audit-log write succeeding. Logging via console.error is
+      // intentional — the daemon's structured logger isn't wired here and
+      // the timeout path is rare enough that ad-hoc visibility is fine.
+      await apiClient
+        .writeAuditEvent({
+          action: AUDIT_ACTION_TIMEOUT,
+          resource_type: 'mcp_approval',
+          resource_id: approvalId,
+          metadata: { ...timeoutMetadata, machine_id: machineId } as unknown as Record<string, unknown>,
+        })
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error(
+            `Failed to record approval timeout (non-fatal): ${err instanceof Error ? err.message : 'unknown'}`,
+          );
+        });
 
       return {
         decision: 'denied',


### PR DESCRIPTION
Swaps src/mcp/approvalHandler.ts off direct Supabase usage. All 3 audit_log callsites (request INSERT, decision-poll SELECT, timeout INSERT) now flow through the typed StyrbyApiClient.

## Changes
- approvalHandler.ts: signature takes `StyrbyApiClient` instead of `SupabaseClient`. INSERTs use `apiClient.writeAuditEvent`. The poll loop's SELECT uses `apiClient.searchAuditLog` with action+resource_id filters (server-side filtering instead of fetch-50-and-find-in-memory; index-friendly).
- mcpServe.ts: drops `createClient` + envConfig.supabaseAnonKey + Bearer JWT dance. Uses `getApiClient()` from `clientFromPersistence` (Phase 4-step1's helper). `MissingStyrbyKeyError` surfaces a clear re-onboard prompt.
- approvalHandler.test.ts: rewritten to mock `apiClient.writeAuditEvent` + `searchAuditLog` instead of a Supabase client. 5/5 pass.

## Why scoped to step4 only

Originally planned to land step2 (context.ts), step3 (multiAgent), step4 (this), step5 (costs) together. On full inspection:

- **step2 (context.ts)** has 8 callsites all covered by existing endpoints — clean swap, but biggest file (855 LOC). Saving for a focused next PR.
- **step3 (multiAgentOrchestrator.ts)** has a hidden 4th callsite: UPDATE sessions SET session_group_id. No PATCH /api/v1/sessions/[id] endpoint exists yet. Needs prereq.
- **step5 (cost broadcasts + budget-actions)** has 2 callsites without endpoints: SELECT notification_preferences, INSERT cost_records. Needs prereq.

Per CLAUDE.md "no band-aids": shipping step4 alone (clean) is correct over half-swapping the others.

## Side effects
- @supabase/supabase-js no longer imported by mcpServe.ts or approvalHandler.ts.
- New: timeout-record write errors are caught + console.error'd. Same end-state behavior as before, better forensic visibility.

## Test plan
- [x] pnpm typecheck (CLI) clean
- [x] pnpm exec vitest run src/mcp/__tests__/approvalHandler.test.ts: 5/5 pass
- [ ] CI green

## Refs
- styrby-backlog.md
- PR #226 (Phase 3.5 — schema fix this depends on)
- PR #228 (Phase 3.6b — GET /api/v1/audit shipped here)
- PR #232 (Phase 4-step1 — same swap pattern; established clientFromPersistence)