### PR TITLE
feat(cli): swap multiAgentOrchestrator to apiClient (H41 Phase 4-step3)

### DIFF
--- a/packages/styrby-cli/src/agent/__tests__/multiAgentOrchestrator.test.ts
+++ b/packages/styrby-cli/src/agent/__tests__/multiAgentOrchestrator.test.ts
@@ -103,8 +103,37 @@ function makeMockApi() {
   };
 }
 
+/**
+ * Builds a deeply-mocked StyrbyApiClient stub.
+ *
+ * H41 Phase 4-step3: orchestrator now uses StyrbyApiClient for every Postgres
+ * op (group create, session attach, focus, audit). The mock returns the
+ * minimal shapes consumed inside start()/focus() so tests can run without a
+ * real /api/v1 server.
+ */
+function makeMockHttpClient(overrides: { createGroupError?: Error } = {}) {
+  return {
+    createSessionGroup: vi.fn(async () => {
+      if (overrides.createGroupError) throw overrides.createGroupError;
+      return { group_id: GROUP_ID, name: 'mock', created_at: new Date().toISOString() };
+    }),
+    deleteSessionGroup: vi.fn(async () => ({ deleted: true, id: GROUP_ID })),
+    updateSession: vi.fn(async () => ({
+      id: 'mock-session-123',
+      session_group_id: GROUP_ID,
+      updated_at: new Date().toISOString(),
+    })),
+    setSessionGroupFocus: vi.fn(async () => ({
+      group_id: GROUP_ID,
+      active_agent_session_id: 'mock-session-123',
+    })),
+    writeAuditEvent: vi.fn(async () => ({ id: 'audit-1', created_at: new Date().toISOString() })),
+  } as unknown as import('@/api/styrbyApiClient').StyrbyApiClient;
+}
+
 function makeConfig(agentIds: AgentId[] = ['claude', 'codex']) {
   return {
+    httpClient: makeMockHttpClient(),
     supabase: makeMockSupabase() as unknown as import('@supabase/supabase-js').SupabaseClient,
     api: makeMockApi() as unknown as import('@/api/api').StyrbyApi,
     agentIds,
@@ -153,11 +182,16 @@ describe('MultiAgentOrchestrator', () => {
 
   // ── Dry-run mode ────────────────────────────────────────────────────────
 
-  it('dry-run returns a group with agents and does not write to Supabase', async () => {
+  it('dry-run returns a group with agents and does not call any backend', async () => {
     const orchestrator = new MultiAgentOrchestrator();
     const mockSupa = makeMockSupabase();
-    const config = { ...makeConfig(['claude', 'codex']), dryRun: true };
-    config.supabase = mockSupa as unknown as import('@supabase/supabase-js').SupabaseClient;
+    const mockHttp = makeMockHttpClient();
+    const config = {
+      ...makeConfig(['claude', 'codex']),
+      dryRun: true,
+      supabase: mockSupa as unknown as import('@supabase/supabase-js').SupabaseClient,
+      httpClient: mockHttp,
+    };
 
     const group = await orchestrator.start(config);
 
@@ -165,8 +199,9 @@ describe('MultiAgentOrchestrator', () => {
     expect(group.agents).toHaveLength(2);
     expect(group.agents[0].agentId).toBe('claude');
     expect(group.agents[1].agentId).toBe('codex');
-    // Supabase.from should NOT have been called in dry-run
+    // Neither supabase nor the http client should have been touched in dry-run.
     expect(mockSupa.from).not.toHaveBeenCalled();
+    expect(mockHttp.createSessionGroup).not.toHaveBeenCalled();
   });
 
   it('dry-run stop() is a no-op', async () => {

--- a/packages/styrby-cli/src/agent/multiAgentOrchestrator.ts
+++ b/packages/styrby-cli/src/agent/multiAgentOrchestrator.ts
@@ -33,6 +33,8 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { StyrbyApi } from '@/api/api';
+import type { StyrbyApiClient } from '@/api/styrbyApiClient';
+import { StyrbyApiError } from '@/api/styrbyApiClient';
 import type { AgentId } from '@/agent/core/AgentBackend';
 import { ApiSessionManager } from '@/api/apiSession';
 import { logger } from '@/ui/logger';
@@ -45,7 +47,21 @@ import { logger } from '@/ui/logger';
  * Configuration for spawning a multi-agent group.
  */
 export interface MultiAgentConfig {
-  /** Authenticated Supabase client */
+  /**
+   * Authenticated StyrbyApiClient for /api/v1/* calls.
+   *
+   * H41 Phase 4-step3: every Postgres operation owned by this file (group
+   * create, session attach, focus update, audit log) flows through /api/v1
+   * via this client. Direct supabase usage in those paths is gone.
+   */
+  httpClient: StyrbyApiClient;
+  /**
+   * Authenticated Supabase client.
+   *
+   * Still required for the downstream ApiSessionManager.startManagedSession
+   * call, which Phase 4 deliberately leaves unchanged (its swap is tracked
+   * separately). When that swap lands this field can be deleted.
+   */
   supabase: SupabaseClient;
   /** Connected StyrbyApi relay instance */
   api: StyrbyApi;
@@ -198,6 +214,7 @@ export class MultiAgentOrchestrator {
    */
   async start(config: MultiAgentConfig): Promise<MultiAgentGroup> {
     const {
+      httpClient,
       supabase,
       api,
       agentIds,
@@ -238,39 +255,39 @@ export class MultiAgentOrchestrator {
       groupName ||
       (prompt ? `${prompt.slice(0, 60)}${prompt.length > 60 ? '...' : ''}` : 'Multi-agent group');
 
-    // ── 2. Create agent_session_groups row ────────────────────────────────────
-    const groupId = crypto.randomUUID();
-
-    const { error: groupInsertError } = await supabase
-      .from('agent_session_groups')
-      .insert({
-        id: groupId,
-        user_id: userId,
-        name: resolvedGroupName,
-      });
-
-    if (groupInsertError) {
-      throw new Error(`Failed to create session group: ${groupInsertError.message}`);
+    // ── 2. Create agent_session_groups row via /api/v1 ───────────────────────
+    // WHY server-generated id: POST /api/v1/sessions/groups returns its own
+    // group_id. We accept that ID rather than client-minting a UUID — keeps
+    // the create call idempotency-key safe and avoids ID-collision risk.
+    let groupId: string;
+    try {
+      const created = await httpClient.createSessionGroup({ name: resolvedGroupName });
+      groupId = created.group_id;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown';
+      throw new Error(`Failed to create session group: ${msg}`);
     }
 
     logger.info('Session group created', { groupId, agentCount: agentIds.length });
 
     // Write audit log entry for group creation.
     // WHY non-fatal: audit log failure must not block the agent sessions.
-    await supabase.from('audit_log').insert({
-      user_id: userId,
-      action: 'session_group_created',
-      metadata: {
-        group_id: groupId,
-        agent_ids: agentIds,
-        project_path: projectPath,
-        group_name: resolvedGroupName,
-      },
-    }).then(({ error }) => {
-      if (error) {
-        logger.debug('Failed to write session_group_created audit log', { error: error.message });
-      }
-    });
+    await httpClient
+      .writeAuditEvent({
+        action: 'session_group_created',
+        resource_type: 'agent_session_group',
+        resource_id: groupId,
+        metadata: {
+          group_id: groupId,
+          agent_ids: agentIds,
+          project_path: projectPath,
+          group_name: resolvedGroupName,
+        },
+      })
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : 'unknown';
+        logger.debug('Failed to write session_group_created audit log', { error: msg });
+      });
 
     // ── 3. Spawn agents ───────────────────────────────────────────────────────
     const { initializeAgents, agentRegistry } = await import('@/agent/index');
@@ -287,7 +304,13 @@ export class MultiAgentOrchestrator {
         for (const spawned of spawnedAgents) {
           await spawned.stop().catch(() => {});
         }
-        await supabase.from('agent_session_groups').delete().eq('id', groupId);
+        // WHY catch+ignore: rollback is best-effort; the throw below is the
+        // primary signal. A failed delete here just leaves an orphaned group
+        // row that gets pruned by background cleanup or the next /multi run.
+        await httpClient.deleteSessionGroup(groupId).catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : 'unknown';
+          logger.debug('Failed to roll back session group', { groupId, error: msg });
+        });
         throw new Error(
           `Agent "${agentId}" is not available. Install with: styrby install ${agentId}`
         );
@@ -332,18 +355,19 @@ export class MultiAgentOrchestrator {
         projectPath,
       });
 
-      // Link the session to its group
-      await supabase
-        .from('sessions')
-        .update({ session_group_id: groupId })
-        .eq('id', activeSession.sessionId)
-        .then(({ error }) => {
-          if (error) {
-            logger.debug('Failed to set session_group_id on session', {
-              sessionId: activeSession.sessionId,
-              error: error.message,
-            });
-          }
+      // Link the session to its group via PATCH /api/v1/sessions/[id].
+      // WHY non-fatal debug-log: a failed link doesn't break the running
+      // session. The mobile UI can still address the session directly; only
+      // the multi-agent group view loses one of its members. We surface the
+      // error in debug logs for forensics rather than aborting the spawn loop.
+      await httpClient
+        .updateSession(activeSession.sessionId, { session_group_id: groupId })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : 'unknown';
+          logger.debug('Failed to set session_group_id on session', {
+            sessionId: activeSession.sessionId,
+            error: msg,
+          });
         });
 
       // Send initial prompt to this agent if provided
@@ -375,14 +399,11 @@ export class MultiAgentOrchestrator {
 
     // ── 4. Set initial focus to first agent ───────────────────────────────────
     if (spawnedAgents.length > 0) {
-      await supabase
-        .from('agent_session_groups')
-        .update({ active_agent_session_id: spawnedAgents[0].sessionId })
-        .eq('id', groupId)
-        .then(({ error }) => {
-          if (error) {
-            logger.debug('Failed to set initial active_agent_session_id', { error: error.message });
-          }
+      await httpClient
+        .setSessionGroupFocus(groupId, spawnedAgents[0].sessionId)
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : 'unknown';
+          logger.debug('Failed to set initial active_agent_session_id', { error: msg });
         });
     }
 
@@ -434,30 +455,36 @@ export class MultiAgentOrchestrator {
           );
         }
 
-        const { error } = await supabase
-          .from('agent_session_groups')
-          .update({ active_agent_session_id: sessionId })
-          .eq('id', groupId);
-
-        if (error) {
-          throw new Error(`Failed to update focus: ${error.message}`);
+        // WHY throw on focus error: the focus method is the public contract
+        // for switching active agents; the caller (e.g. mobile tap handler)
+        // needs to know if the change took effect. Unlike the initial-focus
+        // call above (which is best-effort), this is user-driven and must
+        // surface failure.
+        try {
+          await httpClient.setSessionGroupFocus(groupId, sessionId);
+        } catch (err) {
+          const msg =
+            err instanceof StyrbyApiError ? err.message : err instanceof Error ? err.message : 'unknown';
+          throw new Error(`Failed to update focus: ${msg}`);
         }
 
-        // Write audit log for focus change
-        await supabase.from('audit_log').insert({
-          user_id: userId,
-          action: 'session_group_focus_changed',
-          metadata: {
-            group_id: groupId,
-            focused_session_id: sessionId,
-          },
-        }).then(({ error: auditError }) => {
-          if (auditError) {
-            logger.debug('Failed to write session_group_focus_changed audit log', {
-              error: auditError.message,
-            });
-          }
-        });
+        // Write audit log for focus change. Best-effort; the focus operation
+        // already succeeded — losing the audit entry is an observability gap,
+        // not a correctness one.
+        await httpClient
+          .writeAuditEvent({
+            action: 'session_group_focus_changed',
+            resource_type: 'agent_session_group',
+            resource_id: groupId,
+            metadata: {
+              group_id: groupId,
+              focused_session_id: sessionId,
+            },
+          })
+          .catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : 'unknown';
+            logger.debug('Failed to write session_group_focus_changed audit log', { error: msg });
+          });
 
         logger.info('Group focus updated', { groupId, sessionId });
       },

--- a/packages/styrby-cli/src/cli/handlers/__tests__/multi.test.ts
+++ b/packages/styrby-cli/src/cli/handlers/__tests__/multi.test.ts
@@ -90,6 +90,25 @@ vi.mock('@/api/api', () => ({
   })),
 }));
 
+// ── clientFromPersistence mock ─────────────────────────────────────────────
+// H41 Phase 4-step3: handleMulti now resolves the StyrbyApiClient via
+// getApiClient() before passing it to the orchestrator. Provide a sentinel
+// stub so tests don't blow up at the boundary check.
+
+class MockMissingStyrbyKeyError extends Error {
+  constructor(msg = 'Run `styrby onboard` to provision an API key.') {
+    super(msg);
+    this.name = 'MissingStyrbyKeyError';
+  }
+}
+
+const mockGetApiClient = vi.fn(() => ({}) as unknown as import('@/api/styrbyApiClient').StyrbyApiClient);
+
+vi.mock('@/api/clientFromPersistence', () => ({
+  getApiClient: () => mockGetApiClient(),
+  MissingStyrbyKeyError: MockMissingStyrbyKeyError,
+}));
+
 // ── MultiAgentOrchestrator mock ────────────────────────────────────────────
 
 const mockOrchestratorStart = vi.fn();
@@ -122,6 +141,7 @@ describe('handleMulti', () => {
     });
     mockApiConnect.mockResolvedValue(undefined);
     mockApiDisconnect.mockResolvedValue(undefined);
+    mockGetApiClient.mockReturnValue({} as unknown as import('@/api/styrbyApiClient').StyrbyApiClient);
   });
 
   // ── Argument errors → exit(2) ──────────────────────────────────────────

--- a/packages/styrby-cli/src/cli/handlers/multi.ts
+++ b/packages/styrby-cli/src/cli/handlers/multi.ts
@@ -260,7 +260,25 @@ export async function handleMulti(args: string[]): Promise<void> {
   let group: import('@/agent/multiAgentOrchestrator').MultiAgentGroup;
 
   try {
+    // H41 Phase 4-step3: build the StyrbyApiClient for /api/v1 calls.
+    // ApiSessionManager downstream still consumes the supabase client (its
+    // swap is tracked separately); orchestrator's own Postgres ops now flow
+    // through httpClient.
+    const { getApiClient, MissingStyrbyKeyError } = await import('@/api/clientFromPersistence');
+    let httpClient: import('@/api/styrbyApiClient').StyrbyApiClient;
+    try {
+      httpClient = getApiClient();
+    } catch (err) {
+      if (err instanceof MissingStyrbyKeyError) {
+        console.log(chalk.red('\n' + err.message + '\n'));
+        await apiClient.disconnect();
+        process.exit(1);
+      }
+      throw err;
+    }
+
     group = await orchestrator.start({
+      httpClient,
       supabase,
       api: apiClient,
       agentIds,


### PR DESCRIPTION
## Summary

- Swap 7 .from() callsites in multiAgentOrchestrator.ts to StyrbyApiClient
- Server-generated group IDs (POST /api/v1/sessions/groups now sole source)
- MultiAgentConfig adds `httpClient`, keeps `supabase` (still needed by ApiSessionManager — separate phase)
- multi.ts handler resolves the api client via `getApiClient()` with MissingStyrbyKeyError clean-exit

## Depends on

PR #236 (prereq endpoints) — adds PATCH /api/v1/sessions/[id] used here. This PR is currently rebased onto #236; once #236 lands, quick rebase then merge.

## Test plan

- [x] `pnpm --filter styrby-cli typecheck` — clean
- [x] multi tests: 25/25 pass
- [ ] CI green (after #236 merges + rebase)

## Phase 4 progress

| Step | File | PR |
|------|------|-----|
| 1 | template.ts | #232 done |
| 2 | context.ts | #235 done |
| 3 | multiAgentOrchestrator.ts | this PR |
| 4 | approvalHandler.ts | #234 done |
| 5 | budget-actions + cost-reporter | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)