### PR TITLE
chore(cli): sync hardcoded VERSION strings to 0.2.0-beta.1

### DIFF
--- a/packages/styrby-cli/src/cli/version.ts
+++ b/packages/styrby-cli/src/cli/version.ts
@@ -14,4 +14,4 @@
 /**
  * Semantic version of the Styrby CLI.
  */
-export const VERSION = '0.1.0-beta.7';
+export const VERSION = '0.2.0-beta.1';

--- a/packages/styrby-cli/src/lib.ts
+++ b/packages/styrby-cli/src/lib.ts
@@ -38,7 +38,7 @@ export type {
 /**
  * Version of the Styrby CLI
  */
-export const VERSION = '0.1.0-beta.7';
+export const VERSION = '0.2.0-beta.1';
 
 /**
  * Check if running in development mode


### PR DESCRIPTION
## Summary

Pre-publish bug fix: PR #239 bumped `package.json` to 0.2.0-beta.1, but two hardcoded `VERSION` constants in source still read `0.1.0-beta.7`. Caught by smoke-testing `dist/index.js --version` against the rebuilt bundle.

Without this, `npm publish` would have shipped `styrby-cli@0.2.0-beta.1` whose runtime reports itself as `0.1.0-beta.7` — confusing for users, painful to debug from telemetry.

## Files

- `packages/styrby-cli/src/cli/version.ts`
- `packages/styrby-cli/src/lib.ts`

## Verification

- [x] `pnpm --filter styrby-cli build` clean
- [x] `node dist/index.js --version` → reports `0.2.0-beta.1`
- [x] `pnpm --filter styrby-cli typecheck` clean
- [x] No anon JWT in `dist/index.js`

## Follow-up

Both files carry "keep in sync with package.json" comments. The right long-term fix is reading the version from `package.json` at build time so this drift can't recur. Tracked as a non-blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)