### PR TITLE
ci(verify): re-validate Bundle 3 prebuilt deploy path (P0 #124 closure)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,11 @@
 #
 # ROLLBACK: Set VERCEL_PREBUILT_ENABLED back to "false" (or unset) and
 # re-enable Vercel's git auto-deploy in dashboard. No code change needed.
+#
+# VERIFICATION 2026-04-30: After PR #231 (TURBO_FORCE=1 fix) and the
+# kill-switch flip back on, this PR re-validates the prebuilt deploy path
+# end-to-end. If the Deploy Preview job below produces a working preview
+# URL, the original Bundle 3 incident is fully closed.
 
 name: Deploy (Vercel pre-built)
 


### PR DESCRIPTION
Verifies the prebuilt deploy path works end-to-end after PR #231 fix + kill-switch re-enable.

If Deploy Preview produces a working preview URL: P0 #124 closed.
If it fails: revert kill-switch and investigate.