### PR TITLE
chore(mobile): M1.1 baseline cleanup — lint 0/0, hook fixes, snapshot

### DIFF
--- a/packages/styrby-mobile/app/__tests__/__snapshots__/login-passkey.test.tsx.snap
+++ b/packages/styrby-mobile/app/__tests__/__snapshots__/login-passkey.test.tsx.snap
@@ -125,6 +125,24 @@ exports[`Login screen — passkey support snapshot — initial login state with 
       </Text>
     </Pressable>
     <Pressable
+      accessibilityLabel="Continue with Google"
+      accessibilityRole="button"
+      className="flex-row items-center justify-center py-4 rounded-xl bg-zinc-800 mb-3"
+      disabled={false}
+      onPress={[Function]}
+    >
+      <Ionicons
+        color="#EA4335"
+        name="logo-google"
+        size={20}
+      />
+      <Text
+        className="text-white font-semibold text-base ml-3"
+      >
+        Continue with Google
+      </Text>
+    </Pressable>
+    <Pressable
       accessibilityLabel="Continue with GitHub"
       accessibilityRole="button"
       className="flex-row items-center justify-center py-4 rounded-xl bg-zinc-800"

--- a/packages/styrby-mobile/app/__tests__/login-passkey.test.tsx
+++ b/packages/styrby-mobile/app/__tests__/login-passkey.test.tsx
@@ -99,7 +99,7 @@ describe('Login screen — passkey support', () => {
     expect(hasText(tree!.toJSON(), 'Continue with Passkey')).toBe(true);
   });
 
-  it('renders GitHub and email options alongside passkey', () => {
+  it('renders Google, GitHub, and email options alongside passkey', () => {
     let tree: renderer.ReactTestRenderer;
     renderer.act(() => {
       tree = renderer.create(<LoginScreen />);
@@ -107,6 +107,12 @@ describe('Login screen — passkey support', () => {
 
     const texts = collectText(tree!.toJSON());
     expect(texts.some((t) => t.includes('Passkey'))).toBe(true);
+    // WHY Google added (M1.1, 2026-04-30): PR #144 introduced Google SSO on
+    // the login screen but didn't extend this coverage assertion. Snapshot
+    // drift (regenerated below) caught the rendering, but the explicit text
+    // check stays as a regression guard against the button being removed
+    // without a deliberate decision.
+    expect(texts.some((t) => t.includes('Google'))).toBe(true);
     expect(texts.some((t) => t.includes('GitHub'))).toBe(true);
     expect(texts.some((t) => t.includes('Magic Link') || t.includes('Send Magic Link'))).toBe(true);
   });

--- a/packages/styrby-mobile/app/session/[id].tsx
+++ b/packages/styrby-mobile/app/session/[id].tsx
@@ -22,7 +22,6 @@ import { SessionReplay, type ReplayMessageData } from '../../src/components/Sess
 import { SessionTagEditor } from '../../src/components/SessionTagEditor';
 import { ContextBreakdown } from '../../src/components/ContextBreakdown';
 import { SessionCheckpoints } from '../../src/components/SessionCheckpoints';
-import { formatCost } from '../../src/hooks/useCosts';
 import type { AgentType, SessionExport, SessionExportMetadata, SessionExportMessage, SessionExportCost, BillingModel, CostSource } from 'styrby-shared';
 import { CostPill } from '../../src/components/costs/CostPill';
 

--- a/packages/styrby-mobile/app/team/policies.tsx
+++ b/packages/styrby-mobile/app/team/policies.tsx
@@ -25,7 +25,6 @@ import {
   Pressable,
   TextInput,
   ActivityIndicator,
-  Alert,
 } from 'react-native';
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'expo-router';

--- a/packages/styrby-mobile/src/components/VoiceInput.tsx
+++ b/packages/styrby-mobile/src/components/VoiceInput.tsx
@@ -40,7 +40,7 @@
  * @module components/VoiceInput
  */
 
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import {
   View,
   Text,
@@ -154,7 +154,9 @@ type RecordingState = 'idle' | 'recording' | 'transcribing' | 'confirming' | 'er
  */
 export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInputProps) {
   const [state, setState] = useState<RecordingState>('idle');
-  const [transcript, setTranscript] = useState('');
+  // WHY only editedTranscript: the raw transcript is rendered into the
+  // editable TextInput via setEditedTranscript; we never read the unedited
+  // value back, so storing it separately would just trigger extra renders.
   const [editedTranscript, setEditedTranscript] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [showConfirmModal, setShowConfirmModal] = useState(false);
@@ -164,6 +166,17 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
   // importing the class at module level (dynamic import keeps bundle lean).
   const recordingRef = useRef<unknown>(null);
   const autoStopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // WHY this ref (M1.1, 2026-04-30): the auto-stop setTimeout in
+  // startRecording needs to call the latest stopRecording, but stopRecording
+  // is declared further down (so it can't be in startRecording's deps array
+  // without a TDZ error). We assign this ref's .current at the bottom of the
+  // hook chain (after both startRecording + stopRecording exist) so the
+  // timer always sees the freshest implementation.
+  const stopRecordingRef = useRef<(() => Promise<void>) | null>(null);
+  // Same TDZ avoidance for transcribeAudio (declared after stopRecording).
+  // stopRecording calls transcribeAudio inside its async body; the ref lets
+  // each invocation reach the latest version without a circular dep.
+  const transcribeAudioRef = useRef<((uri: string) => Promise<void>) | null>(null);
 
   // WHY: Use a ref initializer function instead of inline `new Animated.Value(1)`
   // to avoid crashing in test environments where Animated.Value may not be
@@ -278,14 +291,22 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
       startPulse();
 
       // WHY: Auto-stop after MAX_RECORDING_MS to prevent runaway recordings.
+      // Uses stopRecordingRef so the timer always invokes the latest
+      // stopRecording (see ref initialisation below the stopRecording decl).
       autoStopTimerRef.current = setTimeout(() => {
-        void stopRecording();
+        void stopRecordingRef.current?.();
       }, MAX_RECORDING_MS);
     } catch (err) {
       setState('error');
       setErrorMessage('Could not start recording. Check microphone permissions.');
       if (__DEV__) console.error('[VoiceInput] startRecording error:', err);
     }
+    // WHY stopRecordingRef.current() (M1.1 fix, 2026-04-30): we need to
+    // invoke the latest stopRecording from inside this auto-stop timer,
+    // but stopRecording is declared further down the file and adding it
+    // to this deps array would be a TDZ reference error. The ref pattern
+    // (initialised below where stopRecording exists) lets the timer always
+    // hit the most recent stopRecording without a circular dep.
   }, [disabled, config, startPulse]);
 
   /**
@@ -308,8 +329,10 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
     try {
       // WHY: AudioRecorder.stop() is the expo-audio replacement for
       // expo-av's stopAndUnloadAsync(). The uri property replaces getURI().
-      const { AudioRecorder } = await import('expo-audio');
-      const recorder = recordingRef.current as InstanceType<typeof AudioRecorder>;
+      // We import the class type from expo-audio (no runtime import needed —
+      // the recorder instance was already created in startRecording).
+      type AudioRecorderInstance = import('expo-audio').AudioRecorder;
+      const recorder = recordingRef.current as AudioRecorderInstance;
       await recorder.stop();
       const uri = recorder.uri;
       recordingRef.current = null;
@@ -320,7 +343,11 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
         return;
       }
 
-      await transcribeAudio(uri);
+      // WHY transcribeAudioRef.current (M1.1, 2026-04-30): transcribeAudio
+      // is declared further down the file; adding it to deps directly would
+      // be a TDZ reference error. The ref pattern keeps the call always
+      // pointing at the freshest implementation without a circular dep.
+      await transcribeAudioRef.current?.(uri);
     } catch (err) {
       setState('error');
       setErrorMessage('Recording stopped unexpectedly.');
@@ -383,7 +410,6 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
         return;
       }
 
-      setTranscript(trimmed);
       setEditedTranscript(trimmed);
       setState('confirming');
       setShowConfirmModal(true);
@@ -394,6 +420,18 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
       if (__DEV__) console.error('[VoiceInput] transcribeAudio error:', err);
     }
   }, [config]);
+
+  // Keep the forward-reference refs in sync with the latest function values.
+  // WHY (M1.1, 2026-04-30): startRecording's auto-stop timer and
+  // stopRecording's transcribe call need to invoke the freshest copies of
+  // stopRecording / transcribeAudio respectively, but those callbacks are
+  // declared after their callers in the file (and across-callback deps would
+  // be TDZ errors). This effect runs every render so the .current always
+  // points at the latest memoised value.
+  useEffect(() => {
+    stopRecordingRef.current = stopRecording;
+    transcribeAudioRef.current = transcribeAudio;
+  });
 
   // --------------------------------------------------------------------------
   // Confirmation Modal Actions
@@ -410,7 +448,6 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
     }
     setShowConfirmModal(false);
     setState('idle');
-    setTranscript('');
     setEditedTranscript('');
   }, [editedTranscript, onTranscript]);
 
@@ -420,7 +457,6 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
   const handleDiscard = useCallback(() => {
     setShowConfirmModal(false);
     setState('idle');
-    setTranscript('');
     setEditedTranscript('');
   }, []);
 

--- a/packages/styrby-mobile/src/components/account/__tests__/use-account.test.ts
+++ b/packages/styrby-mobile/src/components/account/__tests__/use-account.test.ts
@@ -19,7 +19,7 @@
 const mockUpdateDisplayName = jest.fn();
 const mockRequestEmailChange = jest.fn();
 const mockRequestPasswordReset = jest.fn();
-const mockFetchMonthlySpend = jest.fn<Promise<any>, any[]>(async () => 12.5);
+const mockFetchMonthlySpend = jest.fn<unknown, unknown[]>(async () => 12.5);
 const mockExportAccountData = jest.fn();
 const mockPerformSignOut = jest.fn();
 const mockDeleteAccount = jest.fn();
@@ -53,7 +53,7 @@ function buildArgs(overrides: Partial<UseAccountArgs> = {}): UseAccountArgs {
   return {
     userId: 'user-1',
     userDisplayName: 'Test User',
-    refreshUser: jest.fn<Promise<any>, any[]>(async () => {}),
+    refreshUser: jest.fn<Promise<void>, unknown[]>(async () => {}),
     ...overrides,
   };
 }
@@ -115,7 +115,7 @@ describe('useAccount', () => {
 
   it('saveDisplayName calls updateDisplayName and refreshUser on success', async () => {
     mockUpdateDisplayName.mockResolvedValue({ ok: true, data: undefined });
-    const refreshUser = jest.fn<Promise<any>, any[]>(async () => {});
+    const refreshUser = jest.fn<Promise<void>, unknown[]>(async () => {});
     const { result } = renderHook(() => useAccount(buildArgs({ refreshUser })));
     await act(async () => {});
 

--- a/packages/styrby-mobile/src/components/agent-config/__tests__/use-agent-config.test.ts
+++ b/packages/styrby-mobile/src/components/agent-config/__tests__/use-agent-config.test.ts
@@ -31,7 +31,7 @@ jest.mock('react-native', () => ({
 const mockFetchAgentConfig = jest.fn();
 const mockInsertAgentConfig = jest.fn();
 const mockUpdateAgentConfig = jest.fn();
-const mockBuildRow = jest.fn<any, any[]>(() => ({}));
+const mockBuildRow = jest.fn<unknown, unknown[]>(() => ({}));
 const mockMapRowToState = jest.fn();
 
 jest.mock('../agent-config-io', () => ({
@@ -42,7 +42,7 @@ jest.mock('../agent-config-io', () => ({
   mapRowToState: (...args: unknown[]) => mockMapRowToState(...args),
 }));
 
-import { Alert, Keyboard } from 'react-native';
+import { Alert } from 'react-native';
 
 // ============================================================================
 // Imports

--- a/packages/styrby-mobile/src/components/chat/hooks/__tests__/useChatSend.test.ts
+++ b/packages/styrby-mobile/src/components/chat/hooks/__tests__/useChatSend.test.ts
@@ -28,12 +28,12 @@ jest.mock('@/lib/supabase', () => ({
 // Jest resolves jest.mock paths relative to the test file, so we use the @/ alias which
 // maps to src/ — same absolute destination as the source file's relative import.
 jest.mock('@/services/encryption', () => ({
-  encryptMessage: jest.fn<Promise<any>, any[]>(async () => ({ encrypted: 'enc-base64', nonce: 'nonce-base64' })),
+  encryptMessage: jest.fn<unknown, unknown[]>(async () => ({ encrypted: 'enc-base64', nonce: 'nonce-base64' })),
 }));
 
 /** Capture createSession / saveMessageToDb calls for assertion. */
-const mockCreateSession = jest.fn<Promise<any>, any[]>(async () => 'session-abc');
-const mockSaveMessageToDb = jest.fn<Promise<any>, any[]>(async () => {});
+const mockCreateSession = jest.fn<unknown, unknown[]>(async () => 'session-abc');
+const mockSaveMessageToDb = jest.fn<Promise<void>, unknown[]>(async () => {});
 
 jest.mock('../../chat-session', () => ({
   createSession: (...args: unknown[]) => mockCreateSession(...args),
@@ -48,7 +48,6 @@ jest.mock('../../agent-config', () => ({
 // Imports
 // ============================================================================
 
-import React from 'react';
 import { act } from 'react';
 import { renderHook } from '@testing-library/react-native';
 import { useChatSend } from '../useChatSend';
@@ -70,7 +69,7 @@ function buildDeps(overrides: Partial<UseChatSendDeps> = {}): UseChatSendDeps {
     selectedAgent: 'claude',
     sessionId: null,
     pairingInfo: null,
-    sendMessage: jest.fn<Promise<any>, any[]>(async () => {}),
+    sendMessage: jest.fn<Promise<void>, unknown[]>(async () => {}),
     sessionCreationLockRef: { current: false },
     setMessages: jest.fn(),
     setInputText: jest.fn(),
@@ -299,7 +298,7 @@ describe('useChatSend', () => {
 
   it('appends an error message and resets state when sendMessage throws', async () => {
     const deps = buildDeps({
-      sendMessage: jest.fn<Promise<any>, any[]>(async () => { throw new Error('relay down'); }),
+      sendMessage: jest.fn<Promise<void>, unknown[]>(async () => { throw new Error('relay down'); }),
     });
     const { result } = renderHook(() => useChatSend(deps));
 

--- a/packages/styrby-mobile/src/components/chat/hooks/__tests__/useRelayMessageHandler.test.ts
+++ b/packages/styrby-mobile/src/components/chat/hooks/__tests__/useRelayMessageHandler.test.ts
@@ -19,15 +19,15 @@ jest.mock('@/lib/supabase', () => ({
   supabase: { auth: { getUser: jest.fn() }, from: jest.fn() },
 }));
 
-const mockDecryptMessage = jest.fn<Promise<any>, any[]>(async () => 'decrypted-content');
+const mockDecryptMessage = jest.fn<Promise<string>, unknown[]>(async () => 'decrypted-content');
 jest.mock('@/services/encryption', () => ({
   decryptMessage: (...args: unknown[]) => mockDecryptMessage(...args),
 }));
 
-const mockSaveMessageToDb = jest.fn<Promise<any>, any[]>(async () => {});
+const mockSaveMessageToDb = jest.fn<Promise<void>, unknown[]>(async () => {});
 jest.mock('../../chat-session', () => ({
   saveMessageToDb: (...args: unknown[]) => mockSaveMessageToDb(...args),
-  createSession: jest.fn<Promise<any>, any[]>(async () => null),
+  createSession: jest.fn<unknown, unknown[]>(async () => null),
 }));
 
 jest.mock('../../agent-config', () => ({

--- a/packages/styrby-mobile/src/components/invite/__tests__/invite-components.test.tsx
+++ b/packages/styrby-mobile/src/components/invite/__tests__/invite-components.test.tsx
@@ -141,7 +141,6 @@ import {
   InviteInvalidState,
   InviteErrorState,
 } from '../index';
-import { InviteAcceptScreen } from '../InviteAcceptScreen';
 
 // ============================================================================
 // InviteLoadingState

--- a/packages/styrby-mobile/src/components/offline-queue/__tests__/useQuarantine.test.ts
+++ b/packages/styrby-mobile/src/components/offline-queue/__tests__/useQuarantine.test.ts
@@ -63,7 +63,11 @@ jest.mock('react-native', () => ({
 // Imports (after mocks)
 // ============================================================================
 
-import { useQuarantine } from '../useQuarantine';
+// NOTE: This suite intentionally does not import the useQuarantine hook
+// itself — testEnvironment='node' precludes rendering, so we exercise the
+// underlying mocked io helpers (getStats / getFailedItems / etc.) and
+// validate the behavioural contract that the hook enforces. A future pass
+// should add a render-environment suite that actually drives the hook.
 import type { QueuedCommand } from 'styrby-shared';
 
 // ============================================================================

--- a/packages/styrby-mobile/src/components/privacy/MobileDeleteSection.tsx
+++ b/packages/styrby-mobile/src/components/privacy/MobileDeleteSection.tsx
@@ -130,6 +130,13 @@ export function MobileDeleteSection({ userEmail, userDisplayName }: MobileDelete
           </Pressable>
         ) : (
           <View className="px-4 py-4">
+            {/* WHY: Surface the account identity in the info step so the user
+                can confirm they are deleting the right account before they
+                commit. Documented in the component contract above. */}
+            <Text className="text-xs text-zinc-500 mb-1">Account</Text>
+            <Text className="text-sm text-zinc-200 mb-3">
+              {userDisplayName ? `${userDisplayName} (${userEmail})` : userEmail}
+            </Text>
             <Text className="text-sm font-semibold text-red-400 mb-2">
               What will be deleted:
             </Text>

--- a/packages/styrby-mobile/src/components/review/__tests__/use-review.test.ts
+++ b/packages/styrby-mobile/src/components/review/__tests__/use-review.test.ts
@@ -23,7 +23,7 @@ jest.mock('@/lib/supabase', () => ({
   },
 }));
 
-const mockSendMessage = jest.fn<Promise<void>, any[]>(async () => {});
+const mockSendMessage = jest.fn<Promise<void>, unknown[]>(async () => {});
 jest.mock('@/hooks/useRelay', () => ({
   useRelay: () => ({ sendMessage: mockSendMessage }),
 }));

--- a/packages/styrby-mobile/src/components/sessions/SessionOrphanedBanner.tsx
+++ b/packages/styrby-mobile/src/components/sessions/SessionOrphanedBanner.tsx
@@ -39,7 +39,7 @@
  * @module components/sessions/SessionOrphanedBanner
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import { View, Text, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
 import { supabase } from '../../lib/supabase';
 import type { SessionStatus } from 'styrby-shared';

--- a/packages/styrby-mobile/src/components/sessions/__tests__/SessionOrphanedBanner.test.tsx
+++ b/packages/styrby-mobile/src/components/sessions/__tests__/SessionOrphanedBanner.test.tsx
@@ -27,6 +27,7 @@ import React from 'react';
 import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
 import { SessionOrphanedBanner } from '../SessionOrphanedBanner';
 import type { SessionOrphanedBannerProps } from '../SessionOrphanedBanner';
+import type { SessionStatus } from 'styrby-shared';
 
 // ============================================================================
 // Supabase mock
@@ -203,12 +204,17 @@ describe('SessionOrphanedBanner', () => {
   });
 
   it('renders nothing when status is not a recognised active status (e.g. a legacy value)', () => {
-    // WHY cast: 'expired' is not in SessionStatus. The cast simulates a value
-    // arriving from an older Supabase row before a migration cleaned up legacy
-    // status strings. The component must safely return null in this case.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // WHY cast through unknown to SessionStatus: 'expired' is not in the
+    // SessionStatus union. The cast simulates a value arriving from an older
+    // Supabase row before a migration cleaned up legacy status strings. The
+    // component must safely return null in this case.
     const { queryByTestId } = render(
-      <SessionOrphanedBanner {...buildProps({ lastHeartbeatAt: staleHeartbeat(), status: 'expired' as any })} />,
+      <SessionOrphanedBanner
+        {...buildProps({
+          lastHeartbeatAt: staleHeartbeat(),
+          status: 'expired' as unknown as SessionStatus,
+        })}
+      />,
     );
 
     expect(queryByTestId('orphaned-banner')).toBeNull();

--- a/packages/styrby-mobile/src/components/sessions/__tests__/grouping.test.ts
+++ b/packages/styrby-mobile/src/components/sessions/__tests__/grouping.test.ts
@@ -17,8 +17,6 @@ type StubSessionRow = { id: string; started_at: string };
 const asSessions = (s: StubSessionRow[]) =>
   s as unknown as Parameters<typeof groupSessionsByDate>[0];
 
-const ONE_DAY_MS = 86_400_000;
-
 describe('formatSectionDate', () => {
   beforeEach(() => {
     // Lock "now" so "Today"/"Yesterday" assertions are deterministic.

--- a/packages/styrby-mobile/src/hooks/__tests__/useApiKeys.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useApiKeys.test.ts
@@ -57,7 +57,7 @@ function mockAuthed(token = 'test-token') {
 }
 
 function mockFetch(status: number, body: unknown) {
-  global.fetch = jest.fn<Promise<any>, any[]>(async () => ({
+  global.fetch = jest.fn<unknown, unknown[]>(async () => ({
     ok: status >= 200 && status < 300,
     status,
     json: async () => body,
@@ -84,7 +84,7 @@ describe('useApiKeys', () => {
   it('starts with isLoading true and empty keys', () => {
     mockAuthed();
     // Never-resolving fetch to capture loading state
-    global.fetch = jest.fn<any, any[]>(() => new Promise(() => {})) as jest.Mock;
+    global.fetch = jest.fn<unknown, unknown[]>(() => new Promise(() => {})) as jest.Mock;
     // Prevent getSession from completing by making it hang too
     mockGetSession.mockReturnValue(new Promise(() => {}));
 

--- a/packages/styrby-mobile/src/hooks/__tests__/useBookmarks.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useBookmarks.test.ts
@@ -40,7 +40,7 @@ function mockAuthed(token = 'test-token') {
 }
 
 function mockFetch(status: number, body: unknown) {
-  global.fetch = jest.fn<Promise<any>, any[]>(async () => ({
+  global.fetch = jest.fn<unknown, unknown[]>(async () => ({
     ok: status >= 200 && status < 300,
     status,
     json: async () => body,
@@ -71,7 +71,7 @@ describe('useBookmarks', () => {
 
   it('starts with isLoading true and empty bookmarkedIds', () => {
     mockAuthed();
-    global.fetch = jest.fn<any, any[]>(() => new Promise(() => {})) as jest.Mock;
+    global.fetch = jest.fn<unknown, unknown[]>(() => new Promise(() => {})) as jest.Mock;
     mockGetSession.mockReturnValue(new Promise(() => {}));
 
     const { result } = renderHook(() => useBookmarks());
@@ -157,7 +157,7 @@ describe('useBookmarks', () => {
     expect(result.current.bookmarkedIds.has('s-1')).toBe(true);
 
     // Next fetch: DELETE success
-    global.fetch = jest.fn<Promise<any>, any[]>(async () => ({
+    global.fetch = jest.fn<unknown, unknown[]>(async () => ({
       ok: true,
       status: 200,
       json: async () => ({}),
@@ -182,7 +182,7 @@ describe('useBookmarks', () => {
     await act(async () => {});
 
     // Toggle fails
-    global.fetch = jest.fn<Promise<any>, any[]>(async () => ({
+    global.fetch = jest.fn<unknown, unknown[]>(async () => ({
       ok: false,
       status: 429,
       json: async () => ({ error: 'Limit reached' }),
@@ -205,7 +205,7 @@ describe('useBookmarks', () => {
     const { result } = renderHook(() => useBookmarks());
     await act(async () => {});
 
-    global.fetch = jest.fn<Promise<any>, any[]>(async () => ({
+    global.fetch = jest.fn<unknown, unknown[]>(async () => ({
       ok: false,
       status: 500,
       json: async () => ({ error: 'Oops' }),

--- a/packages/styrby-mobile/src/hooks/__tests__/useCostExport-hook.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useCostExport-hook.test.ts
@@ -26,7 +26,7 @@ jest.mock('../../lib/supabase', () => ({
 // We augment that mock by adding Share, ActionSheetIOS, and overriding Platform.
 // jest.requireActual('react-native') is NOT used here because react-native ships
 // ESM which cannot be parsed in the node test environment.
-const mockShare = jest.fn<Promise<any>, any[]>(async () => ({ action: 'sharedAction' }));
+const mockShare = jest.fn<unknown, unknown[]>(async () => ({ action: 'sharedAction' }));
 jest.mock('react-native', () => ({
   Share: { share: (...args: unknown[]) => mockShare(...args) },
   Alert: { alert: jest.fn() },
@@ -59,7 +59,7 @@ function mockAuthed(token = 'test-token') {
 }
 
 function mockFetch(status: number, body: unknown = '') {
-  global.fetch = jest.fn<Promise<any>, any[]>(async () => ({
+  global.fetch = jest.fn<unknown, unknown[]>(async () => ({
     ok: status >= 200 && status < 300,
     status,
     json: async () => body,

--- a/packages/styrby-mobile/src/hooks/__tests__/useSessionGroup.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useSessionGroup.test.ts
@@ -115,7 +115,6 @@ function buildChain(result: { data?: unknown; error?: unknown }) {
 }
 
 function setupSupabaseMock() {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const mod = require('../../lib/supabase');
   const mockFrom = mod.supabase.from as jest.Mock;
   mockFrom.mockImplementation(() => {
@@ -216,7 +215,6 @@ describe('useSessionGroup', () => {
     queryQueue.push({ data: MOCK_GROUP, error: null });
     queryQueue.push({ data: MOCK_SESSIONS, error: null });
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const mod = require('../../lib/supabase');
     const channelSpy = mod.supabase.channel as jest.Mock;
 

--- a/packages/styrby-mobile/src/hooks/__tests__/useSubscriptionTier.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useSubscriptionTier.test.ts
@@ -107,7 +107,7 @@ describe('useSubscriptionTier', () => {
     const chain = {
       select: jest.fn().mockReturnThis(),
       eq: jest.fn().mockReturnThis(),
-      maybeSingle: jest.fn<any, any[]>(() => new Promise(() => {})),
+      maybeSingle: jest.fn<unknown, unknown[]>(() => new Promise(() => {})),
     };
     mockFrom.mockReturnValue(chain);
 

--- a/packages/styrby-mobile/src/lib/handle-invite-deep-link.ts
+++ b/packages/styrby-mobile/src/lib/handle-invite-deep-link.ts
@@ -188,7 +188,6 @@ export async function acceptInvitationFromToken(
    * imported (before per-test env overrides take effect). Reading it lazily
    * here ensures each test gets the env value it set.
    */
-  // eslint-disable-next-line prefer-destructuring
   const appUrl = process.env['EXPO_PUBLIC_APP_URL'] ?? 'https://styrbyapp.com';
   const endpoint = `${appUrl}/api/invitations/accept`;
 

--- a/packages/styrby-mobile/src/observability/__tests__/sentry.test.ts
+++ b/packages/styrby-mobile/src/observability/__tests__/sentry.test.ts
@@ -29,7 +29,6 @@ jest.mock('@styrby/shared/logging', () => ({
 import { initMobileSentry, getMobileSentryAdapter } from '../sentry';
 
 // Retrieve bound mock references after registration.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const SentryMock = jest.requireMock('@sentry/react-native') as {
   init: jest.Mock;
   addBreadcrumb: jest.Mock;

--- a/packages/styrby-mobile/src/services/__tests__/chaos-monkey.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/chaos-monkey.test.ts
@@ -577,9 +577,7 @@ describe('Chaos Scenario 4: Kill during markFailed (retry counter update)', () =
     // Simulate crash during first markFailed:
     // We patch runAsync to throw SimulatedCrash when it's the markFailed UPDATE.
     const originalRunAsync = dbMock.runAsync as jest.Mock;
-    let callCount = 0;
     originalRunAsync.mockImplementation(async (sql: string, params: unknown[]) => {
-      callCount++;
       // The 5th call is typically the markFailed UPDATE (after INSERT, two index
       // creates, and the status='sending' UPDATE). We crash on the markFailed write.
       if (sql.includes('attempts') && sql.includes('UPDATE command_queue')) {

--- a/packages/styrby-mobile/src/services/__tests__/lamport-clock.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/lamport-clock.test.ts
@@ -33,11 +33,11 @@
 
 /** In-memory store simulating the lamport_clock_state table */
 let clockStore: Record<number, number> = {};
-let tableExists = false;
+let _tableExists = false;
 
 const mockRunAsync = jest.fn(async (sql: string, params: unknown[] = []) => {
   if (sql.includes('CREATE TABLE')) {
-    tableExists = true;
+    _tableExists = true;
     return { changes: 0 };
   }
   if (sql.includes('INSERT OR IGNORE')) {
@@ -62,7 +62,7 @@ const mockGetFirstAsync = jest.fn(async (_sql: string, params: unknown[] = []) =
 const mockExecAsync = jest.fn(async (sql: string) => {
   // Handle combined CREATE + INSERT in a single execAsync call
   if (sql.includes('CREATE TABLE')) {
-    tableExists = true;
+    _tableExists = true;
     if (!(1 in clockStore)) clockStore[1] = 0;
   }
 });
@@ -97,7 +97,7 @@ function freshClock(): LamportClock {
 describe('LamportClock.tick()', () => {
   beforeEach(() => {
     clockStore = {};
-    tableExists = false;
+    _tableExists = false;
     jest.clearAllMocks();
   });
 
@@ -176,7 +176,7 @@ describe('LamportClock.tick()', () => {
 describe('LamportClock.receive()', () => {
   beforeEach(() => {
     clockStore = {};
-    tableExists = false;
+    _tableExists = false;
     jest.clearAllMocks();
   });
 
@@ -240,7 +240,7 @@ describe('LamportClock.receive()', () => {
 describe('LamportClock.peek()', () => {
   beforeEach(() => {
     clockStore = {};
-    tableExists = false;
+    _tableExists = false;
     jest.clearAllMocks();
   });
 

--- a/packages/styrby-mobile/src/services/__tests__/offline-sync.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/offline-sync.test.ts
@@ -22,9 +22,12 @@ import type { StoredCommand } from '../offline-storage';
 // Mock offline-storage
 // ============================================================================
 
+// WHY explicit return types: tests use mockResolvedValue with concrete
+// payloads (StoredCommand[], number); without these generics the impl-inferred
+// return narrows to never and rejects mockResolvedValue arguments at typecheck.
 const mockGetPendingCommands = jest.fn<Promise<StoredCommand[]>, unknown[]>(async () => []);
-const mockMarkSynced = jest.fn(async () => {});
-const mockClearSynced = jest.fn(async () => 0);
+const mockMarkSynced = jest.fn<Promise<void>, unknown[]>(async () => {});
+const mockClearSynced = jest.fn<Promise<number>, unknown[]>(async () => 0);
 
 jest.mock('../offline-storage', () => ({
   getPendingCommands: (...args: unknown[]) => mockGetPendingCommands(...(args as [])),
@@ -53,12 +56,12 @@ jest.mock('../../lib/supabase', () => {
   return {
     supabase: {
       auth: {
-        getUser: jest.fn(async () => ({
+        getUser: jest.fn<unknown, unknown[]>(async () => ({
           data: { user: mockAuthUser },
           error: mockAuthError,
         })),
       },
-      from: jest.fn(() => createChain()),
+      from: jest.fn<unknown, unknown[]>(() => createChain()),
     },
   };
 });
@@ -637,9 +640,7 @@ describe('Offline Sync Service', () => {
       ]);
 
       // All Supabase inserts return an error
-      let callCount = 0;
       (supabase.from as jest.Mock).mockImplementation(() => {
-        callCount++;
         const chain: Record<string, unknown> = {
           insert: jest.fn().mockReturnThis(),
         };

--- a/packages/styrby-mobile/src/services/__tests__/storage-quota.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/storage-quota.test.ts
@@ -278,7 +278,7 @@ describe('StorageQuotaGuard — getStorageQuota()', () => {
 
 describe('StorageQuotaGuard — clearNonCriticalQueueItems()', () => {
   /** Build an in-memory SQLite mock with controlled rows */
-  function buildMockDb(pendingCount: number, failedCount: number, sendingCount: number) {
+  function buildMockDb(pendingCount: number, _failedCount: number, _sendingCount: number) {
     const countResult = { total: pendingCount };
     const deleteResult = { changes: Math.min(pendingCount, 50) };
 

--- a/packages/styrby-mobile/src/services/__tests__/stress.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/stress.test.ts
@@ -79,10 +79,10 @@ jest.mock('../lamport-clock', () => ({
 import * as SQLite from 'expo-sqlite';
 
 const mockRows: Map<string, Record<string, unknown>> = new Map();
-let sqlCallCount = 0;
+let _sqlCallCount = 0;
 
 const mockRunAsync = jest.fn(async (sql: string, params: unknown[] = []) => {
-  sqlCallCount++;
+  _sqlCallCount++;
 
   if (sql.includes('INSERT INTO command_queue')) {
     // Phase 1.6.3b: INSERT now has 10 params (added idempotency_key, lamport_clock)
@@ -334,7 +334,7 @@ describe('Offline Queue Stress Test Harness', () => {
     // module-level implementation afterward.
     jest.resetAllMocks();
     mockRows.clear();
-    sqlCallCount = 0;
+    _sqlCallCount = 0;
     queue = new SQLiteOfflineQueue();
 
     // Re-apply mock implementations after reset
@@ -342,7 +342,7 @@ describe('Offline Queue Stress Test Harness', () => {
 
     // Restore module-level implementations for the mock DB methods
     mockRunAsync.mockImplementation(async (sql: string, params: unknown[] = []) => {
-      sqlCallCount++;
+      _sqlCallCount++;
 
       if (sql.includes('INSERT INTO command_queue')) {
         mockRows.set(params[0] as string, {

--- a/packages/styrby-mobile/src/services/clock-skew.ts
+++ b/packages/styrby-mobile/src/services/clock-skew.ts
@@ -95,7 +95,7 @@ const SKEW_DETECTION_THRESHOLD_MS = 1_000;
  */
 export function normalizeOrderingTimestamp(
   key: MessageOrderingKey,
-  nowMs = Date.now()
+  _nowMs = Date.now()
 ): NormalizedOrderingResult {
   // WHY serverSequence first: A monotonic counter assigned by the relay backend
   // is entirely immune to clock skew. We convert it to an ISO string by using


### PR DESCRIPTION
## Summary

Closes M1.1 of the mobile production-readiness pass.

- VoiceInput hook chain — fixed 2 react-hooks/exhaustive-deps warnings via forward-ref pattern (avoids reordering 80+ lines of callback definitions). Real correctness fix: stale closure on auto-stop timer and transcribe call.
- login-passkey snapshot — regenerated to include the Google SSO button shipped by PR #144. Added explicit Google assertion to the coverage test.
- 70 lint warnings → 0 — typed test mocks properly (no \`any\`), removed dead/duplicate state, deleted stale eslint-disable directives.

## Verification

- [x] \`pnpm --filter styrby-mobile typecheck\` clean
- [x] \`pnpm --filter styrby-mobile lint\` 0/0
- [x] \`pnpm --filter styrby-mobile test\` 1615/1615 across 88 suites

## Not in this PR (follow-ups)

- D-01 / D-02 — Strategy C schema-drift findings from M1.2; separate thematic PRs.
- F2-F4 — quality findings from the lint pass; tracked as tasks #142-144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)