### PR TITLE
fix(mobile): D-01 — surface session_group_id in session list (M1.2 fix)

### DIFF
--- a/packages/styrby-mobile/src/hooks/useSessions.ts
+++ b/packages/styrby-mobile/src/hooks/useSessions.ts
@@ -76,6 +76,19 @@ export interface SessionRow {
   /** Team ID if this is a team session (null for personal sessions, optional if not selected) */
   team_id?: string | null;
   /**
+   * Multi-agent group this session belongs to, or null for solo sessions.
+   *
+   * WHY exposed at the list level (M1.2 D-01 fix, 2026-04-30): Phase 4-step3
+   * (CLI PR #237) wired multiAgentOrchestrator.ts to populate sessions.session_group_id
+   * via PATCH /api/v1/sessions/[id] when sessions are spawned inside `styrby multi`.
+   * The pre-fix mobile list ignored the column entirely, so group affiliation was
+   * invisible in the primary session list — users had to navigate into the
+   * separate group view (useSessionGroup) to see relationships. This field
+   * lets downstream UI (cards, sections, badges) surface group membership
+   * inline.
+   */
+  session_group_id?: string | null;
+  /**
    * ISO 8601 timestamp of the most recent CLI heartbeat for this session.
    * Null if no heartbeat has ever been emitted (pre-heartbeat sessions).
    *
@@ -240,7 +253,7 @@ export function useSessions(): UseSessionsReturn {
           'id, user_id, machine_id, agent_type, status, title, summary, ' +
           'total_input_tokens, total_output_tokens, total_cost_usd, ' +
           'started_at, ended_at, tags, updated_at, message_count, team_id, ' +
-          'last_heartbeat_at',
+          'last_heartbeat_at, session_group_id',
         )
         .is('deleted_at', null)
         .order('updated_at', { ascending: false })

--- a/packages/styrby-mobile/src/lib/__tests__/schemas.test.ts
+++ b/packages/styrby-mobile/src/lib/__tests__/schemas.test.ts
@@ -294,6 +294,31 @@ describe('SessionSchema', () => {
     const result = SessionSchema.safeParse(makeSession({ tags: 'not-an-array' }));
     expect(result.success).toBe(false);
   });
+
+  // M1.2 D-01 (2026-04-30): session_group_id was added to surface multi-agent
+  // group affiliation in the primary session list. Three cases — UUID present,
+  // explicit null (solo session), and column omitted (Realtime forward-compat).
+  it('accepts session with a session_group_id UUID', () => {
+    const result = SessionSchema.safeParse(
+      makeSession({ session_group_id: '11111111-1111-1111-1111-111111111111' }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.session_group_id).toBe('11111111-1111-1111-1111-111111111111');
+    }
+  });
+
+  it('accepts session with null session_group_id (solo session)', () => {
+    const result = SessionSchema.safeParse(makeSession({ session_group_id: null }));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts session row without session_group_id (Realtime forward-compat)', () => {
+    const session = makeSession();
+    delete (session as Record<string, unknown>).session_group_id;
+    const result = SessionSchema.safeParse(session);
+    expect(result.success).toBe(true);
+  });
 });
 
 // ============================================================================

--- a/packages/styrby-mobile/src/lib/schemas.ts
+++ b/packages/styrby-mobile/src/lib/schemas.ts
@@ -140,6 +140,17 @@ export const SessionSchema = z.object({
    * (e.g. in Realtime events before the payload includes it) will default to null.
    */
   last_heartbeat_at: z.string().nullable().optional(),
+  /**
+   * UUID of the agent_session_groups row this session belongs to, or null
+   * for solo sessions. Optional in the schema because Realtime events
+   * predating the explicit selection may not carry the column.
+   *
+   * WHY (M1.2 D-01 fix, 2026-04-30): Phase 4-step3 wired the CLI to populate
+   * this column when sessions are spawned by `styrby multi`. The mobile list
+   * was previously group-blind because the SELECT and the Zod schema both
+   * omitted the field; data was being stripped at the parse boundary.
+   */
+  session_group_id: z.string().nullable().optional(),
 });
 
 /** Inferred TypeScript type for a validated session row. */


### PR DESCRIPTION
## Summary

After Phase 4-step3 wired the CLI to populate `sessions.session_group_id` via PATCH /api/v1/sessions/[id], the mobile primary session list was still group-blind. Three surgical changes restore visibility:

- `useSessions.ts`: SELECT now includes `session_group_id`; `SessionRow` type declares it as `string | null | undefined`.
- `schemas.ts`: `SessionSchema` validates the column (forward-compat optional, mirrors `team_id` pattern).
- `schemas.test.ts`: 3 new cases (UUID present, null, omitted).

## Test plan

- [x] `pnpm --filter styrby-mobile typecheck` clean
- [x] `pnpm --filter styrby-mobile test schemas` 84/84 pass
- [ ] CI green

## Not in this PR (separate workstream)

- Downstream UI (group badge in SessionCard, group section header) needs design decisions.
- D-02 (mobile MCP approval UX) is the larger M1.2 finding; ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)