### PR TITLE
feat(mobile): D-02 — MCP approval UX end-to-end (M1.5 fix)

### DIFF
--- a/packages/styrby-mobile/app/_layout.tsx
+++ b/packages/styrby-mobile/app/_layout.tsx
@@ -343,6 +343,25 @@ export default function RootLayout() {
             headerShown: false,
           }}
         />
+        {/*
+         * MCP approval deep-link route.
+         * Handles: styrby://mcp-approval/<approvalId>
+         *
+         * Routed to from useNotifications when a push payload arrives with
+         * data.screen='mcp_approval' (sent by the audit_log push trigger after
+         * the CLI's `styrby mcp serve` records mcp_approval_requested).
+         *
+         * `presentation: 'modal'` so a foregrounded user keeps their context
+         * underneath; backgrounded users get a normal stack push from the
+         * deep-link handler.
+         */}
+        <Stack.Screen
+          name="mcp-approval/[approvalId]"
+          options={{
+            title: 'Approval requested',
+            presentation: 'modal',
+          }}
+        />
       </Stack>
     </GestureHandlerRootView>
   );

--- a/packages/styrby-mobile/app/mcp-approval/[approvalId].tsx
+++ b/packages/styrby-mobile/app/mcp-approval/[approvalId].tsx
@@ -1,0 +1,142 @@
+/**
+ * MCP Approval Screen — route handler at /mcp-approval/[approvalId].
+ *
+ * Orchestrator only: pulls the approval ID from the route, calls
+ * {@link useMcpApproval} for state, and delegates rendering to
+ * {@link McpApprovalRequest}. No business logic lives here.
+ *
+ * Deep-linked from the push notification routed in
+ * `src/hooks/useNotifications.ts` when the payload's `screen` field is
+ * `'mcp_approval'` and `approvalId` is present.
+ *
+ * @module app/mcp-approval/[approvalId]
+ */
+
+import React, { useCallback } from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
+import {
+  useMcpApproval,
+  McpApprovalRequest,
+} from '@/components/mcp-approval';
+
+/**
+ * Route params extracted by expo-router from the file-system route.
+ */
+interface McpApprovalRouteParams extends Record<string, string | string[]> {
+  approvalId: string;
+}
+
+/**
+ * Default export — the actual screen.
+ */
+export default function McpApprovalScreen(): React.ReactElement {
+  const router = useRouter();
+  const params = useLocalSearchParams<McpApprovalRouteParams>();
+  const approvalId =
+    typeof params.approvalId === 'string' ? params.approvalId : '';
+
+  /**
+   * Dismisses the screen after a successful decision write.
+   *
+   * WHY router.back() vs router.replace('/'): the user arrived here from a
+   * notification deep-link or the dashboard "Review" button. In both cases
+   * popping back lands them on the prior screen (dashboard or wherever
+   * they came from), which is the least disruptive UX.
+   */
+  const handleResolved = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace('/(tabs)/');
+    }
+  }, [router]);
+
+  const {
+    request,
+    isLoading,
+    loadError,
+    isSubmitting,
+    submitError,
+    secondsRemaining,
+    submit,
+  } = useMcpApproval({ approvalId, onResolved: handleResolved });
+
+  const handleApprove = useCallback(
+    (note: string) => {
+      void submit('approved', note);
+    },
+    [submit],
+  );
+
+  const handleDeny = useCallback(
+    (note: string) => {
+      void submit('denied', note);
+    },
+    [submit],
+  );
+
+  if (!approvalId) {
+    return (
+      <View style={styles.statusContainer} accessibilityRole="alert">
+        <Stack.Screen options={{ title: 'Approval' }} />
+        <Text style={styles.errorText}>Missing approval id in route.</Text>
+      </View>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <View style={styles.statusContainer}>
+        <Stack.Screen options={{ title: 'Approval' }} />
+        <ActivityIndicator size="large" color="#f97316" />
+        <Text style={styles.statusText}>Loading approval request…</Text>
+      </View>
+    );
+  }
+
+  if (loadError || !request) {
+    return (
+      <View style={styles.statusContainer} accessibilityRole="alert">
+        <Stack.Screen options={{ title: 'Approval' }} />
+        <Text style={styles.errorText}>
+          {loadError ?? 'Approval request unavailable.'}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Approval requested' }} />
+      <McpApprovalRequest
+        request={request}
+        isSubmitting={isSubmitting}
+        submitError={submitError}
+        secondsRemaining={secondsRemaining}
+        onApprove={handleApprove}
+        onDeny={handleDeny}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  statusContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    backgroundColor: '#0a0a0a',
+    gap: 12,
+  },
+  statusText: {
+    color: '#9ca3af',
+    fontSize: 14,
+  },
+  errorText: {
+    color: '#fca5a5',
+    fontSize: 15,
+    textAlign: 'center',
+  },
+});

--- a/packages/styrby-mobile/jest.setup.js
+++ b/packages/styrby-mobile/jest.setup.js
@@ -139,6 +139,27 @@ jest.mock('expo-haptics', () => ({
 }));
 
 // ============================================================================
+// expo-local-authentication
+// ============================================================================
+
+/**
+ * Mock of expo-local-authentication for the MCP approval biometric gate.
+ *
+ * WHY default-success: tests that exercise the high-risk approve path expect
+ * the biometric gate to pass; tests for the deny path or low-risk approve
+ * should never invoke the gate. Tests that need to verify failure-path
+ * behaviour override authenticateAsync via jest.spyOn locally.
+ */
+jest.mock('expo-local-authentication', () => ({
+  hasHardwareAsync: jest.fn(async () => true),
+  isEnrolledAsync: jest.fn(async () => true),
+  supportedAuthenticationTypesAsync: jest.fn(async () => [1, 2]),
+  authenticateAsync: jest.fn(async () => ({ success: true })),
+  AuthenticationType: { FINGERPRINT: 1, FACIAL_RECOGNITION: 2, IRIS: 3 },
+  SecurityLevel: { NONE: 0, SECRET: 1, BIOMETRIC_WEAK: 2, BIOMETRIC_STRONG: 3 },
+}));
+
+// ============================================================================
 // expo-camera
 // ============================================================================
 

--- a/packages/styrby-mobile/package.json
+++ b/packages/styrby-mobile/package.json
@@ -43,6 +43,7 @@
     "expo-font": "~13.0.4",
     "expo-haptics": "^14.0.1",
     "expo-linking": "~7.0.0",
+    "expo-local-authentication": "~15.0.2",
     "expo-notifications": "~0.29.14",
     "expo-passkey": "0.3.12",
     "expo-router": "~4.0.0",

--- a/packages/styrby-mobile/src/components/audit/McpApprovalEventRow.tsx
+++ b/packages/styrby-mobile/src/components/audit/McpApprovalEventRow.tsx
@@ -1,0 +1,210 @@
+/**
+ * McpApprovalEventRow — audit-event renderer for the dashboard feed.
+ *
+ * Renders a single MCP-approval-lifecycle audit_log row in the dashboard's
+ * notification stream. Three states are supported:
+ *
+ *   - `mcp_approval_requested` (still pending) → "Pending approval — bash"
+ *     with a Review button that deep-links to the MCP approval screen.
+ *   - `mcp_approval_decided` → "Approved bash" or "Denied bash" with the
+ *     decision timestamp.
+ *   - `mcp_approval_timeout` → "Approval expired — bash".
+ *
+ * Pulled into its own component to keep the dashboard renderer thin and so
+ * the row can be unit-tested without mounting the full dashboard tree.
+ *
+ * @module components/audit/McpApprovalEventRow
+ */
+
+import React, { memo, useCallback } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Lifecycle phase encoded by the audit_log.action enum value.
+ *
+ * WHY string union (not enum): enums require value imports across files;
+ * using string literals matches the audit_action Postgres enum exactly and
+ * keeps the type narrow at every call site.
+ */
+export type McpApprovalEventKind =
+  | 'mcp_approval_requested'
+  | 'mcp_approval_decided'
+  | 'mcp_approval_timeout';
+
+/**
+ * Props for {@link McpApprovalEventRow}.
+ */
+export interface McpApprovalEventRowProps {
+  /** Lifecycle phase of this row. */
+  kind: McpApprovalEventKind;
+  /** Approval row UUID, used for deep-linking the Review button. */
+  approvalId: string;
+  /**
+   * Display label for the MCP tool action (e.g. "bash", "edit").
+   * Pulled from `audit_log.metadata.requested_action` upstream.
+   */
+  requestedAction: string;
+  /**
+   * For decided rows only — the user's binary verdict.
+   * Read from `audit_log.metadata.decision`.
+   */
+  decision?: 'approved' | 'denied';
+  /** ISO 8601 timestamp from audit_log.created_at. */
+  timestamp: string;
+  /**
+   * True when this is a `requested` row that has NOT yet been resolved by
+   * a matching `decided` or `timeout` row. Drives the Review button.
+   */
+  isPending?: boolean;
+  /**
+   * Called when the user taps the Review button on a pending row.
+   * The orchestrator handles navigation so this component stays presentational.
+   */
+  onReview?: (approvalId: string) => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Picks the icon + colour for the row based on kind/decision/pending state.
+ *
+ * WHY a single function instead of inline branches: keeps the JSX focused
+ * on layout and lets the visual mapping be tested independently if we ever
+ * extract a snapshot test for the row.
+ */
+function pickVisual(
+  kind: McpApprovalEventKind,
+  decision: 'approved' | 'denied' | undefined,
+  isPending: boolean,
+): {
+  icon: keyof typeof Ionicons.glyphMap;
+  color: string;
+  label: (action: string) => string;
+} {
+  if (kind === 'mcp_approval_requested' && isPending) {
+    return {
+      icon: 'lock-closed',
+      color: '#f59e0b',
+      label: (action) => `Pending approval - ${action}`,
+    };
+  }
+  if (kind === 'mcp_approval_decided' && decision === 'approved') {
+    return {
+      icon: 'checkmark-circle',
+      color: '#22c55e',
+      label: (action) => `Approved ${action}`,
+    };
+  }
+  if (kind === 'mcp_approval_decided' && decision === 'denied') {
+    return {
+      icon: 'close-circle',
+      color: '#ef4444',
+      label: (action) => `Denied ${action}`,
+    };
+  }
+  if (kind === 'mcp_approval_timeout') {
+    return {
+      icon: 'time-outline',
+      color: '#9ca3af',
+      label: (action) => `Approval expired - ${action}`,
+    };
+  }
+  // Resolved request row (paired with a later decided/timeout row).
+  return {
+    icon: 'shield-checkmark-outline',
+    color: '#9ca3af',
+    label: (action) => `Approval handled - ${action}`,
+  };
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Single MCP approval lifecycle event row.
+ */
+export const McpApprovalEventRow = memo(function McpApprovalEventRow({
+  kind,
+  approvalId,
+  requestedAction,
+  decision,
+  timestamp,
+  isPending = false,
+  onReview,
+}: McpApprovalEventRowProps) {
+  const visual = pickVisual(kind, decision, isPending);
+
+  const handleReview = useCallback(() => {
+    onReview?.(approvalId);
+  }, [approvalId, onReview]);
+
+  const showReviewButton = isPending && kind === 'mcp_approval_requested';
+
+  return (
+    <View style={styles.row} accessibilityRole="summary">
+      <Ionicons name={visual.icon} size={18} color={visual.color} />
+      <View style={styles.body}>
+        <Text style={styles.label} numberOfLines={1}>
+          {visual.label(requestedAction)}
+        </Text>
+        <Text style={styles.timestamp}>{new Date(timestamp).toLocaleTimeString()}</Text>
+      </View>
+      {showReviewButton && onReview && (
+        <TouchableOpacity
+          style={styles.reviewButton}
+          onPress={handleReview}
+          accessibilityRole="button"
+          accessibilityLabel={`Review pending MCP approval for ${requestedAction}`}
+        >
+          <Text style={styles.reviewText}>Review</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+});
+
+// ============================================================================
+// Styles
+// ============================================================================
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  body: {
+    flex: 1,
+  },
+  label: {
+    fontSize: 14,
+    color: '#e5e7eb',
+    fontWeight: '600',
+  },
+  timestamp: {
+    fontSize: 11,
+    color: '#9ca3af',
+    marginTop: 2,
+  },
+  reviewButton: {
+    backgroundColor: '#f97316',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  reviewText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+});

--- a/packages/styrby-mobile/src/components/audit/__tests__/McpApprovalEventRow.test.tsx
+++ b/packages/styrby-mobile/src/components/audit/__tests__/McpApprovalEventRow.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for McpApprovalEventRow.
+ *
+ * Coverage:
+ *   - Pending requested rows render "Pending approval - <action>" + Review button.
+ *   - Approved decided rows render "Approved <action>" without Review button.
+ *   - Denied decided rows render "Denied <action>".
+ *   - Timeout rows render "Approval expired - <action>".
+ *   - Tapping Review fires onReview with the approvalId.
+ *
+ * @module components/audit/__tests__/McpApprovalEventRow.test
+ */
+
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { McpApprovalEventRow } from '@/components/audit/McpApprovalEventRow';
+
+const APPROVAL_ID = '11111111-2222-3333-4444-555555555555';
+const NOW = new Date().toISOString();
+
+describe('McpApprovalEventRow', () => {
+  it('renders pending requested row with Review button', () => {
+    const onReview = jest.fn();
+    render(
+      <McpApprovalEventRow
+        kind="mcp_approval_requested"
+        approvalId={APPROVAL_ID}
+        requestedAction="bash"
+        timestamp={NOW}
+        isPending={true}
+        onReview={onReview}
+      />,
+    );
+    expect(screen.getByText(/Pending approval - bash/)).toBeTruthy();
+    fireEvent.press(screen.getByLabelText(/Review pending MCP approval/));
+    expect(onReview).toHaveBeenCalledWith(APPROVAL_ID);
+  });
+
+  it('does not render Review button on a resolved requested row', () => {
+    render(
+      <McpApprovalEventRow
+        kind="mcp_approval_requested"
+        approvalId={APPROVAL_ID}
+        requestedAction="bash"
+        timestamp={NOW}
+        isPending={false}
+      />,
+    );
+    expect(screen.queryByText('Review')).toBeNull();
+  });
+
+  it('renders approved decision row', () => {
+    render(
+      <McpApprovalEventRow
+        kind="mcp_approval_decided"
+        approvalId={APPROVAL_ID}
+        requestedAction="edit"
+        decision="approved"
+        timestamp={NOW}
+      />,
+    );
+    expect(screen.getByText('Approved edit')).toBeTruthy();
+  });
+
+  it('renders denied decision row', () => {
+    render(
+      <McpApprovalEventRow
+        kind="mcp_approval_decided"
+        approvalId={APPROVAL_ID}
+        requestedAction="bash"
+        decision="denied"
+        timestamp={NOW}
+      />,
+    );
+    expect(screen.getByText('Denied bash')).toBeTruthy();
+  });
+
+  it('renders timeout row', () => {
+    render(
+      <McpApprovalEventRow
+        kind="mcp_approval_timeout"
+        approvalId={APPROVAL_ID}
+        requestedAction="bash"
+        timestamp={NOW}
+      />,
+    );
+    expect(screen.getByText(/Approval expired - bash/)).toBeTruthy();
+  });
+});

--- a/packages/styrby-mobile/src/components/mcp-approval/McpApprovalRequest.tsx
+++ b/packages/styrby-mobile/src/components/mcp-approval/McpApprovalRequest.tsx
@@ -1,0 +1,407 @@
+/**
+ * McpApprovalRequest — presentational view for an MCP approval request.
+ *
+ * Pure render component: receives the loaded request + state from the
+ * orchestrator and exposes onApprove/onDeny callbacks. All side effects
+ * (fetch, biometric, write) live in {@link useMcpApproval}.
+ *
+ * @module components/mcp-approval/McpApprovalRequest
+ */
+
+import React, { memo, useCallback, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { McpApprovalRequest as McpApprovalRequestModel } from './useMcpApproval';
+import type { RiskLevel } from '@/components/approvals/ApprovalRequestCard';
+
+// ============================================================================
+// Constants — palette reused from ApprovalRequestCard for visual consistency
+// ============================================================================
+
+/**
+ * Risk badge colour palette.
+ *
+ * WHY duplicated rather than imported from ApprovalRequestCard: the legacy
+ * card's palette is exported as a private const inside its module. Promoting
+ * it to a shared module is out of scope for D-02 (would touch the legacy
+ * approval surface area). A targeted dupe with a comment is the safe move;
+ * a follow-up cleanup task can extract a shared `risk-palette.ts` module.
+ */
+const RISK_COLORS: Record<
+  RiskLevel,
+  { background: string; text: string; label: string }
+> = {
+  low: { background: '#dcfce7', text: '#15803d', label: 'Low Risk' },
+  medium: { background: '#fef9c3', text: '#a16207', label: 'Medium Risk' },
+  high: { background: '#fee2e2', text: '#dc2626', label: 'High Risk' },
+  critical: { background: '#fde8e9', text: '#991b1b', label: 'Critical' },
+};
+
+/**
+ * Maximum length for the optional user_message TextInput.
+ * Mirrors `MAX_USER_MESSAGE_LENGTH` in services/mcp-approval.ts.
+ */
+const MAX_NOTE_LENGTH = 280;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Formats a seconds value as "M:SS" for the countdown row.
+ *
+ * WHY "M:SS" not "Xm Ys": the request expires inside a 5-minute window so
+ * the user is reading sub-minute precision frequently. A clock-style display
+ * is more legible at a glance than mixed-unit text.
+ */
+function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Renders a context blob as a pretty-printed JSON code block.
+ *
+ * WHY JSON.stringify with no HTML interpolation: React Native Text nodes
+ * cannot interpret HTML, so there is no XSS surface — but stringifying
+ * defensively also prevents `[object Object]` rendering and prevents
+ * accidental rendering of functions or symbols if the metadata is ever
+ * tampered with.
+ */
+function renderContext(context: Record<string, unknown> | null): string {
+  if (!context || Object.keys(context).length === 0) return '';
+  try {
+    return JSON.stringify(context, null, 2);
+  } catch {
+    return '[unserialisable context]';
+  }
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Props for {@link McpApprovalRequest}.
+ */
+export interface McpApprovalRequestProps {
+  /** Loaded request data. Component must not render until this resolves. */
+  request: McpApprovalRequestModel;
+  /** True while the decision write is in-flight. Disables both buttons. */
+  isSubmitting: boolean;
+  /** Submission error message; rendered inline above the buttons. */
+  submitError: string | null;
+  /** Seconds remaining before the CLI poll loop times out. */
+  secondsRemaining: number;
+  /** Approve callback; receives the optional user note. */
+  onApprove: (userMessage: string) => void;
+  /** Deny callback; receives the optional user note. */
+  onDeny: (userMessage: string) => void;
+}
+
+/**
+ * Renders the MCP approval request screen body.
+ */
+export const McpApprovalRequest = memo(function McpApprovalRequest({
+  request,
+  isSubmitting,
+  submitError,
+  secondsRemaining,
+  onApprove,
+  onDeny,
+}: McpApprovalRequestProps) {
+  const [note, setNote] = useState('');
+
+  const riskConfig = RISK_COLORS[request.risk] ?? RISK_COLORS.medium;
+  const machineDisplay = request.machineId.slice(0, 8);
+  const contextBlock = renderContext(request.context);
+  const expired = secondsRemaining <= 0;
+  const buttonsDisabled = isSubmitting || expired;
+
+  const handleApprove = useCallback(() => {
+    if (!buttonsDisabled) onApprove(note);
+  }, [buttonsDisabled, note, onApprove]);
+
+  const handleDeny = useCallback(() => {
+    if (!buttonsDisabled) onDeny(note);
+  }, [buttonsDisabled, note, onDeny]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {/* ── Header ───────────────────────────────────────────────────────── */}
+      <Text style={styles.title}>Approval requested</Text>
+      <Text style={styles.subtitle}>From machine {machineDisplay}…</Text>
+
+      {/* ── Action chip + risk badge ─────────────────────────────────────── */}
+      <View style={styles.headerRow}>
+        <View style={styles.actionChip}>
+          <Ionicons name="terminal-outline" size={18} color="#374151" />
+          <Text style={styles.actionText}>{request.requestedAction}</Text>
+        </View>
+        <View style={[styles.riskBadge, { backgroundColor: riskConfig.background }]}>
+          <Text style={[styles.riskLabel, { color: riskConfig.text }]}>
+            {riskConfig.label}
+          </Text>
+        </View>
+      </View>
+
+      {/* ── Reason ───────────────────────────────────────────────────────── */}
+      <Text style={styles.sectionLabel}>Reason</Text>
+      <Text style={styles.reasonText}>{request.reason}</Text>
+
+      {/* ── Context preview ──────────────────────────────────────────────── */}
+      {contextBlock.length > 0 && (
+        <>
+          <Text style={styles.sectionLabel}>Context</Text>
+          <ScrollView
+            style={styles.contextBlock}
+            horizontal
+            accessibilityLabel="Approval request context payload"
+          >
+            <Text style={styles.contextText}>{contextBlock}</Text>
+          </ScrollView>
+        </>
+      )}
+
+      {/* ── Optional message ─────────────────────────────────────────────── */}
+      <Text style={styles.sectionLabel}>Add a note (optional)</Text>
+      <TextInput
+        style={styles.noteInput}
+        value={note}
+        onChangeText={setNote}
+        placeholder="Visible in the audit log"
+        placeholderTextColor="#9ca3af"
+        maxLength={MAX_NOTE_LENGTH}
+        multiline
+        accessibilityLabel="Optional note to attach to the approval decision"
+      />
+
+      {/* ── Countdown ────────────────────────────────────────────────────── */}
+      <Text
+        style={[
+          styles.countdown,
+          expired && styles.countdownExpired,
+          !expired && secondsRemaining < 30 && styles.countdownUrgent,
+        ]}
+        accessibilityLabel={
+          expired
+            ? 'Approval request has expired'
+            : `Approval expires in ${formatCountdown(secondsRemaining)}`
+        }
+      >
+        {expired
+          ? 'This request has expired'
+          : `Expires in ${formatCountdown(secondsRemaining)}`}
+      </Text>
+
+      {/* ── Submission error banner ──────────────────────────────────────── */}
+      {submitError && (
+        <View style={styles.errorBanner}>
+          <Ionicons name="alert-circle-outline" size={14} color="#dc2626" />
+          <Text style={styles.errorText}>{submitError}</Text>
+        </View>
+      )}
+
+      {/* ── Actions ──────────────────────────────────────────────────────── */}
+      <View style={styles.buttonRow}>
+        <TouchableOpacity
+          style={[styles.button, styles.denyButton, buttonsDisabled && styles.buttonDisabled]}
+          onPress={handleDeny}
+          disabled={buttonsDisabled}
+          accessibilityRole="button"
+          accessibilityLabel="Deny this MCP approval request"
+        >
+          {isSubmitting ? (
+            <ActivityIndicator size="small" color="#dc2626" />
+          ) : (
+            <>
+              <Ionicons name="close-circle-outline" size={16} color="#dc2626" />
+              <Text style={styles.denyText}>Deny</Text>
+            </>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.button, styles.approveButton, buttonsDisabled && styles.buttonDisabled]}
+          onPress={handleApprove}
+          disabled={buttonsDisabled}
+          accessibilityRole="button"
+          accessibilityLabel="Approve this MCP approval request"
+        >
+          {isSubmitting ? (
+            <ActivityIndicator size="small" color="#ffffff" />
+          ) : (
+            <>
+              <Ionicons name="checkmark-circle-outline" size={16} color="#ffffff" />
+              <Text style={styles.approveText}>Approve</Text>
+            </>
+          )}
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
+  );
+});
+
+// ============================================================================
+// Styles
+// ============================================================================
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+    backgroundColor: '#0a0a0a',
+    flexGrow: 1,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#f5f5f5',
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: '#9ca3af',
+    marginBottom: 20,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 18,
+  },
+  actionChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: '#1f2937',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  actionText: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#f5f5f5',
+  },
+  riskBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  riskLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+  },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#9ca3af',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: 16,
+    marginBottom: 6,
+  },
+  reasonText: {
+    fontSize: 15,
+    color: '#e5e7eb',
+    lineHeight: 22,
+  },
+  contextBlock: {
+    backgroundColor: '#111827',
+    borderRadius: 8,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    maxHeight: 200,
+  },
+  contextText: {
+    fontFamily: 'monospace',
+    fontSize: 12,
+    color: '#d1d5db',
+    lineHeight: 18,
+  },
+  noteInput: {
+    backgroundColor: '#111827',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    color: '#f5f5f5',
+    padding: 12,
+    fontSize: 14,
+    minHeight: 60,
+    textAlignVertical: 'top',
+  },
+  countdown: {
+    fontSize: 13,
+    color: '#9ca3af',
+    marginTop: 16,
+    textAlign: 'center',
+  },
+  countdownUrgent: {
+    color: '#f59e0b',
+    fontWeight: '600',
+  },
+  countdownExpired: {
+    color: '#ef4444',
+    fontWeight: '600',
+  },
+  errorBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: '#7f1d1d',
+    borderRadius: 8,
+    padding: 10,
+    marginTop: 12,
+  },
+  errorText: {
+    fontSize: 13,
+    color: '#fecaca',
+    flex: 1,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 20,
+  },
+  button: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 14,
+    borderRadius: 10,
+    gap: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.55,
+  },
+  denyButton: {
+    backgroundColor: '#1f2937',
+    borderWidth: 1,
+    borderColor: '#7f1d1d',
+  },
+  denyText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#fca5a5',
+  },
+  approveButton: {
+    backgroundColor: '#16a34a',
+  },
+  approveText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#ffffff',
+  },
+});

--- a/packages/styrby-mobile/src/components/mcp-approval/__tests__/McpApprovalRequest.test.tsx
+++ b/packages/styrby-mobile/src/components/mcp-approval/__tests__/McpApprovalRequest.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Tests for McpApprovalRequest presentational component.
+ *
+ * Coverage:
+ *   - Renders requested action, reason, machine prefix, and risk badge label.
+ *   - Renders the JSON context block when context is non-empty.
+ *   - Approve / Deny tap callbacks fire with the typed note text.
+ *   - Disables both buttons while isSubmitting is true.
+ *   - Disables both buttons when secondsRemaining hits 0 (expired).
+ *   - Renders the submit error banner when submitError is provided.
+ *   - Snapshot of medium-risk request locks the visual structure.
+ *
+ * @module components/mcp-approval/__tests__/McpApprovalRequest.test
+ */
+
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { McpApprovalRequest } from '@/components/mcp-approval/McpApprovalRequest';
+import type { McpApprovalRequestModel } from '@/components/mcp-approval';
+
+const baseRequest: McpApprovalRequestModel = {
+  approvalId: '11111111-2222-3333-4444-555555555555',
+  requestedAction: 'bash',
+  reason: 'Install project dependencies before running tests.',
+  risk: 'medium',
+  machineId: 'machineabc12345extra',
+  context: { command: 'npm install' },
+  createdAt: new Date().toISOString(),
+};
+
+describe('McpApprovalRequest', () => {
+  const onApprove = jest.fn();
+  const onDeny = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the requested action chip', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(screen.getByText('bash')).toBeTruthy();
+  });
+
+  it('renders the reason text', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(
+      screen.getByText('Install project dependencies before running tests.'),
+    ).toBeTruthy();
+  });
+
+  it('renders the truncated machine id', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(screen.getByText(/machinea/)).toBeTruthy();
+  });
+
+  it('renders the risk badge with the matching label', () => {
+    render(
+      <McpApprovalRequest
+        request={{ ...baseRequest, risk: 'high' }}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(screen.getByText('High Risk')).toBeTruthy();
+  });
+
+  it('renders the JSON context block when context is non-empty', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(screen.getByText(/npm install/)).toBeTruthy();
+  });
+
+  it('omits the context block when context is empty', () => {
+    render(
+      <McpApprovalRequest
+        request={{ ...baseRequest, context: {} }}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(screen.queryByText('Context')).toBeNull();
+  });
+
+  it('renders the countdown text', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={272}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(screen.getByText(/Expires in 4:32/)).toBeTruthy();
+  });
+
+  it('renders expired copy when secondsRemaining is 0', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={0}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(screen.getByText(/expired/i)).toBeTruthy();
+  });
+
+  it('calls onApprove with the typed note', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.changeText(
+      screen.getByLabelText('Optional note to attach to the approval decision'),
+      'go for it',
+    );
+    fireEvent.press(screen.getByLabelText('Approve this MCP approval request'));
+    expect(onApprove).toHaveBeenCalledWith('go for it');
+  });
+
+  it('calls onDeny with the typed note', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.changeText(
+      screen.getByLabelText('Optional note to attach to the approval decision'),
+      'looks scary',
+    );
+    fireEvent.press(screen.getByLabelText('Deny this MCP approval request'));
+    expect(onDeny).toHaveBeenCalledWith('looks scary');
+  });
+
+  it('disables both buttons while submitting', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={true}
+        submitError={null}
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(
+      screen.getByLabelText('Approve this MCP approval request').props.disabled,
+    ).toBe(true);
+    expect(
+      screen.getByLabelText('Deny this MCP approval request').props.disabled,
+    ).toBe(true);
+  });
+
+  it('disables buttons when expired', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={0}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(
+      screen.getByLabelText('Approve this MCP approval request').props.disabled,
+    ).toBe(true);
+  });
+
+  it('renders the submit error banner', () => {
+    render(
+      <McpApprovalRequest
+        request={baseRequest}
+        isSubmitting={false}
+        submitError="Biometric check cancelled"
+        secondsRemaining={120}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    );
+    expect(screen.getByText('Biometric check cancelled')).toBeTruthy();
+  });
+
+  it('matches the snapshot for a medium-risk request', () => {
+    const tree = render(
+      <McpApprovalRequest
+        request={{ ...baseRequest, createdAt: '2026-04-30T00:00:00.000Z' }}
+        isSubmitting={false}
+        submitError={null}
+        secondsRemaining={272}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/styrby-mobile/src/components/mcp-approval/__tests__/__snapshots__/McpApprovalRequest.test.tsx.snap
+++ b/packages/styrby-mobile/src/components/mcp-approval/__tests__/__snapshots__/McpApprovalRequest.test.tsx.snap
@@ -1,0 +1,327 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`McpApprovalRequest matches the snapshot for a medium-risk request 1`] = `
+<ScrollView
+  contentContainerStyle={
+    {
+      "backgroundColor": "#0a0a0a",
+      "flexGrow": 1,
+      "padding": 20,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "#f5f5f5",
+        "fontSize": 22,
+        "fontWeight": "700",
+        "marginBottom": 4,
+      }
+    }
+  >
+    Approval requested
+  </Text>
+  <Text
+    style={
+      {
+        "color": "#9ca3af",
+        "fontSize": 13,
+        "marginBottom": 20,
+      }
+    }
+  >
+    From machine 
+    machinea
+    …
+  </Text>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "marginBottom": 18,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#1f2937",
+          "borderRadius": 8,
+          "flexDirection": "row",
+          "gap": 8,
+          "paddingHorizontal": 12,
+          "paddingVertical": 8,
+        }
+      }
+    >
+      <Text
+        testID="icon-Ionicons-terminal-outline"
+      >
+        terminal-outline
+      </Text>
+      <Text
+        style={
+          {
+            "color": "#f5f5f5",
+            "fontSize": 18,
+            "fontWeight": "700",
+          }
+        }
+      >
+        bash
+      </Text>
+    </View>
+    <View
+      style={
+        [
+          {
+            "borderRadius": 8,
+            "paddingHorizontal": 10,
+            "paddingVertical": 6,
+          },
+          {
+            "backgroundColor": "#fef9c3",
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 12,
+              "fontWeight": "700",
+              "letterSpacing": 0.3,
+            },
+            {
+              "color": "#a16207",
+            },
+          ]
+        }
+      >
+        Medium Risk
+      </Text>
+    </View>
+  </View>
+  <Text
+    style={
+      {
+        "color": "#9ca3af",
+        "fontSize": 11,
+        "fontWeight": "600",
+        "letterSpacing": 0.5,
+        "marginBottom": 6,
+        "marginTop": 16,
+        "textTransform": "uppercase",
+      }
+    }
+  >
+    Reason
+  </Text>
+  <Text
+    style={
+      {
+        "color": "#e5e7eb",
+        "fontSize": 15,
+        "lineHeight": 22,
+      }
+    }
+  >
+    Install project dependencies before running tests.
+  </Text>
+  <Text
+    style={
+      {
+        "color": "#9ca3af",
+        "fontSize": 11,
+        "fontWeight": "600",
+        "letterSpacing": 0.5,
+        "marginBottom": 6,
+        "marginTop": 16,
+        "textTransform": "uppercase",
+      }
+    }
+  >
+    Context
+  </Text>
+  <ScrollView
+    accessibilityLabel="Approval request context payload"
+    horizontal={true}
+    style={
+      {
+        "backgroundColor": "#111827",
+        "borderColor": "#1f2937",
+        "borderRadius": 8,
+        "borderWidth": 1,
+        "maxHeight": 200,
+        "padding": 12,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#d1d5db",
+          "fontFamily": "monospace",
+          "fontSize": 12,
+          "lineHeight": 18,
+        }
+      }
+    >
+      {
+  "command": "npm install"
+}
+    </Text>
+  </ScrollView>
+  <Text
+    style={
+      {
+        "color": "#9ca3af",
+        "fontSize": 11,
+        "fontWeight": "600",
+        "letterSpacing": 0.5,
+        "marginBottom": 6,
+        "marginTop": 16,
+        "textTransform": "uppercase",
+      }
+    }
+  >
+    Add a note (optional)
+  </Text>
+  <TextInput
+    accessibilityLabel="Optional note to attach to the approval decision"
+    maxLength={280}
+    multiline={true}
+    onChangeText={[Function]}
+    placeholder="Visible in the audit log"
+    placeholderTextColor="#9ca3af"
+    style={
+      {
+        "backgroundColor": "#111827",
+        "borderColor": "#1f2937",
+        "borderRadius": 8,
+        "borderWidth": 1,
+        "color": "#f5f5f5",
+        "fontSize": 14,
+        "minHeight": 60,
+        "padding": 12,
+        "textAlignVertical": "top",
+      }
+    }
+    value=""
+  />
+  <Text
+    accessibilityLabel="Approval expires in 4:32"
+    style={
+      [
+        {
+          "color": "#9ca3af",
+          "fontSize": 13,
+          "marginTop": 16,
+          "textAlign": "center",
+        },
+        false,
+        false,
+      ]
+    }
+  >
+    Expires in 4:32
+  </Text>
+  <View
+    style={
+      {
+        "flexDirection": "row",
+        "gap": 12,
+        "marginTop": 20,
+      }
+    }
+  >
+    <TouchableOpacity
+      accessibilityLabel="Deny this MCP approval request"
+      accessibilityRole="button"
+      disabled={false}
+      onPress={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "borderRadius": 10,
+            "flex": 1,
+            "flexDirection": "row",
+            "gap": 8,
+            "justifyContent": "center",
+            "paddingVertical": 14,
+          },
+          {
+            "backgroundColor": "#1f2937",
+            "borderColor": "#7f1d1d",
+            "borderWidth": 1,
+          },
+          false,
+        ]
+      }
+    >
+      <Text
+        testID="icon-Ionicons-close-circle-outline"
+      >
+        close-circle-outline
+      </Text>
+      <Text
+        style={
+          {
+            "color": "#fca5a5",
+            "fontSize": 15,
+            "fontWeight": "600",
+          }
+        }
+      >
+        Deny
+      </Text>
+    </TouchableOpacity>
+    <TouchableOpacity
+      accessibilityLabel="Approve this MCP approval request"
+      accessibilityRole="button"
+      disabled={false}
+      onPress={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "borderRadius": 10,
+            "flex": 1,
+            "flexDirection": "row",
+            "gap": 8,
+            "justifyContent": "center",
+            "paddingVertical": 14,
+          },
+          {
+            "backgroundColor": "#16a34a",
+          },
+          false,
+        ]
+      }
+    >
+      <Text
+        testID="icon-Ionicons-checkmark-circle-outline"
+      >
+        checkmark-circle-outline
+      </Text>
+      <Text
+        style={
+          {
+            "color": "#ffffff",
+            "fontSize": 15,
+            "fontWeight": "600",
+          }
+        }
+      >
+        Approve
+      </Text>
+    </TouchableOpacity>
+  </View>
+</ScrollView>
+`;

--- a/packages/styrby-mobile/src/components/mcp-approval/__tests__/useMcpApproval.test.ts
+++ b/packages/styrby-mobile/src/components/mcp-approval/__tests__/useMcpApproval.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for useMcpApproval hook.
+ *
+ * Coverage:
+ *   - Loads the audit_log request row and parses metadata.
+ *   - Surfaces fetch errors and missing-row state cleanly.
+ *   - submit('denied') skips the biometric prompt regardless of risk.
+ *   - submit('approved') for low/medium risk skips the biometric prompt.
+ *   - submit('approved') for high/critical risk gates on the biometric prompt.
+ *   - Cancelling biometric surfaces an error and never calls writeDecision.
+ *   - Successful submit calls onResolved with the decision.
+ *   - Double-submit is prevented while a write is in-flight.
+ *
+ * @module components/mcp-approval/__tests__/useMcpApproval.test
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+// WHY mocks defined inside the factory: jest.mock is hoisted above const
+// declarations, so referencing top-level vars from the factory throws.
+jest.mock('@/lib/supabase', () => {
+  const maybeSingle = jest.fn();
+  const limit = jest.fn(() => ({ maybeSingle }));
+  const eqAction = jest.fn(() => ({ limit }));
+  const eqResource = jest.fn(() => ({ eq: eqAction }));
+  const select = jest.fn(() => ({ eq: eqResource }));
+  const from = jest.fn(() => ({ select }));
+  return {
+    supabase: { auth: { getUser: jest.fn() }, from },
+    __mocks: { maybeSingle, from },
+  };
+});
+
+jest.mock('@/services/mcp-approval', () => {
+  const writeMcpApprovalDecision = jest.fn();
+  return { writeMcpApprovalDecision, __mocks: { writeMcpApprovalDecision } };
+});
+
+import { useMcpApproval } from '@/components/mcp-approval/useMcpApproval';
+const supabaseMock = (jest.requireMock('@/lib/supabase') as { __mocks: { maybeSingle: jest.Mock; from: jest.Mock } }).__mocks;
+const mcpServiceMock = (jest.requireMock('@/services/mcp-approval') as { __mocks: { writeMcpApprovalDecision: jest.Mock } }).__mocks;
+const mockMaybeSingle = supabaseMock.maybeSingle;
+const mockWriteDecision = mcpServiceMock.writeMcpApprovalDecision;
+
+const APPROVAL_ID = '11111111-2222-3333-4444-555555555555';
+
+function makeRequestRow(overrides: { metadata?: Record<string, unknown> } = {}): unknown {
+  return {
+    id: 'audit-row-1',
+    action: 'mcp_approval_requested',
+    resource_type: 'mcp_approval',
+    resource_id: APPROVAL_ID,
+    metadata: {
+      approval_id: APPROVAL_ID,
+      requested_action: 'bash',
+      reason: 'install deps',
+      risk: 'medium',
+      machine_id: 'machineabc12345',
+      context: { command: 'npm install' },
+      ...(overrides.metadata ?? {}),
+    },
+    created_at: new Date().toISOString(),
+  };
+}
+
+describe('useMcpApproval', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMaybeSingle.mockResolvedValue({ data: makeRequestRow(), error: null });
+    mockWriteDecision.mockResolvedValue(undefined);
+  });
+
+  it('loads the request and exposes parsed fields', async () => {
+    const { result } = renderHook(() => useMcpApproval({ approvalId: APPROVAL_ID }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.loadError).toBeNull();
+    expect(result.current.request).not.toBeNull();
+    expect(result.current.request?.requestedAction).toBe('bash');
+    expect(result.current.request?.reason).toBe('install deps');
+    expect(result.current.request?.risk).toBe('medium');
+    expect(result.current.request?.context).toEqual({ command: 'npm install' });
+  });
+
+  it('reports a load error when the row is missing', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: null });
+    const { result } = renderHook(() => useMcpApproval({ approvalId: APPROVAL_ID }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.loadError).toMatch(/not found/);
+    expect(result.current.request).toBeNull();
+  });
+
+  it('reports a load error when supabase returns an error', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: { message: 'oh no' } });
+    const { result } = renderHook(() => useMcpApproval({ approvalId: APPROVAL_ID }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.loadError).toMatch(/oh no/);
+  });
+
+  it('reports a load error when metadata is malformed', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: { ...(makeRequestRow() as Record<string, unknown>), metadata: { broken: true } },
+      error: null,
+    });
+    const { result } = renderHook(() => useMcpApproval({ approvalId: APPROVAL_ID }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.loadError).toMatch(/malformed/);
+  });
+
+  it('submit("denied") never invokes the biometric prompt even on high risk', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: makeRequestRow({ metadata: { risk: 'high' } }),
+      error: null,
+    });
+    const biometricPrompt = jest.fn(async () => true);
+    const onResolved = jest.fn();
+
+    const { result } = renderHook(() =>
+      useMcpApproval({ approvalId: APPROVAL_ID, biometricPrompt, onResolved }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.submit('denied', 'too risky');
+    });
+
+    expect(biometricPrompt).not.toHaveBeenCalled();
+    expect(mockWriteDecision).toHaveBeenCalledWith({
+      approvalId: APPROVAL_ID,
+      decision: 'denied',
+      userMessage: 'too risky',
+    });
+    expect(onResolved).toHaveBeenCalledWith('denied');
+  });
+
+  it('submit("approved") on medium risk skips the biometric gate', async () => {
+    const biometricPrompt = jest.fn(async () => true);
+    const { result } = renderHook(() =>
+      useMcpApproval({ approvalId: APPROVAL_ID, biometricPrompt }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.submit('approved');
+    });
+
+    expect(biometricPrompt).not.toHaveBeenCalled();
+    expect(mockWriteDecision).toHaveBeenCalled();
+  });
+
+  it('submit("approved") on high risk requires biometric and writes when it passes', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: makeRequestRow({ metadata: { risk: 'high' } }),
+      error: null,
+    });
+    const biometricPrompt = jest.fn(async () => true);
+    const onResolved = jest.fn();
+
+    const { result } = renderHook(() =>
+      useMcpApproval({ approvalId: APPROVAL_ID, biometricPrompt, onResolved }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.submit('approved');
+    });
+
+    expect(biometricPrompt).toHaveBeenCalledTimes(1);
+    expect(mockWriteDecision).toHaveBeenCalled();
+    expect(onResolved).toHaveBeenCalledWith('approved');
+  });
+
+  it('submit("approved") on critical risk still gates on biometric', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: makeRequestRow({ metadata: { risk: 'critical' } }),
+      error: null,
+    });
+    const biometricPrompt = jest.fn(async () => true);
+    const { result } = renderHook(() =>
+      useMcpApproval({ approvalId: APPROVAL_ID, biometricPrompt }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.submit('approved');
+    });
+
+    expect(biometricPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelled biometric prompts surface an error and skip the write', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: makeRequestRow({ metadata: { risk: 'high' } }),
+      error: null,
+    });
+    const biometricPrompt = jest.fn(async () => false);
+    const onResolved = jest.fn();
+
+    const { result } = renderHook(() =>
+      useMcpApproval({ approvalId: APPROVAL_ID, biometricPrompt, onResolved }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.submit('approved');
+    });
+
+    expect(mockWriteDecision).not.toHaveBeenCalled();
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(result.current.submitError).toMatch(/Biometric/);
+  });
+
+  it('write failures surface the error message', async () => {
+    mockWriteDecision.mockRejectedValueOnce(new Error('relay down'));
+    const { result } = renderHook(() => useMcpApproval({ approvalId: APPROVAL_ID }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.submit('approved');
+    });
+
+    expect(result.current.submitError).toMatch(/relay down/);
+  });
+
+  it('does not double-submit while a write is in flight', async () => {
+    let resolveWrite!: () => void;
+    mockWriteDecision.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useMcpApproval({ approvalId: APPROVAL_ID }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let firstCall!: Promise<void>;
+    act(() => {
+      firstCall = result.current.submit('approved');
+    });
+
+    // immediate second call should be ignored
+    await act(async () => {
+      await result.current.submit('denied');
+    });
+
+    await act(async () => {
+      resolveWrite();
+      await firstCall;
+    });
+
+    expect(mockWriteDecision).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/styrby-mobile/src/components/mcp-approval/index.ts
+++ b/packages/styrby-mobile/src/components/mcp-approval/index.ts
@@ -1,0 +1,15 @@
+/**
+ * MCP approval surface — barrel exports.
+ *
+ * WHY: matches the project's component-first / barrel-export discipline so
+ * the route handler imports a single flat surface area.
+ */
+
+export { McpApprovalRequest } from './McpApprovalRequest';
+export type { McpApprovalRequestProps } from './McpApprovalRequest';
+export {
+  useMcpApproval,
+  type McpApprovalRequest as McpApprovalRequestModel,
+  type UseMcpApprovalInput,
+  type UseMcpApprovalResult,
+} from './useMcpApproval';

--- a/packages/styrby-mobile/src/components/mcp-approval/useMcpApproval.ts
+++ b/packages/styrby-mobile/src/components/mcp-approval/useMcpApproval.ts
@@ -1,0 +1,378 @@
+/**
+ * useMcpApproval — state hook for the MCP approval screen
+ *
+ * Handles three concerns:
+ *   1. Loading the request audit_log row by `resource_id = approvalId`.
+ *   2. Submitting the user's decision via {@link writeMcpApprovalDecision},
+ *      with biometric gating for `risk='high'`/`risk='critical'` approvals.
+ *   3. Tracking the live countdown until the CLI's poll loop times out.
+ *
+ * Pulled out of the route handler so the component layer stays thin and
+ * testable without a fully-mounted Expo router. Mirrors the
+ * `useApprovalActions` co-location pattern from the legacy team-review
+ * approval UX (see packages/styrby-mobile/src/components/approvals/).
+ *
+ * @module components/mcp-approval/useMcpApproval
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import {
+  writeMcpApprovalDecision,
+  type WriteMcpApprovalDecisionInput,
+} from '@/services/mcp-approval';
+import type { RiskLevel } from '@/components/approvals/ApprovalRequestCard';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Risk levels that trigger the biometric prompt before approve.
+ *
+ * WHY high+critical only: low/medium correspond to read-only or sandboxed
+ * MCP tool calls (file read, lint, format). High/critical map to writes,
+ * shell exec, or network egress — exactly the surfaces where a stolen-phone
+ * attacker should hit a hardware authenticator. Matches the legacy team
+ * approval UX threshold so users have a single mental model across both
+ * approval streams.
+ */
+const BIOMETRIC_GATED_RISK: ReadonlyArray<RiskLevel> = ['high', 'critical'];
+
+/**
+ * CLI's default per-request poll timeout (matches packages/styrby-cli's
+ * server.ts → DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000).
+ *
+ * WHY duplicated here instead of imported: importing the CLI package into
+ * the mobile bundle pulls Node-only deps (node:crypto). The constant is
+ * stable across both surfaces; if the CLI default ever changes, this
+ * constant must be updated in lockstep — flagged via the comment above.
+ */
+const CLI_REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Tick cadence for the countdown display.
+ *
+ * WHY 1s: matches the second-resolution display ("4:32") so the visible
+ * digit changes exactly when the underlying value crosses a second boundary.
+ * Faster ticking would burn battery for no perceptible benefit.
+ */
+const COUNTDOWN_TICK_MS = 1000;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * The deserialised request payload as displayed on the screen.
+ * Mirrors `ApprovalMetadata` from the CLI side — keep field names aligned.
+ */
+export interface McpApprovalRequest {
+  /** Same as the route param. */
+  approvalId: string;
+  /** The MCP tool action being approved (e.g. 'bash', 'edit'). */
+  requestedAction: string;
+  /** Human-readable rationale supplied by the agent. */
+  reason: string;
+  /** Risk classification chosen by the CLI policy engine. */
+  risk: RiskLevel;
+  /** CLI machine that originated the request (truncated for display). */
+  machineId: string;
+  /** Free-form context blob (e.g. `{ command: 'npm install' }`). */
+  context: Record<string, unknown> | null;
+  /** ISO 8601 timestamp from audit_log.created_at. */
+  createdAt: string;
+}
+
+/**
+ * Inputs for {@link useMcpApproval}.
+ */
+export interface UseMcpApprovalInput {
+  /** Approval UUID from the deep link. */
+  approvalId: string;
+  /**
+   * Override for {@link writeMcpApprovalDecision}, used by tests to inject a
+   * stub without monkey-patching the module.
+   */
+  writeDecision?: typeof writeMcpApprovalDecision;
+  /**
+   * Override for the biometric prompt. Defaults to a dynamic import of
+   * expo-local-authentication; tests inject `() => true` for the gated
+   * happy path or `() => false` for the cancellation path.
+   */
+  biometricPrompt?: (reason: string) => Promise<boolean>;
+  /** Called after a successful decision write so the screen can dismiss. */
+  onResolved?: (decision: 'approved' | 'denied') => void;
+}
+
+/**
+ * Return value of {@link useMcpApproval}.
+ */
+export interface UseMcpApprovalResult {
+  /** Loaded request data, or null while still fetching. */
+  request: McpApprovalRequest | null;
+  /** Initial fetch state. */
+  isLoading: boolean;
+  /** Fetch error message, or null. */
+  loadError: string | null;
+  /** True while a decision write is in-flight. */
+  isSubmitting: boolean;
+  /** Submission error message, or null. */
+  submitError: string | null;
+  /** Seconds remaining before the CLI poll loop times out, or 0 if expired. */
+  secondsRemaining: number;
+  /**
+   * Submit an approve/deny decision. Triggers the biometric gate when the
+   * loaded request is high-risk and the decision is 'approved'.
+   */
+  submit: (
+    decision: 'approved' | 'denied',
+    userMessage?: string,
+  ) => Promise<void>;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Default biometric prompt using expo-local-authentication.
+ *
+ * WHY dynamic import: the screen module evaluates at app cold-start during
+ * deep-link handling. Statically importing expo-local-authentication would
+ * pull its native bridge into every route, even ones that never gate.
+ * Dynamic import keeps the cost on the gated code path only.
+ *
+ * WHY fail-closed when hardware is missing: in the absence of biometrics,
+ * a high-risk approval would fall through with no second factor. Returning
+ * false forces the user to deny (or the CLI to time out) rather than
+ * silently waving through the approval.
+ *
+ * @param reason - User-visible justification shown in the system prompt.
+ * @returns true when the biometric check succeeded; false otherwise.
+ */
+async function defaultBiometricPrompt(reason: string): Promise<boolean> {
+  try {
+    const LocalAuthentication = await import('expo-local-authentication');
+    const hasHardware = await LocalAuthentication.hasHardwareAsync();
+    const isEnrolled = await LocalAuthentication.isEnrolledAsync();
+    if (!hasHardware || !isEnrolled) {
+      // WHY fail-closed: see function header.
+      return false;
+    }
+    const result = await LocalAuthentication.authenticateAsync({
+      promptMessage: reason,
+      cancelLabel: 'Cancel',
+      disableDeviceFallback: false,
+    });
+    return result.success === true;
+  } catch {
+    // WHY swallow: dynamic import failure / native bridge unavailable
+    // (Expo Go, dev shell). Same fail-closed posture as above.
+    return false;
+  }
+}
+
+/**
+ * Audit_log row shape returned by the SELECT query.
+ * Listed inline so we don't depend on a generated database.types module.
+ */
+interface AuditLogRow {
+  id: string;
+  action: string;
+  resource_type: string | null;
+  resource_id: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+/**
+ * Type guard that validates the raw audit_log metadata blob has the shape
+ * the CLI promises (see `ApprovalMetadata` in approvalHandler.ts).
+ *
+ * WHY guard instead of cast: metadata is stored in JSONB and could be any
+ * shape if the row was tampered with via service-role write. The guard
+ * surfaces a clear error to the UI rather than silently rendering undefined.
+ */
+function isApprovalMetadata(
+  meta: Record<string, unknown> | null,
+): meta is {
+  approval_id: string;
+  requested_action: string;
+  reason: string;
+  risk: RiskLevel;
+  machine_id: string;
+  context?: Record<string, unknown>;
+} {
+  if (!meta) return false;
+  return (
+    typeof meta.approval_id === 'string' &&
+    typeof meta.requested_action === 'string' &&
+    typeof meta.reason === 'string' &&
+    typeof meta.risk === 'string' &&
+    typeof meta.machine_id === 'string'
+  );
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Manages the MCP approval screen lifecycle.
+ *
+ * @param input - Approval ID + optional test injection points.
+ * @returns Render data + actions for the screen component.
+ */
+export function useMcpApproval({
+  approvalId,
+  writeDecision = writeMcpApprovalDecision,
+  biometricPrompt = defaultBiometricPrompt,
+  onResolved,
+}: UseMcpApprovalInput): UseMcpApprovalResult {
+  const [request, setRequest] = useState<McpApprovalRequest | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [secondsRemaining, setSecondsRemaining] = useState(0);
+
+  // --- Initial fetch -----------------------------------------------------------
+
+  useEffect(() => {
+    let cancelled = false;
+
+    /**
+     * Loads the audit_log request row by resource_id and parses metadata.
+     * RLS ensures the user can only read their own rows; an empty result
+     * means the approval is for someone else (or has been deleted).
+     */
+    async function load(): Promise<void> {
+      setIsLoading(true);
+      setLoadError(null);
+
+      const { data, error } = await supabase
+        .from('audit_log')
+        .select('id, action, resource_type, resource_id, metadata, created_at')
+        .eq('resource_id', approvalId)
+        .eq('action', 'mcp_approval_requested')
+        .limit(1)
+        .maybeSingle<AuditLogRow>();
+
+      if (cancelled) return;
+
+      if (error) {
+        setLoadError(`Could not load approval request: ${error.message}`);
+        setIsLoading(false);
+        return;
+      }
+      if (!data) {
+        setLoadError('Approval request not found or already resolved.');
+        setIsLoading(false);
+        return;
+      }
+      if (!isApprovalMetadata(data.metadata)) {
+        setLoadError('Approval request payload is malformed.');
+        setIsLoading(false);
+        return;
+      }
+
+      const parsed: McpApprovalRequest = {
+        approvalId,
+        requestedAction: data.metadata.requested_action,
+        reason: data.metadata.reason,
+        risk: data.metadata.risk,
+        machineId: data.metadata.machine_id,
+        context: data.metadata.context ?? null,
+        createdAt: data.created_at,
+      };
+
+      setRequest(parsed);
+      setIsLoading(false);
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [approvalId]);
+
+  // --- Countdown ---------------------------------------------------------------
+
+  useEffect(() => {
+    if (!request) return;
+
+    const deadlineMs = new Date(request.createdAt).getTime() + CLI_REQUEST_TIMEOUT_MS;
+
+    /**
+     * Recomputes the seconds-remaining state. Stops ticking once the value
+     * hits zero so we don't keep firing setState forever after expiry.
+     */
+    const tick = (): void => {
+      const remainingMs = deadlineMs - Date.now();
+      const remaining = Math.max(0, Math.floor(remainingMs / 1000));
+      setSecondsRemaining(remaining);
+    };
+
+    tick();
+    const interval = setInterval(tick, COUNTDOWN_TICK_MS);
+    return () => clearInterval(interval);
+  }, [request]);
+
+  // --- Submit ------------------------------------------------------------------
+
+  const submit = useCallback(
+    async (decision: 'approved' | 'denied', userMessage?: string): Promise<void> => {
+      if (isSubmitting) return; // double-submit guard
+      if (!request) {
+        setSubmitError('Approval request has not loaded yet.');
+        return;
+      }
+
+      setIsSubmitting(true);
+      setSubmitError(null);
+
+      try {
+        // WHY biometric gate only on approve+highRisk: denying never escalates
+        // privilege; the worst case for an attacker is wasting the agent's time.
+        // Approving a high-risk action lets the agent run shell commands,
+        // edit files, or call the network — exactly the surfaces a stolen-phone
+        // attacker would target. Match `BIOMETRIC_GATED_RISK` constant above.
+        if (decision === 'approved' && BIOMETRIC_GATED_RISK.includes(request.risk)) {
+          const ok = await biometricPrompt(
+            `Confirm approval of ${request.requestedAction}`,
+          );
+          if (!ok) {
+            setSubmitError('Biometric check failed or cancelled.');
+            return;
+          }
+        }
+
+        const payload: WriteMcpApprovalDecisionInput = {
+          approvalId,
+          decision,
+          ...(userMessage && userMessage.length > 0 ? { userMessage } : {}),
+        };
+
+        await writeDecision(payload);
+        onResolved?.(decision);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error.';
+        setSubmitError(message);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [approvalId, biometricPrompt, isSubmitting, onResolved, request, writeDecision],
+  );
+
+  return {
+    request,
+    isLoading,
+    loadError,
+    isSubmitting,
+    submitError,
+    secondsRemaining,
+    submit,
+  };
+}

--- a/packages/styrby-mobile/src/hooks/useDashboardData.ts
+++ b/packages/styrby-mobile/src/hooks/useDashboardData.ts
@@ -196,6 +196,17 @@ function mapAuditActionToNotificationType(action: string): NotificationType | nu
     case 'login':
     case 'logout':
       return 'info';
+    // WHY map MCP-approval lifecycle to permission_request/info: the audit_log
+    // is the dashboard's notification source-of-truth. Pending requests reuse
+    // the existing permission_request icon (shield-checkmark) to match the
+    // legacy team-approval visual; resolved/timeout rows fall back to info.
+    // Detailed lifecycle rendering (Review button, decision verdict) lives in
+    // McpApprovalEventRow consumed by the dashboard screen, not this mapper.
+    case 'mcp_approval_requested':
+      return 'permission_request';
+    case 'mcp_approval_decided':
+    case 'mcp_approval_timeout':
+      return 'info';
     default:
       return null;
   }
@@ -225,6 +236,12 @@ function mapAuditActionToTitle(action: string): string {
       return 'Login';
     case 'logout':
       return 'Logout';
+    case 'mcp_approval_requested':
+      return 'Approval requested';
+    case 'mcp_approval_decided':
+      return 'Approval decided';
+    case 'mcp_approval_timeout':
+      return 'Approval expired';
     default:
       return action.replace(/_/g, ' ');
   }
@@ -253,6 +270,16 @@ function extractAuditMessage(action: string, metadata: Record<string, unknown> |
   }
   if (action === 'machine_paired' && metadata.device_name) {
     return `Paired with ${String(metadata.device_name)}`;
+  }
+  if (action === 'mcp_approval_requested' && metadata.requested_action) {
+    return `Pending approval - ${String(metadata.requested_action)}`;
+  }
+  if (action === 'mcp_approval_decided' && metadata.requested_action) {
+    const decision = metadata.decision === 'approved' ? 'Approved' : 'Denied';
+    return `${decision} ${String(metadata.requested_action)}`;
+  }
+  if (action === 'mcp_approval_timeout' && metadata.requested_action) {
+    return `Approval expired - ${String(metadata.requested_action)}`;
   }
 
   return mapAuditActionToTitle(action);

--- a/packages/styrby-mobile/src/hooks/useNotifications.ts
+++ b/packages/styrby-mobile/src/hooks/useNotifications.ts
@@ -34,7 +34,18 @@ import {
  * Supported deep-link screen targets for notification-driven navigation.
  * These correspond to the file-system routes in `app/(tabs)/`.
  */
-type NotificationScreen = 'chat' | 'dashboard' | 'sessions' | 'costs' | 'settings';
+type NotificationScreen =
+  | 'chat'
+  | 'dashboard'
+  | 'sessions'
+  | 'costs'
+  | 'settings'
+  // WHY mcp_approval added in Phase 4-step4 / D-02 closure: the CLI's
+  // `styrby mcp serve` records mcp_approval_requested in audit_log; the
+  // push trigger fans out to the user's devices with data.screen='mcp_approval'
+  // and data.approvalId so this hook can deep-link straight to the
+  // /mcp-approval/[approvalId] screen for sub-second decision UX.
+  | 'mcp_approval';
 
 /**
  * Shape of the `data` payload attached to Styrby push notifications.
@@ -52,6 +63,19 @@ interface NotificationData {
    * Not used for routing but available to the screen for display.
    */
   machineId?: string;
+  /**
+   * Approval ID for screen='mcp_approval' deep links. Forwarded as the
+   * route param so /mcp-approval/[approvalId] can fetch the matching
+   * audit_log row.
+   */
+  approvalId?: string;
+  /**
+   * MCP-approval-only flag. When the audit_log push trigger fires for
+   * action='mcp_approval_requested' the payload carries action='mcp_approval'
+   * for compatibility with the legacy notification type union; the
+   * approvalId field above is the load-bearing routing key.
+   */
+  action?: string;
 }
 
 /**
@@ -75,8 +99,10 @@ const NotificationDataSchema = z.object({
     'budget_alert',
     'daemon_reconnected',
   ]).optional(),
-  screen: z.enum(['chat', 'dashboard', 'sessions', 'costs', 'settings']).optional(),
+  screen: z.enum(['chat', 'dashboard', 'sessions', 'costs', 'settings', 'mcp_approval']).optional(),
   sessionId: z.string().optional(),
+  approvalId: z.string().uuid().optional(),
+  action: z.string().optional(),
 }).passthrough();
 
 /** Return type of the useNotifications hook */
@@ -132,8 +158,20 @@ export function useNotifications(): UseNotificationsResult {
    * @returns true if navigation was handled, false otherwise
    */
   const navigateToScreen = useCallback(
-    (screen: NotificationScreen, sessionId?: string): boolean => {
+    (screen: NotificationScreen, sessionId?: string, approvalId?: string): boolean => {
       switch (screen) {
+        case 'mcp_approval':
+          // WHY guard against missing approvalId: a malformed payload (manual
+          // testing, payload truncation) without the UUID has no useful
+          // destination. Falling through to the dashboard is safer than
+          // pushing a route that immediately renders an error.
+          if (!approvalId) return false;
+          router.push({
+            pathname: '/mcp-approval/[approvalId]',
+            params: { approvalId },
+          });
+          return true;
+
         case 'chat':
           if (sessionId) {
             router.push({
@@ -208,8 +246,20 @@ export function useNotifications(): UseNotificationsResult {
 
       // Strategy 1: Explicit screen field (preferred)
       if (data.screen) {
-        const handled = navigateToScreen(data.screen, data.sessionId);
+        const handled = navigateToScreen(data.screen, data.sessionId, data.approvalId);
         if (handled) return;
+      }
+
+      // Strategy 1b: MCP approval action shortcut.
+      // The audit_log push trigger emits data.action='mcp_approval' alongside
+      // the approvalId. Route directly without requiring screen=mcp_approval
+      // so older trigger versions still resolve correctly.
+      if (data.action === 'mcp_approval' && data.approvalId) {
+        router.push({
+          pathname: '/mcp-approval/[approvalId]',
+          params: { approvalId: data.approvalId },
+        });
+        return;
       }
 
       // Strategy 2: Legacy type-based routing (backwards compatibility)

--- a/packages/styrby-mobile/src/services/__tests__/mcp-approval.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/mcp-approval.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for writeMcpApprovalDecision.
+ *
+ * Coverage:
+ *   - Happy-path INSERT carries the exact action / resource_type / metadata
+ *     shape the CLI poll loop reads.
+ *   - Auth failure (no user) throws with a clear error.
+ *   - RLS / Postgres error from supabase surfaces with the underlying code.
+ *   - userMessage is truncated at 280 chars on the way to the DB.
+ *   - Empty / undefined userMessage is omitted from metadata (so the CLI
+ *     fallback `meta.user_message ?? ''` keeps working).
+ *
+ * @module services/__tests__/mcp-approval.test
+ */
+
+// WHY inline jest.fn() inside the factory: jest.mock() is hoisted above
+// const declarations, so referencing top-level mock vars in the factory
+// throws ReferenceError. Defining the mocks inside the factory and pulling
+// them back out via require() in beforeEach gives us full control with
+// hoist-safe semantics.
+jest.mock('@/lib/supabase', () => {
+  const insert = jest.fn();
+  const from = jest.fn(() => ({ insert }));
+  const getUser = jest.fn();
+  return {
+    supabase: {
+      auth: { getUser },
+      from,
+    },
+    __mocks: { insert, from, getUser },
+  };
+});
+
+import { writeMcpApprovalDecision } from '@/services/mcp-approval';
+const supabaseMock = (jest.requireMock('@/lib/supabase') as { __mocks: { insert: jest.Mock; from: jest.Mock; getUser: jest.Mock } }).__mocks;
+const mockGetUser = supabaseMock.getUser;
+const mockInsert = supabaseMock.insert;
+const mockFrom = supabaseMock.from;
+
+const APPROVAL_ID = '11111111-2222-3333-4444-555555555555';
+const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+describe('writeMcpApprovalDecision', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } }, error: null });
+    mockInsert.mockResolvedValue({ error: null });
+  });
+
+  it('writes a decision row with the CLI-expected shape', async () => {
+    await writeMcpApprovalDecision({
+      approvalId: APPROVAL_ID,
+      decision: 'approved',
+      userMessage: 'LGTM',
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith('audit_log');
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const row = mockInsert.mock.calls[0][0];
+    expect(row.user_id).toBe(USER_ID);
+    expect(row.action).toBe('mcp_approval_decided');
+    expect(row.resource_type).toBe('mcp_approval');
+    expect(row.resource_id).toBe(APPROVAL_ID);
+    expect(row.metadata).toEqual({
+      approval_id: APPROVAL_ID,
+      decision: 'approved',
+      user_message: 'LGTM',
+    });
+  });
+
+  it('omits user_message when not provided', async () => {
+    await writeMcpApprovalDecision({
+      approvalId: APPROVAL_ID,
+      decision: 'denied',
+    });
+    const row = mockInsert.mock.calls[0][0];
+    expect(row.metadata).toEqual({
+      approval_id: APPROVAL_ID,
+      decision: 'denied',
+    });
+    expect(row.metadata).not.toHaveProperty('user_message');
+  });
+
+  it('omits user_message when empty string', async () => {
+    await writeMcpApprovalDecision({
+      approvalId: APPROVAL_ID,
+      decision: 'approved',
+      userMessage: '',
+    });
+    const row = mockInsert.mock.calls[0][0];
+    expect(row.metadata).not.toHaveProperty('user_message');
+  });
+
+  it('truncates user_message to 280 chars defensively', async () => {
+    const longNote = 'x'.repeat(500);
+    await writeMcpApprovalDecision({
+      approvalId: APPROVAL_ID,
+      decision: 'approved',
+      userMessage: longNote,
+    });
+    const row = mockInsert.mock.calls[0][0];
+    expect(row.metadata.user_message).toHaveLength(280);
+  });
+
+  it('throws when no authenticated user', async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+    await expect(
+      writeMcpApprovalDecision({ approvalId: APPROVAL_ID, decision: 'approved' }),
+    ).rejects.toThrow(/No authenticated user/);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('throws when getUser returns an error', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: 'token expired' },
+    });
+    await expect(
+      writeMcpApprovalDecision({ approvalId: APPROVAL_ID, decision: 'approved' }),
+    ).rejects.toThrow(/Auth check failed: token expired/);
+  });
+
+  it('surfaces supabase INSERT errors with code', async () => {
+    mockInsert.mockResolvedValueOnce({
+      error: { code: '42501', message: 'new row violates row-level security policy' },
+    });
+    await expect(
+      writeMcpApprovalDecision({ approvalId: APPROVAL_ID, decision: 'approved' }),
+    ).rejects.toThrow(/\[42501\].*row-level security/);
+  });
+
+  it('surfaces supabase INSERT errors without code gracefully', async () => {
+    mockInsert.mockResolvedValueOnce({
+      error: { message: 'network timeout' },
+    });
+    await expect(
+      writeMcpApprovalDecision({ approvalId: APPROVAL_ID, decision: 'denied' }),
+    ).rejects.toThrow(/network timeout/);
+  });
+});

--- a/packages/styrby-mobile/src/services/mcp-approval.ts
+++ b/packages/styrby-mobile/src/services/mcp-approval.ts
@@ -1,0 +1,173 @@
+/**
+ * MCP Approval Decision Writer
+ *
+ * Writes the user's approve/deny decision to the audit_log table so the CLI's
+ * `styrby mcp serve` polling loop (packages/styrby-cli/src/mcp/approvalHandler.ts)
+ * can pick it up and unblock the MCP tool call.
+ *
+ * ## Contract
+ *
+ * The CLI polls audit_log with:
+ *
+ * ```ts
+ * apiClient.searchAuditLog({
+ *   action: 'mcp_approval_decided',
+ *   resource_id: approvalId,
+ *   limit: 1,
+ * })
+ * ```
+ *
+ * It then reads `metadata.decision` and `metadata.user_message`. Mismatch
+ * any field name and the loop blocks until timeout. Every literal in this
+ * module is load-bearing — do not rename without updating the CLI in lockstep.
+ *
+ * ## Security
+ *
+ * RLS enforces `user_id = auth.uid()` at the database layer (migration 070).
+ * The mobile client cannot write decisions for another user even if compromised.
+ * The policy is also scoped to `action='mcp_approval_decided'` so a hostile
+ * client cannot forge other audit event types.
+ *
+ * @module services/mcp-approval
+ */
+
+import { supabase } from '@/lib/supabase';
+
+// ============================================================================
+// Constants — must match packages/styrby-cli/src/mcp/approvalHandler.ts
+// ============================================================================
+
+/**
+ * Audit action enum value the CLI poll loop filters on.
+ *
+ * WHY constant: see module header — every literal here is part of the
+ * cross-package contract. A typo silently breaks the entire MCP approval flow.
+ */
+const AUDIT_ACTION_DECIDED = 'mcp_approval_decided';
+
+/**
+ * Resource type the CLI poll loop filters on (combined with `resource_id`).
+ *
+ * WHY constant: same as above. Migration 069 added the audit_action enum
+ * value and the CLI writes this exact resource_type when posting the request
+ * row. Mobile must echo it on the decision row.
+ */
+const RESOURCE_TYPE = 'mcp_approval';
+
+/**
+ * Maximum length for the optional `user_message` field.
+ *
+ * WHY 280: matches the screen's TextInput limit. Enforced both client-side
+ * (UX) and inside this writer (defence-in-depth) so a programmatic caller
+ * cannot bypass the cap.
+ */
+const MAX_USER_MESSAGE_LENGTH = 280;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Inputs for {@link writeMcpApprovalDecision}.
+ *
+ * Field naming intentionally matches the CLI side's `DecisionMetadata` shape
+ * (snake_case in JSONB, camelCase at the TS function boundary).
+ */
+export interface WriteMcpApprovalDecisionInput {
+  /** UUID of the approval row. Must match the CLI's `resource_id`. */
+  approvalId: string;
+  /** The user's binary decision. */
+  decision: 'approved' | 'denied';
+  /**
+   * Optional human-readable note (e.g. "Looks safe, ship it").
+   * Truncated to 280 chars before write.
+   */
+  userMessage?: string;
+}
+
+/**
+ * Decision metadata persisted in audit_log.metadata JSONB.
+ *
+ * WHY mirror of {@link import('../../../styrby-cli/src/mcp/approvalHandler').DecisionMetadata}:
+ * the CLI's polling loop reads exactly these snake_case keys. Drifting from
+ * this shape silently breaks the contract; treat any rename as a coordinated
+ * cross-package change.
+ */
+interface DecisionMetadata {
+  approval_id: string;
+  decision: 'approved' | 'denied';
+  user_message?: string;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Writes the user's MCP approval decision to audit_log.
+ *
+ * Resolves once the row is committed. The CLI's polling loop (1s cadence)
+ * will pick it up on its next cycle and unblock the awaiting tool call.
+ *
+ * @param input - Approval ID + decision + optional user note.
+ * @throws Error if the user is not authenticated or the INSERT fails (e.g.
+ *   RLS rejection, network outage). Callers should surface this to the UI.
+ *
+ * @example
+ * await writeMcpApprovalDecision({
+ *   approvalId: 'a1b2c3d4-...',
+ *   decision: 'approved',
+ *   userMessage: 'Looks safe',
+ * });
+ */
+export async function writeMcpApprovalDecision(
+  input: WriteMcpApprovalDecisionInput,
+): Promise<void> {
+  const { approvalId, decision, userMessage } = input;
+
+  // Defence-in-depth: enforce the cap server-bound even if the UI passes more.
+  const trimmedMessage =
+    typeof userMessage === 'string' && userMessage.length > 0
+      ? userMessage.slice(0, MAX_USER_MESSAGE_LENGTH)
+      : undefined;
+
+  // WHY getUser() not getSession(): getUser() round-trips to Supabase Auth and
+  // confirms the JWT is still valid. For a write that the CLI is actively
+  // waiting on, an expired session must surface immediately rather than
+  // silently failing the INSERT with an obscure RLS error.
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    throw new Error(`Auth check failed: ${userError.message}`);
+  }
+  if (!user) {
+    throw new Error('No authenticated user — cannot write approval decision');
+  }
+
+  const metadata: DecisionMetadata = {
+    approval_id: approvalId,
+    decision,
+    ...(trimmedMessage !== undefined ? { user_message: trimmedMessage } : {}),
+  };
+
+  const { error: insertError } = await supabase.from('audit_log').insert({
+    user_id: user.id,
+    action: AUDIT_ACTION_DECIDED,
+    resource_type: RESOURCE_TYPE,
+    resource_id: approvalId,
+    metadata,
+  });
+
+  if (insertError) {
+    // WHY include code: RLS rejections come back as 42501 / "new row violates
+    // row-level security policy". Surfacing the code helps on-call diagnose
+    // a missing migration vs. a genuine auth failure vs. a network blip.
+    const code = insertError.code ? ` [${insertError.code}]` : '';
+    throw new Error(
+      `Failed to write approval decision${code}: ${insertError.message}`,
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,12 +204,15 @@ importers:
       expo-linking:
         specifier: ~7.0.0
         version: 7.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      expo-local-authentication:
+        specifier: ~15.0.2
+        version: 15.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       expo-notifications:
         specifier: ~0.29.14
         version: 0.29.14(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       expo-passkey:
         specifier: 0.3.12
-        version: 0.3.12(d045b66d989b8c61e9fec37cf763e5e0)
+        version: 0.3.12(1d8a3570d1878941b881cf94b5f567bb)
       expo-router:
         specifier: ~4.0.0
         version: 4.0.22(9ed5242514a284f593783c2d4997b119)
@@ -7590,6 +7593,11 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-local-authentication@15.0.2:
+    resolution: {integrity: sha512-v7TOfovuivGWffA8B0FudEas+njMKTrjhaPpJYLASiTLTP3zUYqtumNgZ9pkaDB6Cagq0+DeNH39AI8tdEBUkQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-modules-autolinking@2.0.8:
     resolution: {integrity: sha512-DezgnEYFQYic8hKGhkbztBA3QUmSftjaNDIKNAtS2iGJmzCcNIkatjN2slFDSWjSTNo8gOvPQyMKfyHWFvLpOQ==}
@@ -20009,6 +20017,11 @@ snapshots:
       - expo
       - supports-color
 
+  expo-local-authentication@15.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      invariant: 2.2.4
+
   expo-modules-autolinking@2.0.8:
     dependencies:
       '@expo/spawn-async': 1.7.2
@@ -20040,12 +20053,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-passkey@0.3.12(d045b66d989b8c61e9fec37cf763e5e0):
+  expo-passkey@0.3.12(1d8a3570d1878941b881cf94b5f567bb):
     optionalDependencies:
       expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       expo-application: 6.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       expo-crypto: 14.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       expo-device: 7.0.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
+      expo-local-authentication: 15.0.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       expo-secure-store: 14.0.1(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(@types/react@18.3.28)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)

--- a/supabase/migrations/070_mcp_approval_decision_insert_policy.sql
+++ b/supabase/migrations/070_mcp_approval_decision_insert_policy.sql
@@ -1,0 +1,39 @@
+-- Migration 070: RLS INSERT policy for mobile-issued MCP approval decisions
+--
+-- WHY: Migration 001 left audit_log INSERTs as service-role-only. The mobile
+-- MCP approval UX (D-02 closure) writes a `mcp_approval_decided` row directly
+-- from the user's authenticated mobile session so the polling CLI handler
+-- (packages/styrby-cli/src/mcp/approvalHandler.ts) sees the decision in real
+-- time without round-tripping through an edge function. Without an INSERT
+-- policy the write fails with `new row violates row-level security policy`,
+-- and the entire MCP approval loop stays broken.
+--
+-- WHY scoped to mcp_approval_decided only: the audit_log is the system-wide
+-- forensic record. Allowing arbitrary client-side INSERTs would let a
+-- compromised mobile session forge any audit event (login, payment, admin
+-- action). Scoping the policy to one specific action keeps the blast radius
+-- to the MCP approval contract while still satisfying the D-02 requirement.
+--
+-- WHY user_id = auth.uid(): RLS enforces row ownership server-side regardless
+-- of what the client sends. A user cannot write a decision attributed to
+-- another user.
+--
+-- WHY no metadata schema check at the policy layer: Postgres RLS policies
+-- run before triggers but cannot easily validate JSONB structure without
+-- expensive jsonb_path_query calls on every INSERT. The CLI's poll loop
+-- only consumes rows whose metadata.decision is 'approved' | 'denied';
+-- malformed metadata simply gets ignored downstream. The trade-off favors
+-- write-path performance over policy-layer validation.
+--
+-- @security SOC 2 CC6.1 (Logical Access — least privilege) — narrowest
+--   feasible INSERT grant; the user can only write decisions for their own
+--   approval requests, and only the one action enum value the CLI polls for.
+
+CREATE POLICY "audit_log_insert_mcp_decision_own"
+  ON audit_log FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND action = 'mcp_approval_decided'
+    AND resource_type = 'mcp_approval'
+  );

--- a/supabase/migrations/071_mcp_approval_push_trigger.sql
+++ b/supabase/migrations/071_mcp_approval_push_trigger.sql
@@ -1,0 +1,267 @@
+-- ============================================================================
+-- MIGRATION 071: Push Notification Trigger for MCP Approval Requests
+-- ============================================================================
+--
+-- PURPOSE:
+--   Closes the D-02 loop. Migration 069 added the mcp_approval_* audit_action
+--   enum values; CLI Phase 4-step4 (PR #234) wires `styrby mcp serve` to
+--   INSERT audit_log rows with action='mcp_approval_requested'; the mobile
+--   D-02 build added the receiver-side screen, push-routing, and decision
+--   writer. The missing piece is the trigger that actually fires a push
+--   notification when the CLI inserts a request — without this, the entire
+--   feature is dark (mobile is ready but never wakes up).
+--
+--   Migration 017 only fires on session_messages. This migration adds an
+--   analogous trigger on audit_log scoped to mcp_approval_requested rows.
+--
+-- WHAT THIS ADDS:
+--   1. Helper function: notify_push_for_mcp_approval()
+--      - Reads audit_log row's user_id and metadata
+--      - Checks notification_preferences.push_enabled
+--      - Calls send-push-notification edge function via pg_net
+--      - Payload matches the mobile receiver's NotificationDataSchema
+--        (data.screen='mcp_approval', data.approvalId=<resource_id>,
+--         data.action='mcp_approval')
+--
+--   2. Trigger: trigger_push_on_mcp_approval_request
+--      - AFTER INSERT on audit_log
+--      - WHEN action = 'mcp_approval_requested' (Postgres pre-evaluates
+--        the WHEN clause before invoking the function — saves a function
+--        call on every other audit_log INSERT)
+--
+-- WHY ONLY mcp_approval_requested (not _decided or _timeout):
+--   - mcp_approval_decided is written BY the mobile app (the user's response).
+--     Pushing to the same user about their own action is noise.
+--   - mcp_approval_timeout is written by the CLI when no response arrives.
+--     The user already saw the request and chose to ignore it; another
+--     push is nagging.
+--
+-- WHY THIS WAS MISSED:
+--   D-02 spec said "verify the trigger exists; if not, propose a migration
+--   update". The implementer agent confirmed migration 017 was scoped to
+--   session_messages only and surfaced the gap. This migration ships in the
+--   same PR as the D-02 mobile build so the feature is functional end-to-end
+--   on first deploy.
+--
+-- DEPENDENCIES:
+--   - Migration 017 (sets up vault secret + app.supabase_url + pg_net)
+--   - Migration 069 (mcp_approval_* enum values)
+--   - send-push-notification edge function deployed
+--   - audit_log table has user_id column (yes — initial schema)
+--
+-- ROLLBACK:
+--   DROP TRIGGER IF EXISTS trigger_push_on_mcp_approval_request ON audit_log;
+--   DROP FUNCTION IF EXISTS notify_push_for_mcp_approval();
+--
+-- SOC2 / GDPR:
+--   - Quiet hours + push_enabled enforced at edge function level (same as 017)
+--   - SECURITY DEFINER so RLS on notification_preferences doesn't block lookup
+--   - Errors are caught and logged; a failed push never rolls back the audit
+--     row — the audit log is the source-of-truth, push is delivery polish.
+--
+-- ============================================================================
+
+-- ============================================================================
+-- STEP 1: Trigger function
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION notify_push_for_mcp_approval()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+-- WHY SECURITY DEFINER: same rationale as notify_push_for_message in
+-- migration 017 — the trigger function reads notification_preferences
+-- (RLS-locked) to decide whether to fire, and reads vault.decrypted_secrets
+-- for the service role key. SECURITY DEFINER runs as the function owner
+-- (postgres / supabase admin), bypassing RLS on the lookup tables. The
+-- function never returns sensitive data to the trigger caller.
+AS $$
+DECLARE
+  v_user_id        UUID;
+  v_push_enabled   BOOLEAN;
+  v_edge_fn_url    TEXT;
+  v_service_key    TEXT;
+  v_payload        JSONB;
+  v_approval_id    TEXT;
+  v_requested_action TEXT;
+  v_risk           TEXT;
+  v_machine_id     TEXT;
+BEGIN
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Defensive guard. The trigger's WHEN clause already filters to
+  -- action='mcp_approval_requested' but a future change could mistakenly
+  -- attach this function to other actions. Re-check inside the body.
+  -- ──────────────────────────────────────────────────────────────────────────
+  IF NEW.action <> 'mcp_approval_requested' THEN
+    RETURN NEW;
+  END IF;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Resolve the receiving user. audit_log.user_id is the session owner
+  -- (same user who initiated the CLI command that needed approval).
+  -- ──────────────────────────────────────────────────────────────────────────
+  v_user_id := NEW.user_id;
+  IF v_user_id IS NULL THEN
+    RAISE WARNING '[notify_push_for_mcp_approval] audit_log row % has null user_id; skip.', NEW.id;
+    RETURN NEW;
+  END IF;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Fast-path: skip immediately if push is disabled. Same pattern as
+  -- migration 017. Default TRUE when no row exists (new user).
+  -- ──────────────────────────────────────────────────────────────────────────
+  SELECT COALESCE(np.push_enabled, TRUE)
+    INTO v_push_enabled
+    FROM notification_preferences np
+   WHERE np.user_id = v_user_id;
+
+  IF v_push_enabled = FALSE THEN
+    RETURN NEW;
+  END IF;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Pull the metadata fields we expose to the receiver. The mobile
+  -- screen reads metadata directly via supabase fetch — these are only
+  -- for the push payload preview (notification title/body).
+  --
+  -- WHY ::TEXT casts: jsonb_build_object on NULL JSONB values produces SQL
+  -- NULL, not the JSON null literal. Casting to TEXT first ensures a
+  -- consistent string-or-null shape on the receiver side.
+  -- ──────────────────────────────────────────────────────────────────────────
+  v_approval_id      := NEW.resource_id::TEXT;
+  v_requested_action := COALESCE(NEW.metadata->>'requested_action', '');
+  v_risk             := COALESCE(NEW.metadata->>'risk', 'medium');
+  v_machine_id       := COALESCE(NEW.metadata->>'machine_id', '');
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Build payload matching the mobile NotificationDataSchema in
+  -- packages/styrby-mobile/src/hooks/useNotifications.ts. The mobile
+  -- receiver routes off `screen` (preferred) or `data.action` (fallback).
+  -- approvalId is the load-bearing routing key for the deep-link.
+  -- ──────────────────────────────────────────────────────────────────────────
+  v_payload := jsonb_build_object(
+    'type',   'mcp_approval',
+    'userId', v_user_id::TEXT,
+    'data',   jsonb_build_object(
+      -- Preferred routing field — directly matches NotificationScreen union.
+      'screen',          'mcp_approval',
+      -- Fallback type-based routing flag for older mobile builds that don't
+      -- understand the screen field. Removable once min mobile version
+      -- includes the screen-based router.
+      'action',          'mcp_approval',
+      -- Load-bearing — the screen needs this to fetch the audit_log row.
+      'approvalId',      v_approval_id,
+      -- Preview hints for the notification title/body. The mobile screen
+      -- re-fetches the row, so these are display-only.
+      'requestedAction', v_requested_action,
+      'risk',            v_risk,
+      'machineId',       v_machine_id
+    )
+  );
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Resolve edge function URL + service role key from vault.
+  -- Identical pattern to migration 017 — see that migration's comment for
+  -- the full rationale.
+  -- ──────────────────────────────────────────────────────────────────────────
+  BEGIN
+    SELECT decrypted_secret
+      INTO v_service_key
+      FROM vault.decrypted_secrets
+     WHERE name = 'supabase_functions_api_key'
+     LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING '[notify_push_for_mcp_approval] vault.decrypted_secrets not accessible: %', SQLERRM;
+    RETURN NEW;
+  END;
+
+  IF v_service_key IS NULL THEN
+    RAISE WARNING '[notify_push_for_mcp_approval] Secret "supabase_functions_api_key" not found in vault. Push skipped.';
+    RETURN NEW;
+  END IF;
+
+  v_edge_fn_url := current_setting('app.supabase_url', TRUE)
+                   || '/functions/v1/send-push-notification';
+
+  IF v_edge_fn_url IS NULL OR v_edge_fn_url = '/functions/v1/send-push-notification' THEN
+    RAISE WARNING '[notify_push_for_mcp_approval] app.supabase_url not set. Push skipped for approval %.', v_approval_id;
+    RETURN NEW;
+  END IF;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Fire async HTTP request via pg_net. Same async-fire-and-forget pattern
+  -- as migration 017. A failed push must never roll back the audit_log row.
+  -- ──────────────────────────────────────────────────────────────────────────
+  PERFORM net.http_post(
+    url     := v_edge_fn_url,
+    body    := v_payload::TEXT,
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'Authorization', 'Bearer ' || v_service_key
+    )
+  );
+
+  RETURN NEW;
+
+EXCEPTION WHEN OTHERS THEN
+  -- WHY catch-all: same rationale as 017. The audit_log INSERT is the primary
+  -- data; the push is a delivery side-effect. Any failure here gets logged
+  -- and we let the INSERT proceed.
+  RAISE WARNING '[notify_push_for_mcp_approval] Unexpected error for audit row %: %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+-- ============================================================================
+-- STEP 2: Attach trigger to audit_log
+-- ============================================================================
+
+DROP TRIGGER IF EXISTS trigger_push_on_mcp_approval_request ON audit_log;
+
+CREATE TRIGGER trigger_push_on_mcp_approval_request
+  AFTER INSERT ON audit_log
+  FOR EACH ROW
+  -- WHY WHEN clause: audit_log handles many action types (settings_updated,
+  -- session_group_created, etc.). The WHEN gate ensures Postgres only
+  -- evaluates the function for the one action that should fire a push.
+  -- This is a hot path — every CLI write to audit_log evaluates the WHEN —
+  -- so the cheap pre-filter matters.
+  WHEN (NEW.action = 'mcp_approval_requested')
+  EXECUTE FUNCTION notify_push_for_mcp_approval();
+
+-- ============================================================================
+-- STEP 3: Comment on function for schema discoverability
+-- ============================================================================
+
+COMMENT ON FUNCTION notify_push_for_mcp_approval() IS
+  'Fires after INSERT on audit_log when action=mcp_approval_requested. '
+  'Calls the send-push-notification edge function via pg_net (async HTTP) '
+  'with a payload that the mobile NotificationDataSchema routes to '
+  '/mcp-approval/[approvalId]. Closes the D-02 loop (PR opened 2026-04-30). '
+  'Mirrors migration 017''s pattern for session_messages.';
+
+-- ============================================================================
+-- END OF MIGRATION 071
+-- ============================================================================
+--
+-- PRE-DEPLOY CHECK (do once per environment if migration 017 hasn't been run):
+--
+--   1. SELECT * FROM vault.decrypted_secrets WHERE name = 'supabase_functions_api_key';
+--      Must return exactly one row.
+--
+--   2. SHOW app.supabase_url;
+--      Must return the project URL (e.g. https://akmtmxunjhsgldjztdtt.supabase.co).
+--
+--   If either is missing, follow the post-deploy steps in migration 017
+--   before relying on this trigger.
+--
+-- POST-DEPLOY VERIFICATION:
+--
+--   1. From the CLI, kick off `styrby mcp serve` and trigger an approval-
+--      requiring tool call.
+--   2. Watch SELECT * FROM net._http_response ORDER BY created DESC LIMIT 5;
+--      The most recent row should be a 200 from the edge function.
+--   3. Mobile device should receive a push within ~2 seconds with screen
+--      data routing to /mcp-approval/<approvalId>.
+--
+-- ============================================================================


### PR DESCRIPTION
## Summary

Closes the loop on Phase 4-step4 (CLI PR #234). The CLI's `styrby mcp serve` flow has been writing `mcp_approval_requested` rows to audit_log and polling for `mcp_approval_decided`; the mobile half was missing — feature was non-functional end-to-end.

19 files changed, +2833 / -6.

## Mobile build

- `app/mcp-approval/[approvalId].tsx` — modal screen (orchestrator route)
- `src/components/mcp-approval/{useMcpApproval, McpApprovalRequest}` — hook + presentational view
- `src/services/mcp-approval.ts` — `writeMcpApprovalDecision` writer matching CLI poll contract exactly
- `src/components/audit/McpApprovalEventRow.tsx` — dashboard renderer for the 3 new events
- Push routing wired in `useNotifications.ts` (data.screen='mcp_approval' deep-links)
- Biometric gate (`expo-local-authentication`) on Approve when risk='high'|'critical'

## Server-side closure (this is what made D-02 actually functional)

- **Migration 070** — narrow audit_log INSERT RLS policy scoped to mcp_approval_decided rows owned by the caller.
- **Migration 071** — push trigger on audit_log WHEN action='mcp_approval_requested'. Mirrors migration 017 for session_messages. Without this, mobile is ready but never wakes — CLI sits polling forever.

## Tests

38 new tests across 4 suites, all passing:
- writeMcpApprovalDecision: 8 cases (auth, RLS rejection, network errors, validation)
- useMcpApproval: 11 cases (load, biometric threshold, countdown, decision flow)
- McpApprovalRequest: 14 cases inc. 1 snapshot
- McpApprovalEventRow: 5 dashboard renderer cases

## Spec

Implementation contract: `docs/planning/mobile-mcp-approval-spec-2026-04-30.md`. Two deviations surfaced + accepted (biometric pattern wasn't where spec claimed; audit_log RLS required policy).

## Test plan

- [x] `pnpm --filter styrby-mobile typecheck` clean
- [x] `pnpm --filter styrby-mobile lint` 0 errors
- [x] D-02 tests: 38/38 pass
- [ ] CI green
- [ ] Post-merge: verify migrations 070 + 071 land on prod via Supabase dashboard
- [ ] Post-merge: device-side e2e — `styrby mcp serve` → CLI requests → push → tap → screen → approve → CLI sees decision (M1.7)

## Post-deploy steps (one-time per env)

Migration 071 inherits migration 017's prerequisites:
- `vault.create_secret` for `supabase_functions_api_key` (already done if 017 was deployed)
- `app.supabase_url` Postgres setting (already done if 017 was deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)