### PR TITLE
fix(pwa): set skipWaiting=false so update banner can drive activation

### DIFF
--- a/packages/styrby-web/src/__tests__/sw-config.test.ts
+++ b/packages/styrby-web/src/__tests__/sw-config.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Service worker config invariants — guards against regression of the
+ * "Update banner stuck on Updating…" bug observed in production 2026-05-04.
+ *
+ * Root cause: `new Serwist({ skipWaiting: true })` makes Serwist self-skip
+ * on install AND removes the message-listener fallback. The custom
+ * "Update now" banner in `components/sw-register.tsx` then has no waiting
+ * worker to postMessage SKIP_WAITING to, so the click does nothing and the
+ * button gets stuck. The fix is `skipWaiting: false` so the banner's
+ * postMessage path actually runs.
+ *
+ * These tests read the source file (not the bundled output) so they catch
+ * regressions BEFORE the SW gets compiled to public/sw.js. They are
+ * deliberately string-based — testing the runtime behavior would require
+ * a real Service Worker scope, which is heavier than the value here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SW_SOURCE = readFileSync(
+  resolve(__dirname, '..', 'sw.ts'),
+  'utf-8',
+);
+
+describe('Service worker config (regression guards)', () => {
+  it('passes skipWaiting: false to Serwist (so the update banner can drive skipWaiting via postMessage)', () => {
+    // The source must contain the literal `skipWaiting: false` and must NOT
+    // contain `skipWaiting: true`. This is intentionally strict — any
+    // accidental flip back to true reintroduces the stuck-banner bug.
+    expect(SW_SOURCE).toContain('skipWaiting: false');
+    expect(SW_SOURCE).not.toContain('skipWaiting: true');
+  });
+
+  it('registers a message listener that calls self.skipWaiting() on SKIP_WAITING', () => {
+    // The custom message handler is what actually flips the new SW from
+    // waiting → active when the user clicks "Update now". It must exist.
+    expect(SW_SOURCE).toContain("'message'");
+    expect(SW_SOURCE).toMatch(/data\?\.type === 'SKIP_WAITING'/);
+    expect(SW_SOURCE).toContain('self.skipWaiting()');
+  });
+
+  it('keeps clientsClaim: true (so the new SW takes over open tabs immediately after activation)', () => {
+    // After SKIP_WAITING fires and the new SW activates, clientsClaim
+    // ensures it controls the page that triggered the update without a
+    // hard reload. The reload still happens (sw-register listens for
+    // controllerchange) but clientsClaim is what makes the SW the
+    // controller in the first place.
+    expect(SW_SOURCE).toContain('clientsClaim: true');
+  });
+});

--- a/packages/styrby-web/src/sw.ts
+++ b/packages/styrby-web/src/sw.ts
@@ -288,8 +288,14 @@ const styrbyCache = [
  * styrbyCache rules are prepended to defaultCache so Styrby-specific matchers
  * take priority over Serwist's generic Next.js rules.
  *
- * - skipWaiting: Activate the new SW immediately instead of waiting for all
- *   tabs to close. This ensures users get updates on next navigation.
+ * - skipWaiting: **MUST be false** so the new SW enters the `waiting` state
+ *   instead of activating immediately. The "Update now" banner in
+ *   `components/sw-register.tsx` depends on a real waiting worker:
+ *   user clicks → client posts {type:'SKIP_WAITING'} → SW's message
+ *   listener (lines below) calls self.skipWaiting() → controllerchange
+ *   fires → page reloads. If skipWaiting is true here, Serwist self-skips
+ *   on install AND removes the message listener, leaving the banner
+ *   stuck on "Updating…" forever (observed in prod 2026-05-04).
  * - clientsClaim: Take control of all open tabs immediately after activation
  *   so the SW handles fetches from the first navigation onward.
  * - navigationPreload: Uses the Navigation Preload API to fetch pages from
@@ -297,7 +303,9 @@ const styrbyCache = [
  */
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
-  skipWaiting: true,
+  // WHY false: see banner-flow note above. The custom message handler
+  // below (lines ~528-533) is what actually skips on user click.
+  skipWaiting: false,
   clientsClaim: true,
   navigationPreload: true,
   runtimeCaching: [...styrbyCache, ...defaultCache],


### PR DESCRIPTION
## Summary

Production bug observed 2026-05-04: the "A new version of Styrby is available — Update now" banner showed correctly but clicking Update got stuck on "Updating…" forever. Customers had to manually unregister the service worker via DevTools to recover.

**Root cause:** `new Serwist({ skipWaiting: true })` in `sw.ts` line 300 made Serwist self-skip on install AND suppress the message listener that handles SKIP_WAITING posts from clients. The custom "Update now" button in `sw-register.tsx` then had no waiting worker to talk to and no listener to receive its postMessage.

**Fix:** flip `skipWaiting: false`. Serwist now enters proper waiting state; the existing custom message listener at `sw.ts:528-533` takes over the click flow.

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | clean |
| New regression test `sw-config.test.ts` | 3/3 pass |
| Existing `sw-register.test.tsx` | 7/7 pass |

After this deploys, customers currently stuck on "Updating…" get unstuck on their next page load (the new `/sw.js` is detected, registered as `waiting`, and the banner click flow works normally).

## Regression guard

`src/__tests__/sw-config.test.ts` pins three invariants on the SW source:
1. `skipWaiting` must be `false` (and must NOT be `true`)
2. The `message` listener with `SKIP_WAITING` handling must exist
3. `clientsClaim` must remain `true`

These are source-string assertions so they fire at PR review time before the SW even gets compiled.

## Test plan

- [ ] CI green
- [ ] Vercel preview deploys
- [ ] After merge: open https://www.styrbyapp.com/, wait for next deploy, watch the banner — clicking Update should reload the page within ~1s

🤖 Shipped via /gh-ship