### PR TITLE
fix(web): remove residual no-credit-card + stale Free-plan marketing copy

### DIFF
--- a/packages/styrby-web/src/app/signup/page.tsx
+++ b/packages/styrby-web/src/app/signup/page.tsx
@@ -481,9 +481,6 @@ function SignUpPageInner() {
                     <Mail className="h-4 w-4" />
                     {loading ? 'Sending...' : 'Continue with Email'}
                   </Button>
-                  <p className="text-center text-xs text-muted-foreground mt-2">
-                    No credit card required
-                  </p>
                 </form>
 
                 {/* Divider */}

--- a/packages/styrby-web/src/components/landing/cta-banner.tsx
+++ b/packages/styrby-web/src/components/landing/cta-banner.tsx
@@ -60,7 +60,7 @@ export function CTABanner() {
         </div>
 
         <p className="mt-4 text-sm text-muted-foreground/60">
-          Free on one machine. No credit card.
+          Cancel anytime. 7-day refund.
         </p>
       </div>
     </section>

--- a/packages/styrby-web/src/lib/blog-articles/eleven-agents-checkpoints-voice-otel.tsx
+++ b/packages/styrby-web/src/lib/blog-articles/eleven-agents-checkpoints-voice-otel.tsx
@@ -258,17 +258,21 @@ export default function ElevenAgentsCheckpointsVoiceOtel() {
 
       <h2>Getting Started</h2>
       <p>
-        Create a free account at{" "}
+        Create your account at{" "}
         <a href="https://styrbyapp.com/signup">styrbyapp.com/signup</a>. Install
         the CLI bridge on any machine where your agents run, connect your first
         agent in under five minutes, and install the mobile app to start
-        receiving push notifications. No credit card required for the Free plan.
+        receiving push notifications. Pro is $39/mo and includes all 11 agents,
+        unlimited sessions, and one year of encrypted history; Growth is
+        $99/mo for 3 seats with team workspaces and audit-log export. Cancel
+        anytime with a 7-day refund window.
       </p>
       <p>
-        If you are already on the Free plan and want to unlock checkpoints,
-        session sharing, or voice commands, upgrade to Pro from the billing
-        settings in your dashboard. Power tier OTEL export requires a one-time
-        endpoint configuration in settings; documentation is at{" "}
+        Pro unlocks checkpoints, session sharing, and voice commands; Growth
+        adds team workspaces, role-based access, per-developer cost rollups,
+        and SOC2-ready audit export. OTEL export to Grafana / Datadog /
+        Honeycomb / New Relic requires a one-time endpoint configuration in
+        settings; documentation is at{" "}
         <a href="https://styrbyapp.com/docs/dashboard">
           styrbyapp.com/docs/dashboard
         </a>


### PR DESCRIPTION
## Summary
PR #251's E2E billing-flow spec caught what the original PR #250 sweep missed: \`/signup\` still rendered \"No credit card required\" as a footnote under the email submit button. Two adjacent stale references (\`cta-banner.tsx\` and the long-form blog article) cleaned up under boy-scout rule.

## Why production grep didn't catch this
PR #250's verification used \`curl + grep\` on the raw HTML. The \"No credit card required\" string is wrapped in a multi-line \`<p class=\"text-center text-xs ...\">\` element with whitespace + indentation that makes the literal phrase invisible to grep. Playwright's \`innerText()\` flattens the rendered text, which is how the spec from #251 caught it.

**Lesson:** post-PR verification should use rendered text (Playwright eval) for copy assertions, not raw-HTML grep.

## What stayed
Backend code in \`api/budget-alerts\`, \`api/bookmarks\`, \`api/templates\`, \`api/webhooks/user\`, and \`emails/subscription-canceled.tsx\` still references \"Free plan\" — that's intentional. The Free tier is no longer offered as a sign-up option but it's still the cancellation revert-target in the subscription state machine. Removing those references would break the cancellation path.

## Test plan
- [x] Local typecheck clean
- [ ] E2E billing-flow spec passes on the new run (the test that originally caught this)
- [ ] Vercel preview confirms /signup, /, /blog/eleven-agents... pages render the new copy

🤖 Cleanup follow-up to PR #252