### PR TITLE
sec: defense-in-depth — fail-closed rate-limit (SEC-FOLLOWUP-2) + Polar subscription guard (SEC-FOLLOWUP-3)

### DIFF
--- a/packages/styrby-web/src/__tests__/admin/webhook-override.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/webhook-override.integration.test.ts
@@ -53,20 +53,22 @@ vi.mock('@styrby/shared/billing', async (importOriginal) => {
 // for Polar webhook dedup. The chained .select() requires the upsert mock to
 // return an object with a select method, not a plain resolved value.
 const mockUpsertSelectFn = vi.fn();
-const mockSelect  = vi.fn().mockReturnThis();
-const mockEq      = vi.fn().mockReturnThis();
-const mockSingle  = vi.fn();
-const mockUpsert  = vi.fn();
-const mockUpdate  = vi.fn().mockReturnThis();
-const mockInsert  = vi.fn().mockResolvedValue({ data: null, error: null });
+const mockSelect      = vi.fn().mockReturnThis();
+const mockEq          = vi.fn().mockReturnThis();
+const mockSingle      = vi.fn();
+const mockMaybeSingle = vi.fn();
+const mockUpsert      = vi.fn();
+const mockUpdate      = vi.fn().mockReturnThis();
+const mockInsert      = vi.fn().mockResolvedValue({ data: null, error: null });
 
 const mockFrom = vi.fn().mockReturnValue({
-  select:  mockSelect,
-  eq:      mockEq,
-  single:  mockSingle,
-  upsert:  mockUpsert,
-  update:  mockUpdate,
-  insert:  mockInsert,
+  select:      mockSelect,
+  eq:          mockEq,
+  single:      mockSingle,
+  maybeSingle: mockMaybeSingle,
+  upsert:      mockUpsert,
+  update:      mockUpdate,
+  insert:      mockInsert,
 });
 
 vi.mock('@/lib/supabase/server', () => ({
@@ -166,18 +168,32 @@ describe('POST /api/webhooks/polar — manual override honor flow', () => {
 
     // Re-establish mockFrom return value after reset wipes it.
     mockFrom.mockReturnValue({
-      select:  mockSelect,
-      eq:      mockEq,
-      single:  mockSingle,
-      upsert:  mockUpsert,
-      update:  mockUpdate,
-      insert:  mockInsert,
+      select:      mockSelect,
+      eq:          mockEq,
+      single:      mockSingle,
+      maybeSingle: mockMaybeSingle,
+      upsert:      mockUpsert,
+      update:      mockUpdate,
+      insert:      mockInsert,
     });
 
     // Re-establish chainable mocks wiped by resetAllMocks.
     mockSelect.mockReturnThis();
     mockEq.mockReturnThis();
     mockUpdate.mockReturnThis();
+
+    // SEC-FOLLOWUP-3 guard: by default, the subscriptions lookup resolves
+    // to the matching row so the manual-override tests below see the
+    // subscription as known + user-matched, exercising the post-guard path
+    // these tests were written to assert. Tests that want to exercise the
+    // guard's not-found / mismatch branches override this per-test.
+    mockMaybeSingle.mockResolvedValue({
+      data: {
+        user_id: 'user-uuid-integration',
+        polar_subscription_id: 'sub_integration_123',
+      },
+      error: null,
+    });
 
     // Default upsert: the dedup SELECT chain resolves as "new event" (non-empty RETURNING).
     mockUpsertSelectFn.mockResolvedValue({ data: [{ event_id: 'evt_default_new' }], error: null });

--- a/packages/styrby-web/src/app/api/admin/support/[id]/reply/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/reply/__tests__/route.test.ts
@@ -580,4 +580,40 @@ describe('POST /api/admin/support/[id]/reply', () => {
       expect(mockAuditLogInsert).not.toHaveBeenCalled();
     });
   });
+
+  // --------------------------------------------------------------------------
+  // SEC-FOLLOWUP-2: rate limiter fail-closed
+  // --------------------------------------------------------------------------
+
+  describe('SEC-FOLLOWUP-2 — fail-closed on rate limiter outage', () => {
+    /**
+     * Admin reply mutates state (writes reply, audit row, sends email). When
+     * Upstash is unreachable AND failClosed=true, the route must short-circuit
+     * with 503 RATE_LIMIT_UNAVAILABLE rather than allowing unmetered replies
+     * (which would let an attacker with admin creds spam customer inboxes).
+     */
+    it('returns 503 RATE_LIMIT_UNAVAILABLE when rate-limit infrastructure is down', async () => {
+      const { rateLimit } = await import('@/lib/rateLimit');
+      vi.mocked(rateLimit).mockResolvedValueOnce({
+        allowed: false,
+        remaining: 0,
+        resetAt: Date.now() + 60000,
+        retryAfter: 30,
+        infrastructureUnavailable: true,
+      });
+
+      const response = await POST(
+        makePostRequest({ message: 'Will not be sent.' }),
+        makeContext()
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(body.error).toBe('RATE_LIMIT_UNAVAILABLE');
+      expect(response.headers.get('Retry-After')).toBe('30');
+      // Critical: route must NOT have proceeded to send an email or write audit row.
+      expect(mockSendSupportReplyEmail).not.toHaveBeenCalled();
+      expect(mockAuditLogInsert).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/styrby-web/src/app/api/admin/support/[id]/reply/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/reply/route.ts
@@ -37,9 +37,23 @@ export async function POST(
 ) {
   const { id } = await params;
 
-  // A-008: Rate limit admin routes
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.standard, 'admin-support-reply');
-  if (!allowed) return rateLimitResponse(retryAfter!);
+  // A-008: Rate limit admin routes.
+  // SEC-FOLLOWUP-2: failClosed=true on support reply (mutates ticket + sends email).
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.standard,
+    'admin-support-reply',
+    { failClosed: true },
+  );
+  if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
+    return rateLimitResponse(retryAfter!);
+  }
 
   // Verify auth and admin status
   const supabase = await createClient();

--- a/packages/styrby-web/src/app/api/admin/support/[id]/route.ts
+++ b/packages/styrby-web/src/app/api/admin/support/[id]/route.ts
@@ -147,9 +147,24 @@ export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  // A-008: Rate limit admin routes
-  const { allowed: patchAllowed, retryAfter: patchRetryAfter } = await rateLimit(request, RATE_LIMITS.standard, 'admin-support-id');
-  if (!patchAllowed) return rateLimitResponse(patchRetryAfter!);
+  // A-008: Rate limit admin routes.
+  // SEC-FOLLOWUP-2: failClosed=true on admin support PATCH (mutates ticket state).
+  // Read GET above stays fail-open so support staff can debug during a limiter outage.
+  const { allowed: patchAllowed, retryAfter: patchRetryAfter, infrastructureUnavailable: patchInfraDown } = await rateLimit(
+    request,
+    RATE_LIMITS.standard,
+    'admin-support-id',
+    { failClosed: true },
+  );
+  if (!patchAllowed) {
+    if (patchInfraDown) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter: patchRetryAfter },
+        { status: 503, headers: { 'Retry-After': String(patchRetryAfter ?? 30) } },
+      );
+    }
+    return rateLimitResponse(patchRetryAfter!);
+  }
 
   const { id } = await params;
   const result = await verifyAdmin();

--- a/packages/styrby-web/src/app/api/billing/checkout/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/billing/checkout/__tests__/route.test.ts
@@ -537,4 +537,36 @@ describe('POST /api/billing/checkout', () => {
     expect(response.status).toBe(500);
     expect(data.error).toBe('Failed to create checkout session');
   });
+
+  /**
+   * SEC-FOLLOWUP-2: when the Upstash limiter is unreachable AND failClosed=true,
+   * the route must respond 503 RATE_LIMIT_UNAVAILABLE instead of falling through
+   * (would let unmetered checkouts hit Polar) or returning 429 (would mislead
+   * the client into believing they exceeded the cap).
+   */
+  it('returns 503 RATE_LIMIT_UNAVAILABLE when rate-limit infrastructure is down (failClosed)', async () => {
+    const { rateLimit } = await import('@/lib/rateLimit');
+    vi.mocked(rateLimit).mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60000,
+      retryAfter: 30,
+      infrastructureUnavailable: true,
+    });
+
+    const request = new Request('http://localhost/api/billing/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tierId: 'pro' }),
+    });
+
+    const response = await POST(request as never);
+    const data = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(data.error).toBe('RATE_LIMIT_UNAVAILABLE');
+    expect(response.headers.get('Retry-After')).toBe('30');
+    // Critical: verify the route did NOT proceed to call Polar.
+    expect(mockCheckoutCreate).not.toHaveBeenCalled();
+  });
 });

--- a/packages/styrby-web/src/app/api/billing/checkout/route.ts
+++ b/packages/styrby-web/src/app/api/billing/checkout/route.ts
@@ -206,8 +206,23 @@ const polar = new Polar({
 });
 
 export async function POST(request: NextRequest) {
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.checkout, 'checkout');
+  // SEC-FOLLOWUP-2: failClosed=true. Checkout creates payment sessions; an
+  // attacker who can degrade Upstash must not be able to flood Polar with
+  // unmetered checkout creations. 503 + Retry-After distinguishes "limiter
+  // is down" from "you exceeded the cap".
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.checkout,
+    'checkout',
+    { failClosed: true },
+  );
   if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
     return rateLimitResponse(retryAfter!);
   }
 

--- a/packages/styrby-web/src/app/api/billing/seats/route.ts
+++ b/packages/styrby-web/src/app/api/billing/seats/route.ts
@@ -576,12 +576,25 @@ export async function GET(request: Request): Promise<Response> {
 export async function PATCH(request: Request): Promise<Response> {
   // ── Step 1: Rate limit ────────────────────────────────────────────────────
 
-  const { allowed, retryAfter } = await rateLimit(
+  // SEC-FOLLOWUP-2: failClosed=true on the seat-mutating PATCH. An attacker
+  // who can degrade Upstash must not be able to flood seat changes (each one
+  // calls Polar + writes to teams + audit_log). The GET preview stays
+  // fail-open since it's read-only.
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
     request as Parameters<typeof rateLimit>[0],
     RATE_LIMITS.standard,
     'billing-seats-patch',
+    { failClosed: true },
   );
-  if (!allowed) return rateLimitResponse(retryAfter!);
+  if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
+    return rateLimitResponse(retryAfter!);
+  }
 
   // ── Step 2: Parse + validate body ─────────────────────────────────────────
 

--- a/packages/styrby-web/src/app/api/teams/[id]/members/[userId]/route.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/members/[userId]/route.ts
@@ -76,8 +76,20 @@ export async function PATCH(
   context: RouteContext
 ) {
   // Rate limit check
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.budgetAlerts, 'team-members');
+  // SEC-FOLLOWUP-2: failClosed=true on member PATCH (role change).
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.budgetAlerts,
+    'team-members',
+    { failClosed: true },
+  );
   if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
     return rateLimitResponse(retryAfter!);
   }
 
@@ -218,8 +230,20 @@ export async function DELETE(
   context: RouteContext
 ) {
   // Rate limit check
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.budgetAlerts, 'team-members');
+  // SEC-FOLLOWUP-2: failClosed=true on member DELETE (state-changing removal).
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.budgetAlerts,
+    'team-members',
+    { failClosed: true },
+  );
   if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
     return rateLimitResponse(retryAfter!);
   }
 

--- a/packages/styrby-web/src/app/api/teams/[id]/members/route.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/members/route.ts
@@ -118,8 +118,22 @@ export async function POST(
   context: RouteContext
 ) {
   // Rate limit check
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.budgetAlerts, 'team-invite');
+  // SEC-FOLLOWUP-2: failClosed=true. Team invitations are state-changing AND
+  // attacker-spammable (each invite can consume a seat + send email). An
+  // outage of the limiter must not become a free invite-flooding window.
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.budgetAlerts,
+    'team-invite',
+    { failClosed: true },
+  );
   if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
     return rateLimitResponse(retryAfter!);
   }
 

--- a/packages/styrby-web/src/app/api/teams/[id]/policies/route.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/policies/route.ts
@@ -192,8 +192,22 @@ export async function PATCH(
   request: NextRequest,
   context: RouteContext,
 ) {
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.budgetAlerts, 'team-policies');
-  if (!allowed) return rateLimitResponse(retryAfter!);
+  // SEC-FOLLOWUP-2: failClosed=true on policies PATCH (state-changing).
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.budgetAlerts,
+    'team-policies',
+    { failClosed: true },
+  );
+  if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
+    return rateLimitResponse(retryAfter!);
+  }
 
   try {
     const { id: teamId } = await context.params;

--- a/packages/styrby-web/src/app/api/teams/[id]/route.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/route.ts
@@ -233,8 +233,20 @@ export async function PATCH(
   context: RouteContext
 ) {
   // Rate limit check
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.budgetAlerts, 'teams');
+  // SEC-FOLLOWUP-2: failClosed=true on PATCH (team-settings mutation).
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.budgetAlerts,
+    'teams',
+    { failClosed: true },
+  );
   if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
     return rateLimitResponse(retryAfter!);
   }
 
@@ -347,8 +359,20 @@ export async function DELETE(
   context: RouteContext
 ) {
   // Rate limit check
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.sensitive, 'teams-delete');
+  // SEC-FOLLOWUP-2: failClosed=true on DELETE (irreversible team deletion).
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.sensitive,
+    'teams-delete',
+    { failClosed: true },
+  );
   if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
     return rateLimitResponse(retryAfter!);
   }
 

--- a/packages/styrby-web/src/app/api/teams/[id]/sso/route.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/sso/route.ts
@@ -255,8 +255,20 @@ export async function PUT(
   }
 
   // Rate limit: SSO changes are sensitive; tight limit prevents brute-force
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.budgetAlerts, `team-sso-${teamId}`);
+  // SEC-FOLLOWUP-2: failClosed=true on SSO PUT (security-critical mutation).
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.budgetAlerts,
+    `team-sso-${teamId}`,
+    { failClosed: true },
+  );
   if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
     // WHY cast: rateLimitResponse returns Response (not NextResponse) but Next.js
     // route handlers accept both. The cast is safe - this pattern is used across all
     // API routes in the codebase.

--- a/packages/styrby-web/src/app/api/teams/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/teams/__tests__/route.test.ts
@@ -393,5 +393,30 @@ describe('Teams API — /api/teams', () => {
       const body = await response.json();
       expect(body.error).toBe('Failed to create team');
     });
+
+    /**
+     * SEC-FOLLOWUP-2: Upstash limiter outage on the team-creation POST must
+     * surface as 503 RATE_LIMIT_UNAVAILABLE, not silently allow unmetered
+     * team creation. failClosed=true is intentionally narrow — POST mutates;
+     * GET stays fail-open.
+     */
+    it('returns 503 RATE_LIMIT_UNAVAILABLE on POST when rate-limit infrastructure is down', async () => {
+      const { rateLimit } = await import('@/lib/rateLimit');
+      vi.mocked(rateLimit).mockResolvedValueOnce({
+        allowed: false,
+        remaining: 0,
+        resetAt: Date.now() + 60000,
+        retryAfter: 30,
+        infrastructureUnavailable: true,
+      });
+
+      const req = createNextRequest({ name: 'Outage Team' });
+      const response = await POST(req);
+      const body = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(body.error).toBe('RATE_LIMIT_UNAVAILABLE');
+      expect(response.headers.get('Retry-After')).toBe('30');
+    });
   });
 });

--- a/packages/styrby-web/src/app/api/teams/route.ts
+++ b/packages/styrby-web/src/app/api/teams/route.ts
@@ -231,8 +231,22 @@ export async function GET() {
  */
 export async function POST(request: NextRequest) {
   // Rate limit check
-  const { allowed, retryAfter } = await rateLimit(request, RATE_LIMITS.budgetAlerts, 'teams');
+  // SEC-FOLLOWUP-2: failClosed=true. Team creation is state-changing and
+  // gated by Power tier; flooding it during a limiter outage could create
+  // many ghost teams, each consuming downstream resources.
+  const { allowed, retryAfter, infrastructureUnavailable } = await rateLimit(
+    request,
+    RATE_LIMITS.budgetAlerts,
+    'teams',
+    { failClosed: true },
+  );
   if (!allowed) {
+    if (infrastructureUnavailable) {
+      return NextResponse.json(
+        { error: 'RATE_LIMIT_UNAVAILABLE', message: 'Rate limiter unavailable. Please retry shortly.', retryAfter },
+        { status: 503, headers: { 'Retry-After': String(retryAfter ?? 30) } },
+      );
+    }
     return rateLimitResponse(retryAfter!);
   }
 

--- a/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
@@ -82,6 +82,11 @@ vi.mock('@styrby/shared/billing', async (importOriginal) => {
 const mockSelect = vi.fn().mockReturnThis();
 const mockEq = vi.fn();
 const mockSingle = vi.fn();
+// SEC-FOLLOWUP-3 / WAVE-E-006: subscription_id ↔ user_id guard uses maybeSingle()
+// so it can distinguish "row not found" (null) from "DB error". Default behavior
+// returns a row that matches the standard test fixture's user_id='user-uuid-123'
+// so the guard's HAPPY path is the no-op default — existing tests untouched.
+const mockMaybeSingle = vi.fn();
 // WHY mockReturnValue with { select } shape instead of mockResolvedValue:
 // Migration 054 adds event-id dedup to the individual subscription path.
 // The dedup block calls supabase.from('polar_webhook_events').upsert(...).select('event_id').
@@ -122,6 +127,7 @@ const mockFrom = vi.fn().mockReturnValue({
   select: mockSelect,
   eq: mockEq,
   single: mockSingle,
+  maybeSingle: mockMaybeSingle,
   upsert: mockUpsert,
   update: mockUpdate,
   insert: mockInsert,
@@ -251,11 +257,20 @@ describe('POST /api/webhooks/polar', () => {
       select: mockSelect,
       eq: mockEq,
       single: mockSingle,
+      maybeSingle: mockMaybeSingle,
       upsert: mockUpsert,
       update: mockUpdate,
       insert: mockInsert,
       order: mockOrder,
       limit: mockLimit,
+    });
+
+    // SEC-FOLLOWUP-3 default: guard lookup returns a matching subscription row
+    // (user_id matches the standard fixture). Existing tests stay green; tests
+    // exercising the not-found / mismatch paths override this per-test.
+    mockMaybeSingle.mockResolvedValue({
+      data: { user_id: 'user-uuid-123', polar_subscription_id: 'sub_test_123' },
+      error: null,
     });
 
     // Re-establish chain traversal mocks.
@@ -833,6 +848,10 @@ describe('POST /api/webhooks/polar', () => {
         },
       };
 
+      // SEC-FOLLOWUP-3 guard: pre-stub the .from('subscriptions').eq() call
+      // so the guard's .maybeSingle() resolves; the next mockEq overrides feed
+      // the actual handler's queries (.update.eq).
+      mockEq.mockReturnValueOnce({ maybeSingle: mockMaybeSingle });
       // Chain: .update(...).eq(...)
       mockEq.mockResolvedValueOnce({ data: null, error: null });
 
@@ -929,10 +948,13 @@ describe('POST /api/webhooks/polar', () => {
       // mockResolvedValueOnce would land on call 1 (FIFO), breaking the lookup.
       // We explicitly chain: first call returns the mock itself (preserving the
       // chain), second call resolves with success.
+      // SEC-FOLLOWUP-3 guard: pre-stub .eq() on subscriptions for the guard lookup.
+      mockEq.mockReturnValueOnce({ maybeSingle: mockMaybeSingle });
       mockEq.mockReturnValueOnce({
         select: mockSelect,
         eq: mockEq,
         single: mockSingle,
+        maybeSingle: mockMaybeSingle,
         upsert: mockUpsert,
         update: mockUpdate,
         insert: mockInsert,
@@ -1099,6 +1121,7 @@ describe('POST /api/webhooks/polar', () => {
         select: mockSelect,
         eq: mockEq,
         single: mockSingle,
+        maybeSingle: mockMaybeSingle,
         upsert: mockUpsert,
         update: mockUpdate,
         insert: mockInsert,
@@ -1121,10 +1144,13 @@ describe('POST /api/webhooks/polar', () => {
       // First .eq() (lookup) preserves the chain so .single() can resolve;
       // second .eq() (UPDATE on subscriptions) FAILS — simulating the DB error
       // that would otherwise leave the dedup row in place and skip the retry.
+      // SEC-FOLLOWUP-3 guard: pre-stub .eq() on subscriptions for the guard lookup.
+      mockEq.mockReturnValueOnce({ maybeSingle: mockMaybeSingle });
       mockEq.mockReturnValueOnce({
         select: mockSelect,
         eq: mockEq,
         single: mockSingle,
+        maybeSingle: mockMaybeSingle,
         upsert: mockUpsert,
         update: mockUpdate,
         insert: mockInsert,
@@ -1168,6 +1194,7 @@ describe('POST /api/webhooks/polar', () => {
         select: mockSelect,
         eq: mockEq,
         single: mockSingle,
+        maybeSingle: mockMaybeSingle,
         upsert: mockUpsert,
         update: mockUpdate,
         insert: mockInsert,
@@ -1186,10 +1213,13 @@ describe('POST /api/webhooks/polar', () => {
       });
 
       // Lookup chain + successful UPDATE.
+      // SEC-FOLLOWUP-3 guard: pre-stub .eq() on subscriptions for the guard lookup.
+      mockEq.mockReturnValueOnce({ maybeSingle: mockMaybeSingle });
       mockEq.mockReturnValueOnce({
         select: mockSelect,
         eq: mockEq,
         single: mockSingle,
+        maybeSingle: mockMaybeSingle,
         upsert: mockUpsert,
         update: mockUpdate,
         insert: mockInsert,
@@ -1972,10 +2002,13 @@ describe('POST /api/webhooks/polar', () => {
       // resetAllMocks + mockReturnThis would default both to `this`, breaking
       // the UPDATE await. Mirror the order.refunded test pattern: first call
       // returns the chain explicitly, second call resolves.
+      // SEC-FOLLOWUP-3 guard: pre-stub .eq() on subscriptions for the guard lookup.
+      mockEq.mockReturnValueOnce({ maybeSingle: mockMaybeSingle });
       mockEq.mockReturnValueOnce({
         select: mockSelect,
         eq: mockEq,
         single: mockSingle,
+        maybeSingle: mockMaybeSingle,
         upsert: mockUpsert,
         update: mockUpdate,
         insert: mockInsert,
@@ -2074,10 +2107,13 @@ describe('POST /api/webhooks/polar', () => {
         error: null,
       });
       // Same two-step .eq pattern as the cascade-cancel test #1 above.
+      // SEC-FOLLOWUP-3 guard: pre-stub .eq() on subscriptions for the guard lookup.
+      mockEq.mockReturnValueOnce({ maybeSingle: mockMaybeSingle });
       mockEq.mockReturnValueOnce({
         select: mockSelect,
         eq: mockEq,
         single: mockSingle,
+        maybeSingle: mockMaybeSingle,
         upsert: mockUpsert,
         update: mockUpdate,
         insert: mockInsert,
@@ -2320,10 +2356,13 @@ describe('POST /api/webhooks/polar', () => {
         error: null,
       });
       // Two-step .eq pattern: SELECT chain then UPDATE resolve.
+      // SEC-FOLLOWUP-3 guard: pre-stub .eq() on subscriptions for the guard lookup.
+      mockEq.mockReturnValueOnce({ maybeSingle: mockMaybeSingle });
       mockEq.mockReturnValueOnce({
         select: mockSelect,
         eq: mockEq,
         single: mockSingle,
+        maybeSingle: mockMaybeSingle,
         upsert: mockUpsert,
         update: mockUpdate,
         insert: mockInsert,
@@ -2377,6 +2416,177 @@ describe('POST /api/webhooks/polar', () => {
           }),
         }),
       );
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // SEC-FOLLOWUP-3 / WAVE-E-006 — subscription_id ↔ user_id defense-in-depth guard
+  //
+  // Even after HMAC signature verification, the route cross-checks that the
+  // payload's claimed (subscription_id, metadata.userId) pair matches our
+  // durable record in `subscriptions`. These tests pin the three guard outcomes:
+  //   1. Forged event with unknown subscription_id → 200 + audit row + no
+  //      state mutation (path on a wholesale POLAR_WEBHOOK_SECRET leak where
+  //      the attacker invents subscription IDs).
+  //   2. Forged event with a known subscription_id but mismatched metadata.userId
+  //      → 403 (loud failure so Polar's delivery dashboard surfaces the alert
+  //      via repeated retries) + audit row.
+  //   3. Happy path with matching subscription_id + userId → 200 + state
+  //      handler runs (regression: guard does not break the mainline).
+  // --------------------------------------------------------------------------
+  describe('SEC-FOLLOWUP-3: subscription_id ↔ user_id guard', () => {
+    async function sendSignedGuardEvent(body: Record<string, unknown>): Promise<Response> {
+      const payload = JSON.stringify(body);
+      const signature = signPayload(payload);
+      const headersMock = new Headers();
+      headersMock.set('x-polar-signature', signature);
+      vi.mocked(headers).mockResolvedValue(
+        headersMock as unknown as Awaited<ReturnType<typeof headers>>
+      );
+      const request = new Request('http://localhost:3000/api/webhooks/polar', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-forwarded-for': '10.0.0.1',
+        },
+        body: payload,
+      });
+      return POST(request);
+    }
+
+    it('forged event with unknown subscription_id → 200, audit row, no state mutation', async () => {
+      // Guard lookup: subscription_id not found in our `subscriptions` table.
+      // Lenient path — return 200 (no Polar retry storm), audit it, and do
+      // NOT touch downstream state (no upsert, no profile lookup, etc.).
+      mockMaybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+      const event = {
+        id: 'evt_forged_001',
+        type: 'subscription.updated',
+        data: {
+          id: 'sub_attacker_invented_999',
+          customer_id: 'cust_test_456',
+          product_id: 'prod_pro_monthly',
+          status: 'active',
+          metadata: { userId: 'user-uuid-123' },
+        },
+      };
+
+      const response = await sendSignedGuardEvent(event);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.guard).toBe('unknown_subscription');
+
+      // Audit_log row recorded with the unknown_subscription action, the
+      // attacker-claimed subscription_id, and the claimed userId for forensics.
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'polar_webhook_unknown_subscription',
+          metadata: expect.objectContaining({
+            event_type: 'subscription.updated',
+            polar_subscription_id: 'sub_attacker_invented_999',
+            claimed_user_id: 'user-uuid-123',
+          }),
+        }),
+      );
+
+      // No state mutation: subscription upsert never called, the post-guard
+      // event-id dedup upsert (which would touch polar_webhook_events) never
+      // runs either. mockUpsert is the shared mock for both, so a clean
+      // assertion is "never".
+      expect(mockUpsert).not.toHaveBeenCalled();
+    });
+
+    it('forged event with mismatched userId → 403 + audit row', async () => {
+      // Guard lookup: subscription is known, but its user_id in DB is DIFFERENT
+      // from the userId claimed in the forged payload's metadata. Hard mismatch
+      // → 403 (loud failure surfacing the alert in monitoring).
+      mockMaybeSingle.mockResolvedValueOnce({
+        data: {
+          user_id: 'real-owner-user-aaa',
+          polar_subscription_id: 'sub_legit_xyz',
+        },
+        error: null,
+      });
+
+      const event = {
+        id: 'evt_forged_002',
+        type: 'subscription.updated',
+        data: {
+          id: 'sub_legit_xyz',
+          customer_id: 'cust_test_456',
+          product_id: 'prod_pro_monthly',
+          status: 'active',
+          // Attacker tries to attribute this real subscription to a different
+          // user (e.g., to grant themselves a tier upgrade by hijacking sub_legit_xyz).
+          metadata: { userId: 'attacker-user-bbb' },
+        },
+      };
+
+      const response = await sendSignedGuardEvent(event);
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe('subscription_user_mismatch');
+
+      // Mismatch audit row carries BOTH the real db_user_id and the claimed
+      // attacker-supplied userId so an investigator can pinpoint the attempt.
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'polar_webhook_user_id_mismatch',
+          user_id: 'real-owner-user-aaa',
+          metadata: expect.objectContaining({
+            event_type: 'subscription.updated',
+            polar_subscription_id: 'sub_legit_xyz',
+            db_user_id: 'real-owner-user-aaa',
+            claimed_user_id: 'attacker-user-bbb',
+          }),
+        }),
+      );
+
+      // Hard-stop: no state mutation followed.
+      expect(mockUpsert).not.toHaveBeenCalled();
+    });
+
+    it('happy path: matching subscription_id + userId → 200 + state handler runs', async () => {
+      // Guard lookup returns a row whose user_id matches the payload's metadata.userId.
+      // Guard falls through to the existing handler, which then exercises its
+      // normal subscription.updated flow.
+      mockMaybeSingle.mockResolvedValueOnce({
+        data: { user_id: 'user-uuid-123', polar_subscription_id: 'sub_legit_xyz' },
+        error: null,
+      });
+      // Mocks for the existing handler downstream of the guard:
+      //  - profile lookup, customer lookup, existing-tier check.
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'pro', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { id: 'user-uuid-123', user_id: 'user-uuid-123', tier: 'pro', status: 'active' },
+        error: null,
+      });
+      mockSingle.mockResolvedValueOnce({
+        data: { tier: 'pro', status: 'active' },
+        error: null,
+      });
+
+      const event = {
+        id: 'evt_legit_003',
+        type: 'subscription.updated',
+        data: {
+          id: 'sub_legit_xyz',
+          customer_id: 'cust_test_456',
+          product_id: 'prod_power_monthly',
+          user_id: 'user-uuid-123',
+          status: 'active',
+          metadata: { userId: 'user-uuid-123' },
+        },
+      };
+
+      const response = await sendSignedGuardEvent(event);
+      expect(response.status).toBe(200);
+      // Downstream state handler ran (subscriptions upsert was invoked).
+      expect(mockUpsert).toHaveBeenCalled();
     });
   });
 });

--- a/packages/styrby-web/src/app/api/webhooks/polar/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/route.ts
@@ -1077,6 +1077,145 @@ export async function POST(request: Request) {
 
   const supabase = createAdminClient();
 
+  // ============================================================================
+  // SEC-FOLLOWUP-3 / WAVE-E-006: subscription_id ↔ user_id defense-in-depth guard
+  //
+  // WHY: Even after HMAC signature verification, we trust the signed payload
+  // implicitly — including its claim about which user (`metadata.userId`) and
+  // which subscription (`subscription_id`) the event refers to. If POLAR_WEBHOOK_SECRET
+  // ever leaks OR Polar's infrastructure is compromised, an attacker could craft
+  // a forged-but-HMAC-valid event for ANY user/subscription combination and we
+  // would dutifully apply it. The guard cross-checks the payload's claimed
+  // (subscription_id, userId) against our durable record in `subscriptions`.
+  //
+  // Behavior:
+  //  - Allowlist of event types: only events that mutate per-user billing state
+  //    AND reference a subscription we should already know about.
+  //  - subscription.created is EXCLUDED: by definition the row does not exist
+  //    in `subscriptions` until this very handler creates it. Guarding here
+  //    would break every legitimate signup. Defense for .created relies on
+  //    HMAC + downgrade protection + manual-override rules already in place.
+  //  - Not found: lenient — log warn + audit + return 200. A `created` webhook
+  //    may have landed before profile sync; legitimate clock skew, not attack.
+  //  - Mismatch: hard alert — log error + audit + 403. We WANT this loud so
+  //    Polar's delivery dashboard surfaces it via repeated retries.
+  //  - Other event types (customer.*, product.*) skip the guard.
+  //
+  // SOC2 CC7.2 / CC9.2: every guard outcome (skip, not-found, mismatch) is
+  // observable in audit_log so an investigator can replay the decision trail.
+  // ============================================================================
+  const SUBSCRIPTION_USER_GUARD_TYPES = new Set<string>([
+    // subscription.created intentionally omitted — see WHY above.
+    'subscription.updated',
+    'subscription.canceled',
+    'subscription.uncanceled',
+    'subscription.active',
+    'subscription.revoked',
+    'subscription.past_due',
+    'order.created',
+    'order.updated',
+    'order.paid',
+    'order.refunded',
+  ]);
+
+  if (SUBSCRIPTION_USER_GUARD_TYPES.has(event.type)) {
+    // Extract subscription_id depending on event family.
+    // For subscription.* the subscription is data.id; for order.* it is
+    // data.subscription_id (Polar's order payload references the parent sub).
+    const guardData = rawData ?? {};
+    const guardSubscriptionId = (
+      event.type.startsWith('order.')
+        ? (guardData.subscription_id as string | undefined)
+        : (guardData.id as string | undefined)
+    );
+
+    // metadata.userId is the user-claim we are verifying. Polar uses camelCase
+    // for metadata keys we set at checkout (matches our checkout code).
+    const claimedUserId = (rawMetadata?.userId as string | undefined)
+      ?? (rawMetadata?.user_id as string | undefined);
+
+    if (!guardSubscriptionId) {
+      // Some events in the allowlist (e.g. order.created for one-off purchases)
+      // legitimately do not carry a subscription_id. Skip the guard with a
+      // debug log; existing per-event handlers still validate their own inputs.
+      if (process.env.NODE_ENV === 'development') {
+        console.debug(
+          `polar/route: subscription-user guard skipped for ${event.type} — no subscription_id in payload`
+        );
+      }
+    } else {
+      const { data: subRow, error: subLookupErr } = await supabase
+        .from('subscriptions')
+        .select('user_id, polar_subscription_id')
+        .eq('polar_subscription_id', guardSubscriptionId)
+        .maybeSingle();
+
+      if (subLookupErr) {
+        // DB error during the guard lookup — fail open with a warning so we
+        // do not block legitimate billing events on transient infra hiccups.
+        // The handler's own per-event validation will still apply.
+        console.warn(
+          `polar/route: subscription-user guard lookup failed for ${guardSubscriptionId} (${event.type}): ${subLookupErr.message} — failing open`
+        );
+      } else if (!subRow) {
+        // Lenient path: webhook references an unknown subscription. This can
+        // happen if `created` events landed before profile sync, OR if this
+        // is a forged event for a subscription we have never seen. Either way
+        // we have no state to mutate — return 200 (no Polar retry) and audit.
+        console.warn(
+          `polar/route: subscription-user guard — unknown subscription_id ${guardSubscriptionId} for event ${event.type}`
+        );
+        try {
+          await supabase.from('audit_log').insert({
+            action: 'polar_webhook_unknown_subscription',
+            user_id: null,
+            metadata: {
+              event_type: event.type,
+              polar_subscription_id: guardSubscriptionId,
+              claimed_user_id: claimedUserId ?? null,
+            },
+          });
+        } catch (e) {
+          console.error(
+            'polar/route: audit_log insert failed for polar_webhook_unknown_subscription (non-fatal):',
+            e
+          );
+        }
+        return NextResponse.json({ received: true, guard: 'unknown_subscription' });
+      } else if (claimedUserId && subRow.user_id !== claimedUserId) {
+        // Hard mismatch: the signed payload claims this subscription belongs
+        // to a different user than our durable record. Either (a) Polar's
+        // webhook secret was compromised and an attacker is forging events,
+        // or (b) we have data corruption. Both warrant a 403 + audit + alert.
+        console.error(
+          `polar/route: subscription-user MISMATCH for ${guardSubscriptionId} — db.user_id=${subRow.user_id} payload.userId=${claimedUserId} event=${event.type}`
+        );
+        try {
+          await supabase.from('audit_log').insert({
+            action: 'polar_webhook_user_id_mismatch',
+            user_id: subRow.user_id,
+            metadata: {
+              event_type: event.type,
+              polar_subscription_id: guardSubscriptionId,
+              db_user_id: subRow.user_id,
+              claimed_user_id: claimedUserId,
+            },
+          });
+        } catch (e) {
+          console.error(
+            'polar/route: audit_log insert failed for polar_webhook_user_id_mismatch (non-fatal):',
+            e
+          );
+        }
+        return NextResponse.json(
+          { error: 'subscription_user_mismatch' },
+          { status: 403 }
+        );
+      }
+      // Happy path falls through to the existing switch.
+    }
+  }
+
   try {
     switch (event.type) {
       case 'subscription.created':

--- a/supabase/migrations/076_polar_webhook_guard_audit_actions.sql
+++ b/supabase/migrations/076_polar_webhook_guard_audit_actions.sql
@@ -1,0 +1,35 @@
+-- Migration 076: Polar webhook subscription_id ↔ user_id guard audit_action values
+--
+-- WHY (SEC-FOLLOWUP-3 / WAVE-E-006): The Polar webhook handler at
+-- packages/styrby-web/src/app/api/webhooks/polar/route.ts trusts the signed
+-- payload's claim about which subscription_id and metadata.userId an event
+-- references. After HMAC verification proves the request is authentic-by-secret,
+-- a defense-in-depth guard cross-checks the (subscription_id, userId) pair
+-- against our durable record in `subscriptions`. This insulates us from a
+-- POLAR_WEBHOOK_SECRET leak or Polar-infra compromise scenario where an
+-- attacker could craft a forged-but-HMAC-valid event for any user/sub combo.
+--
+-- The guard emits one audit_log row per non-happy-path outcome:
+--   • polar_webhook_unknown_subscription — webhook references a subscription_id
+--     we have no record of. Treated leniently (200 + warn) because legitimate
+--     ordering/clock-skew can produce this; a forged event lands here too and
+--     leaves a forensic trail.
+--   • polar_webhook_user_id_mismatch — webhook's metadata.userId disagrees
+--     with subscriptions.user_id for the looked-up subscription. Hard 403,
+--     loud log, audit row — we WANT this to fail audibly so Polar's delivery
+--     dashboard surfaces it via repeated retries.
+--
+-- Without these enum values the audit_log insert in the route handler fails
+-- with "invalid input value for enum audit_action", which would mask the
+-- security signal we are trying to surface.
+--
+-- WHY no rollback: ENUM values cannot be removed without recreating the type
+-- and rewriting every dependent column. The route code that emits these values
+-- ships in the same PR; if the migration applies but the code rolls back, the
+-- values are simply unused (no harm).
+--
+-- @security SOC 2 CC7.2 (System Monitoring) + CC9.2 (Risk Mitigation) —
+--   establishes a forensic trail for forged-webhook detection.
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'polar_webhook_unknown_subscription';
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'polar_webhook_user_id_mismatch';


### PR DESCRIPTION
## Summary
Closes the two defense-in-depth follow-ups left open after [PR #252](https://github.com/VetSecItPro/styrby-app/pull/252)'s comprehensive scan. Both are additive — no behavior change on the happy path.

## SEC-FOLLOWUP-2 — fail-closed rate-limit on mutating routes
12 mutating handlers across billing/teams/admin now call `rateLimit()` with `{ failClosed: true }` and return **503 RATE_LIMIT_UNAVAILABLE** when Upstash is unreachable (distinct from 429).

**Applied to:** billing checkout/seats, teams CRUD, team members POST/PATCH/DELETE, team policies + SSO, admin support reply.

**Intentionally LEFT fail-open:** all admin GET handlers (founder-metrics, audit/verify, support list/show, sentry-smoke). Admin debugging during an Upstash outage matters more than rate-limit on read.

**Codebase deviations from spec:** /api/billing/cancel + /api/billing/refund don't exist — both flow through Polar's hosted portal + webhooks. /api/teams/invitations/* is nested under /api/teams/[id]/members — all four mutating verbs hit.

**Pre-existing gap surfaced (not addressed here):** /api/teams/[id]/sso DELETE has no rateLimit() call at all. Logged as future follow-up.

## SEC-FOLLOWUP-3 — Polar webhook subscription_id → user guard
After HMAC verify + team-routing, the Polar webhook now looks up the payload's subscription_id in public.subscriptions and verifies user_id matches metadata.userId.

**Three branches:**
- **Not found** → log warning + audit_log row \`polar_webhook_unknown_subscription\` + return 200 (avoid Polar retry storms on legitimate-but-unsynced subs)
- **Mismatch** → log security alert + audit_log row \`polar_webhook_user_id_mismatch\` + return 403 (intentionally errors so Polar's retry queue surfaces the issue in monitoring)
- **Match** → continue to existing handler dispatch (happy path unchanged)

**Allowlist (10 event types carrying subscription_id):** subscription.{updated, canceled, uncanceled, active, revoked, past_due}, order.{created, updated, paid, refunded}.

**Excluded:** subscription.created (no row exists yet — this handler creates it); team-tier events (use teams table, out of scope).

**.maybeSingle() not .single()** so not-found vs DB error stay distinguishable. DB-error path fails open with warn — billing shouldn't hard-fail on transient infra hiccups.

## Migration
- \`076_polar_webhook_guard_audit_actions.sql\` — adds two audit_action enum values. **Already applied to remote** (akmtmxunjhsgldjztdtt) during this PR's orchestration.

## Test plan
- [x] +6 net new regression tests
- [x] 287/287 on followup-2 touched paths
- [x] 66/66 on polar webhook
- [x] \`npm run typecheck\` clean
- [ ] Vercel preview manual smoke
- [ ] Re-run \`/sec-ship --diff\` post-merge

🤖 Continuation of \`/sec-ship --comprehensive\` 2026-05-05