### PR TITLE
fix(polar): make Team/Business product IDs optional — 7-day webhook outage root cause

### DIFF
--- a/packages/styrby-web/src/app/api/health/route.ts
+++ b/packages/styrby-web/src/app/api/health/route.ts
@@ -58,7 +58,12 @@ const AGGREGATE_TIMEOUT_MS = 10_000;
  */
 const POLAR_HEALTH_URL = 'https://polar.sh';
 
-const OPENROUTER_CREDITS_URL = 'https://openrouter.ai/api/v1/credits';
+// WHY /auth/key (not /credits): /credits requires a "management" (provisioning)
+// key, but our runtime OPENROUTER_API_KEY only has scope for chat/completions.
+// /auth/key returns the key's metadata (label, limit, usage) and accepts any
+// valid runtime key — perfect health probe. Caught 2026-05-05 when /credits
+// flagged the runtime key as 401 even though it works for completions.
+const OPENROUTER_AUTH_KEY_URL = 'https://openrouter.ai/api/v1/auth/key';
 
 /**
  * Resend's /domains endpoint requires a valid API key and returns the list
@@ -166,10 +171,11 @@ async function checkOpenRouter(): Promise<boolean> {
   const key = process.env.OPENROUTER_API_KEY;
   if (!key) return true;
   try {
-    const res = await fetch(OPENROUTER_CREDITS_URL, {
+    const res = await fetch(OPENROUTER_AUTH_KEY_URL, {
       method: 'GET',
       headers: { Authorization: `Bearer ${key}` },
       cache: 'no-store',
+      redirect: 'follow',
     });
     return res.ok;
   } catch {

--- a/packages/styrby-web/src/lib/__tests__/polar-env.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/polar-env.test.ts
@@ -117,7 +117,11 @@ describe('validatePolarEnv()', () => {
   });
 
   it('throws when both required vars are unset', () => {
-    // No stubFullEnv() — only ACCESS_TOKEN + WEBHOOK_SECRET being missing should still throw
+    // Explicitly clear the 2 required vars (CI env may have them set,
+    // unlike local where the default-missing state worked). Optional
+    // Team/Business vars left untouched — their state doesn't matter.
+    vi.stubEnv('POLAR_ACCESS_TOKEN', '');
+    vi.stubEnv('POLAR_WEBHOOK_SECRET', '');
     expect(() => validatePolarEnv()).toThrow(/POLAR_ACCESS_TOKEN|POLAR_WEBHOOK_SECRET/);
   });
 

--- a/packages/styrby-web/src/lib/__tests__/polar-env.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/polar-env.test.ts
@@ -43,8 +43,40 @@ beforeEach(() => {
 // ============================================================================
 
 describe('validatePolarEnv()', () => {
-  it('passes without throwing when all 6 required vars are set', () => {
+  // CONTRACT (updated 2026-05-05 incident response):
+  //
+  //   REQUIRED at cold-start:
+  //     - POLAR_ACCESS_TOKEN
+  //     - POLAR_WEBHOOK_SECRET
+  //
+  //   OPTIONAL (validation never throws on absence):
+  //     - POLAR_TEAM_MONTHLY_PRODUCT_ID
+  //     - POLAR_TEAM_ANNUAL_PRODUCT_ID
+  //     - POLAR_BUSINESS_MONTHLY_PRODUCT_ID
+  //     - POLAR_BUSINESS_ANNUAL_PRODUCT_ID
+  //
+  // WHY the Team/Business IDs are optional now: those tiers were planned
+  // but never launched. Public pricing only ships Pro + Growth. Treating
+  // them as required at cold-start blocked the entire webhook route from
+  // loading whenever those env vars were absent — root cause of the
+  // 7-day Polar webhook outage 2026-04-28 → 2026-05-05.
+  //
+  // The runtime resolver `resolvePolarProductId('team'|'business', ...)`
+  // is the right place to fail loudly: it'll throw "Tier not available"
+  // only when an actual team/business webhook event arrives, not on
+  // every cold-start.
+
+  it('passes without throwing when both required vars are set', () => {
     stubFullEnv();
+    expect(() => validatePolarEnv()).not.toThrow();
+  });
+
+  it('passes when only the 2 required vars are set (Team/Business IDs absent)', () => {
+    stubFullEnv();
+    vi.stubEnv('POLAR_TEAM_MONTHLY_PRODUCT_ID', '');
+    vi.stubEnv('POLAR_TEAM_ANNUAL_PRODUCT_ID', '');
+    vi.stubEnv('POLAR_BUSINESS_MONTHLY_PRODUCT_ID', '');
+    vi.stubEnv('POLAR_BUSINESS_ANNUAL_PRODUCT_ID', '');
     expect(() => validatePolarEnv()).not.toThrow();
   });
 
@@ -60,38 +92,38 @@ describe('validatePolarEnv()', () => {
     expect(() => validatePolarEnv()).toThrow(/POLAR_WEBHOOK_SECRET/);
   });
 
-  it('throws when POLAR_TEAM_MONTHLY_PRODUCT_ID is missing', () => {
+  it('does NOT throw when POLAR_TEAM_MONTHLY_PRODUCT_ID is missing (now optional — see schema comment)', () => {
     stubFullEnv();
     vi.stubEnv('POLAR_TEAM_MONTHLY_PRODUCT_ID', '');
-    expect(() => validatePolarEnv()).toThrow(/POLAR_TEAM_MONTHLY_PRODUCT_ID/);
+    expect(() => validatePolarEnv()).not.toThrow();
   });
 
-  it('throws when POLAR_TEAM_ANNUAL_PRODUCT_ID is missing', () => {
+  it('does NOT throw when POLAR_TEAM_ANNUAL_PRODUCT_ID is missing (now optional)', () => {
     stubFullEnv();
     vi.stubEnv('POLAR_TEAM_ANNUAL_PRODUCT_ID', '');
-    expect(() => validatePolarEnv()).toThrow(/POLAR_TEAM_ANNUAL_PRODUCT_ID/);
+    expect(() => validatePolarEnv()).not.toThrow();
   });
 
-  it('throws when POLAR_BUSINESS_MONTHLY_PRODUCT_ID is missing', () => {
+  it('does NOT throw when POLAR_BUSINESS_MONTHLY_PRODUCT_ID is missing (now optional)', () => {
     stubFullEnv();
     vi.stubEnv('POLAR_BUSINESS_MONTHLY_PRODUCT_ID', '');
-    expect(() => validatePolarEnv()).toThrow(/POLAR_BUSINESS_MONTHLY_PRODUCT_ID/);
+    expect(() => validatePolarEnv()).not.toThrow();
   });
 
-  it('throws when POLAR_BUSINESS_ANNUAL_PRODUCT_ID is missing', () => {
+  it('does NOT throw when POLAR_BUSINESS_ANNUAL_PRODUCT_ID is missing (now optional)', () => {
     stubFullEnv();
     vi.stubEnv('POLAR_BUSINESS_ANNUAL_PRODUCT_ID', '');
-    expect(() => validatePolarEnv()).toThrow(/POLAR_BUSINESS_ANNUAL_PRODUCT_ID/);
+    expect(() => validatePolarEnv()).not.toThrow();
   });
 
-  it('throws when all vars are unset', () => {
-    // No stubFullEnv() call — all undefined
-    expect(() => validatePolarEnv()).toThrow();
+  it('throws when both required vars are unset', () => {
+    // No stubFullEnv() — only ACCESS_TOKEN + WEBHOOK_SECRET being missing should still throw
+    expect(() => validatePolarEnv()).toThrow(/POLAR_ACCESS_TOKEN|POLAR_WEBHOOK_SECRET/);
   });
 
-  it('includes the missing var names in the error message (not the values)', () => {
+  it('includes the missing required var names in the error message (not the values)', () => {
     stubFullEnv();
-    vi.stubEnv('POLAR_TEAM_ANNUAL_PRODUCT_ID', '');
+    vi.stubEnv('POLAR_ACCESS_TOKEN', '');
 
     let errorMessage = '';
     try {
@@ -100,8 +132,8 @@ describe('validatePolarEnv()', () => {
       errorMessage = (e as Error).message;
     }
 
-    // Must include the var name
-    expect(errorMessage).toContain('POLAR_TEAM_ANNUAL_PRODUCT_ID');
+    // Must include the missing required var name
+    expect(errorMessage).toContain('POLAR_ACCESS_TOKEN');
     // Must NOT include any secret values
     expect(errorMessage).not.toContain('pat_test_abc');
     expect(errorMessage).not.toContain('whsec_test_xyz');
@@ -158,8 +190,12 @@ describe('validatePolarEnv() rethrow contract (simulates non-test module scope)'
   }
 
   it('swallows the error in the test branch (test isolation)', () => {
-    // All env vars missing — validatePolarEnv() will throw.
-    // The test-mode branch should swallow and return the error, not propagate it.
+    // Required vars missing → validatePolarEnv() will throw.
+    // Stub a partial env (Team/Business absent — those are now optional)
+    // and clear the required ACCESS_TOKEN to force the throw.
+    stubFullEnv();
+    vi.stubEnv('POLAR_ACCESS_TOKEN', '');
+    // The test-mode branch should swallow and return the error, not propagate.
     const swallowed = runWithRethrowSuppressed();
     expect(swallowed).not.toBeNull();
     expect(swallowed).toBeInstanceOf(Error);
@@ -167,7 +203,9 @@ describe('validatePolarEnv() rethrow contract (simulates non-test module scope)'
   });
 
   it('rethrows the error in the prod/dev branch (cold-start must fail loudly)', () => {
-    // All env vars missing — validatePolarEnv() will throw.
+    // Same setup: clear a REQUIRED var so validatePolarEnv() throws.
+    stubFullEnv();
+    vi.stubEnv('POLAR_WEBHOOK_SECRET', '');
     // The prod/dev branch must rethrow so deploy-time health checks catch it.
     expect(() => runWithRethrowEnabled()).toThrow(/missing or blank/);
   });
@@ -252,11 +290,14 @@ describe('NEXT_PHASE build-time gate (simulates route.ts module-scope wrapper)',
   });
 
   it('calls validatePolarEnv and rethrows when NEXT_PHASE is undefined and NODE_ENV is not test', () => {
-    // WHY: In production (no NEXT_PHASE, no NODE_ENV=test), a missing env var
-    // must cause the cold-start to fail loudly. The gate is inactive (NEXT_PHASE
-    // not set), and the rethrow path is active (nodeEnvIsTest = false).
+    // WHY: In production (no NEXT_PHASE, no NODE_ENV=test), a missing REQUIRED
+    // env var must cause the cold-start to fail loudly. The gate is inactive
+    // (NEXT_PHASE not set), and the rethrow path is active (nodeEnvIsTest = false).
+    // Need to clear a REQUIRED var explicitly post-2026-05-05 — Team/Business
+    // are now optional and missing them no longer triggers a throw.
     vi.stubEnv('NEXT_PHASE', ''); // unset — gate inactive
-    // All env vars absent — validatePolarEnv() will throw.
+    stubFullEnv();
+    vi.stubEnv('POLAR_ACCESS_TOKEN', ''); // force the throw
     expect(() => runGatedValidation(false)).toThrow(/missing or blank/);
   });
 

--- a/packages/styrby-web/src/lib/polar-env.ts
+++ b/packages/styrby-web/src/lib/polar-env.ts
@@ -92,13 +92,21 @@ export type BillingCycle = 'monthly' | 'annual';
  * process.env values on Vercel are already trimmed. We use getEnv()
  * only in getPolarProductId() where we need the trimmed runtime value.
  */
+// WHY Team/Business optional (2026-05-05): the public pricing surface only
+// ships Pro + Growth. Team and Business product IDs are vestigial — required
+// by an earlier planned tier scheme that was never launched. Treating them
+// as required at cold-start blocks the entire webhook route from loading
+// when those env vars are absent (root cause of the Apr-28 → May-5 webhook
+// outage). The runtime resolver `resolvePolarProductId('team'|'business', ...)`
+// is the right place to fail loudly: it'll throw "Tier not available" only
+// when an actual team/business webhook event arrives, not on every cold-start.
 const PolarEnvSchema = z.object({
   POLAR_ACCESS_TOKEN: z.string().min(1),
   POLAR_WEBHOOK_SECRET: z.string().min(1),
-  POLAR_TEAM_MONTHLY_PRODUCT_ID: z.string().min(1),
-  POLAR_TEAM_ANNUAL_PRODUCT_ID: z.string().min(1),
-  POLAR_BUSINESS_MONTHLY_PRODUCT_ID: z.string().min(1),
-  POLAR_BUSINESS_ANNUAL_PRODUCT_ID: z.string().min(1),
+  POLAR_TEAM_MONTHLY_PRODUCT_ID: z.string().optional(),
+  POLAR_TEAM_ANNUAL_PRODUCT_ID: z.string().optional(),
+  POLAR_BUSINESS_MONTHLY_PRODUCT_ID: z.string().optional(),
+  POLAR_BUSINESS_ANNUAL_PRODUCT_ID: z.string().optional(),
 });
 
 // ============================================================================


### PR DESCRIPTION
## URGENT: Polar webhook silence root cause

OPS-6 polar-webhook-health monitor (shipped in #258) fired the alert this morning. Investigation found a **7-day Polar webhook outage since 2026-04-28** caused by **two compounding bugs**.

## Root cause

| # | Bug | Where | Status |
|---|---|---|---|
| 1 | Polar webhook URL pointed to apex (\`styrbyapp.com\`) which 307-redirects to \`www.\`. Polar webhook delivery doesn't follow redirects on POST. | Polar dashboard config | **Already fixed via Polar API** (modified_at 2026-05-05T19:07:42Z) |
| 2 | \`PolarEnvSchema\` required Team/Business product IDs that don't exist in Vercel prod env. Cold-start validation threw → route module failed to load → every request returned Next.js 500 HTML | \`packages/styrby-web/src/lib/polar-env.ts\` | **Fixed in this PR** |
| 3 (context) | Team/Business tiers were planned but never launched (only Pro + Growth shipped publicly). Schema inherited a vestigial requirement. | n/a | Documented inline |

## Why both bugs together explain the silence

Even after I fixed bug 1 (Polar URL → www.), webhooks still couldn't process because the route module crashes at cold-start (bug 2). Real Polar events arrive → route module crash → 500 → Polar retries → exhausts → gives up.

After this PR ships, the route module will load successfully, and the URL fix from this morning will take full effect.

## Schema change

4 fields go from \`.min(1)\` to \`.optional()\`. The runtime resolver \`resolvePolarProductId('team'|'business', ...)\` is the right place to fail loudly — it'll throw "Tier not available" only when an actual team/business webhook arrives, not on every cold-start.

## Pre-push checklist (all GREEN locally)

- [x] typecheck clean
- [x] lint 0 errors (95 pre-existing warnings, none new)
- [x] build PASS (Next.js production build)
- [x] tests 66/66 pass on src/lib/polar-env + src/app/api/webhooks/polar

## Post-deploy verification

- [ ] POST to https://www.styrbyapp.com/api/webhooks/polar with fake signature → HTTP 401 JSON (not 500 HTML)
- [ ] polar-webhook-events table gets a new row when next real Polar event lands
- [ ] polar-webhook-health cron stops alerting within 1h after first new event

🤖 Shipped via /gh-ship — pipeline will verify post-deploy.