### PR TITLE
fix(cron): make OR /credits failure non-fatal in credit-monitor (same root cause as #259)

### DIFF
--- a/packages/styrby-web/src/app/api/cron/openrouter-credit-monitor/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/cron/openrouter-credit-monitor/__tests__/route.test.ts
@@ -299,19 +299,26 @@ describe('GET /api/cron/openrouter-credit-monitor', () => {
     expect(auditInserts[0].action).toBe('openrouter_credit_check');
   });
 
-  it('/credits failure: returns 502 and audit row tags endpoint=credits', async () => {
+  it('/credits failure: continues with /auth/key data only (200, not 502)', async () => {
+    // CONTRACT (updated 2026-05-05): /credits requires a "management"
+    // (provisioning) key. The runtime OPENROUTER_API_KEY in env is
+    // forbidden from /credits with 403 'Only management keys can fetch
+    // credits'. The cap-based alert decision uses /auth/key data only,
+    // so /credits failure is logged + skipped, NOT fatal.
     mockOpenRouter(
-      { ok: false, status: 503, bodyText: 'service unavailable' },
+      { ok: false, status: 403, bodyText: 'Only management keys can fetch credits' },
       { ok: true, body: { data: { limit: 50, limit_remaining: 40, usage_monthly: 10 } } }
     );
 
     const res = await GET(makeRequest());
-    expect(res.status).toBe(502);
+    // Above threshold ($40 remaining, default $20 threshold) → no alert,
+    // happy 200 with check audit row only.
+    expect(res.status).toBe(200);
     expect(mockSendEmail).not.toHaveBeenCalled();
     expect(auditInserts).toHaveLength(1);
     const meta = auditInserts[0].metadata as Record<string, unknown>;
-    expect(meta.ok).toBe(false);
-    expect(meta.endpoint).toBe('credits');
+    expect(meta.ok).toBe(true);
+    expect(meta.endpoint).toBeUndefined(); // no failure endpoint tagged
   });
 
   it('/auth/key failure: returns 502 and audit row tags endpoint=auth/key', async () => {

--- a/packages/styrby-web/src/app/api/cron/openrouter-credit-monitor/route.ts
+++ b/packages/styrby-web/src/app/api/cron/openrouter-credit-monitor/route.ts
@@ -172,32 +172,47 @@ export async function GET(request: NextRequest) {
       }),
     ]);
 
-    if (!creditsRes.ok || !authKeyRes.ok) {
-      const failing = !creditsRes.ok ? creditsRes : authKeyRes;
-      const which = !creditsRes.ok ? 'credits' : 'auth/key';
-      const text = await failing.text().catch(() => '');
+    // /auth/key is REQUIRED — it carries the cap + cycle metrics that the
+    // alert decision is built on. A failure here is fatal.
+    if (!authKeyRes.ok) {
+      const text = await authKeyRes.text().catch(() => '');
       console.error(
-        '[openrouter-credit-monitor] OpenRouter API failed:',
-        which,
-        failing.status,
+        '[openrouter-credit-monitor] /auth/key failed:',
+        authKeyRes.status,
         text
       );
       await supabase.from('audit_log').insert({
         action: 'openrouter_credit_check',
         metadata: {
           ok: false,
-          endpoint: which,
-          status: failing.status,
+          endpoint: 'auth/key',
+          status: authKeyRes.status,
           error: text.slice(0, 500),
         },
       });
       return NextResponse.json(
-        { error: 'OpenRouter API failed', endpoint: which, status: failing.status },
+        { error: 'OpenRouter API failed', endpoint: 'auth/key', status: authKeyRes.status },
         { status: 502 }
       );
     }
 
-    creditsBody = (await creditsRes.json()) as OpenRouterCreditsResponse;
+    // /credits is OPTIONAL — it requires a "management" (provisioning) key.
+    // Our runtime OPENROUTER_API_KEY only has scope for chat/completions, so
+    // /credits returns 403 'Only management keys can fetch credits'. Lifetime
+    // totals (total_credits, total_usage) are informational; the cap-based
+    // alert decision uses /auth/key data, which works with the runtime key.
+    // Caught 2026-05-05 same root cause as the /api/health fix in PR #259.
+    if (!creditsRes.ok) {
+      const text = await creditsRes.text().catch(() => '');
+      console.warn(
+        '[openrouter-credit-monitor] /credits unavailable (likely runtime key without management scope) — continuing with /auth/key data only:',
+        creditsRes.status,
+        text.slice(0, 200)
+      );
+      creditsBody = { data: { total_credits: 0, total_usage: 0 } };
+    } else {
+      creditsBody = (await creditsRes.json()) as OpenRouterCreditsResponse;
+    }
     authKeyBody = (await authKeyRes.json()) as OpenRouterAuthKeyResponse;
   } catch (err) {
     console.error('[openrouter-credit-monitor] fetch threw:', err);


### PR DESCRIPTION
## Summary
Followup to PR #259 — same OpenRouter /credits permissions issue, this time in the credit-monitor cron. Caught proactively before the 7am Central tomorrow run would have sent a 502 alert email.

## Root cause (recap)
GET /api/v1/credits requires a "management" (provisioning) key. Our \`OPENROUTER_API_KEY\` is a runtime key (correct for chat/completions, the actual product use), so /credits returns 403 'Only management keys can fetch credits for an account'.

## Fix
- /auth/key failure → still fatal (502, load-bearing data for cap-based alert decision)
- /credits failure → log warning + continue with empty lifetime totals (informational only; cap-based alert uses /auth/key)

Inline WHY comment documents the 2026-05-05 same-root-cause pattern (this + PR #259's /api/health fix).

## Test update
\`/credits failure: returns 502\` → \`/credits failure: continues with /auth/key data only (200, not 502)\`. Asserts the new contract.

## Test plan
- [x] typecheck clean
- [x] lint 0 errors (95 pre-existing warnings)
- [x] build PASS
- [x] credit-monitor tests 12/12 pass
- [ ] First cron tick at 7am Central tomorrow (or next manual trigger) — expect 200 + audit row, no false-positive alert email

🤖 Shipped via /gh-ship