### PR TITLE
clean(cli): add CostReportMessage to AgentMessage union, drop 8 `as any`

### DIFF
--- a/packages/styrby-cli/src/agent/core/AgentBackend.ts
+++ b/packages/styrby-cli/src/agent/core/AgentBackend.ts
@@ -36,6 +36,13 @@ export type AgentMessage =
   | { type: 'exec-approval-request'; call_id: string; [key: string]: unknown } // Exec approval request (like Codex exec_approval_request)
   | { type: 'patch-apply-begin'; call_id: string; auto_approved?: boolean; changes: Record<string, unknown> } // Patch operation begin (like Codex patch_apply_begin)
   | { type: 'patch-apply-end'; call_id: string; stdout?: string; stderr?: string; success: boolean } // Patch operation end (like Codex patch_apply_end)
+  // Cost report emitted by every agent factory after a model call completes.
+  // The `report` field is a CostReport from `@styrby/shared/cost`, kept loose
+  // here (`unknown`) to avoid pulling the shared package into this universal
+  // type — the cost-reporter validates with `CostReportSchema.safeParse()`.
+  // Adding this variant eliminated the `as any` cast at every emit site
+  // (8 agent factories: aider/amp/crush/droid/goose/kilo/kiro/opencode).
+  | { type: 'cost-report'; report: unknown }
 
 /** MCP server configuration for tools */
 export interface McpServerConfig {

--- a/packages/styrby-cli/src/agent/core/AgentMessage.ts
+++ b/packages/styrby-cli/src/agent/core/AgentMessage.ts
@@ -149,6 +149,26 @@ export interface PatchApplyEndMessage {
 }
 
 /**
+ * Cost report emitted by an agent backend after a model call completes.
+ *
+ * WHY this lives in the AgentMessage union: every agent factory
+ * (claude/codex/gemini/opencode/aider/goose/amp/crush/kilo/kiro/droid)
+ * emits this same shape on each turn so the cost-reporter can persist a
+ * unified row to `cost_records`. Adding it to the union eliminates the
+ * `as any` cast that was previously required at every emit site.
+ *
+ * The `report` field is a `CostReport` from `@styrby/shared/cost`, but
+ * the type is kept loose here (`unknown`) to avoid pulling the shared
+ * package into the universal-message graph — the cost-reporter parses
+ * + validates with `CostReportSchema.safeParse()` at the consumer end.
+ */
+export interface CostReportMessage {
+  type: 'cost-report';
+  /** Validated against `CostReportSchema` from `@styrby/shared/cost` at the consumer. */
+  report: unknown;
+}
+
+/**
  * Union type of all agent messages.
  *
  * These messages are emitted by agent backends and forwarded
@@ -167,7 +187,8 @@ export type AgentMessage =
   | TokenCountMessage
   | ExecApprovalRequestMessage
   | PatchApplyBeginMessage
-  | PatchApplyEndMessage;
+  | PatchApplyEndMessage
+  | CostReportMessage;
 
 /**
  * Handler function type for agent messages

--- a/packages/styrby-cli/src/agent/factories/aider.ts
+++ b/packages/styrby-cli/src/agent/factories/aider.ts
@@ -409,7 +409,7 @@ class AiderBackend extends StreamingAgentBackendBase {
           });
 
           // Emit unified CostReport for the cost-reporter to persist.
-          this.emit({ type: 'cost-report', report: costReport } as any);
+          this.emit({ type: 'cost-report', report: costReport });
 
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });

--- a/packages/styrby-cli/src/agent/factories/amp.ts
+++ b/packages/styrby-cli/src/agent/factories/amp.ts
@@ -396,7 +396,7 @@ class AmpBackend extends StreamingAgentBackendBase {
             cacheWriteTokens: incrCacheWrite,
             rawAgentPayload: rawPayload,
           };
-          this.emit({ type: 'cost-report', report: costReport } as any);
+          this.emit({ type: 'cost-report', report: costReport });
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/crush.ts
+++ b/packages/styrby-cli/src/agent/factories/crush.ts
@@ -340,7 +340,7 @@ class CrushBackend extends StreamingAgentBackendBase {
             cacheWriteTokens: incrCacheWrite,
             rawAgentPayload: event.usage as unknown as Record<string, unknown>,
           };
-          this.emit({ type: 'cost-report', report: costReport } as any);
+          this.emit({ type: 'cost-report', report: costReport });
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/droid.ts
+++ b/packages/styrby-cli/src/agent/factories/droid.ts
@@ -465,7 +465,7 @@ class DroidBackend extends StreamingAgentBackendBase {
             cacheWriteTokens: newCacheWrite,
             rawAgentPayload: hasAgentCost ? (msg.usage as unknown as Record<string, unknown>) : null,
           };
-          this.emit({ type: 'cost-report', report: costReport } as any);
+          this.emit({ type: 'cost-report', report: costReport });
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/goose.ts
+++ b/packages/styrby-cli/src/agent/factories/goose.ts
@@ -313,7 +313,7 @@ class GooseBackend extends StreamingAgentBackendBase {
             cacheWriteTokens: event.usage.cache_creation_input_tokens ?? 0,
             rawAgentPayload: hasAgentCost ? (event.usage as unknown as Record<string, unknown>) : null,
           };
-          this.emit({ type: 'cost-report', report: costReport } as any);
+          this.emit({ type: 'cost-report', report: costReport });
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/kilo.ts
+++ b/packages/styrby-cli/src/agent/factories/kilo.ts
@@ -474,7 +474,7 @@ class KiloBackend extends StreamingAgentBackendBase {
             cacheWriteTokens: incrCacheWrite,
             rawAgentPayload: hasAgentCost ? (msg.usage as unknown as Record<string, unknown>) : null,
           };
-          this.emit({ type: 'cost-report', report: costReport } as any);
+          this.emit({ type: 'cost-report', report: costReport });
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/kiro.ts
+++ b/packages/styrby-cli/src/agent/factories/kiro.ts
@@ -352,7 +352,7 @@ class KiroBackend extends StreamingAgentBackendBase {
             },
             rawAgentPayload: event.usage as unknown as Record<string, unknown>,
           };
-          this.emit({ type: 'cost-report', report: costReport } as any);
+          this.emit({ type: 'cost-report', report: costReport });
         }
         break;
 

--- a/packages/styrby-cli/src/agent/factories/opencode.ts
+++ b/packages/styrby-cli/src/agent/factories/opencode.ts
@@ -271,7 +271,7 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
               cacheWriteTokens: 0,
               rawAgentPayload: session as unknown as Record<string, unknown>,
             };
-            this.emit({ type: 'cost-report', report: costReport } as any);
+            this.emit({ type: 'cost-report', report: costReport });
           }
         }
         break;


### PR DESCRIPTION
## Summary

Type-safety win: extends the `AgentMessage` union to include
`{ type: 'cost-report'; report: unknown }`, eliminating the `as any` cast
that was previously required at every cost-report emit site across 8 agent
factories.

## Why this exists

Every agent factory (aider, amp, crush, droid, goose, kilo, kiro, opencode)
contained the same line:
```ts
this.emit({ type: 'cost-report', report: costReport } as any);
```
The `as any` was needed because `'cost-report'` wasn't in the
`AgentMessage` union's discriminator. Same pattern × 8 files = same
architectural fix in one place: extend the union, drop all 8 casts.

WHY `report: unknown` (not the actual `CostReport` type): keeps this
universal-message type free of the `@styrby/shared/cost` import. The
cost-reporter consumer parses + validates with
`CostReportSchema.safeParse()` at the boundary — the right place for
runtime validation. Two consumers (e2e tests + agentSmokeTests) already
type-narrow at the consumption site.

## Changes

- `src/agent/core/AgentBackend.ts` — added `'cost-report'` variant to runtime union
- `src/agent/core/AgentMessage.ts` — same on the exported public type
- 8 factories — removed `as any` from the emit call

## Net `as any` count in production code

- Before: ~32 instances
- After: 26 instances
- Removed: 8 (all 8 agent factories — same shared pattern)

Remaining `as any` in production (filed for follow-up B2 PRs):
- `gemini/messageHandler.ts` (10) — different shape, needs separate analysis
- `claudeRemoteLauncher.ts` (2), `agent/acp/sessionUpdateHandlers.ts` (2),
  `utils/runtime.ts` (2)
- 8 single-instance files (each needs targeted look)

## Test results

- Full suite: **2694 passing**, 2 skipped, 0 failed
- Typecheck: clean

🤖 Shipped via /gh-ship