### PR TITLE
clean(cli): drop 6 more `as any` across 3 files (B2 batch 2)

### DIFF
--- a/packages/styrby-cli/src/agent/acp/sessionUpdateHandlers.ts
+++ b/packages/styrby-cli/src/agent/acp/sessionUpdateHandlers.ts
@@ -732,16 +732,19 @@ export function handleGeminiUsageMetadata(
   );
 
   // Emit legacy token-count (keep for existing consumers).
+  // The 'token-count' AgentMessage variant has `[key: string]: unknown`,
+  // which permits extra fields like inputTokens / outputTokens / etc.
   ctx.emit({
     type: 'token-count',
     inputTokens,
     outputTokens,
     cacheReadTokens,
     estimatedCostUsd: costUsd,
-  } as any);
+  });
 
-  // Emit unified CostReport.
-  ctx.emit({ type: 'cost-report', report: costReport } as any);
+  // Emit unified CostReport (CostReportMessage variant added to AgentMessage
+  // union in PR #266 — no `as any` needed).
+  ctx.emit({ type: 'cost-report', report: costReport });
 
   return { handled: true };
 }

--- a/packages/styrby-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/styrby-cli/src/claude/claudeRemoteLauncher.ts
@@ -276,8 +276,17 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
             let umessage = message as SDKAssistantMessage;
             if (umessage.message.content && Array.isArray(umessage.message.content)) {
                 for (let c of umessage.message.content) {
-                    if (c.type === 'tool_use' && c.name === 'Task' && c.input && typeof (c.input as any).prompt === 'string') {
-                        const logMessage2 = sdkToLogConverter.convertSidechainUserMessage(c.id!, (c.input as any).prompt);
+                    // c.input is typed as `unknown` by the SDK; narrow once
+                    // and reach for `prompt` defensively to avoid runtime crash
+                    // when upstream sends a non-object input shape.
+                    const inputObj = (c.input && typeof c.input === 'object')
+                        ? (c.input as Record<string, unknown>)
+                        : null;
+                    const taskPrompt = (inputObj && typeof inputObj.prompt === 'string')
+                        ? inputObj.prompt
+                        : null;
+                    if (c.type === 'tool_use' && c.name === 'Task' && taskPrompt !== null) {
+                        const logMessage2 = sdkToLogConverter.convertSidechainUserMessage(c.id!, taskPrompt);
                         if (logMessage2) {
                             messageQueue.enqueue(logMessage2);
                         }

--- a/packages/styrby-cli/src/utils/runtime.ts
+++ b/packages/styrby-cli/src/utils/runtime.ts
@@ -17,12 +17,12 @@ export function getRuntime(): Runtime {
     if (cachedRuntime) return cachedRuntime;
 
     // Method 1: Global runtime objects (most reliable)
-    if (typeof (globalThis as any).Bun !== 'undefined') {
+    if ('Bun' in globalThis) {
         cachedRuntime = 'bun';
         return cachedRuntime;
     }
 
-    if (typeof (globalThis as any).Deno !== 'undefined') {
+    if ('Deno' in globalThis) {
         cachedRuntime = 'deno';
         return cachedRuntime;
     }


### PR DESCRIPTION
## Summary

B2 batch 2. Closes the next-best `as any` cluster: 3 files × 2 instances each = 6 removals.

| File | Pattern fixed |
|------|---------------|
| `utils/runtime.ts` | Replaced `typeof (globalThis as any).Bun !== 'undefined'` with `'Bun' in globalThis` (+ same for Deno) |
| `claude/claudeRemoteLauncher.ts` | SDK input `unknown` → proper `typeof === 'object'` + `Record<string, unknown>` narrowing + `typeof === 'string'` on `.prompt`. Defends runtime crash on non-object input. |
| `agent/acp/sessionUpdateHandlers.ts` | Both `ctx.emit({type: 'cost-report'} as any)` and `ctx.emit({type: 'token-count', ...} as any)` — both gratuitous (CostReportMessage in union since #266; token-count variant has `[key: string]: unknown` index sig) |

## Net production `as any` count: 32 → 26 → 17 → **11** today

Remaining 11 are single instances across 9 files; no batched cluster left.

## Test results

- Typecheck: clean
- Full suite: 2753 passing (no regressions; the 2 perf-test failures under load are pre-existing — measurement noise from execSync under parallel load, see vitest.config.ts comment)

🤖 Shipped via /gh-ship