### PR TITLE
test(cli): extract + test costs.ts formatters (+10 tests)

### DIFF
--- a/packages/styrby-cli/src/cli/handlers/__tests__/costs-helpers.test.ts
+++ b/packages/styrby-cli/src/cli/handlers/__tests__/costs-helpers.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for cli/handlers/costs-helpers.ts.
+ *
+ * Coverage target: 0% → 100% on the 2 exported pure functions.
+ *
+ * @module cli/handlers/__tests__/costs-helpers
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatTokens, formatCost } from '@/cli/handlers/costs-helpers';
+
+describe('formatTokens', () => {
+  it('formats sub-thousand counts as integer strings', () => {
+    expect(formatTokens(0)).toBe('0');
+    expect(formatTokens(1)).toBe('1');
+    expect(formatTokens(42)).toBe('42');
+    expect(formatTokens(999)).toBe('999');
+  });
+
+  it('formats thousand-range counts with 1 decimal + K suffix', () => {
+    expect(formatTokens(1_000)).toBe('1.0K');
+    expect(formatTokens(1_234)).toBe('1.2K');
+    expect(formatTokens(12_500)).toBe('12.5K');
+    expect(formatTokens(999_999)).toBe('1000.0K'); // edge: just-under-1M still K
+  });
+
+  it('formats million-range counts with 2 decimals + M suffix', () => {
+    expect(formatTokens(1_000_000)).toBe('1.00M');
+    expect(formatTokens(1_500_000)).toBe('1.50M');
+    expect(formatTokens(42_345_678)).toBe('42.35M');
+  });
+
+  it('boundary: exactly 1000 picks K branch', () => {
+    expect(formatTokens(1000)).toBe('1.0K');
+  });
+
+  it('boundary: exactly 1_000_000 picks M branch', () => {
+    expect(formatTokens(1_000_000)).toBe('1.00M');
+  });
+});
+
+describe('formatCost', () => {
+  it('formats zero as $0.0000', () => {
+    expect(formatCost(0)).toBe('$0.0000');
+  });
+
+  it('formats sub-cent costs with 4 decimals', () => {
+    expect(formatCost(0.0001)).toBe('$0.0001');
+    expect(formatCost(0.00123)).toBe('$0.0012'); // rounds (banker's)
+  });
+
+  it('formats normal costs preserving precision', () => {
+    expect(formatCost(1.2345)).toBe('$1.2345');
+    expect(formatCost(0.5)).toBe('$0.5000');
+  });
+
+  it('formats large costs with 4 decimals', () => {
+    expect(formatCost(42.5)).toBe('$42.5000');
+    expect(formatCost(1234.567)).toBe('$1234.5670');
+  });
+
+  it('rounds to 4 decimals (does not truncate)', () => {
+    // 0.00125 with toFixed(4) rounds to "0.0013" (banker's rounding may
+    // produce 0.0012 or 0.0013 depending on host — assert it's one of those)
+    const result = formatCost(0.00125);
+    expect(['$0.0012', '$0.0013']).toContain(result);
+  });
+});

--- a/packages/styrby-cli/src/cli/handlers/costs-helpers.ts
+++ b/packages/styrby-cli/src/cli/handlers/costs-helpers.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure formatting helpers for the `styrby costs` command.
+ *
+ * Extracted from cli/handlers/costs.ts so they can be unit-tested without
+ * standing up the full handler (which dynamically imports the cost
+ * aggregation lib + writes to console).
+ *
+ * NOTE: there are sibling formatters in `ui/welcome.ts` (smaller — only
+ * handles K-scale, not M-scale) and `commands/cloud.ts` (chalk-colored,
+ * null-tolerant). They should be consolidated to use these helpers in a
+ * follow-up dedup PR; this file is the canonical M-scale token formatter
+ * and 4-decimal-USD formatter.
+ *
+ * @module cli/handlers/costs-helpers
+ */
+
+/**
+ * Format a token count for human-readable display.
+ *
+ * - Counts ≥ 1,000,000 → "X.YYM" (millions, 2 decimal places)
+ * - Counts ≥ 1,000     → "X.YK"  (thousands, 1 decimal place)
+ * - Counts < 1,000     → exact integer string
+ *
+ * @param n - The token count (must be a non-negative integer; behavior
+ *            is unspecified for negatives or fractions but won't throw).
+ * @returns Formatted string suitable for terminal output.
+ *
+ * @example
+ * formatTokens(0);          // "0"
+ * formatTokens(999);        // "999"
+ * formatTokens(1234);       // "1.2K"
+ * formatTokens(1_500_000);  // "1.50M"
+ */
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toString();
+}
+
+/**
+ * Format a cost in USD to 4 decimal places with a leading dollar sign.
+ *
+ * Why 4 decimals: token-level costs are often in the $0.0042 range; with
+ * 2 decimals everything would round to $0.00 and the dashboard would be
+ * useless.
+ *
+ * @param n - The cost in USD as a number (can be 0).
+ * @returns Formatted string like "$0.0042".
+ *
+ * @example
+ * formatCost(0);        // "$0.0000"
+ * formatCost(0.00123);  // "$0.0012"
+ * formatCost(42.5);     // "$42.5000"
+ */
+export function formatCost(n: number): string {
+  return `$${n.toFixed(4)}`;
+}

--- a/packages/styrby-cli/src/cli/handlers/costs.ts
+++ b/packages/styrby-cli/src/cli/handlers/costs.ts
@@ -6,6 +6,8 @@
  * @module cli/handlers/costs
  */
 
+import { formatTokens, formatCost } from '@/cli/handlers/costs-helpers';
+
 /**
  * Handle the `styrby costs` command.
  *
@@ -30,14 +32,9 @@ export async function handleCosts(args: string[]): Promise<void> {
     summary = await aggregateCosts();
   }
 
-  // Format numbers
-  const formatTokens = (n: number): string => {
-    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
-    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-    return n.toString();
-  };
-
-  const formatCost = (n: number): string => `$${n.toFixed(4)}`;
+  // formatTokens + formatCost imported from sibling costs-helpers (extracted
+  // 2026-05-05 so they could be unit-tested independently of this I/O-heavy
+  // handler). See cli/handlers/__tests__/costs-helpers.test.ts.
 
   // Print summary
   console.log(`\n📊 Cost Summary (${periodLabel})`);


### PR DESCRIPTION
## Summary

Third C2 PR. Extracts `formatTokens` + `formatCost` from `cli/handlers/costs.ts` into `costs-helpers.ts`, adds 10 unit tests.

## Coverage

- `costs-helpers.ts`: 0% → 100%
- Tests cover: sub-1K, 1K, 1M boundaries; precision edge cases for cost formatter

## Discovered duplication (NOT fixed in this PR)

Three different `formatTokens` and two different `formatCost` definitions exist across the codebase (`costs.ts`, `ui/welcome.ts`, `commands/cloud.ts`). They differ in scale (K-only vs K+M) and color/null-tolerance. Filed as follow-up — consolidating now would change `welcome.ts`'s display when token counts cross 1M, which is technically an upgrade but worth a separate intentional change.

## Test results

- This file: 10/10 passing
- Typecheck: clean

🤖 Shipped via /gh-ship