### PR TITLE
refactor+test(cli): extract relay-dispatch decision logic + 23 tests

### DIFF
--- a/packages/styrby-cli/src/api/__tests__/relayMessageDispatch.test.ts
+++ b/packages/styrby-cli/src/api/__tests__/relayMessageDispatch.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the pure relay-message classifier (security-critical).
+ *
+ * Coverage target: 0% → ~100% on classifyRelayMessage.
+ *
+ * SECURITY: this classifier is the gate between mobile-sent messages and
+ * the agent's tool-execution + sendPrompt surface. Bugs here are either
+ * silent message loss (UX) OR — in the case of the nonce check —
+ * compromised-account-key bypass of the approval gate (RCE-class).
+ *
+ * Test categories match the classifier's decision sequence:
+ *   1. Schema validation (CLI-008)
+ *   2. Nonce verification on permission_response (CLI-009)
+ *   3. Cross-session protection on chat
+ *   4. Type-specific routing for chat / permission-response / command
+ *   5. Unhandled-type / unhandled-command catch-alls
+ *
+ * @module api/__tests__/relayMessageDispatch
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { classifyRelayMessage, type NonceVerifier } from '@/api/relayMessageDispatch';
+
+const SESSION_ID = 'session-abc';
+
+/** Always-true nonce verifier. Used in tests that don't focus on the nonce gate. */
+const ALWAYS_OK: NonceVerifier = () => true;
+/** Always-false nonce verifier — simulates a forged nonce. */
+const ALWAYS_REJECT: NonceVerifier = () => false;
+
+/** Required base fields that every relay message has per styrby-shared schema. */
+const BASE = {
+  id: 'msg-1',
+  timestamp: '2026-05-05T20:00:00Z',
+  sender_device_id: 'device-mobile-1',
+  sender_type: 'mobile' as const,
+};
+
+/** Build a valid chat message with the given payload overrides. */
+function chat(payload: { content: string; agent?: string; session_id?: string }) {
+  return {
+    ...BASE,
+    type: 'chat' as const,
+    payload: { agent: 'claude', ...payload },
+  };
+}
+
+/** Build a valid permission_response with the given payload overrides. */
+function permResponse(payload: { request_id: string; request_nonce: string; approved: boolean; agent?: string }) {
+  return {
+    ...BASE,
+    type: 'permission_response' as const,
+    payload: { agent: 'claude', ...payload },
+  };
+}
+
+/** Build a valid command message. */
+function command(action: string, agent?: string) {
+  return {
+    ...BASE,
+    type: 'command' as const,
+    payload: { agent: agent ?? 'claude', action },
+  };
+}
+
+describe('classifyRelayMessage: schema validation (CLI-008)', () => {
+  it('drops a non-object payload', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, 'just a string', ALWAYS_OK);
+    expect(verdict.action).toBe('drop-schema-invalid');
+  });
+
+  it('drops a payload missing required `type` discriminator', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, { ...BASE, payload: { content: 'hi' } }, ALWAYS_OK);
+    expect(verdict.action).toBe('drop-schema-invalid');
+  });
+
+  it('drops a payload with unknown `type` value', () => {
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      { ...BASE, type: 'bogus-type', payload: { content: 'x' } },
+      ALWAYS_OK,
+    );
+    expect(verdict.action).toBe('drop-schema-invalid');
+  });
+
+  it('drops a chat with non-string content', () => {
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      { ...BASE, type: 'chat', payload: { content: 12345, agent: 'claude' } },
+      ALWAYS_OK,
+    );
+    expect(verdict.action).toBe('drop-schema-invalid');
+  });
+
+  it('drops a chat missing required base fields (id/timestamp/etc)', () => {
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      { type: 'chat', payload: { content: 'hi', agent: 'claude' } },
+      ALWAYS_OK,
+    );
+    expect(verdict.action).toBe('drop-schema-invalid');
+  });
+
+  it('captures issues array (limited to 5) on schema-invalid', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, { type: 'chat' /* missing all */ }, ALWAYS_OK);
+    if (verdict.action !== 'drop-schema-invalid') throw new Error('expected schema invalid');
+    expect(verdict.issues).toBeDefined();
+    expect(Array.isArray(verdict.issues)).toBe(true);
+    expect(verdict.issues.length).toBeLessThanOrEqual(5);
+  });
+
+  it('preserves the original (unverified) `type` in the drop verdict for logging', () => {
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      { ...BASE, type: 'sneaky-type', payload: {} },
+      ALWAYS_OK,
+    );
+    if (verdict.action !== 'drop-schema-invalid') throw new Error('expected schema invalid');
+    expect(verdict.type).toBe('sneaky-type');
+  });
+});
+
+describe('classifyRelayMessage: nonce verification (CLI-009)', () => {
+  const validPermissionResponse = permResponse({ request_id: 'req-123', request_nonce: 'nonce-abc', approved: true });
+
+  it('drops permission_response when verifyNonce returns false', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, validPermissionResponse, ALWAYS_REJECT);
+    expect(verdict.action).toBe('drop-nonce-mismatch');
+    if (verdict.action === 'drop-nonce-mismatch') {
+      expect(verdict.requestId).toBe('req-123');
+    }
+  });
+
+  it('forwards permission_response when verifyNonce returns true', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, validPermissionResponse, ALWAYS_OK);
+    expect(verdict.action).toBe('permission-response');
+    if (verdict.action === 'permission-response') {
+      expect(verdict.requestId).toBe('req-123');
+      expect(verdict.approved).toBe(true);
+    }
+  });
+
+  it('CALLS verifyNonce with request_id + request_nonce (consumes the nonce)', () => {
+    const verifyMock = vi.fn(() => true);
+    classifyRelayMessage(SESSION_ID, validPermissionResponse, verifyMock);
+    expect(verifyMock).toHaveBeenCalledTimes(1);
+    expect(verifyMock).toHaveBeenCalledWith('req-123', 'nonce-abc');
+  });
+
+  it('does NOT call verifyNonce on chat messages', () => {
+    const verifyMock = vi.fn(() => true);
+    classifyRelayMessage(SESSION_ID, chat({ content: 'hi' }), verifyMock);
+    expect(verifyMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call verifyNonce on command messages', () => {
+    const verifyMock = vi.fn(() => true);
+    classifyRelayMessage(SESSION_ID, command('cancel'), verifyMock);
+    expect(verifyMock).not.toHaveBeenCalled();
+  });
+
+  it('passes denied=false through the verdict (only nonce gates the dispatch)', () => {
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      permResponse({ request_id: 'r', request_nonce: 'n', approved: false }),
+      ALWAYS_OK,
+    );
+    expect(verdict.action).toBe('permission-response');
+    if (verdict.action === 'permission-response') {
+      expect(verdict.approved).toBe(false);
+    }
+  });
+});
+
+describe('classifyRelayMessage: chat routing + cross-session protection', () => {
+  it('forwards chat with no session_id to the current session', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, chat({ content: 'hello agent' }), ALWAYS_OK);
+    expect(verdict.action).toBe('chat');
+    if (verdict.action === 'chat') {
+      expect(verdict.sessionId).toBe(SESSION_ID);
+      expect(verdict.content).toBe('hello agent');
+    }
+  });
+
+  it('forwards chat targeted at the current session_id', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, chat({ content: 'hi', session_id: SESSION_ID }), ALWAYS_OK);
+    expect(verdict.action).toBe('chat');
+  });
+
+  it('drops chat targeted at a different session_id', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, chat({ content: 'hi', session_id: 'session-other' }), ALWAYS_OK);
+    expect(verdict.action).toBe('drop-wrong-session');
+    if (verdict.action === 'drop-wrong-session') {
+      expect(verdict.targetSession).toBe('session-other');
+    }
+  });
+});
+
+describe('classifyRelayMessage: command routing', () => {
+  it('routes command:cancel to action=cancel', () => {
+    expect(classifyRelayMessage(SESSION_ID, command('cancel'), ALWAYS_OK).action).toBe('cancel');
+  });
+
+  it('routes command:interrupt to action=cancel (alias)', () => {
+    expect(classifyRelayMessage(SESSION_ID, command('interrupt'), ALWAYS_OK).action).toBe('cancel');
+  });
+
+  it('routes command:end_session to action=end-session', () => {
+    expect(classifyRelayMessage(SESSION_ID, command('end_session'), ALWAYS_OK).action).toBe('end-session');
+  });
+
+  it('routes command:ping to action=ping (no-op)', () => {
+    expect(classifyRelayMessage(SESSION_ID, command('ping'), ALWAYS_OK).action).toBe('ping');
+  });
+
+  it('drops unknown command actions with the action name preserved for logging', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, command('shutdown-everything'), ALWAYS_OK);
+    // Unknown action may either be schema-rejected (if schema enums actions)
+    // or fall through to drop-unhandled-command. Either is correct dropped
+    // behavior — assert it's NOT a forwarded action.
+    expect(verdict.action).toMatch(/drop-/);
+  });
+});
+
+describe('classifyRelayMessage: cancel/end-session carry the current session_id', () => {
+  it('cancel verdict carries sessionId', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, command('cancel'), ALWAYS_OK);
+    if (verdict.action !== 'cancel') throw new Error('expected cancel');
+    expect(verdict.sessionId).toBe(SESSION_ID);
+  });
+
+  it('end-session verdict carries sessionId', () => {
+    const verdict = classifyRelayMessage(SESSION_ID, command('end_session'), ALWAYS_OK);
+    if (verdict.action !== 'end-session') throw new Error('expected end-session');
+    expect(verdict.sessionId).toBe(SESSION_ID);
+  });
+});

--- a/packages/styrby-cli/src/api/apiSession.ts
+++ b/packages/styrby-cli/src/api/apiSession.ts
@@ -17,8 +17,8 @@ import type { ApiSession, ApiMessage, SessionUpdate } from './types';
 import type { StyrbyApi } from './api';
 import type { AgentBackend, AgentMessage, AgentMessageHandler } from '@/agent/core/AgentBackend';
 import type { RelayMessage, AgentType as SharedAgentType } from 'styrby-shared';
-import { RelayMessageSchema } from 'styrby-shared';
 import { logger } from '@/ui/logger';
+import { classifyRelayMessage } from './relayMessageDispatch';
 
 /**
  * Callback type for session updates (status changes, errors, completion).
@@ -397,62 +397,58 @@ export class ApiSessionManager {
     agentType: SharedAgentType,
     api: StyrbyApi
   ): void {
-    // SECURITY (CLI-008, audit 2026-05-04): Validate the relay payload with
-    // zod BEFORE acting on it. Without this, a malicious or buggy peer could
-    // blast oversized strings (memory DoS), inject unexpected types, or send
-    // fields the dispatch logic doesn't expect. The schema enforces hard
-    // length caps (MAX_CONTENT_LEN=100KB, MAX_ID_LEN=128, etc.) and
-    // discriminated-union shape per message type.
-    const parsed = RelayMessageSchema.safeParse(message);
-    if (!parsed.success) {
-      logger.warn('Dropping invalid relay message (schema validation failed)', {
-        sessionId,
-        type: (message as { type?: unknown })?.type,
-        issues: parsed.error.issues.slice(0, 5).map((i) => ({ path: i.path.join('.'), code: i.code })),
-      });
-      return;
-    }
-    message = parsed.data;
+    // SECURITY: classification (schema validation + nonce verify + routing)
+    // is delegated to the pure `classifyRelayMessage` helper. See
+    // `relayMessageDispatch.ts` for the full decision sequence + the
+    // CLI-008/CLI-009 audit context. Tests live in
+    // `__tests__/relayMessageDispatch.test.ts` (the helper is fully
+    // unit-tested in isolation; this method is pure dispatch on the
+    // returned verdict).
+    const verdict = classifyRelayMessage(
+      sessionId,
+      message,
+      (id, nonce) => api.verifyAndConsumePermissionNonce(id, nonce),
+    );
 
-    // SECURITY (CLI-009, audit 2026-05-04): Verify the echoed nonce on
-    // permission_response BEFORE forwarding to the agent. Closes the
-    // compromised-account-key -> approve-all -> RCE chain. An attacker with
-    // only the API key (no live mobile session) cannot fabricate a valid
-    // nonce, so the response is rejected.
-    if (message.type === 'permission_response') {
-      const { request_id, request_nonce } = message.payload;
-      const ok = api.verifyAndConsumePermissionNonce(request_id, request_nonce);
-      if (!ok) {
-        logger.warn('Rejecting permission_response: nonce mismatch or unknown request_id', {
+    switch (verdict.action) {
+      case 'drop-schema-invalid':
+        logger.warn('Dropping invalid relay message (schema validation failed)', {
           sessionId,
-          requestId: request_id,
+          type: verdict.type,
+          issues: verdict.issues.map((i) => ({ path: i.path.join('.'), code: i.code })),
         });
         return;
-      }
-    }
 
-    switch (message.type) {
-      case 'chat': {
-        const { content, session_id } = message.payload;
-
-        // Only process messages for this session (or no session specified)
-        if (session_id && session_id !== sessionId) {
-          logger.debug('Chat message for different session, ignoring', {
-            targetSession: session_id,
-            ourSession: sessionId,
-          });
-          return;
-        }
-
-        logger.debug('Relay chat received, forwarding to agent', {
+      case 'drop-nonce-mismatch':
+        logger.warn('Rejecting permission_response: nonce mismatch or unknown request_id', {
           sessionId,
-          contentLength: content.length,
+          requestId: verdict.requestId,
         });
+        return;
 
-        // Forward user message to agent
-        agent.sendPrompt(sessionId, content).catch((error) => {
+      case 'drop-wrong-session':
+        logger.debug('Chat message for different session, ignoring', {
+          targetSession: verdict.targetSession,
+          ourSession: sessionId,
+        });
+        return;
+
+      case 'drop-unhandled-command':
+        logger.debug('Unhandled relay command', { action: verdict.commandAction });
+        return;
+
+      case 'drop-unhandled-type':
+        logger.debug('Unhandled relay message type in bridge', { type: verdict.type });
+        return;
+
+      case 'chat':
+        logger.debug('Relay chat received, forwarding to agent', {
+          sessionId: verdict.sessionId,
+          contentLength: verdict.content.length,
+        });
+        agent.sendPrompt(verdict.sessionId, verdict.content).catch((error) => {
           logger.error('Failed to send prompt to agent', { error });
-          api.sendSessionState(sessionId, agentType, 'error', {
+          api.sendSessionState(verdict.sessionId, agentType, 'error', {
             error: {
               type: 'agent',
               message: error instanceof Error ? error.message : String(error),
@@ -460,54 +456,34 @@ export class ApiSessionManager {
             },
           }).catch(() => {});
         });
-        break;
-      }
+        return;
 
-      case 'permission_response': {
-        const { request_id, approved } = message.payload;
-        logger.debug('Relay permission response received', { requestId: request_id, approved });
-
+      case 'permission-response':
+        logger.debug('Relay permission response received', {
+          requestId: verdict.requestId,
+          approved: verdict.approved,
+        });
         if (agent.respondToPermission) {
-          agent.respondToPermission(request_id, approved).catch((error) => {
+          agent.respondToPermission(verdict.requestId, verdict.approved).catch((error) => {
             logger.debug('Error responding to permission', { error });
           });
         }
-        break;
-      }
+        return;
 
-      case 'command': {
-        const { action, params } = message.payload;
-        logger.debug('Relay command received', { action, params });
+      case 'cancel':
+        agent.cancel(verdict.sessionId).catch((error) => {
+          logger.debug('Error cancelling agent', { error });
+        });
+        return;
 
-        switch (action) {
-          case 'cancel':
-          case 'interrupt':
-            agent.cancel(sessionId).catch((error) => {
-              logger.debug('Error cancelling agent', { error });
-            });
-            break;
+      case 'end-session':
+        // Session stop is handled by the caller via ActiveSession.stop()
+        this.emitUpdate(verdict.sessionId, { type: 'end_session_requested' });
+        return;
 
-          case 'end_session':
-            // Session stop is handled by the caller via ActiveSession.stop()
-            this.emitUpdate(sessionId, { type: 'end_session_requested' });
-            break;
-
-          case 'ping':
-            // Heartbeat -- no action needed, relay handles it
-            break;
-
-          default:
-            logger.debug('Unhandled relay command', { action });
-            break;
-        }
-        break;
-      }
-
-      default: {
-        // Ignore other relay message types (ack, cost_update, etc.)
-        logger.debug('Unhandled relay message type in bridge', { type: message.type });
-        break;
-      }
+      case 'ping':
+        // Heartbeat — no action needed, relay handles it
+        return;
     }
   }
 

--- a/packages/styrby-cli/src/api/relayMessageDispatch.ts
+++ b/packages/styrby-cli/src/api/relayMessageDispatch.ts
@@ -1,0 +1,137 @@
+/**
+ * Pure dispatch logic for relay messages from mobile to the CLI.
+ *
+ * SECURITY-CRITICAL (CLI-008 + CLI-009): this module owns the schema
+ * validation + nonce verification + session-routing logic that decides
+ * whether a relay message gets forwarded to the agent or dropped on the
+ * floor. Bugs here = either silent message loss (UX) OR — worse — a
+ * compromised-account-key attacker bypasses the approval-nonce gate
+ * (RCE-class).
+ *
+ * Extracted from `apiSession.ts` (PR #279) so the security-critical logic
+ * could be unit-tested directly. The class-method `handleRelayMessage`
+ * now delegates to `classifyRelayMessage()` + dispatches on the returned
+ * verdict; effect-side calls (agent.sendPrompt, api.send*) stay in the
+ * class.
+ *
+ * @module api/relayMessageDispatch
+ */
+
+import type { z } from 'zod';
+import type { RelayMessage } from 'styrby-shared';
+import { RelayMessageSchema } from 'styrby-shared';
+
+/**
+ * Discriminated-union verdict returned by `classifyRelayMessage`. Each
+ * variant fully describes what the caller should do without leaving
+ * any decision-making in the class. The class's switch on `verdict.action`
+ * is pure dispatch — no further logic.
+ */
+export type RelayDispatchVerdict =
+  | { action: 'drop-schema-invalid'; type: unknown; issues: z.ZodIssue[] }
+  | { action: 'drop-nonce-mismatch'; requestId: string }
+  | { action: 'drop-wrong-session'; targetSession: string }
+  | { action: 'drop-unhandled-command'; commandAction: string }
+  | { action: 'drop-unhandled-type'; type: string }
+  | { action: 'chat'; sessionId: string; content: string }
+  | { action: 'permission-response'; requestId: string; approved: boolean }
+  | { action: 'cancel'; sessionId: string }
+  | { action: 'end-session'; sessionId: string }
+  | { action: 'ping' };
+
+/**
+ * Verify-nonce callback. Implemented by `StyrbyApi.verifyAndConsumePermissionNonce`
+ * in production; tests pass a stub that returns deterministic true/false.
+ */
+export type NonceVerifier = (requestId: string, nonce: string) => boolean;
+
+/**
+ * Classify an incoming relay message into a verdict.
+ *
+ * Decision sequence (matches the in-class flow exactly):
+ *   1. zod schema validation (rejects oversized strings, wrong types, etc.)
+ *   2. For permission_response: nonce verification (closes RCE chain)
+ *   3. For chat: session-ID match check
+ *   4. Otherwise: dispatch by message type / command action
+ *
+ * @param sessionId - The session we're handling a message for
+ * @param rawMessage - The unverified payload from the relay (may be malformed)
+ * @param verifyNonce - Callback that verifies + CONSUMES the permission nonce.
+ *                      Side-effecting by design (consumes the nonce on success
+ *                      so it can't be replayed). The classifier doesn't care
+ *                      about the side effect; it just needs the boolean answer.
+ * @returns A verdict describing what action the caller should take.
+ */
+export function classifyRelayMessage(
+  sessionId: string,
+  rawMessage: unknown,
+  verifyNonce: NonceVerifier,
+): RelayDispatchVerdict {
+  // ─── Step 1: Schema validation ───────────────────────────────────────
+  // SECURITY (CLI-008): without this, a malicious peer could blast oversized
+  // strings (memory DoS), inject unexpected types, or send fields the dispatch
+  // logic doesn't expect. The schema enforces hard length caps and shape.
+  const parsed = RelayMessageSchema.safeParse(rawMessage);
+  if (!parsed.success) {
+    return {
+      action: 'drop-schema-invalid',
+      type: (rawMessage as { type?: unknown })?.type,
+      issues: parsed.error.issues.slice(0, 5),
+    };
+  }
+  const message: RelayMessage = parsed.data;
+
+  // ─── Step 2: Nonce verification on permission_response ───────────────
+  // SECURITY (CLI-009): closes the compromised-account-key -> approve-all
+  // -> RCE chain. An attacker with only the API key (no live mobile session)
+  // cannot fabricate a valid nonce, so the response is rejected.
+  if (message.type === 'permission_response') {
+    const { request_id, request_nonce } = message.payload;
+    const ok = verifyNonce(request_id, request_nonce);
+    if (!ok) {
+      return { action: 'drop-nonce-mismatch', requestId: request_id };
+    }
+    // Nonce verified — consumed by verifyNonce side effect. Continue to
+    // dispatch.
+  }
+
+  // ─── Step 3: Type-specific routing ───────────────────────────────────
+  switch (message.type) {
+    case 'chat': {
+      const { content, session_id } = message.payload;
+
+      // Cross-session protection: silently drop chat messages targeted at
+      // a different session. Caller logs at debug.
+      if (session_id && session_id !== sessionId) {
+        return { action: 'drop-wrong-session', targetSession: session_id };
+      }
+
+      return { action: 'chat', sessionId, content };
+    }
+
+    case 'permission_response': {
+      // Already nonce-verified above. Forward to agent.
+      const { request_id, approved } = message.payload;
+      return { action: 'permission-response', requestId: request_id, approved };
+    }
+
+    case 'command': {
+      const { action: commandAction } = message.payload;
+      switch (commandAction) {
+        case 'cancel':
+        case 'interrupt':
+          return { action: 'cancel', sessionId };
+        case 'end_session':
+          return { action: 'end-session', sessionId };
+        case 'ping':
+          return { action: 'ping' };
+        default:
+          return { action: 'drop-unhandled-command', commandAction };
+      }
+    }
+
+    default:
+      // Other relay types (ack, cost_update, etc.) — known-but-unhandled.
+      return { action: 'drop-unhandled-type', type: message.type };
+  }
+}


### PR DESCRIPTION
## Summary

B1+C2 combined PR. Extracts security-critical decision logic from
\`ApiSessionManager.handleRelayMessage\` into a pure module
(\`relayMessageDispatch.ts\`), then unit-tests it. The class method shrinks
to pure verdict-dispatch.

## Why this matters

handleRelayMessage is the gate between mobile-sent messages and the
agent. CLI-008 (schema validation) + CLI-009 (nonce verification) both
live in it. Both were at 0% coverage. Regression in either = security
vuln invisible to other tests.

## Design

\`classifyRelayMessage(sessionId, rawMessage, verifyNonce)\` returns a
discriminated-union verdict (drop-schema-invalid, drop-nonce-mismatch,
chat, permission-response, cancel, end-session, ping, etc). The class's
handleRelayMessage becomes ~80 lines of mechanical dispatch — one
effect per branch.

## Tests (23)

- Schema validation: 6
- Nonce verification: 6
- Chat routing + cross-session protection: 3
- Command routing: 5
- Verdict payloads carry sessionId: 3

## Test results

- This file: 23/23 passing
- Full suite: **2856 passing**, 5 skipped, 0 failed
- Typecheck: clean

🤖 Shipped via /gh-ship