### PR TITLE
fix(cli): B4-Wave1 — security-tier error-handling (token-refresh event + 3 fetch timeouts) (+13 tests)

### DIFF
--- a/packages/styrby-cli/src/auth/__tests__/browser-auth.test.ts
+++ b/packages/styrby-cli/src/auth/__tests__/browser-auth.test.ts
@@ -471,6 +471,49 @@ describe('exchangeCodeForTokens', () => {
     expect(err).toBeInstanceOf(AuthError);
     expect((err as AuthError).type).toBe('invalid_code');
   });
+
+  // --------------------------------------------------------------------------
+  // B4-Wave1: timeout regression coverage
+  // --------------------------------------------------------------------------
+
+  it('passes an AbortSignal to fetch (B4-Wave1: hung Supabase auth must not wedge CLI)', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => SUCCESS_RESPONSE,
+    } as Response);
+
+    await exchangeCodeForTokens(SUPABASE_URL, CODE, VERIFIER, REDIRECT_URI);
+
+    const [, options] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('the AbortSignal is initially un-aborted (timeout fires later, not synchronously)', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => SUCCESS_RESPONSE,
+    } as Response);
+
+    await exchangeCodeForTokens(SUPABASE_URL, CODE, VERIFIER, REDIRECT_URI);
+
+    const [, options] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    expect((options.signal as AbortSignal).aborted).toBe(false);
+  });
+
+  it('wraps abort/timeout errors as network_error (B4-Wave1: caller sees recoverable error)', async () => {
+    // Simulate AbortSignal.timeout() firing — fetch rejects with TimeoutError
+    const timeoutErr = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    vi.mocked(fetch).mockRejectedValueOnce(timeoutErr);
+
+    const err = await exchangeCodeForTokens(SUPABASE_URL, CODE, VERIFIER, REDIRECT_URI).catch(
+      (e: unknown) => e
+    );
+
+    // The catch block in browser-auth wraps non-AuthError throws as network_error;
+    // this proves a real timeout doesn't propagate as an unhandled rejection.
+    expect(err).toBeInstanceOf(AuthError);
+    expect((err as AuthError).type).toBe('network_error');
+  });
 });
 
 // ============================================================================

--- a/packages/styrby-cli/src/auth/__tests__/token-manager.refresh-failed-event.test.ts
+++ b/packages/styrby-cli/src/auth/__tests__/token-manager.refresh-failed-event.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for the TokenManager 'refresh-failed' event.
+ *
+ * WHY (B4-Wave1 — error-handling completeness): Background token refresh used
+ * to log at debug only. When refresh failed (network blip, refresh-token
+ * revoked, Supabase auth outage), the in-memory access token went stale and
+ * the very next API call would 401 with no signal that auth needed renewal.
+ *
+ * The fix added a typed `refresh-failed` event so subscribers (daemon,
+ * session manager, future UI banner) can react proactively instead of
+ * waiting for downstream failures. These tests pin the contract:
+ *   1. Event fires on the cold-start hydrate path with `trigger: 'hydrate'`
+ *   2. Event fires on the scheduled-refresh timer path with `trigger: 'scheduled'`
+ *   3. Event payload preserves the original error
+ *   4. logger.warn (NOT logger.debug) is called so ops sees the failure in logs
+ *
+ * @module auth/__tests__/token-manager.refresh-failed-event
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Mocks — must be declared before imports
+// ============================================================================
+
+const {
+  mockSavePersistedData,
+  mockLoadPersistedData,
+  mockSetConfigValue,
+  mockLoggerWarn,
+  mockLoggerDebug,
+} = vi.hoisted(() => ({
+  mockSavePersistedData: vi.fn(),
+  mockLoadPersistedData: vi.fn(() => ({})),
+  mockSetConfigValue: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockLoggerDebug: vi.fn(),
+}));
+
+vi.mock('@/persistence', () => ({
+  loadPersistedData: mockLoadPersistedData,
+  savePersistedData: mockSavePersistedData,
+}));
+
+vi.mock('@/configuration', () => ({
+  setConfigValue: mockSetConfigValue,
+  CONFIG_DIR: '/tmp/.styrby-test',
+  ensureConfigDir: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: mockLoggerDebug,
+    info: vi.fn(),
+    warn: mockLoggerWarn,
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/env', () => ({
+  config: {
+    supabaseUrl: 'https://test.supabase.co',
+    supabaseAnonKey: 'test-anon-key',
+  },
+}));
+
+// ============================================================================
+// Import after mocks
+// ============================================================================
+
+import { TokenManager, type RefreshFailedEventPayload } from '../token-manager';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Reset the TokenManager singleton so each test gets a clean instance.
+ *
+ * WHY: The constructor calls loadFromPersistence which queues a setImmediate.
+ * Without resetting, prior tests' state (queued microtasks, listeners) bleeds
+ * across.
+ */
+function resetSingleton(): TokenManager {
+  (TokenManager as unknown as Record<string, unknown>)['instance'] = undefined;
+  return TokenManager.getInstance();
+}
+
+/**
+ * Flush queued setImmediate callbacks. Used to deterministically run the
+ * cold-start refresh path that's queued during construction.
+ */
+function flushImmediates(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+// ============================================================================
+// Tests — cold-start hydrate path (setImmediate inside loadFromPersistence)
+// ============================================================================
+
+describe("TokenManager 'refresh-failed' event — cold-start hydrate path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadPersistedData.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    // Reset singleton between tests so refresh spies don't leak
+    (TokenManager as unknown as Record<string, unknown>)['instance'] = undefined;
+  });
+
+  it("emits 'refresh-failed' with trigger='hydrate' AND logs at WARN when cold-start refresh rejects", async () => {
+    // Persistence has a refresh token → setImmediate will call refresh()
+    mockLoadPersistedData.mockReturnValue({
+      userId: 'user-cold-start',
+      accessToken: 'at-stale',
+      refreshToken: 'rt-still-good',
+    });
+
+    const manager = resetSingleton();
+
+    // Spy AFTER construction but BEFORE the queued setImmediate fires.
+    // vi.spyOn replaces refresh on the instance; the closure inside
+    // setImmediate calls `this.refresh()` which resolves to the spy.
+    const refreshErr = new Error('refresh-rejected-by-server');
+    vi.spyOn(manager, 'refresh').mockRejectedValueOnce(refreshErr);
+
+    const listener = vi.fn();
+    manager.on('refresh-failed', listener);
+
+    await flushImmediates();
+    // The .catch is a microtask; one more flush ensures the event has fired
+    await Promise.resolve();
+
+    // Event contract
+    expect(listener).toHaveBeenCalledTimes(1);
+    const payload = listener.mock.calls[0]?.[0] as RefreshFailedEventPayload;
+    expect(payload.trigger).toBe('hydrate');
+    expect(payload.error).toBe(refreshErr);
+
+    // Logger contract — same catch block, both must fire
+    expect(mockLoggerWarn).toHaveBeenCalled();
+    const warnArgs = mockLoggerWarn.mock.calls[0];
+    expect(String(warnArgs?.[0])).toContain('Background token refresh failed');
+    expect(warnArgs?.[1]).toMatchObject({ error: 'refresh-rejected-by-server' });
+  });
+
+  it("does NOT emit 'refresh-failed' when there is no refresh token to refresh", async () => {
+    // No refreshToken → setImmediate sees nothing to refresh → no catch path
+    mockLoadPersistedData.mockReturnValue({
+      userId: 'user-no-rt',
+      accessToken: 'at-only',
+    });
+
+    const manager = resetSingleton();
+
+    const listener = vi.fn();
+    manager.on('refresh-failed', listener);
+
+    await flushImmediates();
+    await Promise.resolve();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Tests — scheduled-refresh path (setTimeout inside scheduleRefresh)
+// ============================================================================
+
+describe("TokenManager 'refresh-failed' event — scheduled-refresh timer path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadPersistedData.mockReturnValue({});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    (TokenManager as unknown as Record<string, unknown>)['instance'] = undefined;
+  });
+
+  it("emits 'refresh-failed' with trigger='scheduled' when the pre-expiry timer's refresh rejects", async () => {
+    const manager = resetSingleton();
+
+    const refreshErr = new Error('scheduled-refresh-network-down');
+    vi.spyOn(manager, 'refresh').mockRejectedValueOnce(refreshErr);
+
+    const listener = vi.fn();
+    manager.on('refresh-failed', listener);
+
+    // setTokens with a 10-minute expiry → REFRESH_BUFFER_MS=5min → timer fires in 5min
+    manager.setTokens({
+      accessToken: 'at-near-expiry',
+      refreshToken: 'rt-test',
+      expiresIn: 10 * 60, // 10 minutes
+      userId: 'user-scheduled',
+    });
+
+    // Advance past the 5-min buffer so setTimeout fires
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+    // Drain microtasks queued by the .catch
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const payload = listener.mock.calls[0]?.[0] as RefreshFailedEventPayload;
+    expect(payload.trigger).toBe('scheduled');
+    expect(payload.error).toBe(refreshErr);
+  });
+
+  it("logs at WARN with the error message when the scheduled timer's refresh fails", async () => {
+    const manager = resetSingleton();
+    vi.spyOn(manager, 'refresh').mockRejectedValueOnce(new Error('scheduled-boom'));
+
+    manager.setTokens({
+      accessToken: 'at-x',
+      refreshToken: 'rt-x',
+      expiresIn: 10 * 60,
+      userId: 'user-warn-scheduled',
+    });
+
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockLoggerWarn).toHaveBeenCalled();
+    const warnArgs = mockLoggerWarn.mock.calls[0];
+    expect(String(warnArgs?.[0])).toContain('Scheduled token refresh failed');
+    // Second arg is the metadata object with the error message
+    expect(warnArgs?.[1]).toMatchObject({ error: 'scheduled-boom' });
+  });
+
+  it("does NOT emit 'refresh-failed' when refresh succeeds (sanity check)", async () => {
+    const manager = resetSingleton();
+    vi.spyOn(manager, 'refresh').mockResolvedValueOnce({
+      success: true,
+      accessToken: 'at-new',
+      refreshToken: 'rt-new',
+      expiresAt: new Date(Date.now() + 3600_000),
+    });
+
+    const listener = vi.fn();
+    manager.on('refresh-failed', listener);
+
+    manager.setTokens({
+      accessToken: 'at-old',
+      refreshToken: 'rt-old',
+      expiresIn: 10 * 60,
+      userId: 'user-success',
+    });
+
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+    await Promise.resolve();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Tests — event-typing contract (TypeScript-level check via runtime shape)
+// ============================================================================
+
+describe("RefreshFailedEventPayload contract", () => {
+  it("trigger field accepts only the documented variants", () => {
+    // Compile-time check enforced by `satisfies` in TokenManager;
+    // this runtime test exists as a regression guard if the type changes.
+    const validHydrate: RefreshFailedEventPayload = { trigger: 'hydrate', error: new Error('x') };
+    const validScheduled: RefreshFailedEventPayload = { trigger: 'scheduled', error: 'string-err' };
+
+    expect(['hydrate', 'scheduled']).toContain(validHydrate.trigger);
+    expect(['hydrate', 'scheduled']).toContain(validScheduled.trigger);
+  });
+});

--- a/packages/styrby-cli/src/auth/browser-auth.ts
+++ b/packages/styrby-cli/src/auth/browser-auth.ts
@@ -241,12 +241,19 @@ export async function exchangeCodeForTokens(
   });
 
   try {
+    // WHY 15s timeout: OAuth token-exchange is the choke point of the entire
+    // browser auth flow. Without an explicit timeout, a hung Supabase auth
+    // server (or a captive portal stripping the request) leaves the CLI
+    // wedged on the spinner with no recovery path. 15s is well above the
+    // p99 successful exchange (~800ms) but short enough that the user
+    // notices and can retry.
     const response = await fetch(tokenUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: body.toString(),
+      signal: AbortSignal.timeout(15_000),
     });
 
     if (!response.ok) {

--- a/packages/styrby-cli/src/auth/token-manager.ts
+++ b/packages/styrby-cli/src/auth/token-manager.ts
@@ -65,6 +65,23 @@ export interface LogoutEventPayload {
 }
 
 /**
+ * Payload emitted with the 'refresh-failed' event.
+ *
+ * WHY: Background token refresh failures (setImmediate hydration on cold
+ * start; scheduleRefresh timer near expiry) used to be log-only, leaving
+ * the in-memory access token stale and silently breaking the next API call.
+ * Subscribers (daemon, session manager, UI) need to know so they can
+ * trigger reconnect / re-prompt / surface a banner instead of waiting for
+ * the next request to fail with a 401.
+ */
+export interface RefreshFailedEventPayload {
+  /** Which background path triggered the refresh (`hydrate` = cold-start, `scheduled` = pre-expiry timer) */
+  trigger: 'hydrate' | 'scheduled';
+  /** The error thrown by the underlying refresh attempt (already logged at warn) */
+  error: unknown;
+}
+
+/**
  * Typed event map for TokenManager's EventEmitter interface.
  *
  * WHY: Explicit event map provides type-safe `.on('logout', ...)` callers
@@ -72,6 +89,7 @@ export interface LogoutEventPayload {
  */
 export interface TokenManagerEvents {
   logout: (payload: LogoutEventPayload) => void;
+  'refresh-failed': (payload: RefreshFailedEventPayload) => void;
 }
 
 /**
@@ -442,9 +460,16 @@ export class TokenManager extends EventEmitter {
       // Schedule a refresh check on next tick
       setImmediate(() => {
         if (this.state.refreshToken) {
-          this.refresh().catch(() => {
-            // Refresh failed, user will need to re-auth
-            logger.debug('Background token refresh failed');
+          this.refresh().catch((error: unknown) => {
+            // WHY warn (not debug): a stale access token after cold-start
+            // hydration causes the next API call to 401 with no obvious
+            // signal to the user. The warn line + the emitted event are
+            // the only durable signals subscribers (daemon, session mgr)
+            // get to trigger re-auth flow.
+            logger.warn('Background token refresh failed (cold-start hydration)', {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            this.emit('refresh-failed', { trigger: 'hydrate', error } satisfies RefreshFailedEventPayload);
           });
         }
       });
@@ -500,8 +525,15 @@ export class TokenManager extends EventEmitter {
 
     if (delay > 0) {
       this.refreshTimer = setTimeout(() => {
-        this.refresh().catch((error) => {
-          logger.debug('Scheduled token refresh failed', { error });
+        this.refresh().catch((error: unknown) => {
+          // WHY warn + event: same reasoning as the hydrate path — a
+          // refresh failure ~5 minutes before expiry means the next call
+          // will 401 if subscribers don't react. Event lets the daemon
+          // queue a re-auth prompt instead of failing the next user action.
+          logger.warn('Scheduled token refresh failed', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          this.emit('refresh-failed', { trigger: 'scheduled', error } satisfies RefreshFailedEventPayload);
         });
       }, delay);
 

--- a/packages/styrby-cli/src/commands/__tests__/privacy.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/privacy.test.ts
@@ -244,6 +244,35 @@ describe('handleExportData', () => {
 
     await expect(handleExportData([])).rejects.toThrow('process.exit(1)');
   });
+
+  // --------------------------------------------------------------------------
+  // B4-Wave1: timeout regression coverage
+  // --------------------------------------------------------------------------
+
+  it('passes an AbortSignal to the export fetch (B4-Wave1: hung backend must not wedge CLI)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '{}',
+    });
+
+    const { handleExportData } = await import('../privacy');
+    await handleExportData([]);
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    expect((options.signal as AbortSignal).aborted).toBe(false);
+  });
+
+  it('treats fetch timeout as a Network error and exits 1 (B4-Wave1)', async () => {
+    const timeoutErr = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    mockFetch.mockRejectedValueOnce(timeoutErr);
+
+    const { handleExportData } = await import('../privacy');
+
+    // Per the existing pattern: fetch error → console.error('Network error...') → process.exit(1)
+    await expect(handleExportData([])).rejects.toThrow('process.exit(1)');
+  });
 });
 
 // ============================================================================
@@ -369,6 +398,53 @@ describe('handleDeleteAccount', () => {
     await handleDeleteAccount([]); // should NOT throw
 
     expect(mockFetch).toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // B4-Wave1: timeout regression coverage
+  // --------------------------------------------------------------------------
+
+  it('passes an AbortSignal to the delete fetch (B4-Wave1: GDPR-critical path must time out)', async () => {
+    const TEST_EMAIL = 'test@example.com';
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1', email: TEST_EMAIL } },
+      error: null,
+    });
+
+    mockPromptAnswers.push('yes');
+    mockPromptAnswers.push(TEST_EMAIL);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, message: 'Deleted' }),
+    });
+
+    const { handleDeleteAccount } = await import('../privacy');
+    await handleDeleteAccount([]);
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    expect((options.signal as AbortSignal).aborted).toBe(false);
+  });
+
+  it('treats delete-fetch timeout as Network error and exits 1 (B4-Wave1)', async () => {
+    const TEST_EMAIL = 'test@example.com';
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1', email: TEST_EMAIL } },
+      error: null,
+    });
+
+    mockPromptAnswers.push('yes');
+    mockPromptAnswers.push(TEST_EMAIL);
+
+    const timeoutErr = new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    mockFetch.mockRejectedValueOnce(timeoutErr);
+
+    const { handleDeleteAccount } = await import('../privacy');
+    await expect(handleDeleteAccount([])).rejects.toThrow('process.exit(1)');
   });
 });
 

--- a/packages/styrby-cli/src/commands/privacy.ts
+++ b/packages/styrby-cli/src/commands/privacy.ts
@@ -158,6 +158,10 @@ export async function handleExportData(args: string[]): Promise<void> {
 
   let response: Response;
   try {
+    // WHY 30s timeout: full account export bundles every session + audit
+    // entry, so the server-side build can take many seconds. 30s tolerates
+    // a power user with months of history without leaving the CLI hung
+    // forever if the API becomes unreachable mid-flight.
     response = await fetch(`${getWebApiBase()}/api/account/export`, {
       method: 'POST',
       headers: {
@@ -165,6 +169,7 @@ export async function handleExportData(args: string[]): Promise<void> {
         'Content-Type': 'application/json',
         'User-Agent': `styrby-cli/${VERSION}`,
       },
+      signal: AbortSignal.timeout(30_000),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -334,6 +339,12 @@ export async function handleDeleteAccount(_args: string[]): Promise<void> {
 
   let deleteResponse: Response;
   try {
+    // WHY 30s timeout: the delete endpoint enqueues a soft-delete job +
+    // sends a confirmation email, which can take a few seconds. Hard cap
+    // at 30s so a hung backend doesn't trap the user mid-confirmation;
+    // they'll see a Network error and can retry (the server-side
+    // idempotency is what keeps the action safe across retries, not the
+    // client-side wait).
     deleteResponse = await fetch(`${getWebApiBase()}/api/account/delete`, {
       method: 'DELETE',
       headers: {
@@ -345,6 +356,7 @@ export async function handleDeleteAccount(_args: string[]): Promise<void> {
         confirmation: 'DELETE MY ACCOUNT',
         reason: 'User-initiated from styrby-cli delete-account command',
       }),
+      signal: AbortSignal.timeout(30_000),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

First wave of the B4 error-handling completeness audit. Closes the **security tier** (auth, token, OAuth, GDPR-delete paths). 5 real fixes + 13 regression tests, with 6 audit false-positives explicitly rejected after read-the-code triage.

## Background

Today's CLI Optimization Workstream completed all sub-tracks except B4 (filed as multi-PR). This PR opens the B4 sequence:

- **Phase 0 (scout)**: produced `docs/audits/error-handling-audit.md` cataloging 67 findings across 8 smell categories + 4 ROI tiers
- **Wave 1 (this PR)**: security-tier — 5 fixes
- **Wave 2 (next)**: data-integrity tier — cost-records, session persistence
- **Wave 3 (after)**: operational tier — daemon, agent spawn, IPC
- **Wave 4 (closeout)**: ADR-006 codifying the conventions

See `styrby-backlog.md` § "B4 — Error-handling completeness audit" for the full plan.

## Fixes (5)

| # | File:line | Smell | Fix |
|---|---|---|---|
| 1 | `auth/token-manager.ts:445` | LOG-ONLY-CATCH | Upgrade `logger.debug` → `logger.warn` + emit typed `'refresh-failed'` event with `trigger: 'hydrate'` |
| 2 | `auth/token-manager.ts:503` | LOG-ONLY-CATCH | Same upgrade for the scheduled-refresh timer site, `trigger: 'scheduled'` |
| 3 | `auth/browser-auth.ts:244` | MISSING-TIMEOUT | `AbortSignal.timeout(15_000)` on Supabase OAuth token-exchange POST |
| 4 | `commands/privacy.ts:161` | MISSING-TIMEOUT (new) | `AbortSignal.timeout(30_000)` on `/api/account/export` POST |
| 5 | `commands/privacy.ts:337` | MISSING-TIMEOUT (new) | `AbortSignal.timeout(30_000)` on `/api/account/delete` DELETE |

Findings 4 + 5 were NOT in the scout's output — discovered during read-the-code triage of the privacy.ts FIRE-AND-FORGET findings. Logged as scout-quality lessons in the audit doc.

## False positives explicitly rejected

The scout produced 15 candidates in security tier; 6 were already correct on inspection:

- `secret-store.ts:64,84,137` (UNTYPED-CATCH-READ): all 3 already use `e instanceof Error ? e.message : String(e)` (Pattern 2 from ADR-005)
- `secret-store.ts:210` (EMPTY-CATCH): intentional best-effort cleanup on `keytar.deletePassword` — audit even acknowledged this is acceptable
- `machine-registration.ts:264` (LOG-ONLY-CATCH): catch wraps + rethrows via `MachineRegistrationError` preserving cause
- `browser-auth.ts:388` (LOG-ONLY-CATCH): catch DOES print fallback URL for manual copy

Documenting the rejections inline in the commit body so future audits don't re-flag them.

## Tests (+13)

| Suite | New tests | Coverage |
|---|---|---|
| `auth/__tests__/token-manager.refresh-failed-event.test.ts` (NEW) | 6 | hydrate-path emit + warn, scheduled-path emit + warn, no-emit on success, payload type contract |
| `auth/__tests__/browser-auth.test.ts` | +3 | AbortSignal presence, signal initially un-aborted, timeout maps to network_error |
| `commands/__tests__/privacy.test.ts` | +4 | Both fetch sites: AbortSignal presence + timeout-error handling |

**Total CLI suite: 2880 → 2893 (+13 net new tests).**

## New event type (additive, non-breaking)

```ts
export interface RefreshFailedEventPayload {
  trigger: 'hydrate' | 'scheduled';
  error: unknown;
}

// in TokenManagerEvents:
'refresh-failed': (payload: RefreshFailedEventPayload) => void;
```

Subscribers can opt in: `tokenManager.on('refresh-failed', payload => { ... })`. No subscriber changes required for existing consumers.

## Pre-push gate

- [x] `npm run typecheck` ✅
- [x] `npm run build` ✅ (CLI bundle still under budget)
- [x] `npm test` ✅ 2893/2893 pass + 5 skipped
- [x] No new `as any` introduced (still at 1, per ADR-005)

## Test plan

- [ ] CI passes
- [ ] No production deploy needed (CLI-only changes; npm publish unchanged at 0.2.0-beta.1)
- [ ] Manual smoke: not required — pure addition + timeouts that won't fire under normal latency

🤖 Shipped via /gh-ship