### PR TITLE
fix(cli): B4-Wave2 — data-integrity error-handling via safeRelaySend wrapper (+13 tests)

### DIFF
--- a/packages/styrby-cli/src/api/__tests__/safeRelaySend.test.ts
+++ b/packages/styrby-cli/src/api/__tests__/safeRelaySend.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for safeRelaySend — uniform error-handling wrapper for relay sends.
+ *
+ * WHY (B4-Wave2): The wrapper REPLACES ~10 disparate `.catch(() => {})` and
+ * `.catch((e) => logger.debug(...))` sites in apiSession.ts. The contract that
+ * matters:
+ *   1. Always resolves (never rejects); callers don't need their own .catch
+ *   2. Success returns { ok: true; result }
+ *   3. Failure returns { ok: false; error } AND logs at WARN with full context
+ *   4. Context (sessionId, messageType, detail) reaches the warn line
+ *
+ * @module api/__tests__/safeRelaySend
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockLoggerWarn } = vi.hoisted(() => ({
+  mockLoggerWarn: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockLoggerWarn,
+    error: vi.fn(),
+  },
+}));
+
+import { safeRelaySend, type SafeRelaySendContext } from '../safeRelaySend';
+
+describe('safeRelaySend', () => {
+  beforeEach(() => {
+    mockLoggerWarn.mockClear();
+  });
+
+  // --------------------------------------------------------------------------
+  // Success path
+  // --------------------------------------------------------------------------
+
+  it('returns { ok: true; result } when the inner send resolves', async () => {
+    const ctx: SafeRelaySendContext = { sessionId: 's-1', messageType: 'session-state' };
+    const r = await safeRelaySend(Promise.resolve('sent'), ctx);
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.result).toBe('sent');
+    }
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('preserves the resolved value type (object / number / void are all fine)', async () => {
+    const objRes = await safeRelaySend(Promise.resolve({ id: 123 }), {
+      sessionId: 's-2',
+      messageType: 'agent-response',
+    });
+    expect(objRes.ok).toBe(true);
+    if (objRes.ok) expect(objRes.result).toEqual({ id: 123 });
+
+    const numRes = await safeRelaySend(Promise.resolve(42), {
+      sessionId: 's-3',
+      messageType: 'permission-request',
+    });
+    if (numRes.ok) expect(numRes.result).toBe(42);
+
+    const voidRes = await safeRelaySend<void>(Promise.resolve(), {
+      sessionId: 's-4',
+      messageType: 'unknown',
+    });
+    if (voidRes.ok) expect(voidRes.result).toBeUndefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // Failure path — never rethrows
+  // --------------------------------------------------------------------------
+
+  it('returns { ok: false; error } when the inner send rejects (does NOT rethrow)', async () => {
+    const failure = new Error('relay-down');
+    const ctx: SafeRelaySendContext = { sessionId: 's-5', messageType: 'agent-response' };
+
+    // The very fact that `await` doesn't throw is the contract we're pinning
+    const r = await safeRelaySend(Promise.reject(failure), ctx);
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe(failure);
+    }
+  });
+
+  it('handles non-Error rejections (string, plain object) without crashing', async () => {
+    const stringErr = await safeRelaySend(Promise.reject('not-an-error-instance'), {
+      sessionId: 's-6',
+      messageType: 'session-state',
+    });
+    expect(stringErr.ok).toBe(false);
+    if (!stringErr.ok) expect(stringErr.error).toBe('not-an-error-instance');
+
+    const objErr = await safeRelaySend(Promise.reject({ code: 'EBOOM' }), {
+      sessionId: 's-7',
+      messageType: 'session-state',
+    });
+    expect(objErr.ok).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
+  // Logging contract
+  // --------------------------------------------------------------------------
+
+  it('logs at WARN (not debug) on rejection with sessionId + messageType + error in context', async () => {
+    await safeRelaySend(Promise.reject(new Error('network-blip')), {
+      sessionId: 'sess-abc-123',
+      messageType: 'permission-request',
+      detail: 'tool-Bash',
+    });
+
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    const [msg, ctx] = mockLoggerWarn.mock.calls[0] as [string, Record<string, unknown>];
+    expect(msg).toBe('Relay send failed');
+    expect(ctx.sessionId).toBe('sess-abc-123');
+    expect(ctx.messageType).toBe('permission-request');
+    expect(ctx.detail).toBe('tool-Bash');
+    expect(ctx.error).toBe('network-blip');
+  });
+
+  it('logs the string form of non-Error rejections so log-grep still works', async () => {
+    await safeRelaySend(Promise.reject({ status: 503 }), {
+      sessionId: 's-9',
+      messageType: 'session-state',
+    });
+
+    const [, ctx] = mockLoggerWarn.mock.calls[0] as [string, Record<string, unknown>];
+    // Non-Error → stringified via String(error). For plain object, that's '[object Object]'.
+    // The exact representation doesn't matter; the field must be present + non-empty.
+    expect(typeof ctx.error).toBe('string');
+    expect((ctx.error as string).length).toBeGreaterThan(0);
+  });
+
+  it('does NOT log on success (no warn spam for the happy path)', async () => {
+    await safeRelaySend(Promise.resolve('ok'), {
+      sessionId: 's-10',
+      messageType: 'agent-response',
+    });
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('keeps detail field optional (undefined) — no crash if caller omits it', async () => {
+    await safeRelaySend(Promise.reject(new Error('x')), {
+      sessionId: 's-11',
+      messageType: 'unknown',
+      // detail intentionally omitted
+    });
+
+    const [, ctx] = mockLoggerWarn.mock.calls[0] as [string, Record<string, unknown>];
+    expect(ctx.detail).toBeUndefined();
+  });
+});
+
+describe('safeRelaySend — fire-and-forget call site idiom', () => {
+  beforeEach(() => {
+    mockLoggerWarn.mockClear();
+  });
+
+  it("the void-prefix idiom (`void safeRelaySend(...)`) doesn't propagate rejections to the unhandled-rejection handler", async () => {
+    // Simulate the apiSession.ts pattern where we DON'T await the result.
+    // The call returns a promise; if that promise ever rejected, Node's
+    // unhandled-rejection handler would fire. The point of safeRelaySend
+    // is that this CAN'T happen — internal try/catch absorbs everything.
+    let unhandledFired = false;
+    const handler = (): void => {
+      unhandledFired = true;
+    };
+    process.on('unhandledRejection', handler);
+
+    void safeRelaySend(Promise.reject(new Error('drop me silently from external view')), {
+      sessionId: 's-fire',
+      messageType: 'agent-response',
+    });
+
+    // Wait long enough that any unhandled-rejection would have fired.
+    // 50ms is well past the microtask + nextTick boundary.
+    await new Promise((r) => setTimeout(r, 50));
+
+    process.off('unhandledRejection', handler);
+
+    expect(unhandledFired).toBe(false);
+    // BUT the warn DID fire — failure is visible via logs, not via unhandled-rejection.
+    expect(mockLoggerWarn).toHaveBeenCalled();
+  });
+});

--- a/packages/styrby-cli/src/api/apiSession.ts
+++ b/packages/styrby-cli/src/api/apiSession.ts
@@ -19,6 +19,7 @@ import type { AgentBackend, AgentMessage, AgentMessageHandler } from '@/agent/co
 import type { RelayMessage, AgentType as SharedAgentType } from 'styrby-shared';
 import { logger } from '@/ui/logger';
 import { classifyRelayMessage } from './relayMessageDispatch';
+import { safeRelaySend } from './safeRelaySend';
 
 /**
  * Callback type for session updates (status changes, errors, completion).
@@ -215,10 +216,13 @@ export class ApiSessionManager {
         // Update session status in Supabase
         await this.updateSessionStatus(supabase, sessionId, 'stopped');
 
-        // Send final session state to mobile
-        await api.sendSessionState(sessionId, agentType, 'idle').catch(() => {
-          // Swallow errors -- relay might already be disconnected
-        });
+        // Send final session state to mobile (B4-Wave2: warn-on-failure
+        // via safeRelaySend; relay may already be disconnected at stop time
+        // so this is allowed to fail, but the failure is now visible).
+        await safeRelaySend(
+          api.sendSessionState(sessionId, agentType, 'idle'),
+          { sessionId, messageType: 'session-state', detail: 'idle-on-stop' }
+        );
 
         // End session on the API (clears relay presence)
         await api.endSession(sessionId);
@@ -267,12 +271,13 @@ export class ApiSessionManager {
         // Stream agent text output to mobile
         const content = msg.textDelta ?? msg.fullText ?? '';
         if (content) {
-          api.sendAgentResponse(sessionId, agentType, content, {
-            isStreaming: !!msg.textDelta,
-            isComplete: !!msg.fullText,
-          }).catch((error) => {
-            logger.debug('Failed to send agent response to relay', { error });
-          });
+          void safeRelaySend(
+            api.sendAgentResponse(sessionId, agentType, content, {
+              isStreaming: !!msg.textDelta,
+              isComplete: !!msg.fullText,
+            }),
+            { sessionId, messageType: 'agent-response', detail: 'model-output' }
+          );
         }
         break;
       }
@@ -288,16 +293,17 @@ export class ApiSessionManager {
         };
         const relayState = stateMap[msg.status] || 'idle';
 
-        api.sendSessionState(
-          sessionId,
-          agentType,
-          relayState,
-          msg.status === 'error' && msg.detail
-            ? { error: { type: 'agent', message: msg.detail, recoverable: true } }
-            : undefined
-        ).catch((error) => {
-          logger.debug('Failed to send session state to relay', { error });
-        });
+        void safeRelaySend(
+          api.sendSessionState(
+            sessionId,
+            agentType,
+            relayState,
+            msg.status === 'error' && msg.detail
+              ? { error: { type: 'agent', message: msg.detail, recoverable: true } }
+              : undefined
+          ),
+          { sessionId, messageType: 'session-state', detail: relayState }
+        );
 
         // Emit local update
         this.emitUpdate(sessionId, { type: 'status', payload: { status: msg.status, detail: msg.detail } });
@@ -307,62 +313,78 @@ export class ApiSessionManager {
       case 'permission-request': {
         // Forward permission request to mobile for user approval
         const payload = msg.payload as Record<string, unknown>;
-        api.sendPermissionRequest(sessionId, agentType, {
-          requestId: msg.id,
-          toolName: msg.reason,
-          toolArgs: payload || {},
-          riskLevel: 'medium',
-          description: `${agentType} wants to use: ${msg.reason}`,
-        }).catch((error) => {
-          logger.debug('Failed to send permission request to relay', { error });
-        });
+        void safeRelaySend(
+          api.sendPermissionRequest(sessionId, agentType, {
+            requestId: msg.id,
+            toolName: msg.reason,
+            toolArgs: payload || {},
+            riskLevel: 'medium',
+            description: `${agentType} wants to use: ${msg.reason}`,
+          }),
+          { sessionId, messageType: 'permission-request', detail: msg.reason }
+        );
         break;
       }
 
       case 'tool-call': {
         // Notify mobile that agent is executing a tool
-        api.sendSessionState(sessionId, agentType, 'executing').catch(() => {});
+        void safeRelaySend(
+          api.sendSessionState(sessionId, agentType, 'executing'),
+          { sessionId, messageType: 'session-state', detail: 'executing-tool' }
+        );
 
         // Also send tool info as an agent response so mobile can display it
-        api.sendAgentResponse(
-          sessionId,
-          agentType,
-          JSON.stringify({ type: 'tool-call', toolName: msg.toolName, args: msg.args }),
-          { isStreaming: false, isComplete: true }
-        ).catch(() => {});
+        void safeRelaySend(
+          api.sendAgentResponse(
+            sessionId,
+            agentType,
+            JSON.stringify({ type: 'tool-call', toolName: msg.toolName, args: msg.args }),
+            { isStreaming: false, isComplete: true }
+          ),
+          { sessionId, messageType: 'agent-response', detail: `tool-call:${msg.toolName}` }
+        );
         break;
       }
 
       case 'tool-result': {
         // Send tool result back to mobile
-        api.sendAgentResponse(
-          sessionId,
-          agentType,
-          JSON.stringify({ type: 'tool-result', toolName: msg.toolName, result: msg.result }),
-          { isStreaming: false, isComplete: true }
-        ).catch(() => {});
+        void safeRelaySend(
+          api.sendAgentResponse(
+            sessionId,
+            agentType,
+            JSON.stringify({ type: 'tool-result', toolName: msg.toolName, result: msg.result }),
+            { isStreaming: false, isComplete: true }
+          ),
+          { sessionId, messageType: 'agent-response', detail: `tool-result:${msg.toolName}` }
+        );
         break;
       }
 
       case 'fs-edit': {
         // Send file edit notification to mobile
-        api.sendAgentResponse(
-          sessionId,
-          agentType,
-          JSON.stringify({ type: 'fs-edit', description: msg.description, path: msg.path }),
-          { isStreaming: false, isComplete: true }
-        ).catch(() => {});
+        void safeRelaySend(
+          api.sendAgentResponse(
+            sessionId,
+            agentType,
+            JSON.stringify({ type: 'fs-edit', description: msg.description, path: msg.path }),
+            { isStreaming: false, isComplete: true }
+          ),
+          { sessionId, messageType: 'agent-response', detail: 'fs-edit' }
+        );
         break;
       }
 
       case 'terminal-output': {
         // Stream terminal output to mobile
-        api.sendAgentResponse(
-          sessionId,
-          agentType,
-          msg.data,
-          { isStreaming: true, isComplete: false }
-        ).catch(() => {});
+        void safeRelaySend(
+          api.sendAgentResponse(
+            sessionId,
+            agentType,
+            msg.data,
+            { isStreaming: true, isComplete: false }
+          ),
+          { sessionId, messageType: 'agent-response', detail: 'terminal-output' }
+        );
         break;
       }
 
@@ -448,13 +470,23 @@ export class ApiSessionManager {
         });
         agent.sendPrompt(verdict.sessionId, verdict.content).catch((error) => {
           logger.error('Failed to send prompt to agent', { error });
-          api.sendSessionState(verdict.sessionId, agentType, 'error', {
-            error: {
-              type: 'agent',
-              message: error instanceof Error ? error.message : String(error),
-              recoverable: true,
-            },
-          }).catch(() => {});
+          // Also surface the error to mobile via session-state. Wrapped in
+          // safeRelaySend so a relay-down condition doesn't mask the
+          // already-logged agent error.
+          void safeRelaySend(
+            api.sendSessionState(verdict.sessionId, agentType, 'error', {
+              error: {
+                type: 'agent',
+                message: error instanceof Error ? error.message : String(error),
+                recoverable: true,
+              },
+            }),
+            {
+              sessionId: verdict.sessionId,
+              messageType: 'session-state-error',
+              detail: 'sendPrompt-failed',
+            }
+          );
         });
         return;
 

--- a/packages/styrby-cli/src/api/safeRelaySend.ts
+++ b/packages/styrby-cli/src/api/safeRelaySend.ts
@@ -1,0 +1,98 @@
+/**
+ * safeRelaySend — uniform error-handling wrapper for outbound relay sends
+ *
+ * WHY (B4-Wave2 — error-handling completeness): The bridge in apiSession.ts
+ * has ~10 sites that call `api.sendSessionState(...)` / `api.sendAgentResponse(...)` /
+ * `api.sendPermissionRequest(...)` and chain `.catch(() => {})` or
+ * `.catch((e) => logger.debug(...))`. The relay is the critical path for
+ * mobile <-> CLI communication; silent send failures cause:
+ *   - mobile UI never learning the agent finished a tool
+ *   - permission-request prompts never reaching the user (agent appears hung)
+ *   - session-state transitions invisible to the user
+ *
+ * Switching every site to a uniform wrapper buys:
+ *   1. **One place to upgrade logging** (warn instead of debug; context attached)
+ *   2. **One place to add Sentry capture** later (single import, single tag set)
+ *   3. **Consistent context shape** so log scrapers can group failures
+ *   4. **Telemetry hook** for future `relay.send_failed` metric emission
+ *
+ * The wrapper NEVER rethrows — callers don't need to defensively `.catch()`
+ * around it. The return value is a discriminated union so callers that DO
+ * want to react (e.g. fall back to a different transport) can switch on it.
+ *
+ * @module api/safeRelaySend
+ */
+
+import { logger } from '@/ui/logger';
+
+/**
+ * Categorical message types we send through the relay. Used for log
+ * grouping + future telemetry tags.
+ */
+export type RelayMessageCategory =
+  | 'session-state'
+  | 'agent-response'
+  | 'permission-request'
+  | 'session-state-error'
+  | 'unknown';
+
+/**
+ * Context attached to every safeRelaySend call. Becomes the second
+ * argument to logger.warn so log scrapers can group + filter.
+ */
+export interface SafeRelaySendContext {
+  /** Session the message belongs to (for cross-correlation with mobile logs). */
+  sessionId: string;
+  /** Categorical send type — drives telemetry grouping. */
+  messageType: RelayMessageCategory;
+  /** Optional: secondary qualifier (e.g. relay state 'idle' / 'executing'). */
+  detail?: string;
+}
+
+/**
+ * Result of a safeRelaySend call. Discriminated on `ok`.
+ *
+ * Success: `{ ok: true; result: T }` — the resolved value of the send promise
+ * Failure: `{ ok: false; error: unknown }` — the original rejection (already logged)
+ *
+ * Callers that don't care about the result can ignore the return value entirely
+ * (the wrapper still logs + would emit telemetry). Callers that DO care can
+ * switch on `result.ok` without any try/catch boilerplate.
+ */
+export type SafeRelaySendResult<T> =
+  | { ok: true; result: T }
+  | { ok: false; error: unknown };
+
+/**
+ * Wrap a relay-send promise so its rejection becomes a structured logger.warn
+ * call (instead of a silent `.catch(() => {})` or low-signal `logger.debug`).
+ *
+ * Always resolves; never rejects. Caller does not need a `.catch()`.
+ *
+ * @param send - The promise returned by an `api.send*(...)` call.
+ * @param context - Session + categorization metadata for the log line.
+ * @returns A discriminated-union result.
+ *
+ * @example
+ *   await safeRelaySend(
+ *     api.sendSessionState(sessionId, agentType, 'idle'),
+ *     { sessionId, messageType: 'session-state', detail: 'idle' }
+ *   );
+ */
+export async function safeRelaySend<T>(
+  send: Promise<T>,
+  context: SafeRelaySendContext
+): Promise<SafeRelaySendResult<T>> {
+  try {
+    const result = await send;
+    return { ok: true, result };
+  } catch (error: unknown) {
+    logger.warn('Relay send failed', {
+      sessionId: context.sessionId,
+      messageType: context.messageType,
+      detail: context.detail,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { ok: false, error };
+  }
+}

--- a/packages/styrby-cli/src/costs/__tests__/budget-actions.stop-notification.test.ts
+++ b/packages/styrby-cli/src/costs/__tests__/budget-actions.stop-notification.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for BudgetActions stop-notification failure handling (B4-Wave2).
+ *
+ * WHY: When a budget alert fires `hard_stop`, the action chain calls
+ * `relayClient.send({ action: 'end_session' })` to tell the mobile UI the
+ * session is being terminated. If that send rejects (relay disconnected,
+ * server returning 5xx), the previous code silently swallowed via
+ * `this.log()` — which only emits when `config.debug=true`. In production,
+ * the failure was completely invisible.
+ *
+ * The fix upgrades to `logger.warn` with structured context so ops can see
+ * the failure even though the local stop callback still fires (CLI does
+ * halt; only the mobile-side notification is lost).
+ *
+ * @module costs/__tests__/budget-actions.stop-notification
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const { mockLoggerWarn } = vi.hoisted(() => ({
+  mockLoggerWarn: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockLoggerWarn,
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@styrby/shared/pricing', () => ({
+  getModelPriceSync: vi.fn(() => ({
+    inputPer1k: 0.003,
+    outputPer1k: 0.015,
+    cachePer1k: 0.0003,
+    cacheWritePer1k: 0.00375,
+  })),
+}));
+
+vi.mock('../jsonl-parser.js', () => ({
+  getCostsForDateRange: vi.fn(async () => ({
+    totalCostUsd: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    entries: [],
+  })),
+}));
+
+import { BudgetActions, type BudgetActionsConfig } from '../budget-actions.js';
+import type { BudgetAlert, BudgetCheckResult } from '../budget-monitor.js';
+import type { RelayClient } from 'styrby-shared';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const VALID_UUID = '12345678-1234-4234-8234-123456789abc';
+
+function makeAlert(overrides: Partial<BudgetAlert> = {}): BudgetAlert {
+  return {
+    id: VALID_UUID,
+    user_id: VALID_UUID,
+    name: 'Daily Budget',
+    threshold_usd: 50,
+    period: 'daily',
+    agent_type: null,
+    action: 'hard_stop',
+    notification_channels: ['in_app'],
+    is_enabled: true,
+    last_triggered_at: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeExceededResult(): BudgetCheckResult {
+  return {
+    level: 'exceeded',
+    alert: makeAlert(),
+    currentSpendUsd: 75,
+    percentUsed: 150,
+    remainingUsd: -25,
+    exceeded: true,
+    isNewTrigger: true,
+  };
+}
+
+function makeSupabase() {
+  const channelMock = {
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn().mockResolvedValue(undefined),
+    unsubscribe: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    channel: vi.fn(() => channelMock),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function makeApiClient() {
+  return {
+    getNotificationPreferences: vi.fn(async () => ({ preferences: null })),
+    writeAuditEvent: vi.fn(async () => ({ id: 'a-1', created_at: new Date().toISOString() })),
+  } as unknown as import('@/api/styrbyApiClient').StyrbyApiClient;
+}
+
+function makeConfig(overrides: Partial<BudgetActionsConfig> = {}): BudgetActionsConfig {
+  return {
+    supabase: makeSupabase(),
+    apiClient: makeApiClient(),
+    userId: VALID_UUID,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('BudgetActions stop-notification failure (B4-Wave2)', () => {
+  beforeEach(() => {
+    mockLoggerWarn.mockClear();
+  });
+
+  it('logs at WARN with alert context when relayClient.send rejects', async () => {
+    const failingRelay: RelayClient = {
+      send: vi.fn().mockRejectedValue(new Error('relay-disconnected')),
+    } as unknown as RelayClient;
+
+    const onStopSession = vi.fn().mockResolvedValue(undefined);
+    const actions = new BudgetActions(
+      makeConfig({ relayClient: failingRelay, onStopSession })
+    );
+
+    // hard_stop action triggers stopSession()
+    await actions.executeAction(makeExceededResult());
+
+    expect(mockLoggerWarn).toHaveBeenCalled();
+    const [msg, ctx] = mockLoggerWarn.mock.calls[0] as [string, Record<string, unknown>];
+    expect(msg).toContain('stop-notification failed');
+    // Structured context — ops can grep by alert ID
+    expect(ctx.alertId).toBe(VALID_UUID);
+    expect(ctx.alertName).toBe('Daily Budget');
+    expect(ctx.error).toBe('relay-disconnected');
+  });
+
+  it('local stop callback STILL fires even when relay-notification fails (CLI halts regardless)', async () => {
+    const failingRelay: RelayClient = {
+      send: vi.fn().mockRejectedValue(new Error('relay-down')),
+    } as unknown as RelayClient;
+
+    const onStopSession = vi.fn().mockResolvedValue(undefined);
+    const actions = new BudgetActions(
+      makeConfig({ relayClient: failingRelay, onStopSession })
+    );
+
+    await actions.executeAction(makeExceededResult());
+
+    // The CLI-side stop must still fire — mobile-notification failure
+    // does NOT stop the user from being protected from over-spend
+    expect(onStopSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT log warn when relay-notification succeeds (no spam on happy path)', async () => {
+    const okRelay: RelayClient = {
+      send: vi.fn().mockResolvedValue(undefined),
+    } as unknown as RelayClient;
+
+    const actions = new BudgetActions(
+      makeConfig({ relayClient: okRelay, onStopSession: vi.fn() })
+    );
+
+    await actions.executeAction(makeExceededResult());
+
+    // No warn fired; the only path that warns is rejection
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('handles non-Error rejections from relay (string, plain object) without crashing', async () => {
+    const stringRejecting: RelayClient = {
+      send: vi.fn().mockRejectedValue('relay-error-string'),
+    } as unknown as RelayClient;
+
+    const actions = new BudgetActions(
+      makeConfig({ relayClient: stringRejecting, onStopSession: vi.fn() })
+    );
+
+    await actions.executeAction(makeExceededResult());
+
+    expect(mockLoggerWarn).toHaveBeenCalled();
+    const [, ctx] = mockLoggerWarn.mock.calls[0] as [string, Record<string, unknown>];
+    expect(ctx.error).toBe('relay-error-string');
+  });
+});

--- a/packages/styrby-cli/src/costs/budget-actions.ts
+++ b/packages/styrby-cli/src/costs/budget-actions.ts
@@ -18,6 +18,7 @@ import type {
   BudgetAlertAction,
   BudgetMonitor,
 } from './budget-monitor.js';
+import { logger } from '@/ui/logger';
 
 // ============================================================================
 // Types
@@ -569,7 +570,17 @@ export class BudgetActions {
         });
       }
     } catch (error) {
-      this.log('Failed to send stop notification:', error);
+      // WHY warn (B4-Wave2): a budget-stop notification failure means the
+      // user's mobile UI never learns the session was force-stopped due to
+      // budget. The local stop callback (this.config.onStopSession) still
+      // fires below, so the CLI does halt — but the user sees a frozen
+      // mobile UI until they manually refresh. The previous `this.log`
+      // only emitted in debug mode, masking this in production.
+      logger.warn('Budget stop-notification failed (CLI stops anyway, mobile UI may show stale state)', {
+        alertId: result.alert.id,
+        alertName: result.alert.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
 
     // Call the stop callback if configured


### PR DESCRIPTION
## Summary

Second wave of the B4 error-handling completeness audit. Closes the **data-integrity tier** (relay path, cost flushes, budget actions). 11 real fixes via a single uniform wrapper + 13 regression tests, with 14 audit false-positives explicitly rejected after read-the-code triage.

## Approach: extract uniform `safeRelaySend()` wrapper

Per [ADR-003](../blob/main/docs/decisions/ADR-003-extract-decision-then-test-pattern.md) (extract-pure-decision-then-test), the 10 \`.catch\` sites in \`apiSession.ts\` shared a structural problem — all wanted "log + carry on" but each did it differently (some \`logger.debug\`, some \`.catch(() => {})\`, varying context). Extracting one wrapper:

\`\`\`ts
// api/safeRelaySend.ts (NEW, ~70 LOC)
async function safeRelaySend<T>(
  send: Promise<T>,
  context: SafeRelaySendContext
): Promise<{ ok: true; result: T } | { ok: false; error: unknown }>
\`\`\`

After the refactor, every relay-send site is a one-liner:

\`\`\`ts
void safeRelaySend(api.sendX(...), { sessionId, messageType, detail });
\`\`\`

vs. the prior 4-line \`.catch\` boilerplate. **Single import point for future Sentry.captureException + telemetry.**

## Fixes (11)

\`apiSession.ts\` — 10 sites converted to \`safeRelaySend\`:

| Line | Send | What previously hid the failure |
|---|---|---|
| 219 | \`sendSessionState('idle')\` on stop | empty \`.catch(() => {})\` |
| 270-275 | \`sendAgentResponse\` (model-output) | \`logger.debug\` |
| 291-300 | \`sendSessionState\` (status) | \`logger.debug\` |
| 310-318 | \`sendPermissionRequest\` ⚠️ critical | \`logger.debug\` |
| 322 + 327-332 | \`tool-call\` pair | empty \`.catch(() => {})\` |
| 338-343 | \`tool-result\` | empty \`.catch(() => {})\` |
| 349-354 | \`fs-edit\` | empty \`.catch(() => {})\` |
| 360-365 | \`terminal-output\` | empty \`.catch(() => {})\` |
| 451-457 | \`sendSessionState('error')\` in chat-error | empty \`.catch(() => {})\` |

\`budget-actions.ts\` — 1 fix:

| Line | Smell | Fix |
|---|---|---|
| 571-572 | stop-notification \`this.log\` (debug-only) | upgrade to \`logger.warn\` with structured \`{ alertId, alertName, error }\` context. CLI-side stop callback still fires; only the mobile-side notification was previously silent. |

## False positives explicitly rejected (14 of 18)

\`cost-reporter.ts\` (lines 203, 272, 753): all 3 \`.catch\` blocks call \`emit('error', ...)\` with structured payloads. Subscribers receive the error via the EventEmitter contract. **Not silent.**

\`budget-actions.ts\`:
- L252 (executeAction catch): returns structured failure (\`success: false, error: msg\`); caller checks
- L441 (sendRealtimeNotification catch): returns \`false\`; caller routes channels accordingly
- L482-501 (writeAuditEvent .catch): explicitly documented as non-fatal via inline WHY comment. The actual notification fires upstream. **Audit conflated audit-log write with email send.**
- L504 (queueEmailNotification catch): returns \`false\`; caller skips email channel

## Tests (+13)

\`api/__tests__/safeRelaySend.test.ts\` (NEW, 9 tests):
- Success: returns \`{ ok: true; result }\` with type preservation
- Failure: returns \`{ ok: false; error }\` — never rethrows
- Non-Error rejections (string, plain object) handled cleanly
- \`logger.warn\` called with full context (sessionId, messageType, detail, error)
- \`logger.warn\` NOT called on success
- void-prefix idiom doesn't trigger Node \`unhandledRejection\` handler

\`costs/__tests__/budget-actions.stop-notification.test.ts\` (NEW, 4 tests):
- \`logger.warn\` called with alert context when relay rejects
- Local stop callback STILL fires when relay-notification fails
- No warn on success path
- Non-Error rejections handled

**Total CLI suite: 2893 → 2906 (+13).**

## Pre-push gate

- [x] \`npm run typecheck\` ✅
- [x] \`npm run build\` ✅ (no bundle size regression)
- [x] \`npm test\` ✅ 2906/2906 pass + 5 skipped
- [x] No new \`as any\` (still at 1, per ADR-005)

## Wave plan progress

- ✅ Wave 1 (security tier) — PR #281 merged
- 🔧 Wave 2 (data-integrity tier) — **this PR**
- ⏳ Wave 3 (operational tier) — daemon, agent spawn, IPC paths (next)
- ⏳ Wave 4 (closeout) — ADR-006 codifying the wrapper + tier discipline

🤖 Shipped via /gh-ship