### PR TITLE
fix(cli): B4-Wave3 — operational error-handling (bounded launch retry) (+12 tests)

### DIFF
--- a/packages/styrby-cli/src/claude/claudeLocalLauncher.ts
+++ b/packages/styrby-cli/src/claude/claudeLocalLauncher.ts
@@ -3,6 +3,7 @@ import { claudeLocal, ExitCodeError } from "./claudeLocal";
 import { Session } from "./session";
 import { Future } from "@/utils/future";
 import { createSessionScanner } from "./utils/sessionScanner";
+import { createLaunchRetryState, decideRetry } from "./utils/launchRetryPolicy";
 
 export type LauncherResult = { type: 'switch' } | { type: 'exit', code: number };
 
@@ -90,7 +91,9 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
             scanner.onNewSession(sessionId);
         }
 
-        // Run local mode
+        // Run local mode (B4-Wave3: bounded-retry via decideRetry helper —
+        // see claude/utils/launchRetryPolicy.ts for the exact policy).
+        const retryState = createLaunchRetryState();
         while (true) {
             // If we already have an exit reason, return it
             if (exitReason) {
@@ -99,6 +102,7 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
 
             // Launch
             logger.debug('[local]: launch');
+            const launchStartMs = Date.now();
             try {
                 await claudeLocal({
                     path: session.path,
@@ -130,6 +134,21 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
                     break;
                 }
                 if (!exitReason) {
+                    // Decide whether to keep retrying or give up. The policy
+                    // gives up after N consecutive fast failures (default 3
+                    // within 2s each) — that pattern means the binary itself
+                    // is broken (missing PATH, corrupt install) and looping
+                    // burns CPU without making progress.
+                    const decision = decideRetry(retryState, Date.now() - launchStartMs);
+                    if (decision.action === 'give-up') {
+                        logger.error('[local]: launch retry policy gave up', {
+                            reason: decision.reason,
+                            consecutiveFastFailures: decision.consecutiveFastFailures,
+                        });
+                        session.client.sendSessionEvent({ type: 'message', message: decision.reason });
+                        exitReason = { type: 'exit', code: 1 };
+                        break;
+                    }
                     session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
                     continue;
                 } else {

--- a/packages/styrby-cli/src/claude/utils/__tests__/launchRetryPolicy.test.ts
+++ b/packages/styrby-cli/src/claude/utils/__tests__/launchRetryPolicy.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for launchRetryPolicy — bounded-retry decision logic.
+ *
+ * WHY (B4-Wave3): The previous claudeLocalLauncher loop had no retry cap.
+ * If the Claude binary kept failing within milliseconds (PATH issue,
+ * missing install, corrupted node_modules), the loop spun forever burning
+ * CPU. The policy added here caps consecutive fast failures at 3 with a
+ * clear give-up message. These tests pin that contract.
+ *
+ * @module claude/utils/__tests__/launchRetryPolicy
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createLaunchRetryState,
+  decideRetry,
+  FAST_FAIL_WINDOW_MS,
+  MAX_CONSECUTIVE_FAST_FAILURES,
+} from '../launchRetryPolicy';
+
+describe('launchRetryPolicy', () => {
+  // --------------------------------------------------------------------------
+  // createLaunchRetryState
+  // --------------------------------------------------------------------------
+
+  it('createLaunchRetryState returns a fresh state with 0 consecutive failures', () => {
+    const state = createLaunchRetryState();
+    expect(state.consecutiveFastFailures).toBe(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // Slow failures: never give up
+  // --------------------------------------------------------------------------
+
+  it('a SLOW failure (>= FAST_FAIL_WINDOW_MS) decides RETRY', () => {
+    const state = createLaunchRetryState();
+    const decision = decideRetry(state, FAST_FAIL_WINDOW_MS + 100);
+
+    expect(decision.action).toBe('retry');
+    if (decision.action === 'retry') {
+      expect(decision.consecutiveFastFailures).toBe(0);
+    }
+  });
+
+  it('many SLOW failures in a row never trigger give-up (counter stays at 0)', () => {
+    const state = createLaunchRetryState();
+
+    for (let i = 0; i < 50; i++) {
+      const decision = decideRetry(state, FAST_FAIL_WINDOW_MS + 500);
+      expect(decision.action).toBe('retry');
+    }
+
+    expect(state.consecutiveFastFailures).toBe(0);
+  });
+
+  it('a SLOW failure RESETS the fast-fail counter (different problem class)', () => {
+    const state = createLaunchRetryState();
+
+    // Two fast failures
+    decideRetry(state, 100);
+    decideRetry(state, 100);
+    expect(state.consecutiveFastFailures).toBe(2);
+
+    // One slow failure resets
+    const slowDecision = decideRetry(state, FAST_FAIL_WINDOW_MS + 100);
+    expect(slowDecision.action).toBe('retry');
+    expect(state.consecutiveFastFailures).toBe(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // Fast failures: give up after threshold
+  // --------------------------------------------------------------------------
+
+  it('a single FAST failure decides RETRY (under threshold)', () => {
+    const state = createLaunchRetryState();
+    const decision = decideRetry(state, 100);
+
+    expect(decision.action).toBe('retry');
+    if (decision.action === 'retry') {
+      expect(decision.consecutiveFastFailures).toBe(1);
+    }
+  });
+
+  it(`gives up after exactly MAX_CONSECUTIVE_FAST_FAILURES (${MAX_CONSECUTIVE_FAST_FAILURES}) consecutive fast failures`, () => {
+    const state = createLaunchRetryState();
+
+    // First (MAX - 1) fast failures: still retry
+    for (let i = 0; i < MAX_CONSECUTIVE_FAST_FAILURES - 1; i++) {
+      const d = decideRetry(state, 100);
+      expect(d.action).toBe('retry');
+    }
+
+    // The Nth fast failure trips give-up
+    const giveUp = decideRetry(state, 100);
+    expect(giveUp.action).toBe('give-up');
+    if (giveUp.action === 'give-up') {
+      expect(giveUp.consecutiveFastFailures).toBe(MAX_CONSECUTIVE_FAST_FAILURES);
+      // Reason mentions the threshold + the binary so users get an actionable hint
+      expect(giveUp.reason).toContain('claude');
+      expect(giveUp.reason).toContain(String(MAX_CONSECUTIVE_FAST_FAILURES));
+      expect(giveUp.reason).toContain('PATH');
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // Edge: failure RIGHT AT the boundary
+  // --------------------------------------------------------------------------
+
+  it('a failure exactly at FAST_FAIL_WINDOW_MS counts as SLOW (>= boundary)', () => {
+    const state = createLaunchRetryState();
+    const decision = decideRetry(state, FAST_FAIL_WINDOW_MS);
+
+    // Equal-to is the slow side per the helper's `<` comparison
+    expect(decision.action).toBe('retry');
+    expect(state.consecutiveFastFailures).toBe(0);
+  });
+
+  it('a failure at FAST_FAIL_WINDOW_MS - 1 counts as FAST', () => {
+    const state = createLaunchRetryState();
+    const decision = decideRetry(state, FAST_FAIL_WINDOW_MS - 1);
+
+    expect(decision.action).toBe('retry');
+    if (decision.action === 'retry') {
+      expect(decision.consecutiveFastFailures).toBe(1);
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // Mixed sequences
+  // --------------------------------------------------------------------------
+
+  it('fast → fast → slow → fast: no give-up (slow reset broke the streak)', () => {
+    const state = createLaunchRetryState();
+
+    expect(decideRetry(state, 100).action).toBe('retry'); // fast: counter=1
+    expect(decideRetry(state, 100).action).toBe('retry'); // fast: counter=2
+    expect(decideRetry(state, FAST_FAIL_WINDOW_MS + 1).action).toBe('retry'); // slow: counter=0
+    expect(decideRetry(state, 100).action).toBe('retry'); // fast: counter=1, no give-up
+
+    expect(state.consecutiveFastFailures).toBe(1);
+  });
+
+  it('fast x N times after a slow reset: gives up only after another N consecutive fast', () => {
+    const state = createLaunchRetryState();
+
+    // Two fast, then a slow reset
+    decideRetry(state, 100);
+    decideRetry(state, 100);
+    decideRetry(state, FAST_FAIL_WINDOW_MS + 100);
+
+    // Now do MAX-1 more fast failures
+    for (let i = 0; i < MAX_CONSECUTIVE_FAST_FAILURES - 1; i++) {
+      const d = decideRetry(state, 100);
+      expect(d.action).toBe('retry');
+    }
+
+    // The next one hits give-up
+    expect(decideRetry(state, 100).action).toBe('give-up');
+  });
+
+  // --------------------------------------------------------------------------
+  // Constants exported for callers + the contract that they're sane
+  // --------------------------------------------------------------------------
+
+  it('FAST_FAIL_WINDOW_MS is at least 1 second (avoid catching real session crashes)', () => {
+    expect(FAST_FAIL_WINDOW_MS).toBeGreaterThanOrEqual(1_000);
+  });
+
+  it('MAX_CONSECUTIVE_FAST_FAILURES is at least 2 (so a single-blip transient gets a retry)', () => {
+    expect(MAX_CONSECUTIVE_FAST_FAILURES).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/styrby-cli/src/claude/utils/launchRetryPolicy.ts
+++ b/packages/styrby-cli/src/claude/utils/launchRetryPolicy.ts
@@ -1,0 +1,114 @@
+/**
+ * launchRetryPolicy — bounded-retry decision for the local Claude launcher
+ *
+ * WHY (B4-Wave3 — error-handling completeness): The launch loop in
+ * `claudeLocalLauncher.ts` previously did `while (true) { try { await
+ * claudeLocal(...) } catch { continue } }` with no upper bound on retries.
+ * If the Claude binary kept failing synchronously (missing PATH entry,
+ * corrupted install, missing dependency on first launch after node-modules
+ * wipe), the loop burned CPU forever, never surfacing the underlying
+ * problem to the user.
+ *
+ * The policy:
+ *   - **Fast failure** = a thrown error that occurs within
+ *     `FAST_FAIL_WINDOW_MS` (default 2s) of attempt start.
+ *   - **Slow failure** = thrown error after the binary ran for >2s. This
+ *     usually indicates a real session that crashed; retry is appropriate.
+ *   - After **MAX_CONSECUTIVE_FAST_FAILURES** (default 3) consecutive fast
+ *     failures, give up and surface as an error exit code instead of
+ *     looping. The user gets a clear error message; the CPU stops burning.
+ *   - Slow failures reset the fast-fail counter (a session that ran for a
+ *     while + crashed isn't the same problem class as "binary won't start").
+ *
+ * Extracted as a pure helper so the policy can be unit-tested without
+ * spawning real subprocesses.
+ *
+ * @module claude/utils/launchRetryPolicy
+ */
+
+/**
+ * A failure that ran for less than this duration counts as "fast" — i.e.
+ * the spawn is likely failing synchronously rather than partway through
+ * a real session.
+ */
+export const FAST_FAIL_WINDOW_MS = 2_000;
+
+/**
+ * After this many consecutive fast failures, the policy says "give up" —
+ * something is structurally broken (missing binary, bad PATH, etc.) and
+ * spinning the loop won't fix it.
+ */
+export const MAX_CONSECUTIVE_FAST_FAILURES = 3;
+
+/**
+ * Decision returned by the policy after a launch attempt fails.
+ *
+ * - `retry` — keep going; the failure looks transient.
+ * - `give-up` — too many fast failures in a row; surface as exit code 1.
+ */
+export type LaunchRetryDecision =
+  | { action: 'retry'; consecutiveFastFailures: number }
+  | { action: 'give-up'; reason: string; consecutiveFastFailures: number };
+
+/**
+ * Internal state carried across launch attempts.
+ *
+ * Construct one per launcher instance via `createLaunchRetryState()`.
+ */
+export interface LaunchRetryState {
+  consecutiveFastFailures: number;
+}
+
+/**
+ * Build a fresh retry-state. Call once per launcher invocation.
+ */
+export function createLaunchRetryState(): LaunchRetryState {
+  return { consecutiveFastFailures: 0 };
+}
+
+/**
+ * Decide whether to retry a launch given how long the previous attempt ran
+ * for before it threw, and the cumulative fast-failure count.
+ *
+ * @param state - Mutable retry state (mutated in-place — the caller's state
+ *                object reflects the new counter after the call).
+ * @param attemptDurationMs - How long the failed attempt ran before throwing.
+ * @returns A decision describing whether to retry or give up.
+ *
+ * @example
+ *   const state = createLaunchRetryState();
+ *   const start = Date.now();
+ *   try {
+ *     await claudeLocal(...);
+ *   } catch (e) {
+ *     const decision = decideRetry(state, Date.now() - start);
+ *     if (decision.action === 'give-up') break;
+ *   }
+ */
+export function decideRetry(
+  state: LaunchRetryState,
+  attemptDurationMs: number
+): LaunchRetryDecision {
+  if (attemptDurationMs < FAST_FAIL_WINDOW_MS) {
+    state.consecutiveFastFailures += 1;
+  } else {
+    // Slow failure: reset counter — this is a different problem class.
+    state.consecutiveFastFailures = 0;
+  }
+
+  if (state.consecutiveFastFailures >= MAX_CONSECUTIVE_FAST_FAILURES) {
+    return {
+      action: 'give-up',
+      reason:
+        `Claude binary failed to start ${state.consecutiveFastFailures} times in a row ` +
+        `(each within ${FAST_FAIL_WINDOW_MS}ms). Likely cause: missing or unreachable ` +
+        `'claude' binary on PATH, or a broken install. Check 'styrby doctor' for diagnostics.`,
+      consecutiveFastFailures: state.consecutiveFastFailures,
+    };
+  }
+
+  return {
+    action: 'retry',
+    consecutiveFastFailures: state.consecutiveFastFailures,
+  };
+}


### PR DESCRIPTION
## Summary

Third wave of the B4 error-handling completeness audit. Closes the **operational tier** (daemon, agent spawn, IPC paths). One real fix + 12 regression tests, with **16 of 17 audit findings explicitly rejected** as false positives.

## The one real fix: bounded launch retry

\`claudeLocalLauncher.ts:94\` had \`while (true) { try { await claudeLocal(...) } catch { continue } }\` with no upper bound. If the Claude binary kept failing synchronously (PATH issue, corrupted install, missing native dep), the loop spun forever burning CPU.

### Approach: extract \`launchRetryPolicy\` helper (ADR-003 pattern)

NEW: \`claude/utils/launchRetryPolicy.ts\` (~80 LOC) — pure decision function:

\`\`\`ts
export function decideRetry(
  state: LaunchRetryState,
  attemptDurationMs: number
): { action: 'retry' | 'give-up'; consecutiveFastFailures: number; reason?: string }
\`\`\`

Policy:
- **Fast failure** = thrown error within \`FAST_FAIL_WINDOW_MS\` (2s) of attempt start
- **Slow failure** = ran for >=2s before throwing — likely a real session crashed; retry OK
- **Cap** = \`MAX_CONSECUTIVE_FAST_FAILURES\` (3); after that, give-up + actionable reason
- **Slow failures RESET the fast-fail counter** (different problem class)

After give-up, the launcher sets \`exitReason = { type: 'exit', code: 1 }\` and surfaces:
> Claude binary failed to start 3 times in a row (each within 2000ms). Likely cause: missing or unreachable 'claude' binary on PATH, or a broken install. Check 'styrby doctor' for diagnostics.

## False positives explicitly rejected (16 of 17)

| File | Lines | Why rejected |
|---|---|---|
| \`daemon/run.ts\` | 477, 550 | Already \`logger.error\` with full context |
| \`commands/daemon.ts\` | 277, 313, 441, 469 | All 4 install/uninstall errors do red console + \`logger.error\` + \`process.exit(1)\` |
| \`multiAgentOrchestrator.ts\` | 287, 305, 310, 365, 404, 484 | All 6 catches have explicit inline WHY-comments |
| \`mcp/approvalHandler.ts\` | 234 | Explicit best-effort with WHY + \`console.error\` fallback |
| \`claudeLocalLauncher.ts\` | 125 | Uses \`e instanceof ExitCodeError\` narrowing — not UNTYPED-CATCH-READ |
| \`claude/loop.ts\` | 68 | \`while (true)\` mode-switch loop; each iter awaits a launcher (seconds-to-minutes) |
| \`utils/MessageQueue.ts\` | 82 | \`while (true)\` async iterator; each iter awaits \`waitForNext()\` |

## Tests (+12)

\`claude/utils/__tests__/launchRetryPolicy.test.ts\` (NEW, 12 tests):
- Fresh state initializes counter to 0
- Slow failure → RETRY + counter stays at 0
- 50 slow failures in a row never give up
- Slow failure RESETS counter mid-streak
- Single fast failure → RETRY (under threshold)
- Exactly MAX consecutive fast failures trips give-up
- Give-up reason contains 'claude' + count + 'PATH' (actionable)
- Boundary: failure at exactly \`FAST_FAIL_WINDOW_MS\` counts as slow
- Boundary: failure at \`FAST_FAIL_WINDOW_MS - 1\` counts as fast
- Mixed sequences: fast-fast-slow-fast doesn't trip give-up
- Counter re-trips after slow reset + N more consecutive fast
- Constants are sane (window >= 1s, max >= 2)

**Total CLI suite: 2906 → 2918 (+12).**

## Wave statistics across all 3 waves

| Tier | Audit candidates | Real fixes | False-positive rate |
|---|---:|---:|---:|
| Security | 15 | 5 | 67% |
| Data-integrity | 18 | 11 | 39% |
| Operational | 17 | 1 | **94%** |
| **TOTAL** | **50** | **17** | **66%** |

Operational tier had the highest false-positive rate, consistent with "old + stable code is already correct because someone got burned and added the WHY-comment defensive pattern." Will codify in **ADR-006 (Wave 4)**.

## Pre-push gate

- [x] \`npm run typecheck\` ✅
- [x] \`npm run build\` ✅
- [x] \`npm test\` ✅ 2918/2918 pass + 5 skipped

## Wave plan progress

- ✅ Wave 1 (security tier) — PR #281
- ✅ Wave 2 (data-integrity tier) — PR #282
- 🔧 Wave 3 (operational tier) — **this PR**
- ⏳ Wave 4 (closeout) — ADR-006

🤖 Shipped via /gh-ship