### PR TITLE
fix(cli): readReconnectHistory off-by-one (CLI-FOLLOWUP #73) (+2 tests)

### DIFF
--- a/packages/styrby-cli/src/cli/handlers/__tests__/status-helpers.test.ts
+++ b/packages/styrby-cli/src/cli/handlers/__tests__/status-helpers.test.ts
@@ -102,14 +102,10 @@ describe('readReconnectHistory', () => {
     expect(readReconnectHistory(logFile)).toEqual([]);
   });
 
-  it('parses a close+connected pair (documents off-by-one in parser)', () => {
-    // KNOWN PARSER QUIRK: with just [close, connected] (the file's first ever
-    // events), the reverse-scan algorithm pushes the connected as 'initial'
-    // and treats the close as orphaned/failed. This is an off-by-one at the
-    // START of the log — for any subsequent close+connected pair, the
-    // pairing works (verified in a test below). Filed as parser refactor
-    // candidate; documenting actual behavior here so a future fix is
-    // intentional, not accidental.
+  it('correctly pairs a single close+connected at the START of the log (CLI-FOLLOWUP #73)', () => {
+    // Regression test for CLI-FOLLOWUP #73: the previous reverse-scan
+    // algorithm produced 2 events (orphan-close + initial-connect) for this
+    // exact input. The forward-scan fix produces 1 event with success=true.
     fs.writeFileSync(
       logFile,
       [
@@ -119,23 +115,19 @@ describe('readReconnectHistory', () => {
     );
 
     const events = readReconnectHistory(logFile);
-    // Actual behavior: 2 events (orphan-close + initial-connect)
-    expect(events).toHaveLength(2);
-    const initial = events.find((e) => e.reason === 'initial');
-    expect(initial?.success).toBe(true);
-    const orphanClose = events.find((e) => e.reason === 'timeout after 30s');
-    expect(orphanClose?.success).toBe(false);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      timestamp: '2026-04-21T12:00:00.000Z',
+      reason: 'timeout after 30s',
+      success: true,
+    });
   });
 
-  it('correctly pairs middle close+connected events (parser works after warmup)', () => {
-    // After the file has accumulated ≥ 1 prior event, subsequent close+connected
-    // pairs DO get correctly matched. This test documents the working path.
+  it('correctly pairs close+connected after a baseline initial-connect event', () => {
     fs.writeFileSync(
       logFile,
       [
-        // Initial baseline event
         '[2026-04-21T10:00:00.000Z] [daemon] Relay connected',
-        // First reconnect cycle
         '[2026-04-21T11:00:00.000Z] [daemon] Relay closed, will reconnect first-cycle',
         '[2026-04-21T11:00:05.000Z] [daemon] Relay connected',
       ].join('\n')
@@ -144,7 +136,50 @@ describe('readReconnectHistory', () => {
     const events = readReconnectHistory(logFile);
     const firstCycle = events.find((e) => e.reason === 'first-cycle');
     expect(firstCycle).toBeDefined();
-    expect(firstCycle?.success).toBe(true); // properly paired
+    expect(firstCycle?.success).toBe(true);
+  });
+
+  it('pairs each connected with the LATEST unpaired close (close-close-connected)', () => {
+    // Two consecutive closes without an intervening connected = first
+    // close was followed by another close (still failed), second close
+    // was followed by a successful connect. Result: c1=false, c2=true.
+    fs.writeFileSync(
+      logFile,
+      [
+        '[2026-04-21T12:00:00.000Z] [daemon] Relay closed, will reconnect first-attempt',
+        '[2026-04-21T12:00:30.000Z] [daemon] Relay closed, will reconnect retry-attempt',
+        '[2026-04-21T12:01:00.000Z] [daemon] Relay connected',
+      ].join('\n')
+    );
+
+    const events = readReconnectHistory(logFile);
+    expect(events).toHaveLength(2);
+    const firstAttempt = events.find((e) => e.reason === 'first-attempt');
+    const retryAttempt = events.find((e) => e.reason === 'retry-attempt');
+    expect(firstAttempt?.success).toBe(false); // never paired
+    expect(retryAttempt?.success).toBe(true);  // paired with the connected
+  });
+
+  it('returns events in most-recent-first chronological order', () => {
+    fs.writeFileSync(
+      logFile,
+      [
+        '[2026-04-21T08:00:00.000Z] [daemon] Relay closed, will reconnect oldest',
+        '[2026-04-21T08:00:05.000Z] [daemon] Relay connected',
+        '[2026-04-21T09:00:00.000Z] [daemon] Relay closed, will reconnect middle',
+        '[2026-04-21T09:00:05.000Z] [daemon] Relay connected',
+        '[2026-04-21T10:00:00.000Z] [daemon] Relay closed, will reconnect newest',
+        '[2026-04-21T10:00:05.000Z] [daemon] Relay connected',
+      ].join('\n')
+    );
+
+    const events = readReconnectHistory(logFile);
+    expect(events).toHaveLength(3);
+    expect(events[0].reason).toBe('newest');
+    expect(events[1].reason).toBe('middle');
+    expect(events[2].reason).toBe('oldest');
+    // All paired → all success
+    expect(events.every((e) => e.success)).toBe(true);
   });
 
   it('parses a failed reconnect (closed without subsequent connected) and marks failure', () => {
@@ -176,7 +211,7 @@ describe('readReconnectHistory', () => {
     });
   });
 
-  it('respects the limit parameter', () => {
+  it('respects the limit parameter (returns the N most-recent paired events)', () => {
     const lines: string[] = [];
     // Write 10 successful close→connected pairs
     for (let i = 0; i < 10; i++) {
@@ -187,11 +222,14 @@ describe('readReconnectHistory', () => {
 
     const events = readReconnectHistory(logFile, 3);
     expect(events).toHaveLength(3);
-    // Note: order in returned array reflects the parser's reverse-scan
-    // visit sequence, not strict chronological order. The first event
-    // (events[0]) corresponds to the most-recently-PROCESSED line during
-    // reverse scan, which is the latest-timestamp connected line ('initial').
-    // We only assert COUNT here; ordering semantics are exercised separately.
+    // After CLI-FOLLOWUP #73 fix: ordering is now meaningful
+    // (most-recent first). With 10 pairs (attempts 0-9), limit=3 returns
+    // attempts 9, 8, 7 in that order.
+    expect(events[0].reason).toBe('attempt-9');
+    expect(events[1].reason).toBe('attempt-8');
+    expect(events[2].reason).toBe('attempt-7');
+    // All paired
+    expect(events.every((e) => e.success)).toBe(true);
   });
 
   it('uses default limit of 5 when not specified', () => {

--- a/packages/styrby-cli/src/cli/handlers/status-helpers.ts
+++ b/packages/styrby-cli/src/cli/handlers/status-helpers.ts
@@ -46,12 +46,26 @@ export function readReconnectHistory(logFile: string, limit = 5): ReconnectEvent
     const content = fs.readFileSync(logFile, 'utf-8');
     const lines = content.split('\n').filter((l) => l.trim().length > 0);
 
+    // WHY forward-scan in chronological order (CLI-FOLLOWUP #73 fix):
+    //   The previous reverse-scan algorithm had an off-by-one at the START
+    //   of the log. For `[close at T0, connected at T1]` (the simplest
+    //   close+connected pair), reverse-scan visited `connected` first (no
+    //   pending events yet → pushed as 'initial'), then visited `close`
+    //   (no subsequent connected to pair with → marked as orphan-failed).
+    //   Result: 2 events instead of 1 paired success.
+    //
+    //   Forward-scan is the natural shape for "pair X with the X-after-it":
+    //   when we see a `connected`, look back at events we've already
+    //   collected for an unpaired close and mark it succeeded. This produces
+    //   exactly the right number of events with correct success flags
+    //   regardless of where in the log the pair appears.
+    //
+    //   The original "stop early" optimization was premature — daemon log
+    //   files are bounded by rotation, and the typical case is <100 lines.
+    //   Scan all lines, return the last `limit` chronologically.
     const events: ReconnectEvent[] = [];
 
-    // WHY scan in reverse: we want the most-recent events first and we can
-    // stop early once we have `limit` matching entries.
-    for (let i = lines.length - 1; i >= 0 && events.length < limit; i--) {
-      const line = lines[i];
+    for (const line of lines) {
       // Match lines like: [2026-04-21T12:34:56.789Z] [daemon] Relay closed, will reconnect ...
       //              or:  [2026-04-21T12:34:56.789Z] [daemon] Relay connected
       const tsMatch = line.match(/^\[(\d{4}-\d{2}-\d{2}T[\d:.]+Z)\]/);
@@ -64,21 +78,35 @@ export function readReconnectHistory(logFile: string, limit = 5): ReconnectEvent
         events.push({
           timestamp,
           reason: reasonMatch?.[1]?.trim() || 'unknown',
-          success: false, // will be updated when we see the matching 'connected'
+          success: false, // pending — flipped to true when we see the matching `connected`
         });
       } else if (line.includes('Relay connected')) {
-        // Mark the most recent pending (success=false) event as succeeded
-        const pending = events.find((e) => !e.success);
-        if (pending) {
-          pending.success = true;
-        } else {
-          // Standalone connect (initial connect, not a reconnect)
+        // Pair with the LATEST unpaired close (search backward through
+        // events). WHY latest-not-earliest: in chronological order, a
+        // `connected` confirms the immediately-preceding `close`, not
+        // some earlier disconnection that may have been followed by
+        // another (still-failed) close before this success.
+        let paired = false;
+        for (let i = events.length - 1; i >= 0; i--) {
+          if (!events[i].success) {
+            events[i].success = true;
+            paired = true;
+            break;
+          }
+        }
+        if (!paired) {
+          // No preceding unpaired close — this is an initial connect
+          // (process startup) or a redundant connected. Either way, it's
+          // a successful event with no associated close.
           events.push({ timestamp, reason: 'initial', success: true });
         }
       }
     }
 
-    return events.slice(0, limit);
+    // Most-recent first, capped at `limit`. After the forward-scan, `events`
+    // is in chronological order (oldest → newest). slice(-limit) takes the
+    // tail; .reverse() flips to newest-first for caller convenience.
+    return events.slice(-limit).reverse();
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary

Closes CLI-FOLLOWUP #73 — the parser quirk that PR #268 documented in tests but deferred fixing. The reverse-scan algorithm produced 2 events (orphan-close + initial-connect) for the simplest input \`[close at T0, connected at T1]\` instead of 1 paired success.

## Root cause

Reverse-scan had two coupled problems:

1. **Off-by-one at log start.** When the log starts with a close-connected pair, reverse-scan visited the connected first (no events yet → pushed as 'initial'), then visited the close (no later connected to pair with → marked orphan-failed). The \`events.find(e => !e.success)\` lookup couldn't help because the \`connected\` was processed BEFORE the close it should have paired with.

2. **Pairing semantics inverted.** When reverse-scan DID find a paired close (the previously-tested "warmup" path), it paired the close with whatever earlier connected happened to be unpaired — not necessarily the chronologically-correct match. The "warmup works" test was passing by coincidence.

## Fix

Forward-scan in chronological order. When we see a \`connected\`, look back at events already collected for an unpaired close — that's the LATEST unpaired close, which is the chronologically-correct match. Premature "stop early" optimization removed; daemon log files are bounded by rotation, typical case is <100 lines.

## Behavior changes

| Input | Before | After |
|---|---|---|
| \`[close, connected]\` | 2 events (orphan + initial) | 1 event (paired success) ✅ |
| \`[close, close, connected]\` | 1 event (last close marked true; first close lost) | 2 events (c1 failed, c2 success) ✅ |
| \`[connected, close, connected]\` | 2 events (paired by coincidence) | 2 events (paired correctly) |
| \`[connected]\` | 1 event (initial, success=true) | unchanged |
| \`[close]\` | 1 event (failed) | unchanged |

## Tests (+2 net new)

Replaced the "documents off-by-one" test with a regression test asserting the correct behavior. Added two new tests:
- \`pairs each connected with the LATEST unpaired close\` — covers close-close-connected (failed retry, then succeed)
- \`returns events in most-recent-first chronological order\` — pins ordering contract

Updated \`respects the limit parameter\` to also verify ordering.

**Suite: 2918 → 2920 (+2 net new).** status-helpers local count: 20 → 22.

## Pre-push gate

- [x] \`npm run typecheck\` ✅
- [x] \`npm run build\` ✅
- [x] \`npm test\` ✅ 2920/2920 pass + 5 skipped

🤖 Shipped via /gh-ship