### PR TITLE
chore(mobile): bind to real Expo project (#71-A unblocked)

### DIFF
--- a/packages/styrby-mobile/README.md
+++ b/packages/styrby-mobile/README.md
@@ -48,19 +48,22 @@ pnpm test          # Jest test suite
 
 ### EAS Builds (CI/CD)
 
-**First-time setup (one-shot, per fresh clone of the repo):**
+**Project binding (completed 2026-05-06):**
 
-`app.json` ships with `extra.eas.projectId` set to the placeholder
-`TODO_OPERATOR_RUN_eas_init`. Before the first EAS Build will succeed,
-an operator must claim the project from the Expo dashboard:
+`app.json` is bound to the Expo project `@vetsecitpro/styrby`
+(projectId: `747dccfc-82d1-4d4d-9544-19c5632a6c5e`). The projectId is
+not a secret — it's a stable public identifier for the project in EAS.
+
+To run EAS commands locally for the first time on a fresh clone, you
+must authenticate the EAS CLI with your Expo account:
 
 ```bash
 cd packages/styrby-mobile
-npx eas init     # writes the real projectId UUID into app.json
+npx eas-cli@latest login   # one-time auth; tied to your Expo account
 ```
 
-Commit the resulting change (the projectId is not a secret — it's a
-stable public identifier for the project in EAS).
+After login, you can run any EAS command (`eas build`, `eas
+credentials`, `eas submit`) without re-authenticating.
 
 ```bash
 pnpm build:dev     # EAS development build

--- a/packages/styrby-mobile/app.json
+++ b/packages/styrby-mobile/app.json
@@ -135,9 +135,9 @@
         "origin": false
       },
       "eas": {
-        "projectId": "TODO_OPERATOR_RUN_eas_init"
+        "projectId": "747dccfc-82d1-4d4d-9544-19c5632a6c5e"
       }
     },
-    "owner": "steelmotion"
+    "owner": "vetsecitpro"
   }
 }


### PR DESCRIPTION
## Summary

Replaces the \`TODO_OPERATOR_RUN_eas_init\` placeholder in \`app.json\` with the real Expo projectId UUID assigned when the operator created \`@vetsecitpro/styrby\` on expo.dev. **One-line code change unblocks the entire mobile push pipeline.**

## Why this matters

Per the audit done earlier today (see backlog § \"Did we validate APNs/FCM?\"), the engineering for mobile push was already complete — Expo Push API integration in the Edge Function, mobile registration via \`getExpoPushTokenAsync\`, \`device_tokens\` table CRUD, the whole thing. **The ONLY thing breaking it was this one placeholder string.**

Before this PR: \`getExpoPushTokenAsync()\` threw because the projectId was a placeholder; the catch returned null; mobile silently never registered for push.

After this PR: real Expo project bound, mobile gets real tokens, \`device_tokens\` rows populate, Edge Function has targets to send to.

## Changes (2 files, 12 lines)

\`\`\`diff
# packages/styrby-mobile/app.json
       "eas": {
-        "projectId": "TODO_OPERATOR_RUN_eas_init"
+        "projectId": "747dccfc-82d1-4d4d-9544-19c5632a6c5e"
       }
     },
-    "owner": "steelmotion"
+    "owner": "vetsecitpro"
\`\`\`

The \`owner\` change matches the Expo account that hosts the project (\`vetsecitpro\` — same namespace as the GitHub org per CLAUDE.md). README updated to reflect the now-bound state.

## What this DOES NOT do (still operator-pending, separate steps)

This PR **only** does the projectId bind. The rest of the original \"#71 APNs + FCM\" task split:

- **#71-A** (this PR) — \`eas init\` equivalent. Unblocks Expo Push API end-to-end. ✅
- **#71-B** (next, when ready) — \`eas credentials\` for iOS APNs. Operator has Apple Developer account; ready to do this whenever.
- **#71-C** (still in progress operator-side) — Firebase + \`google-services.json\` for Android.

## Security note

The projectId is **not a secret** — it's a stable public identifier for the project in EAS, visible in any built binary and safe to commit publicly. The actual secrets (APNs auth key, Firebase service account, EAS Robot Token) stay in EAS / Vercel env / GitHub secrets and are not committed.

## Verification

- [x] \`app.json\` parses cleanly (Python \`json.load\`)
- [x] Mobile typecheck passes (no consumer of the previous placeholder string)
- [x] Mobile test suite: **1666/1666 pass** + 4 snapshots
- [x] No other \`TODO_OPERATOR_RUN_eas_init\` references remain in code or docs (grep)
- [x] No other \`\"owner\": \"steelmotion\"\` references in mobile config (grep)

## Test plan

- [ ] CI passes (no risk; one-line config change)
- [ ] Post-merge: when you next run \`pnpm dev\` on the mobile app, \`getExpoPushTokenAsync()\` should now succeed (you'll see a real \`ExponentPushToken[...]\` string)
- [ ] (Future, once Apple credentials done): real notification delivery to a test device

🤖 Shipped via /gh-ship