### PR TITLE
fix(mobile): eas.json — remove invalid empty-string credential placeholders (unblocks P2-B)

### DIFF
--- a/packages/styrby-mobile/eas.json
+++ b/packages/styrby-mobile/eas.json
@@ -36,7 +36,6 @@
       }
     },
     "cold-start-test": {
-      "_comment": "WHY this profile: Detox cold-start measurement requires a release-mode binary with the JS bundle embedded. Debug builds include Metro bundler overhead (hot-reload socket, Flipper bridge) that inflates cold-start by 200-400 ms and would produce unrepresentative measurements. This profile matches what end-users experience.",
       "distribution": "internal",
       "android": {
         "buildType": "apk",
@@ -54,24 +53,12 @@
   },
   "submit": {
     "production": {
-      "ios": {
-        "appleId": "",
-        "ascAppId": "",
-        "appleTeamId": ""
-      },
       "android": {
-        "serviceAccountKeyPath": "",
         "track": "production"
       }
     },
     "preview": {
-      "ios": {
-        "appleId": "",
-        "ascAppId": "",
-        "appleTeamId": ""
-      },
       "android": {
-        "serviceAccountKeyPath": "",
         "track": "internal"
       }
     }


### PR DESCRIPTION
## Summary

EAS CLI v13+ refused to validate \`eas.json\` due to empty-string credential placeholders + an out-of-schema \`_comment\` field. Surfaced when the operator ran \`npx eas-cli@latest credentials\` for the iOS APNs key setup (P2-B). This PR removes the invalid fields so the credentials walkthrough can proceed.

## What was rejected

\`\`\`
eas.json is not valid.
- "build.cold-start-test._comment" is not allowed
- "submit.production.android.serviceAccountKeyPath" is not allowed to be empty
- "submit.production.ios.appleId" is not allowed to be empty
- "submit.production.ios.ascAppId" is not allowed to be empty
- "submit.production.ios.appleTeamId" is not allowed to be empty
- "submit.preview.android.serviceAccountKeyPath" is not allowed to be empty
- "submit.preview.ios.appleId" is not allowed to be empty
- "submit.preview.ios.ascAppId" is not allowed to be empty
- "submit.preview.ios.appleTeamId" is not allowed to be empty
\`\`\`

## Why these patterns no longer work

1. **\`_comment\` fields:** strict JSON has no comment syntax. EAS now rejects out-of-schema fields. The rationale that comment captured (Release-mode binary required for Detox cold-start accuracy; Debug builds inflate by 200-400ms) is preserved in the commit message + the eas-cold-start.yml workflow header.

2. **Empty-string credentials:** EAS distinguishes \`""\` (empty: "I set this to nothing on purpose" → invalid) from omitted-entirely (\`"ask me at \`eas submit\` time"\` → valid). The empty-string placeholders were a convention to "remind future-you to fill these in" but are now actively rejected.

## Changes (-13 lines, 0 added)

- Removed \`_comment\` from \`build.cold-start-test\`
- Removed \`submit.production.ios\` block (was 3 empty strings → omitted entirely)
- Removed \`submit.production.android.serviceAccountKeyPath\` (was empty)
- Removed \`submit.preview.ios\` block (same as above)
- Removed \`submit.preview.android.serviceAccountKeyPath\` (was empty)

The \`android.track\` fields ("production" + "internal") are kept since they have real non-empty values.

## Behavioral impact

**Zero.** The empty-string fields were never used — \`eas submit\` would have prompted interactively anyway. The \`_comment\` was documentation only. No build, no submit, no test exercises these fields. Diff is purely a cleanup.

The actual iOS submit credentials (\`appleId\`, \`ascAppId\`, \`appleTeamId\`) will be added back in a follow-up PR (P2-B continuation) once the operator completes the now-unblocked \`eas credentials\` walkthrough.

## Verification

- [x] JSON parses cleanly (\`python json.load\`)
- [x] Mobile typecheck passes
- [x] Mobile test suite: **1666/1666 pass** + 4 snapshots
- [x] Diff is purely deletion (-13/+0)

## Operator next step

After this merges, re-run:

\`\`\`bash
cd packages/styrby-mobile
npx eas-cli@latest credentials
\`\`\`

It should now proceed past the validation gate and walk you through the APNs key generation.

🤖 Shipped via /gh-ship