### PR TITLE
fix(mobile): app.json slug → "styrby-app" to match Expo project

### DIFF
--- a/packages/styrby-mobile/README.md
+++ b/packages/styrby-mobile/README.md
@@ -50,7 +50,7 @@ pnpm test          # Jest test suite
 
 **Project binding (completed 2026-05-06):**
 
-`app.json` is bound to the Expo project `@vetsecitpro/styrby`
+`app.json` is bound to the Expo project `@vetsecitpro/styrby-app`
 (projectId: `747dccfc-82d1-4d4d-9544-19c5632a6c5e`). The projectId is
 not a secret — it's a stable public identifier for the project in EAS.
 

--- a/packages/styrby-mobile/app.json
+++ b/packages/styrby-mobile/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "Styrby",
-    "slug": "styrby",
+    "slug": "styrby-app",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",


### PR DESCRIPTION
## Summary

\`eas credentials\` rejected with:
\`\`\`
Project config: Slug for project identified by "extra.eas.projectId" (styrby-app) does not match the "slug" field (styrby).
\`\`\`

When the operator created the Expo project (PR #287's projectId bind), Expo assigned slug \`styrby-app\` (auto-suffixed; \`@global/styrby\` was likely taken). Local \`app.json\` had \`"slug": "styrby"\` — pre-dating the bind. Updating local to match.

## Why "change app.json" not "rename Expo project"

- Slug is Expo-internal (URL identifier on expo.dev); not user-visible
- Bundle IDs (\`com.steelmotion.styrby\`) are separate fields, unchanged
- Display name (\"Styrby\") is separate, unchanged
- No builds yet tied to old slug → zero history loss
- 1 line of code vs UI dashboard navigation

## Diff (2 lines)

\`\`\`diff
# packages/styrby-mobile/app.json
-    "slug": "styrby",
+    "slug": "styrby-app",

# packages/styrby-mobile/README.md
-`app.json` is bound to the Expo project `@vetsecitpro/styrby`
+`app.json` is bound to the Expo project `@vetsecitpro/styrby-app`
\`\`\`

## Verification

- [x] \`app.json\` parses cleanly
- [x] Mobile typecheck passes (no runtime consumer of slug)
- [x] No other \`"slug": "styrby"\` references (grep)

After merge, re-run \`npx eas-cli@latest credentials\` and the validation should pass.

🤖 Shipped via /gh-ship