### PR TITLE
chore(mobile): wire Android FCM via google-services.json (P2-C — push setup COMPLETE)

### DIFF
--- a/packages/styrby-mobile/README.md
+++ b/packages/styrby-mobile/README.md
@@ -54,6 +54,16 @@ pnpm test          # Jest test suite
 (projectId: `747dccfc-82d1-4d4d-9544-19c5632a6c5e`). The projectId is
 not a secret — it's a stable public identifier for the project in EAS.
 
+**Push credentials wired (2026-05-06 → 2026-05-07):**
+
+- iOS APNs: managed by EAS Credentials (Developer Portal ID
+  `Q96HYC3PR9`). Apple Team `L68P4Y7N55`. Built into binaries
+  automatically; not stored in this repo.
+- Android FCM: `google-services.json` committed at the root of this
+  package. Firebase project `rowan-c8006` (shared with Rowan). Per
+  Firebase docs, `google-services.json` is safe to commit — the
+  values are public identifiers, not secrets.
+
 To run EAS commands locally for the first time on a fresh clone, you
 must authenticate the EAS CLI with your Expo account:
 

--- a/packages/styrby-mobile/app.json
+++ b/packages/styrby-mobile/app.json
@@ -29,6 +29,7 @@
     "android": {
       "package": "com.steelmotion.styrby",
       "versionCode": 1,
+      "googleServicesFile": "./google-services.json",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#09090b"

--- a/packages/styrby-mobile/google-services.json
+++ b/packages/styrby-mobile/google-services.json
@@ -1,0 +1,48 @@
+{
+  "project_info": {
+    "project_number": "531471972009",
+    "project_id": "rowan-c8006",
+    "storage_bucket": "rowan-c8006.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:531471972009:android:35147bdb41a99e69e0dbb8",
+        "android_client_info": {
+          "package_name": "com.rowan.app"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAre5jzoUi8WBMFKiJw9K1yy2C03zAeI7g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:531471972009:android:de6480a0a56ca74fe0dbb8",
+        "android_client_info": {
+          "package_name": "com.steelmotion.styrby"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAre5jzoUi8WBMFKiJw9K1yy2C03zAeI7g"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## Summary

Adds \`google-services.json\` (generated by adding \`com.steelmotion.styrby\` as a second Android app inside the existing \`rowan-c8006\` Firebase project) and references it in \`app.json\` under \`android.googleServicesFile\`.

**This completes the P2 push setup workstream end-to-end (iOS + Android + web).**

## Pipeline status after this PR

\`\`\`
Mobile registration (getExpoPushTokenAsync)
     ↓
device_tokens upsert via /api/v1/push/subscribe
     ↓
send-push-notification Edge Function (Supabase)
     ↓
POST https://exp.host/--/api/v2/push/send
     ↓
Expo's relay infrastructure
     ↓
APNs (iOS — EAS Credentials handles signing) OR
FCM (Android — google-services.json provides project + key)
     ↓
Notification delivered to device
\`\`\`

**Every step is now wired in code.** What remains: end-to-end testing on real devices (P12). iOS half can be done immediately via Expo Go. Android half waits for a physical device.

## Firebase architecture decision

Operator hit Firebase's default 1-project quota and chose to add Styrby Android as a second app inside the existing \`rowan-c8006\` Firebase project rather than wait 24-48h for a quota-increase request. Trade-offs are documented in the commit message — short version: **fine for early stage, migrate to a separate project later if needed.**

Per-app fields are distinct (each Android app gets its own \`mobilesdk_app_id\` and FCM quota). Project-level fields are shared (analytics dashboard, billing if upgraded to Blaze plan, the \`api_key\` value).

## Why \`google-services.json\` is safe to commit publicly

The file contains:
- \`project_number\`, \`project_id\` — public identifiers
- \`mobilesdk_app_id\` — per-app Firebase identifier, public
- \`api_key\` (AIzaSy...) — Google API key, public-by-design

**Per Firebase official docs:** \"Unlike how API keys are typically used, API keys for Firebase services are not used to control access to backend resources; only Firebase Security Rules can do that.\" ([reference](https://firebase.google.com/docs/projects/api-keys))

The actual server-side FCM secret (used to send pushes) is NOT in this file — it lives in EAS-managed server config + Supabase Edge Function env. This file just enables the mobile app to identify itself to FCM at runtime.

## Backlog progress

| Sub-task | Status | PR |
|---|---|---|
| 71-A: Expo project bind | ✅ DONE | #287 |
| 71-B: iOS APNs + submit credentials | ✅ DONE | #290 |
| 71-C: Android FCM | ✅ DONE | **THIS PR** |

**ENTIRE P2 PUSH SETUP WORKSTREAM IS COMPLETE.** Mobile push is fully wired iOS + Android + web.

## Next up: P12 (real-device testing)

- **P12-iOS:** doable now via Expo Go on any iPhone (~15 min smoke test)
- **P12-Android:** waits for a physical Android device (emulators are flaky for FCM)

## Verification

- [x] All 3 JSON files parse cleanly: \`app.json\`, \`eas.json\`, \`google-services.json\`
- [x] Mobile typecheck passes
- [x] Mobile test suite: **1666/1666 pass** + 4 snapshots
- [x] \`google-services.json\` package_name \`com.steelmotion.styrby\` matches \`app.json\` android.package

🤖 Shipped via /gh-ship