### PR TITLE
chore(env): document 5 env vars in .env.example

### DIFF
--- a/packages/styrby-mobile/.env.example
+++ b/packages/styrby-mobile/.env.example
@@ -40,3 +40,29 @@ EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 # Find this at: https://expo.dev > Your Project > Project Settings > Project ID
 # Also used in app.json under extra.eas.projectId.
 EXPO_PUBLIC_PROJECT_ID=your-eas-project-id
+
+# -----------------------------------------------------------------------------
+# Web App URLs (used by mobile to deep-link into the web dashboard)
+# -----------------------------------------------------------------------------
+# Public URL of the marketing/dashboard site. Mobile uses this for "Open in
+# browser" links, billing portal redirects, and OAuth callback returns.
+# Default: https://styrbyapp.com (production). Override for staging/local dev.
+EXPO_PUBLIC_APP_URL=https://styrbyapp.com
+
+# Same as EXPO_PUBLIC_APP_URL but referenced explicitly in some helper modules
+# that distinguish "the app" (mobile) from "the web" (browser dashboard).
+# Keep equal to EXPO_PUBLIC_APP_URL unless they intentionally differ.
+EXPO_PUBLIC_WEB_URL=https://styrbyapp.com
+
+# -----------------------------------------------------------------------------
+# Sentry (mobile crash + error reporting)
+# -----------------------------------------------------------------------------
+# Sentry DSN for the mobile app. Leave UNSET in development to disable Sentry
+# entirely (no events sent, no SDK overhead). Get a DSN from:
+# https://sentry.io > Settings > Projects > styrby-mobile > Client Keys (DSN)
+# EXPO_PUBLIC_SENTRY_DSN=https://...@...ingest.us.sentry.io/...
+
+# Optional kill-switch: if set to "1" or "true", disables all Sentry event
+# reporting at runtime even when DSN is configured. Useful when a noisy
+# release is shipping and we want the SDK to stay silent until next deploy.
+# EXPO_PUBLIC_STYRBY_SENTRY_MUTED=

--- a/packages/styrby-web/.env.example
+++ b/packages/styrby-web/.env.example
@@ -76,3 +76,15 @@ CRON_SECRET=your-cron-secret
 # Users verify this in their receiving server to confirm events are from Styrby.
 # Generate with: openssl rand -hex 32
 STYRBY_WEBHOOK_SECRET=your-webhook-secret
+
+# -----------------------------------------------------------------------------
+# Auth / MFA Enforcement
+# -----------------------------------------------------------------------------
+# Operator kill-switch for AAL2 (TOTP) enforcement on the
+# POST /api/v1/auth/exchange endpoint. When 'true' (default), CLI key
+# exchange requires the user to have completed an AAL2 challenge if any
+# MFA factor is enrolled. Set to 'false' ONLY as an emergency escape hatch
+# when Supabase's MFA-listing API misbehaves in prod and is blocking
+# legitimate users from CLI auth.
+# Default behaviour (unset or any non-'false' value): enforcement enabled.
+EXCHANGE_REQUIRE_AAL2_IF_ENROLLED=true


### PR DESCRIPTION
## Summary

Static /secrets-audit found 5 env vars used in code but missing from .env.example. Adding them with WHY comments so new-dev onboarding doesn't hit silent runtime failures.

## Mobile (.env.example)
- \`EXPO_PUBLIC_APP_URL\` — web dashboard URL for deep links
- \`EXPO_PUBLIC_WEB_URL\` — same as APP_URL but for "open in browser" semantics
- \`EXPO_PUBLIC_SENTRY_DSN\` — mobile crash reporting
- \`EXPO_PUBLIC_STYRBY_SENTRY_MUTED\` — runtime kill-switch

## Web (.env.example)
- \`EXCHANGE_REQUIRE_AAL2_IF_ENROLLED\` — AAL2 enforcement kill-switch on auth/exchange

## Test Plan

- [x] Files written, content reviewed
- [ ] CI passes

🤖 Shipped via /gh-ship