### PR TITLE
a11y(web): bump text-zinc-500 → text-zinc-400 for WCAG AA contrast

### DIFF
--- a/packages/styrby-web/src/app/billing/offer/[offerId]/page.tsx
+++ b/packages/styrby-web/src/app/billing/offer/[offerId]/page.tsx
@@ -238,7 +238,7 @@ function OfferDetails({ offer }: { offer: OfferRow }) {
 
   return (
     <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-      <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+      <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider text-zinc-400">
         Offer details
       </h2>
 
@@ -249,14 +249,14 @@ function OfferDetails({ offer }: { offer: OfferRow }) {
             <Tag className="h-6 w-6 text-indigo-400" aria-hidden="true" />
           </div>
           <div>
-            <dt className="text-xs text-zinc-500">Discount</dt>
+            <dt className="text-xs text-zinc-400">Discount</dt>
             <dd className="text-2xl font-bold text-zinc-100">{offer.discount_pct}% off</dd>
           </div>
         </div>
 
         {/* Duration */}
         <div>
-          <dt className="text-xs text-zinc-500">Duration</dt>
+          <dt className="text-xs text-zinc-400">Duration</dt>
           <dd className="mt-0.5 text-sm text-zinc-200">
             {formatDuration(offer.discount_duration_months)}
           </dd>
@@ -264,13 +264,13 @@ function OfferDetails({ offer }: { offer: OfferRow }) {
 
         {/* Reason — why this offer was sent */}
         <div>
-          <dt className="text-xs text-zinc-500">Why we&apos;re offering this</dt>
+          <dt className="text-xs text-zinc-400">Why we&apos;re offering this</dt>
           <dd className="mt-0.5 text-sm leading-relaxed text-zinc-300">{reason}</dd>
         </div>
 
         {/* Expiry */}
         <div>
-          <dt className="text-xs text-zinc-500">Offer expires</dt>
+          <dt className="text-xs text-zinc-400">Offer expires</dt>
           <dd className="mt-0.5 text-sm text-zinc-300">{formatDate(offer.expires_at)}</dd>
         </div>
       </dl>
@@ -355,7 +355,7 @@ export default async function ChurnSaveOfferPage({ params }: PageProps) {
     <div className="mx-auto max-w-lg px-4 py-10 sm:px-6">
       {/* Page header */}
       <div className="mb-6">
-        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-400">
           Styrby
         </p>
         <h1 className="text-xl font-bold text-zinc-100">Special Offer</h1>
@@ -394,11 +394,11 @@ export default async function ChurnSaveOfferPage({ params }: PageProps) {
       )}
 
       {/* Footer */}
-      <p className="mt-8 text-center text-xs text-zinc-500">
+      <p className="mt-8 text-center text-xs text-zinc-400">
         Offer ID {offerId} &middot; Questions?{' '}
         <a
           href="/dashboard/support"
-          className="text-zinc-500 underline-offset-2 hover:text-zinc-400 hover:underline"
+          className="text-zinc-400 underline-offset-2 hover:text-zinc-400 hover:underline"
         >
           Contact support
         </a>

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/page.tsx
@@ -291,8 +291,8 @@ export default function AdminTicketDetailPage() {
   if (loading) {
     return (
       <div className="py-16 text-center">
-        <RefreshCw className="mx-auto h-8 w-8 animate-spin text-zinc-500" />
-        <p className="mt-4 text-sm text-zinc-500">Loading ticket...</p>
+        <RefreshCw className="mx-auto h-8 w-8 animate-spin text-zinc-400" />
+        <p className="mt-4 text-sm text-zinc-400">Loading ticket...</p>
       </div>
     );
   }
@@ -341,14 +341,14 @@ export default function AdminTicketDetailPage() {
                   Priority: {ticket.priority}
                 </span>
               )}
-              <span className="font-mono text-xs text-zinc-500">{ticket.id.slice(0, 8)}</span>
+              <span className="font-mono text-xs text-zinc-400">{ticket.id.slice(0, 8)}</span>
             </div>
 
             <h1 className="mb-2 text-xl font-bold text-zinc-100">{ticket.subject}</h1>
             <p className="whitespace-pre-wrap text-sm leading-relaxed text-zinc-300">
               {ticket.description}
             </p>
-            <p className="mt-4 text-xs text-zinc-500">
+            <p className="mt-4 text-xs text-zinc-400">
               Submitted {getRelativeTime(ticket.created_at)}
               {ticket.updated_at !== ticket.created_at && (
                 <> &middot; Updated {getRelativeTime(ticket.updated_at)}</>
@@ -404,7 +404,7 @@ export default function AdminTicketDetailPage() {
                       <p className="whitespace-pre-wrap text-sm text-zinc-200">
                         {reply.message}
                       </p>
-                      <p className="mt-2 text-xs text-zinc-500">
+                      <p className="mt-2 text-xs text-zinc-400">
                         {getRelativeTime(reply.created_at)}
                       </p>
                     </div>
@@ -437,7 +437,7 @@ export default function AdminTicketDetailPage() {
               <p className="mb-3 text-sm text-green-400">{replySuccess}</p>
             )}
             <div className="flex items-center justify-between">
-              <p className="text-xs text-zinc-500">
+              <p className="text-xs text-zinc-400">
                 Reply will be emailed to {ticketUser?.email || 'the user'}.
               </p>
               <button
@@ -457,7 +457,7 @@ export default function AdminTicketDetailPage() {
               <label htmlFor="admin-notes" className="text-sm font-medium text-zinc-300">
                 Internal Notes
               </label>
-              <span className="text-xs text-zinc-500">
+              <span className="text-xs text-zinc-400">
                 {notesSaving ? 'Saving...' : notesSaved ? 'Saved' : 'Auto-saves on blur'}
               </span>
             </div>
@@ -485,13 +485,13 @@ export default function AdminTicketDetailPage() {
                 <p className="truncate text-sm font-medium text-zinc-100">
                   {ticketUser?.display_name || 'No display name'}
                 </p>
-                <p className="truncate text-xs text-zinc-500">{ticketUser?.email}</p>
+                <p className="truncate text-xs text-zinc-400">{ticketUser?.email}</p>
               </div>
             </div>
 
             <div className="space-y-3 border-t border-zinc-800 pt-4">
               <div className="flex items-center justify-between">
-                <span className="text-xs text-zinc-500">Tier</span>
+                <span className="text-xs text-zinc-400">Tier</span>
                 <span
                   className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${tierBadge.bg} ${tierBadge.text}`}
                 >
@@ -499,17 +499,17 @@ export default function AdminTicketDetailPage() {
                 </span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-xs text-zinc-500">Machines</span>
+                <span className="text-xs text-zinc-400">Machines</span>
                 <span className="text-xs text-zinc-300">{ticketUser?.machines_count || 0}</span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-xs text-zinc-500">Account ID</span>
-                <span className="font-mono text-xs text-zinc-500">
+                <span className="text-xs text-zinc-400">Account ID</span>
+                <span className="font-mono text-xs text-zinc-400">
                   {ticketUser?.id?.slice(0, 8) || 'N/A'}
                 </span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-xs text-zinc-500">Joined</span>
+                <span className="text-xs text-zinc-400">Joined</span>
                 <span className="text-xs text-zinc-300">
                   {ticketUser?.joined_at
                     ? new Date(ticketUser.joined_at).toLocaleDateString()
@@ -543,11 +543,11 @@ export default function AdminTicketDetailPage() {
             </div>
 
             {grantsLoading ? (
-              <p className="text-xs text-zinc-500" data-testid="grants-loading">
+              <p className="text-xs text-zinc-400" data-testid="grants-loading">
                 Loading grants...
               </p>
             ) : accessGrants.length === 0 ? (
-              <p className="text-xs text-zinc-500" data-testid="no-grants-message">
+              <p className="text-xs text-zinc-400" data-testid="no-grants-message">
                 No session access grants yet for this ticket.
               </p>
             ) : (
@@ -563,7 +563,7 @@ export default function AdminTicketDetailPage() {
                     ? 'text-green-400'
                     : isPendingGrant
                     ? 'text-amber-400'
-                    : 'text-zinc-500';
+                    : 'text-zinc-400';
 
                   return (
                     <div
@@ -572,7 +572,7 @@ export default function AdminTicketDetailPage() {
                       data-testid={`grant-item-${grant.id}`}
                     >
                       <div className="flex items-start justify-between gap-2">
-                        <p className="font-mono text-xs text-zinc-500">
+                        <p className="font-mono text-xs text-zinc-400">
                           {grant.session_id.slice(0, 8)}...
                         </p>
                         <span className={`shrink-0 text-xs font-medium ${statusColor}`}>
@@ -587,7 +587,7 @@ export default function AdminTicketDetailPage() {
                         {grant.reason.slice(0, 60)}
                         {grant.reason.length > 60 ? '…' : ''}
                       </p>
-                      <p className="mt-1 text-xs text-zinc-500">
+                      <p className="mt-1 text-xs text-zinc-400">
                         Expires {new Date(grant.expires_at).toLocaleDateString()}
                       </p>
                     </div>

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/page.tsx
@@ -191,7 +191,7 @@ export default async function RequestAccessPage({ params }: RequestAccessPagePro
                 ? 'text-green-400'
                 : isPending
                 ? 'text-amber-400'
-                : 'text-zinc-500';
+                : 'text-zinc-400';
 
               return (
                 <div
@@ -200,7 +200,7 @@ export default async function RequestAccessPage({ params }: RequestAccessPagePro
                   data-testid={`existing-grant-${grant.id}`}
                 >
                   <div className="min-w-0">
-                    <p className="truncate text-xs font-mono text-zinc-500">
+                    <p className="truncate text-xs font-mono text-zinc-400">
                       Session: {grant.session_id.slice(0, 8)}...
                     </p>
                     <p className="mt-0.5 truncate text-xs text-zinc-400">
@@ -211,7 +211,7 @@ export default async function RequestAccessPage({ params }: RequestAccessPagePro
                     <span className={`text-xs font-medium ${statusColor}`}>
                       {grant.status}
                     </span>
-                    <p className="text-xs text-zinc-500">
+                    <p className="text-xs text-zinc-400">
                       Expires {new Date(grant.expires_at).toLocaleDateString()}
                     </p>
                   </div>

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/success/TokenDisplay.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/success/TokenDisplay.tsx
@@ -150,7 +150,7 @@ export function TokenDisplay({ rawToken, ticketId: _ticketId, grantId }: TokenDi
             <Copy className="h-3 w-3" />
             Copy link
           </button>
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="mt-1 text-xs text-zinc-400">
             Share this link with the user via the ticket reply form. The user must be
             signed in to approve - no token is embedded in the URL.
           </p>

--- a/packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/success/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/[id]/request-access/success/page.tsx
@@ -135,7 +135,7 @@ export default async function RequestAccessSuccessPage({
             The user will be notified and must approve before you can view session metadata.
           </p>
           {grantIdStr && (
-            <p className="mt-1 font-mono text-xs text-zinc-500">
+            <p className="mt-1 font-mono text-xs text-zinc-400">
               Grant ID: {grantIdStr}
             </p>
           )}

--- a/packages/styrby-web/src/app/dashboard/admin/support/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/page.tsx
@@ -180,15 +180,15 @@ export default function AdminSupportPage() {
       {/* Loading state */}
       {loading && tickets.length === 0 && (
         <div className="py-16 text-center">
-          <RefreshCw className="mx-auto h-8 w-8 animate-spin text-zinc-500" />
-          <p className="mt-4 text-sm text-zinc-500">Loading tickets...</p>
+          <RefreshCw className="mx-auto h-8 w-8 animate-spin text-zinc-400" />
+          <p className="mt-4 text-sm text-zinc-400">Loading tickets...</p>
         </div>
       )}
 
       {/* Empty state */}
       {!loading && tickets.length === 0 && !error && (
         <div className="py-16 text-center">
-          <p className="text-sm text-zinc-500">No tickets found.</p>
+          <p className="text-sm text-zinc-400">No tickets found.</p>
         </div>
       )}
 
@@ -216,7 +216,7 @@ export default function AdminSupportPage() {
                       <td className="px-4 py-3">
                         <Link
                           href={`/dashboard/admin/support/${ticket.id}`}
-                          className="font-mono text-xs text-zinc-500 hover:text-amber-400"
+                          className="font-mono text-xs text-zinc-400 hover:text-amber-400"
                         >
                           {shortId(ticket.id)}
                         </Link>
@@ -246,7 +246,7 @@ export default function AdminSupportPage() {
                           {statusBadge.label}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-xs text-zinc-500">
+                      <td className="px-4 py-3 text-xs text-zinc-400">
                         {getRelativeTime(ticket.created_at)}
                       </td>
                     </tr>
@@ -278,14 +278,14 @@ export default function AdminSupportPage() {
                     >
                       {statusBadge.label}
                     </span>
-                    <span className="text-xs text-zinc-500">
+                    <span className="text-xs text-zinc-400">
                       {getRelativeTime(ticket.created_at)}
                     </span>
                   </div>
                   <p className="truncate text-sm font-medium text-zinc-100">
                     {ticket.subject}
                   </p>
-                  <p className="mt-1 text-xs text-zinc-500">
+                  <p className="mt-1 text-xs text-zinc-400">
                     {ticket.profiles?.display_name || ticket.user_email}
                   </p>
                 </Link>

--- a/packages/styrby-web/src/app/dashboard/admin/support/session/[sessionId]/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/session/[sessionId]/page.tsx
@@ -223,7 +223,7 @@ function SessionMetaCard({
       <div className="mb-4 flex items-start justify-between gap-4">
         <div>
           <h2 className="text-sm font-semibold text-zinc-300">Session Overview</h2>
-          <p className="mt-0.5 font-mono text-xs text-zinc-500">{session.id}</p>
+          <p className="mt-0.5 font-mono text-xs text-zinc-400">{session.id}</p>
         </div>
         <span
           className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ${
@@ -240,46 +240,46 @@ function SessionMetaCard({
 
       <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
         <div>
-          <dt className="text-xs text-zinc-500">Agent</dt>
+          <dt className="text-xs text-zinc-400">Agent</dt>
           <dd className="mt-0.5 font-medium text-zinc-200">{session.agent_type}</dd>
         </div>
         {session.model && (
           <div>
-            <dt className="text-xs text-zinc-500">Model</dt>
+            <dt className="text-xs text-zinc-400">Model</dt>
             <dd className="mt-0.5 font-medium text-zinc-200">{session.model}</dd>
           </div>
         )}
         <div>
-          <dt className="text-xs text-zinc-500">Started</dt>
+          <dt className="text-xs text-zinc-400">Started</dt>
           <dd className="mt-0.5 text-zinc-200">
             {new Date(session.started_at).toLocaleString()}
           </dd>
         </div>
         {session.ended_at && (
           <div>
-            <dt className="text-xs text-zinc-500">Ended</dt>
+            <dt className="text-xs text-zinc-400">Ended</dt>
             <dd className="mt-0.5 text-zinc-200">
               {new Date(session.ended_at).toLocaleString()}
             </dd>
           </div>
         )}
         <div>
-          <dt className="text-xs text-zinc-500">Total tokens</dt>
+          <dt className="text-xs text-zinc-400">Total tokens</dt>
           <dd className="mt-0.5 text-zinc-200">{totalTokens.toLocaleString()}</dd>
         </div>
         <div>
-          <dt className="text-xs text-zinc-500">Cost (USD)</dt>
+          <dt className="text-xs text-zinc-400">Cost (USD)</dt>
           <dd className="mt-0.5 text-zinc-200">${session.total_cost_usd.toFixed(4)}</dd>
         </div>
         <div>
-          <dt className="text-xs text-zinc-500">Messages</dt>
+          <dt className="text-xs text-zinc-400">Messages</dt>
           <dd className="mt-0.5 text-zinc-200">{session.message_count}</dd>
         </div>
       </dl>
 
       {/* Grant context — shows grant_id (never token_hash) */}
       <div className="mt-4 border-t border-zinc-800 pt-4">
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-zinc-400">
           Support grant:{' '}
           <span className="font-mono text-zinc-400">#{grantId.toString()}</span>
           {' · '}
@@ -307,7 +307,7 @@ function MessageMetaTable({ messages }: { messages: MessageRow[] }) {
   if (messages.length === 0) {
     return (
       <div className="rounded-xl border border-zinc-800 bg-zinc-900 px-6 py-10 text-center">
-        <p className="text-sm text-zinc-500">No messages found for this session.</p>
+        <p className="text-sm text-zinc-400">No messages found for this session.</p>
       </div>
     );
   }
@@ -331,13 +331,13 @@ function MessageMetaTable({ messages }: { messages: MessageRow[] }) {
         >
           <thead>
             <tr className="border-b border-zinc-800 text-left">
-              <th className="px-4 py-3 text-xs font-semibold text-zinc-500">#</th>
-              <th className="px-4 py-3 text-xs font-semibold text-zinc-500">Timestamp</th>
-              <th className="px-4 py-3 text-xs font-semibold text-zinc-500">Type</th>
-              <th className="px-4 py-3 text-xs font-semibold text-zinc-500">Tool</th>
-              <th className="px-4 py-3 text-xs font-semibold text-zinc-500">In tokens</th>
-              <th className="px-4 py-3 text-xs font-semibold text-zinc-500">Out tokens</th>
-              <th className="px-4 py-3 text-xs font-semibold text-zinc-500">Duration (ms)</th>
+              <th className="px-4 py-3 text-xs font-semibold text-zinc-400">#</th>
+              <th className="px-4 py-3 text-xs font-semibold text-zinc-400">Timestamp</th>
+              <th className="px-4 py-3 text-xs font-semibold text-zinc-400">Type</th>
+              <th className="px-4 py-3 text-xs font-semibold text-zinc-400">Tool</th>
+              <th className="px-4 py-3 text-xs font-semibold text-zinc-400">In tokens</th>
+              <th className="px-4 py-3 text-xs font-semibold text-zinc-400">Out tokens</th>
+              <th className="px-4 py-3 text-xs font-semibold text-zinc-400">Duration (ms)</th>
             </tr>
           </thead>
           <tbody>
@@ -346,7 +346,7 @@ function MessageMetaTable({ messages }: { messages: MessageRow[] }) {
                 key={msg.id}
                 className="border-b border-zinc-800/50 transition-colors hover:bg-zinc-800/30"
               >
-                <td className="px-4 py-2.5 font-mono text-xs text-zinc-500">
+                <td className="px-4 py-2.5 font-mono text-xs text-zinc-400">
                   {msg.sequence_number}
                 </td>
                 <td className="px-4 py-2.5 text-xs text-zinc-400">
@@ -380,7 +380,7 @@ function MessageMetaTable({ messages }: { messages: MessageRow[] }) {
       </div>
 
       <div className="border-t border-zinc-800 px-4 py-3">
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-zinc-400">
           Showing {messages.length} most recent message{messages.length !== 1 ? 's' : ''}
           {messages.length === MESSAGE_LIMIT ? ` (limited to ${MESSAGE_LIMIT})` : ''}
         </p>

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/churn-save/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/churn-save/page.tsx
@@ -117,12 +117,12 @@ export default async function SendChurnSaveOfferPage({ params }: ChurnSavePagePr
       </Link>
 
       <h1 className="mb-2 text-xl font-bold text-zinc-100">Send churn-save offer</h1>
-      <p className="mb-1 text-sm text-zinc-500">
+      <p className="mb-1 text-sm text-zinc-400">
         For:{' '}
         <span className="font-mono text-zinc-300">{profile.email ?? userId}</span>
       </p>
       {sub && (
-        <p className="mb-6 text-sm text-zinc-500">
+        <p className="mb-6 text-sm text-zinc-400">
           Current tier:{' '}
           <span className="font-medium text-zinc-300">
             {sub.tier ?? 'unknown'} / {sub.is_annual ? 'annual' : 'monthly'}

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/credit/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/credit/page.tsx
@@ -83,7 +83,7 @@ export default async function IssueCreditPage({ params }: CreditPageProps) {
       </Link>
 
       <h1 className="mb-2 text-xl font-bold text-zinc-100">Issue account credit</h1>
-      <p className="mb-6 text-sm text-zinc-500">
+      <p className="mb-6 text-sm text-zinc-400">
         For:{' '}
         <span className="font-mono text-zinc-300">{profile.email ?? userId}</span>
       </p>

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/page.tsx
@@ -132,21 +132,21 @@ async function SubscriptionSection({ userId }: { userId: string }) {
       </div>
       {sub ? (
         <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
-          <dt className="text-zinc-500">Tier</dt>
+          <dt className="text-zinc-400">Tier</dt>
           <dd className="font-medium text-zinc-100" data-testid="subscription-tier">
             {sub.tier ?? '—'}
           </dd>
-          <dt className="text-zinc-500">Billing cycle</dt>
+          <dt className="text-zinc-400">Billing cycle</dt>
           <dd className="text-zinc-300">{sub.is_annual ? 'Annual' : 'Monthly'}</dd>
-          <dt className="text-zinc-500">Period end</dt>
+          <dt className="text-zinc-400">Period end</dt>
           <dd className="text-zinc-300">{fmtDate(sub.current_period_end)}</dd>
-          <dt className="text-zinc-500">Override source</dt>
+          <dt className="text-zinc-400">Override source</dt>
           <dd className="font-mono text-xs text-zinc-300">{sub.override_source ?? '—'}</dd>
-          <dt className="text-zinc-500">Updated</dt>
-          <dd className="text-xs text-zinc-500">{fmtDateTime(sub.updated_at)}</dd>
+          <dt className="text-zinc-400">Updated</dt>
+          <dd className="text-xs text-zinc-400">{fmtDateTime(sub.updated_at)}</dd>
         </dl>
       ) : (
-        <p className="text-sm text-zinc-500" data-testid="no-subscription">
+        <p className="text-sm text-zinc-400" data-testid="no-subscription">
           No subscription record found.
         </p>
       )}
@@ -202,7 +202,7 @@ async function RefundsSection({ userId }: { userId: string }) {
         <div className="overflow-x-auto">
           <table className="w-full text-sm" data-testid="refunds-table">
             <thead>
-              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-400">
                 <th className="pb-2 pr-4 font-medium">Amount</th>
                 <th className="pb-2 pr-4 font-medium">Reason</th>
                 <th className="pb-2 pr-4 font-medium">Date</th>
@@ -225,7 +225,7 @@ async function RefundsSection({ userId }: { userId: string }) {
                   <td className="py-2 pr-4 text-zinc-400 text-xs">
                     {fmtDateTime(r.processed_at)}
                   </td>
-                  <td className="py-2 font-mono text-xs text-zinc-500 truncate max-w-[100px]">
+                  <td className="py-2 font-mono text-xs text-zinc-400 truncate max-w-[100px]">
                     {r.refund_id}
                   </td>
                 </tr>
@@ -234,7 +234,7 @@ async function RefundsSection({ userId }: { userId: string }) {
           </table>
         </div>
       ) : (
-        <p className="text-sm text-zinc-500" data-testid="no-refunds">
+        <p className="text-sm text-zinc-400" data-testid="no-refunds">
           No refunds on record.
         </p>
       )}
@@ -303,7 +303,7 @@ async function CreditsSection({ userId }: { userId: string }) {
         <div className="overflow-x-auto">
           <table className="w-full text-sm" data-testid="credits-table">
             <thead>
-              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-400">
                 <th className="pb-2 pr-4 font-medium">Amount</th>
                 <th className="pb-2 pr-4 font-medium">State</th>
                 <th className="pb-2 pr-4 font-medium">Reason</th>
@@ -319,7 +319,7 @@ async function CreditsSection({ userId }: { userId: string }) {
                   ? 'Applied'
                   : 'Active';
                 const stateClass = c.revoked_at
-                  ? 'text-zinc-500'
+                  ? 'text-zinc-400'
                   : c.applied_at
                   ? 'text-blue-400'
                   : 'text-green-400';
@@ -352,7 +352,7 @@ async function CreditsSection({ userId }: { userId: string }) {
           </table>
         </div>
       ) : (
-        <p className="text-sm text-zinc-500" data-testid="no-credits">
+        <p className="text-sm text-zinc-400" data-testid="no-credits">
           No credits on record.
         </p>
       )}
@@ -430,7 +430,7 @@ async function ChurnSaveOffersSection({ userId }: { userId: string }) {
         <div className="overflow-x-auto">
           <table className="w-full text-sm" data-testid="churn-offers-table">
             <thead>
-              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-400">
                 <th className="pb-2 pr-4 font-medium">Kind</th>
                 <th className="pb-2 pr-4 font-medium">State</th>
                 <th className="pb-2 pr-4 font-medium">Sent</th>
@@ -448,11 +448,11 @@ async function ChurnSaveOffersSection({ userId }: { userId: string }) {
                   ? 'Expired'
                   : 'Active';
                 const stateClass = o.revoked_at
-                  ? 'text-zinc-500'
+                  ? 'text-zinc-400'
                   : o.accepted_at
                   ? 'text-green-400'
                   : expired
-                  ? 'text-zinc-500'
+                  ? 'text-zinc-400'
                   : 'text-amber-400';
 
                 return (
@@ -478,7 +478,7 @@ async function ChurnSaveOffersSection({ userId }: { userId: string }) {
           </table>
         </div>
       ) : (
-        <p className="text-sm text-zinc-500" data-testid="no-churn-offers">
+        <p className="text-sm text-zinc-400" data-testid="no-churn-offers">
           No churn-save offers on record.
         </p>
       )}

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/refund/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/refund/page.tsx
@@ -110,7 +110,7 @@ export default async function IssueRefundPage({ params }: RefundPageProps) {
       </Link>
 
       <h1 className="mb-2 text-xl font-bold text-zinc-100">Issue refund</h1>
-      <p className="mb-6 text-sm text-zinc-500">
+      <p className="mb-6 text-sm text-zinc-400">
         For:{' '}
         <span className="font-mono text-zinc-300">{profile.email ?? userId}</span>
       </p>

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/override-tier/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/override-tier/page.tsx
@@ -103,7 +103,7 @@ export default async function OverrideTierPage({ params }: OverrideTierPageProps
       </Link>
 
       <h1 className="mb-2 text-xl font-bold text-zinc-100">Override tier</h1>
-      <p className="mb-6 text-sm text-zinc-500">
+      <p className="mb-6 text-sm text-zinc-400">
         For:{' '}
         <span className="font-mono text-zinc-300">{profile.email ?? userId}</span>
       </p>

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/reset-password/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/reset-password/page.tsx
@@ -114,7 +114,7 @@ export default async function ResetPasswordPage({ params }: ResetPasswordPagePro
       </Link>
 
       <h1 className="mb-2 text-xl font-bold text-zinc-100">Reset password</h1>
-      <p className="mb-6 text-sm text-zinc-500">
+      <p className="mb-6 text-sm text-zinc-400">
         Sends a one-time password-reset magic link to the user.
       </p>
 

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/toggle-consent/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/toggle-consent/page.tsx
@@ -121,7 +121,7 @@ export default async function ToggleConsentPage({ params }: ToggleConsentPagePro
       </Link>
 
       <h1 className="mb-2 text-xl font-bold text-zinc-100">Toggle consent</h1>
-      <p className="mb-6 text-sm text-zinc-500">
+      <p className="mb-6 text-sm text-zinc-400">
         For:{' '}
         <span className="font-mono text-zinc-300">{profile.email ?? userId}</span>
       </p>

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts-summary.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts-summary.tsx
@@ -129,7 +129,7 @@ export function BudgetAlertsSummary({
               </div>
               <div>
                 <p className="text-sm font-medium text-zinc-100">Budget Alerts</p>
-                <p className="text-xs text-zinc-500">
+                <p className="text-xs text-zinc-400">
                   Upgrade to Pro to set spending thresholds and get notified
                 </p>
               </div>
@@ -155,7 +155,7 @@ export function BudgetAlertsSummary({
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 rounded-lg bg-zinc-800 flex items-center justify-center flex-shrink-0">
                 <svg
-                  className="h-5 w-5 text-zinc-500"
+                  className="h-5 w-5 text-zinc-400"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -171,7 +171,7 @@ export function BudgetAlertsSummary({
               </div>
               <div>
                 <p className="text-sm font-medium text-zinc-100">No budget alerts set</p>
-                <p className="text-xs text-zinc-500">
+                <p className="text-xs text-zinc-400">
                   Create alerts to get notified when spending reaches your thresholds
                 </p>
               </div>
@@ -246,13 +246,13 @@ export function BudgetAlertsSummary({
               <div className="flex items-baseline gap-2 mt-0.5">
                 <span className="text-sm text-zinc-300">
                   ${mostCriticalAlert.current_spend_usd.toFixed(2)}
-                  <span className="text-zinc-500">
+                  <span className="text-zinc-400">
                     {' '}/ ${mostCriticalAlert.threshold_usd.toFixed(2)}
                   </span>
                 </span>
                 <span
                   className={`text-xs font-medium ${
-                    isOverBudget ? 'text-red-400' : 'text-zinc-500'
+                    isOverBudget ? 'text-red-400' : 'text-zinc-400'
                   }`}
                 >
                   ({mostCriticalAlert.percentage_used.toFixed(0)}%)
@@ -281,7 +281,7 @@ export function BudgetAlertsSummary({
 
         {/* Alert count indicator */}
         {alertCount > 1 && (
-          <p className="text-xs text-zinc-500 mt-2">
+          <p className="text-xs text-zinc-400 mt-2">
             Showing most critical of {alertCount} active alert{alertCount !== 1 ? 's' : ''}
           </p>
         )}

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertCard.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertCard.tsx
@@ -100,7 +100,7 @@ export function AlertCard({
         <div className="flex items-baseline justify-between mb-1">
           <span className="text-sm text-zinc-300">
             ${alert.current_spend_usd.toFixed(2)}{' '}
-            <span className="text-zinc-500">
+            <span className="text-zinc-400">
               / ${Number(alert.threshold_usd).toFixed(2)}
             </span>
           </span>
@@ -148,7 +148,7 @@ export function AlertCard({
         <div className="flex items-center gap-1">
           <button
             onClick={() => onEdit(alert)}
-            className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
+            className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
             aria-label={`Edit ${alert.name} alert`}
           >
             <svg
@@ -168,7 +168,7 @@ export function AlertCard({
           </button>
           <button
             onClick={() => onDelete(alert.id)}
-            className="p-1.5 rounded-lg text-zinc-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+            className="p-1.5 rounded-lg text-zinc-400 hover:text-red-400 hover:bg-red-500/10 transition-colors"
             disabled={isDeleting}
             aria-label={`Delete ${alert.name} alert`}
           >
@@ -192,7 +192,7 @@ export function AlertCard({
 
       {/* Last triggered */}
       {alert.last_triggered_at && (
-        <p className="text-xs text-zinc-500 mt-2">
+        <p className="text-xs text-zinc-400 mt-2">
           Last triggered:{' '}
           {new Date(alert.last_triggered_at).toLocaleDateString('en-US', {
             month: 'short',

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertModal.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertModal.tsx
@@ -156,7 +156,7 @@ export function AlertModal({
                     >
                       {info.label}
                     </p>
-                    <p className="text-xs text-zinc-500 mt-0.5">{info.description}</p>
+                    <p className="text-xs text-zinc-400 mt-0.5">{info.description}</p>
                   </button>
                 );
               })}
@@ -171,12 +171,12 @@ export function AlertModal({
                 className="block text-sm font-medium text-zinc-300 mb-1.5"
               >
                 {ALERT_TYPE_INFO.cost_usd.thresholdLabel}
-                <span className="text-xs text-zinc-500 font-normal ml-2">
+                <span className="text-xs text-zinc-400 font-normal ml-2">
                   {ALERT_TYPE_INFO.cost_usd.thresholdHint}
                 </span>
               </label>
               <div className="relative">
-                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-zinc-500">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-zinc-400">
                   $
                 </span>
                 <input
@@ -204,7 +204,7 @@ export function AlertModal({
                 className="block text-sm font-medium text-zinc-300 mb-1.5"
               >
                 {ALERT_TYPE_INFO.subscription_quota.thresholdLabel}
-                <span className="text-xs text-zinc-500 font-normal ml-2">
+                <span className="text-xs text-zinc-400 font-normal ml-2">
                   {ALERT_TYPE_INFO.subscription_quota.thresholdHint}
                 </span>
               </label>
@@ -230,7 +230,7 @@ export function AlertModal({
                   placeholder="80"
                   className="w-full rounded-lg border border-zinc-700 bg-zinc-800 pr-7 pl-3 py-2 text-sm text-zinc-100 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
                 />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-zinc-500">
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-zinc-400">
                   %
                 </span>
               </div>
@@ -244,7 +244,7 @@ export function AlertModal({
                 className="block text-sm font-medium text-zinc-300 mb-1.5"
               >
                 {ALERT_TYPE_INFO.credits.thresholdLabel}
-                <span className="text-xs text-zinc-500 font-normal ml-2">
+                <span className="text-xs text-zinc-400 font-normal ml-2">
                   {ALERT_TYPE_INFO.credits.thresholdHint}
                 </span>
               </label>
@@ -289,7 +289,7 @@ export function AlertModal({
           <fieldset className="border-0 p-0 m-0">
             <legend className="block text-sm font-medium text-zinc-300 mb-1.5">
               Agent Filter
-              <span className="text-zinc-500 font-normal ml-1">(optional)</span>
+              <span className="text-zinc-400 font-normal ml-1">(optional)</span>
             </legend>
             <div className="grid grid-cols-4 gap-2">
               <OptionPill
@@ -337,7 +337,7 @@ export function AlertModal({
                     <div className="flex items-center gap-3">
                       <svg
                         className={`h-5 w-5 flex-shrink-0 ${
-                          isSelected ? 'text-orange-400' : 'text-zinc-500'
+                          isSelected ? 'text-orange-400' : 'text-zinc-400'
                         }`}
                         fill="none"
                         viewBox="0 0 24 24"
@@ -359,7 +359,7 @@ export function AlertModal({
                         >
                           {info.label}
                         </p>
-                        <p className="text-xs text-zinc-500">
+                        <p className="text-xs text-zinc-400">
                           {info.description}
                         </p>
                       </div>

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertsHeader.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/AlertsHeader.tsx
@@ -43,7 +43,7 @@ export function AlertsHeader({
       <div>
         <p className="text-sm text-zinc-400">
           {alertCount} / {alertLimit} alerts used
-          <span className="text-zinc-500 ml-2">({tier} plan)</span>
+          <span className="text-zinc-400 ml-2">({tier} plan)</span>
         </p>
       </div>
       <div className="flex items-center gap-3">

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/EmptyState.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/_components/EmptyState.tsx
@@ -27,7 +27,7 @@ export function EmptyState({ alertLimit, onCreate }: EmptyStateProps) {
     <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
       <div className="mx-auto h-16 w-16 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
         <svg
-          className="h-8 w-8 text-zinc-500"
+          className="h-8 w-8 text-zinc-400"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -44,7 +44,7 @@ export function EmptyState({ alertLimit, onCreate }: EmptyStateProps) {
       <h3 className="text-lg font-medium text-zinc-100 mb-2">No budget alerts</h3>
       {alertLimit > 0 ? (
         <>
-          <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
+          <p className="text-zinc-400 mb-6 max-w-sm mx-auto">
             Set up budget alerts to get notified when your AI spending reaches
             your thresholds.
           </p>
@@ -58,7 +58,7 @@ export function EmptyState({ alertLimit, onCreate }: EmptyStateProps) {
         </>
       ) : (
         <>
-          <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
+          <p className="text-zinc-400 mb-6 max-w-sm mx-auto">
             Budget alerts help you control AI spending. Upgrade to Pro to
             create up to 3 budget alerts.
           </p>

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/error.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/error.tsx
@@ -46,12 +46,12 @@ export default function BudgetAlertsError({
         </p>
 
         {error.digest && (
-          <p className="text-xs text-zinc-500 mb-6">Error ID: {error.digest}</p>
+          <p className="text-xs text-zinc-400 mb-6">Error ID: {error.digest}</p>
         )}
 
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mb-6 p-3 rounded-lg bg-zinc-900 border border-zinc-800 text-left">
-            <p className="text-xs text-zinc-500 mb-1">Dev only:</p>
+            <p className="text-xs text-zinc-400 mb-1">Dev only:</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">{error.message}</pre>
           </div>
         )}

--- a/packages/styrby-web/src/app/dashboard/costs/budget-alerts/loading.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/budget-alerts/loading.tsx
@@ -13,7 +13,7 @@ export default function BudgetAlertsLoading() {
           role="status"
           aria-label="Loading budget alerts"
         />
-        <p className="text-sm text-zinc-500">Loading Budget Alerts...</p>
+        <p className="text-sm text-zinc-400">Loading Budget Alerts...</p>
       </div>
     </div>
   );

--- a/packages/styrby-web/src/app/dashboard/costs/cost-charts.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/cost-charts.tsx
@@ -67,7 +67,7 @@ export function CostCharts({ data }: CostChartsProps) {
       <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
         <div className="mx-auto h-12 w-12 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
           <svg
-            className="h-6 w-6 text-zinc-500"
+            className="h-6 w-6 text-zinc-400"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -81,7 +81,7 @@ export function CostCharts({ data }: CostChartsProps) {
           </svg>
         </div>
         <h3 className="text-lg font-medium text-zinc-100">No cost data yet</h3>
-        <p className="mt-2 text-zinc-500">
+        <p className="mt-2 text-zinc-400">
           Start using your AI agents to see cost analytics here.
         </p>
       </div>

--- a/packages/styrby-web/src/app/dashboard/costs/costs-realtime.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/costs-realtime.tsx
@@ -131,7 +131,7 @@ export function CostsRealtime({
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
         {/* Monthly total - with real-time ticker */}
         <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
-          <p className="text-sm text-zinc-500 mb-1">Monthly Total</p>
+          <p className="text-sm text-zinc-400 mb-1">Monthly Total</p>
           <CostTicker
             userId={userId}
             initialTotal={currentMonthlyTotal}
@@ -158,12 +158,12 @@ export function CostsRealtime({
                         : 'bg-blue-500'
                   }`}
                 />
-                <p className="text-sm text-zinc-500 capitalize">{agent}</p>
+                <p className="text-sm text-zinc-400 capitalize">{agent}</p>
               </div>
               <p className="text-2xl font-bold text-zinc-100 mt-1">
                 ${data.cost.toFixed(2)}
               </p>
-              <p className="text-xs text-zinc-500 mt-1">
+              <p className="text-xs text-zinc-400 mt-1">
                 {((data.inputTokens + data.outputTokens) / 1000).toFixed(1)}K tokens
               </p>
             </div>

--- a/packages/styrby-web/src/app/dashboard/costs/error.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/error.tsx
@@ -46,12 +46,12 @@ export default function CostsError({
         </p>
 
         {error.digest && (
-          <p className="text-xs text-zinc-500 mb-6">Error ID: {error.digest}</p>
+          <p className="text-xs text-zinc-400 mb-6">Error ID: {error.digest}</p>
         )}
 
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mb-6 p-3 rounded-lg bg-zinc-900 border border-zinc-800 text-left">
-            <p className="text-xs text-zinc-500 mb-1">Dev only:</p>
+            <p className="text-xs text-zinc-400 mb-1">Dev only:</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">{error.message}</pre>
           </div>
         )}

--- a/packages/styrby-web/src/app/dashboard/dashboard-realtime.tsx
+++ b/packages/styrby-web/src/app/dashboard/dashboard-realtime.tsx
@@ -265,7 +265,7 @@ export function DashboardRealtime({
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         {/* Today's spend - with real-time ticker */}
         <dl className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
-          <dt className="text-sm text-zinc-500 mb-1">Today&apos;s Spend</dt>
+          <dt className="text-sm text-zinc-400 mb-1">Today&apos;s Spend</dt>
           <dd>
             <CostTicker
               userId={userId}
@@ -278,7 +278,7 @@ export function DashboardRealtime({
 
         {/* Active sessions */}
         <dl className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
-          <dt className="text-sm text-zinc-500">Active Sessions</dt>
+          <dt className="text-sm text-zinc-400">Active Sessions</dt>
           <dd className="text-2xl font-bold text-zinc-100 mt-1">
             {activeSessionCount}
           </dd>
@@ -286,7 +286,7 @@ export function DashboardRealtime({
 
         {/* Connected machines */}
         <dl className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
-          <dt className="text-sm text-zinc-500">Connected Machines</dt>
+          <dt className="text-sm text-zinc-400">Connected Machines</dt>
           <dd className="text-2xl font-bold text-zinc-100 mt-1">
             {connectedMachineCount}
           </dd>
@@ -294,7 +294,7 @@ export function DashboardRealtime({
 
         {/* Total machines */}
         <dl className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
-          <dt className="text-sm text-zinc-500">Total Machines</dt>
+          <dt className="text-sm text-zinc-400">Total Machines</dt>
           <dd className="text-2xl font-bold text-zinc-100 mt-1">
             {machines.length}
           </dd>
@@ -307,12 +307,12 @@ export function DashboardRealtime({
       {userTier === 'free' ? (
         <div className="mb-8 rounded-xl border border-zinc-800 bg-zinc-900/50 p-6 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <svg className="h-5 w-5 text-zinc-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <svg className="h-5 w-5 text-zinc-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
             </svg>
             <div>
               <p className="text-sm font-medium text-zinc-300">Activity Graph</p>
-              <p className="text-xs text-zinc-500">52-week coding activity heatmap. Available on Pro.</p>
+              <p className="text-xs text-zinc-400">52-week coding activity heatmap. Available on Pro.</p>
             </div>
           </div>
           <a
@@ -398,7 +398,7 @@ export function DashboardRealtime({
                     </span>
                   </div>
 
-                  <div className="flex items-center gap-4 text-sm text-zinc-500">
+                  <div className="flex items-center gap-4 text-sm text-zinc-400">
                     <span>{session.message_count} messages</span>
                     <span>${Number(session.total_cost_usd).toFixed(4)}</span>
                   </div>
@@ -407,7 +407,7 @@ export function DashboardRealtime({
             ))}
           </ul>
         ) : (
-          <div className="px-4 py-8 text-center text-zinc-500">
+          <div className="px-4 py-8 text-center text-zinc-400">
             <p>No sessions yet.</p>
             <p className="mt-1 text-sm">
               Install the CLI and start a session to see it here.
@@ -438,7 +438,7 @@ export function DashboardRealtime({
                     />
                     <span className="text-zinc-100">{machine.name}</span>
                   </div>
-                  <span className="text-sm text-zinc-500">
+                  <span className="text-sm text-zinc-400">
                     {machine.is_online
                       ? 'Online'
                       : `Last seen ${new Date(machine.last_seen_at).toLocaleDateString()}`}
@@ -448,7 +448,7 @@ export function DashboardRealtime({
             ))}
           </ul>
         ) : (
-          <div className="px-4 py-8 text-center text-zinc-500">
+          <div className="px-4 py-8 text-center text-zinc-400">
             <p>No machines registered.</p>
             <p className="mt-1 text-sm">
               Run <code className="text-orange-500">styrby auth</code> on your development machine to get started.
@@ -467,12 +467,12 @@ export function DashboardRealtime({
       ) : (
         <div className="mt-8 rounded-xl border border-zinc-800 bg-zinc-900/50 p-6 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <svg className="h-5 w-5 text-zinc-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <svg className="h-5 w-5 text-zinc-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
             </svg>
             <div>
               <p className="text-sm font-medium text-zinc-300">Cloud Monitoring</p>
-              <p className="text-xs text-zinc-500">Real-time cloud task monitoring. Available on Power.</p>
+              <p className="text-xs text-zinc-400">Real-time cloud task monitoring. Available on Power.</p>
             </div>
           </div>
           <a

--- a/packages/styrby-web/src/app/dashboard/devices/pair/error.tsx
+++ b/packages/styrby-web/src/app/dashboard/devices/pair/error.tsx
@@ -55,14 +55,14 @@ export default function PairingError({ error, reset }: ErrorProps) {
 
         {/* Error digest for support */}
         {error.digest && (
-          <p className="text-xs text-zinc-500 mb-6 font-mono">
+          <p className="text-xs text-zinc-400 mb-6 font-mono">
             Error ID: {error.digest}
           </p>
         )}
 
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mb-6 p-3 rounded-lg bg-zinc-900 border border-zinc-800 text-left">
-            <p className="text-xs text-zinc-500 mb-1">Dev only:</p>
+            <p className="text-xs text-zinc-400 mb-1">Dev only:</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">{error.message}</pre>
           </div>
         )}

--- a/packages/styrby-web/src/app/dashboard/devices/pair/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/devices/pair/page.tsx
@@ -195,12 +195,12 @@ export default async function PairDevicePage() {
                           <span className="h-2 w-2 rounded-full bg-green-500 animate-pulse" />
                         )}
                       </div>
-                      <div className="text-sm text-zinc-500">
+                      <div className="text-sm text-zinc-400">
                         {machine.hostname && (
                           <span className="mr-2">{machine.hostname}</span>
                         )}
                         {machine.cli_version && (
-                          <span className="text-zinc-500">
+                          <span className="text-zinc-400">
                             v{machine.cli_version}
                           </span>
                         )}
@@ -209,7 +209,7 @@ export default async function PairDevicePage() {
                   </div>
 
                   {/* Last seen */}
-                  <div className="text-sm text-zinc-500">
+                  <div className="text-sm text-zinc-400">
                     {machine.is_online ? (
                       <span className="text-green-500">Online</span>
                     ) : (
@@ -234,7 +234,7 @@ export default async function PairDevicePage() {
 
         {/* No devices message */}
         {(!machines || machines.length === 0) && (
-          <div className="mt-12 text-center text-zinc-500">
+          <div className="mt-12 text-center text-zinc-400">
             <p>No devices paired yet. Scan the QR code above to get started.</p>
           </div>
         )}

--- a/packages/styrby-web/src/app/dashboard/devices/pair/pairing-qr.tsx
+++ b/packages/styrby-web/src/app/dashboard/devices/pair/pairing-qr.tsx
@@ -304,7 +304,7 @@ export function PairingQR({ userId }: PairingQRProps) {
       {status === 'expired' && (
         <div className="flex flex-col items-center gap-4 text-center">
           <div className="flex h-20 w-20 items-center justify-center rounded-full bg-zinc-800">
-            <ClockIcon className="h-10 w-10 text-zinc-500" />
+            <ClockIcon className="h-10 w-10 text-zinc-400" />
           </div>
           <div>
             <h3 className="text-xl font-semibold text-zinc-100">

--- a/packages/styrby-web/src/app/dashboard/error.tsx
+++ b/packages/styrby-web/src/app/dashboard/error.tsx
@@ -46,12 +46,12 @@ export default function DashboardError({
         </p>
 
         {error.digest && (
-          <p className="text-xs text-zinc-500 mb-6">Error ID: {error.digest}</p>
+          <p className="text-xs text-zinc-400 mb-6">Error ID: {error.digest}</p>
         )}
 
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mb-6 p-3 rounded-lg bg-zinc-900 border border-zinc-800 text-left">
-            <p className="text-xs text-zinc-500 mb-1">Dev only:</p>
+            <p className="text-xs text-zinc-400 mb-1">Dev only:</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">{error.message}</pre>
           </div>
         )}

--- a/packages/styrby-web/src/app/dashboard/loading.tsx
+++ b/packages/styrby-web/src/app/dashboard/loading.tsx
@@ -13,7 +13,7 @@ export default function DashboardLoading() {
           role="status"
           aria-label="Loading dashboard"
         />
-        <p className="text-sm text-zinc-500">Loading Dashboard...</p>
+        <p className="text-sm text-zinc-400">Loading Dashboard...</p>
       </div>
     </div>
   );

--- a/packages/styrby-web/src/app/dashboard/privacy/_components/DataMapSection.tsx
+++ b/packages/styrby-web/src/app/dashboard/privacy/_components/DataMapSection.tsx
@@ -211,9 +211,9 @@ function DataMapRow({ entry }: { entry: DataMapEntry }) {
         aria-expanded={expanded}
       >
         {expanded ? (
-          <ChevronDown className="h-4 w-4 text-zinc-500 flex-shrink-0" aria-hidden />
+          <ChevronDown className="h-4 w-4 text-zinc-400 flex-shrink-0" aria-hidden />
         ) : (
-          <ChevronRight className="h-4 w-4 text-zinc-500 flex-shrink-0" aria-hidden />
+          <ChevronRight className="h-4 w-4 text-zinc-400 flex-shrink-0" aria-hidden />
         )}
         <span className="font-mono text-xs text-zinc-300 flex-shrink-0 w-44">{entry.table}</span>
         <span className="text-xs text-zinc-400 flex-1 truncate">{entry.description.split(':')[0]}</span>
@@ -237,12 +237,12 @@ function DataMapRow({ entry }: { entry: DataMapEntry }) {
         <div className="px-11 pb-4 space-y-2">
           <p className="text-xs text-zinc-400">{entry.description}</p>
           {entry.plaintextFields && (
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-zinc-400">
               <span className="text-zinc-400 font-medium">What is not encrypted: </span>
               {entry.plaintextFields}
             </p>
           )}
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-zinc-400">
             <span className="text-zinc-400 font-medium">Retention: </span>
             {entry.retention}
           </p>
@@ -263,7 +263,7 @@ export function DataMapSection() {
       <div className="px-6 py-4 border-b border-zinc-800 flex items-center gap-3">
         <Database className="h-4 w-4 text-purple-400" aria-hidden />
         <h2 className="text-base font-semibold text-zinc-100">What We Store</h2>
-        <span className="ml-auto text-xs text-zinc-500">GDPR Art. 13/14</span>
+        <span className="ml-auto text-xs text-zinc-400">GDPR Art. 13/14</span>
       </div>
 
       <div className="px-6 py-4">

--- a/packages/styrby-web/src/app/dashboard/privacy/_components/DeletionSection.tsx
+++ b/packages/styrby-web/src/app/dashboard/privacy/_components/DeletionSection.tsx
@@ -108,7 +108,7 @@ export function DeletionSection({ userEmail }: DeletionSectionProps) {
       <div className="px-6 py-4 border-b border-red-500/20 flex items-center gap-3">
         <Trash2 className="h-4 w-4 text-red-400" aria-hidden />
         <h2 className="text-base font-semibold text-red-400">Delete Account</h2>
-        <span className="ml-auto text-xs text-zinc-500">GDPR Art. 17</span>
+        <span className="ml-auto text-xs text-zinc-400">GDPR Art. 17</span>
       </div>
 
       {/* Step 1 (idle): Entry point — minimal friction, clear CTA */}
@@ -190,7 +190,7 @@ export function DeletionSection({ userEmail }: DeletionSectionProps) {
             onChange={(e) => setConfirmEmail(e.target.value)}
             placeholder={userEmail}
             disabled={step === 'deleting'}
-            className="w-full rounded-lg bg-zinc-800 border border-zinc-700 text-zinc-100 px-4 py-2 text-sm mb-4 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-red-500/50 disabled:opacity-50"
+            className="w-full rounded-lg bg-zinc-800 border border-zinc-700 text-zinc-100 px-4 py-2 text-sm mb-4 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-red-500/50 disabled:opacity-50"
             aria-label={`Type ${userEmail} to confirm account deletion`}
             autoComplete="off"
             autoCapitalize="off"

--- a/packages/styrby-web/src/app/dashboard/privacy/_components/EncryptionSection.tsx
+++ b/packages/styrby-web/src/app/dashboard/privacy/_components/EncryptionSection.tsx
@@ -78,9 +78,9 @@ function FaqRow({ item }: { item: FaqItem }) {
         aria-expanded={expanded}
       >
         {expanded ? (
-          <ChevronDown className="h-4 w-4 text-zinc-500 flex-shrink-0 mt-0.5" aria-hidden />
+          <ChevronDown className="h-4 w-4 text-zinc-400 flex-shrink-0 mt-0.5" aria-hidden />
         ) : (
-          <ChevronRight className="h-4 w-4 text-zinc-500 flex-shrink-0 mt-0.5" aria-hidden />
+          <ChevronRight className="h-4 w-4 text-zinc-400 flex-shrink-0 mt-0.5" aria-hidden />
         )}
         <span className="text-sm text-zinc-200">{item.question}</span>
       </button>
@@ -103,7 +103,7 @@ export function EncryptionSection() {
       <div className="px-6 py-4 border-b border-zinc-800 flex items-center gap-3">
         <Lock className="h-4 w-4 text-yellow-400" aria-hidden />
         <h2 className="text-base font-semibold text-zinc-100">Encryption Details</h2>
-        <span className="ml-auto text-xs text-zinc-500">For technical verification</span>
+        <span className="ml-auto text-xs text-zinc-400">For technical verification</span>
       </div>
 
       <div className="px-6 py-4 border-b border-zinc-800">

--- a/packages/styrby-web/src/app/dashboard/privacy/_components/ExportSection.tsx
+++ b/packages/styrby-web/src/app/dashboard/privacy/_components/ExportSection.tsx
@@ -118,7 +118,7 @@ export function ExportSection({ lastExportedAt }: ExportSectionProps) {
       <div className="px-6 py-4 border-b border-zinc-800 flex items-center gap-3">
         <Download className="h-4 w-4 text-green-400" aria-hidden />
         <h2 className="text-base font-semibold text-zinc-100">Export Your Data</h2>
-        <span className="ml-auto text-xs text-zinc-500">GDPR Art. 15 / Art. 20</span>
+        <span className="ml-auto text-xs text-zinc-400">GDPR Art. 15 / Art. 20</span>
       </div>
 
       <div className="px-6 py-4">
@@ -127,13 +127,13 @@ export function ExportSection({ lastExportedAt }: ExportSectionProps) {
           billing history, and audit logs. This is your right under GDPR Article 15
           (Subject Access Request) and Article 20 (Data Portability).
         </p>
-        <p className="text-xs text-zinc-500 mb-4">
+        <p className="text-xs text-zinc-400 mb-4">
           The export contains all your data in JSON format. Message content is included
           in encrypted form - only your device can decrypt it.
         </p>
 
         {lastExportedAt && (
-          <p className="text-xs text-zinc-500 mb-3">
+          <p className="text-xs text-zinc-400 mb-3">
             Last exported: {formatDate(lastExportedAt)}
           </p>
         )}

--- a/packages/styrby-web/src/app/dashboard/privacy/_components/RetentionSection.tsx
+++ b/packages/styrby-web/src/app/dashboard/privacy/_components/RetentionSection.tsx
@@ -108,7 +108,7 @@ export function RetentionSection({ initialRetentionDays }: RetentionSectionProps
       <div className="px-6 py-4 border-b border-zinc-800 flex items-center gap-3">
         <Shield className="h-4 w-4 text-blue-400" aria-hidden />
         <h2 className="text-base font-semibold text-zinc-100">Session Retention</h2>
-        <span className="ml-auto text-xs text-zinc-500">GDPR Art. 5(1)(e)</span>
+        <span className="ml-auto text-xs text-zinc-400">GDPR Art. 5(1)(e)</span>
       </div>
 
       <div className="px-6 py-4">
@@ -143,7 +143,7 @@ export function RetentionSection({ initialRetentionDays }: RetentionSectionProps
                   <p className={`text-sm font-medium ${isSelected ? 'text-blue-300' : 'text-zinc-200'}`}>
                     {option.label}
                   </p>
-                  <p className="text-xs text-zinc-500 mt-0.5">{option.description}</p>
+                  <p className="text-xs text-zinc-400 mt-0.5">{option.description}</p>
                 </div>
               </button>
             );

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-input.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-input.tsx
@@ -188,7 +188,7 @@ export function ChatInput({ sessionId }: ChatInputProps) {
       </div>
 
       {/* Keyboard shortcut hint */}
-      <p className="mt-2 text-xs text-zinc-500">
+      <p className="mt-2 text-xs text-zinc-400">
         Press <kbd className="px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400">Enter</kbd> to send,{' '}
         <kbd className="px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400">Shift + Enter</kbd> for new line
       </p>

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-thread.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-thread.tsx
@@ -400,7 +400,7 @@ const MessageRow = memo(function MessageRow({ message, decryptedContent, copiedI
       {/* Message content */}
       <div className="whitespace-pre-wrap break-words">
         {isEncryptedAndUnreadable ? (
-          <span className="inline-flex items-center gap-1.5 text-zinc-500 italic">
+          <span className="inline-flex items-center gap-1.5 text-zinc-400 italic">
             <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
             </svg>
@@ -424,7 +424,7 @@ const MessageRow = memo(function MessageRow({ message, decryptedContent, copiedI
           {message.message_type === 'agent_response' && userTier === 'free' && (
             <a
               href="/pricing"
-              className="inline-flex items-center gap-1 rounded-full bg-zinc-700/40 px-1.5 py-0.5 text-[10px] text-zinc-500 hover:text-orange-400 transition-colors"
+              className="inline-flex items-center gap-1 rounded-full bg-zinc-700/40 px-1.5 py-0.5 text-[10px] text-zinc-400 hover:text-orange-400 transition-colors"
               title="Upgrade to Pro to see per-message costs"
               aria-label="Per-message cost tracking requires Pro plan"
             >
@@ -595,7 +595,7 @@ export function ChatThread({
       aria-relevant="additions"
     >
       {messages.length === 0 ? (
-        <div className="flex flex-col items-center justify-center h-full text-zinc-500">
+        <div className="flex flex-col items-center justify-center h-full text-zinc-400">
           <svg
             className="h-12 w-12 mb-4"
             fill="none"

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/error.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/error.tsx
@@ -55,14 +55,14 @@ export default function SessionError({ error, reset }: ErrorProps) {
 
         {/* Error digest for support */}
         {error.digest && (
-          <p className="text-xs text-zinc-500 mb-6 font-mono">
+          <p className="text-xs text-zinc-400 mb-6 font-mono">
             Error ID: {error.digest}
           </p>
         )}
 
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mb-6 p-3 rounded-lg bg-zinc-900 border border-zinc-800 text-left">
-            <p className="text-xs text-zinc-500 mb-1">Dev only:</p>
+            <p className="text-xs text-zinc-400 mb-1">Dev only:</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">{error.message}</pre>
           </div>
         )}

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/page.tsx
@@ -193,7 +193,7 @@ export default async function SessionPage({ params }: SessionPageProps) {
           <div className="flex items-center gap-2">
             {session.project_path && (
               <span
-                className="text-xs text-zinc-500 font-mono max-w-[200px] truncate"
+                className="text-xs text-zinc-400 font-mono max-w-[200px] truncate"
                 title={session.project_path}
               >
                 {session.project_path}
@@ -213,7 +213,7 @@ export default async function SessionPage({ params }: SessionPageProps) {
             {userTier === 'free' ? (
               <a
                 href="/pricing"
-                className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-zinc-500 hover:text-orange-400 transition-colors"
+                className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-zinc-400 hover:text-orange-400 transition-colors"
                 title="Upgrade to Pro to share sessions"
                 aria-label="Session sharing requires Pro plan"
               >
@@ -242,7 +242,7 @@ export default async function SessionPage({ params }: SessionPageProps) {
             after a session completes, which is the most common workflow for freelancers
             billing multiple clients. */}
         <div className="mt-3 flex items-center gap-2">
-          <span className="text-xs text-zinc-500 shrink-0">Tags:</span>
+          <span className="text-xs text-zinc-400 shrink-0">Tags:</span>
           <SessionTagEditor
             sessionId={session.id}
             initialTags={(session.tags as string[]) ?? []}
@@ -281,12 +281,12 @@ export default async function SessionPage({ params }: SessionPageProps) {
           {!isSessionActive && userTier === 'free' ? (
             <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-4">
               <div className="flex items-center gap-2 mb-2">
-                <svg className="h-4 w-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <svg className="h-4 w-4 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                 </svg>
-                <h3 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Context Breakdown</h3>
+                <h3 className="text-xs font-medium uppercase tracking-wide text-zinc-400">Context Breakdown</h3>
               </div>
-              <p className="text-xs text-zinc-500 mb-3">
+              <p className="text-xs text-zinc-400 mb-3">
                 Per-file context usage is a Pro feature.
               </p>
               <a
@@ -307,12 +307,12 @@ export default async function SessionPage({ params }: SessionPageProps) {
           {userTier === 'free' ? (
             <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-4">
               <div className="flex items-center gap-2 mb-2">
-                <svg className="h-4 w-4 text-zinc-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <svg className="h-4 w-4 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                 </svg>
-                <h3 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Checkpoints</h3>
+                <h3 className="text-xs font-medium uppercase tracking-wide text-zinc-400">Checkpoints</h3>
               </div>
-              <p className="text-xs text-zinc-500 mb-3">
+              <p className="text-xs text-zinc-400 mb-3">
                 Session checkpoints are a Pro feature.
               </p>
               <a

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/permission-card.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/permission-card.tsx
@@ -271,7 +271,7 @@ export function PermissionCard({ message, sessionId, isActive, machineId }: Perm
           {/* Description */}
           <p className="text-sm text-zinc-300 mt-1">
             {isEncrypted && (
-              <span className="inline-flex items-center gap-1 text-zinc-500 mr-1.5">
+              <span className="inline-flex items-center gap-1 text-zinc-400 mr-1.5">
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                 </svg>

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/session-bookmark-button.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/session-bookmark-button.tsx
@@ -123,7 +123,7 @@ export function SessionBookmarkButton({
           ${
             isBookmarked
               ? 'text-orange-400 hover:text-orange-300'
-              : 'text-zinc-500 hover:text-orange-400'
+              : 'text-zinc-400 hover:text-orange-400'
           }
           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500
         `}

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/session-checkpoints.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/session-checkpoints.tsx
@@ -284,7 +284,7 @@ export function SessionCheckpoints({
             }}
             placeholder="Checkpoint name (e.g. before-refactor)"
             maxLength={80}
-            className="w-full rounded-lg bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 border border-zinc-700 focus:border-zinc-500 focus:outline-none"
+            className="w-full rounded-lg bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-400 border border-zinc-700 focus:border-zinc-500 focus:outline-none"
             aria-label="Checkpoint name"
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleSave();
@@ -297,7 +297,7 @@ export function SessionCheckpoints({
             value={newDescription}
             onChange={(e) => setNewDescription(e.target.value)}
             placeholder="Optional description"
-            className="w-full rounded-lg bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 border border-zinc-700 focus:border-zinc-500 focus:outline-none"
+            className="w-full rounded-lg bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-400 border border-zinc-700 focus:border-zinc-500 focus:outline-none"
             aria-label="Checkpoint description"
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleSave();
@@ -336,7 +336,7 @@ export function SessionCheckpoints({
 
       {/* Loading state */}
       {isLoading && (
-        <p className="text-xs text-zinc-500 py-2">Loading checkpoints…</p>
+        <p className="text-xs text-zinc-400 py-2">Loading checkpoints…</p>
       )}
 
       {/* Error state */}
@@ -347,7 +347,7 @@ export function SessionCheckpoints({
       {/* Empty state */}
       {!isLoading && !error && checkpoints.length === 0 && (
         <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-4 text-center">
-          <p className="text-xs text-zinc-500">No checkpoints yet.</p>
+          <p className="text-xs text-zinc-400">No checkpoints yet.</p>
           <p className="text-xs text-zinc-400 mt-1">
             Save a checkpoint to mark a position in this session.
           </p>
@@ -373,7 +373,7 @@ export function SessionCheckpoints({
                   </p>
                   {cp.description && (
                     <p
-                      className="text-xs text-zinc-500 mt-0.5 line-clamp-2"
+                      className="text-xs text-zinc-400 mt-0.5 line-clamp-2"
                       title={cp.description}
                     >
                       {cp.description}

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/session-share-button.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/session-share-button.tsx
@@ -193,7 +193,7 @@ export function SessionShareButton({ sessionId, machineId }: SessionShareButtonP
               </h2>
               <button
                 onClick={() => setIsOpen(false)}
-                className="text-zinc-500 hover:text-zinc-300 transition-colors"
+                className="text-zinc-400 hover:text-zinc-300 transition-colors"
                 aria-label="Close share dialog"
               >
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -274,7 +274,7 @@ export function SessionShareButton({ sessionId, machineId }: SessionShareButtonP
                       {machineId ? ` (machine ${machineId.slice(0, 8)}...)` : ''}.
                       Ask the session owner to share the key via a secure channel (Signal, 1Password, etc.).
                     </p>
-                    <p className="mt-2 text-xs text-zinc-500">
+                    <p className="mt-2 text-xs text-zinc-400">
                       The key is never stored in Styrby. This ensures your session content
                       is private even from Styrby servers.
                     </p>

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/session-view.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/session-view.tsx
@@ -205,7 +205,7 @@ export function SessionView({
                 ? 'bg-orange-500/20 text-orange-400'
                 : canAccessReplay
                   ? 'text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800/50'
-                  : 'text-zinc-500 cursor-not-allowed'
+                  : 'text-zinc-400 cursor-not-allowed'
             )}
             aria-pressed={viewMode === 'replay'}
             aria-disabled={!canAccessReplay}
@@ -217,7 +217,7 @@ export function SessionView({
             )}
             Replay
             {!canAccessReplay && (
-              <span className="ml-1 text-xs text-zinc-500">Pro</span>
+              <span className="ml-1 text-xs text-zinc-400">Pro</span>
             )}
           </button>
           </div>
@@ -276,7 +276,7 @@ export function SessionView({
               </div>
 
               {/* Session end info */}
-              <div className="px-6 py-3 border-t border-zinc-800/50 text-center text-sm text-zinc-500">
+              <div className="px-6 py-3 border-t border-zinc-800/50 text-center text-sm text-zinc-400">
                 Session ended{' '}
                 {session.ended_at
                   ? new Date(session.ended_at).toLocaleString()

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/summary-tab.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/summary-tab.tsx
@@ -232,7 +232,7 @@ export function SummaryTab({
             Upgrade to Pro
           </Link>
 
-          <p className="text-xs text-zinc-500 mt-3">
+          <p className="text-xs text-zinc-400 mt-3">
             Available on Pro and Growth plans
           </p>
         </div>
@@ -339,7 +339,7 @@ export function SummaryTab({
           <div className="text-left">
             <h3 className="text-sm font-semibold text-zinc-100">AI Summary</h3>
             {summaryGeneratedAt && (
-              <p className="text-xs text-zinc-500">
+              <p className="text-xs text-zinc-400">
                 Generated{' '}
                 {new Date(summaryGeneratedAt).toLocaleDateString('en-US', {
                   month: 'short',
@@ -372,7 +372,7 @@ export function SummaryTab({
                 AI summaries can hallucinate or miss nuance from a long
                 session. Plain-language disclaimer keeps the user calibrated
                 without scaring them away from the feature. */}
-            <p className="mt-3 text-xs text-zinc-500 italic">
+            <p className="mt-3 text-xs text-zinc-400 italic">
               AI-generated. May not reflect every detail of the session.
               Open the full transcript above to verify.
             </p>

--- a/packages/styrby-web/src/app/dashboard/sessions/error.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/error.tsx
@@ -46,12 +46,12 @@ export default function SessionsError({
         </p>
 
         {error.digest && (
-          <p className="text-xs text-zinc-500 mb-6">Error ID: {error.digest}</p>
+          <p className="text-xs text-zinc-400 mb-6">Error ID: {error.digest}</p>
         )}
 
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mb-6 p-3 rounded-lg bg-zinc-900 border border-zinc-800 text-left">
-            <p className="text-xs text-zinc-500 mb-1">Dev only:</p>
+            <p className="text-xs text-zinc-400 mb-1">Dev only:</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">{error.message}</pre>
           </div>
         )}

--- a/packages/styrby-web/src/app/dashboard/sessions/loading.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/loading.tsx
@@ -13,7 +13,7 @@ export default function SessionsLoading() {
           role="status"
           aria-label="Loading sessions"
         />
-        <p className="text-sm text-zinc-500">Loading Sessions...</p>
+        <p className="text-sm text-zinc-400">Loading Sessions...</p>
       </div>
     </div>
   );

--- a/packages/styrby-web/src/app/dashboard/sessions/sessions-filter.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/sessions-filter.tsx
@@ -497,7 +497,7 @@ export function SessionsFilter({
               />
               {/* Search icon */}
               <svg
-                className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500"
+                className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-400"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -514,7 +514,7 @@ export function SessionsFilter({
               {searchQuery && (
                 <button
                   onClick={() => setSearchQuery('')}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-300"
                   aria-label="Clear search"
                 >
                   <svg
@@ -752,13 +752,13 @@ export function SessionsFilter({
 
                         {/* Summary */}
                         {session.summary && (
-                          <p className="text-sm text-zinc-500 mt-1 line-clamp-2">
+                          <p className="text-sm text-zinc-400 mt-1 line-clamp-2">
                             {session.summary}
                           </p>
                         )}
                       </div>
 
-                      <div className="flex flex-col items-end gap-1 text-sm text-zinc-500 ml-4">
+                      <div className="flex flex-col items-end gap-1 text-sm text-zinc-400 ml-4">
                         {/* Bookmark star — click to toggle without navigating to detail */}
                         <SessionBookmarkButton
                           sessionId={session.id}
@@ -810,11 +810,11 @@ export function SessionsFilter({
                   d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                 />
               </svg>
-              <span className="ml-2 text-sm text-zinc-500">Loading more sessions...</span>
+              <span className="ml-2 text-sm text-zinc-400">Loading more sessions...</span>
             </div>
           )}
           {!hasMore && allSessions.length > 0 && (
-            <p className="text-center text-sm text-zinc-500 py-4">
+            <p className="text-center text-sm text-zinc-400 py-4">
               All sessions loaded
             </p>
           )}
@@ -824,7 +824,7 @@ export function SessionsFilter({
         <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
           <div className="mx-auto h-12 w-12 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
             <svg
-              className="h-6 w-6 text-zinc-500"
+              className="h-6 w-6 text-zinc-400"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -840,7 +840,7 @@ export function SessionsFilter({
           <h3 className="text-lg font-medium text-zinc-100">
             No matching sessions
           </h3>
-          <p className="mt-2 text-zinc-500">
+          <p className="mt-2 text-zinc-400">
             No sessions match your current search or filter criteria.
           </p>
           <button
@@ -855,7 +855,7 @@ export function SessionsFilter({
         <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
           <div className="mx-auto h-12 w-12 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
             <svg
-              className="h-6 w-6 text-zinc-500"
+              className="h-6 w-6 text-zinc-400"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -871,13 +871,13 @@ export function SessionsFilter({
           <h3 className="text-lg font-medium text-zinc-100">
             {scope === 'team' ? 'No team sessions yet' : 'No sessions yet'}
           </h3>
-          <p className="mt-2 text-zinc-500">
+          <p className="mt-2 text-zinc-400">
             {scope === 'team'
               ? 'Team sessions will appear here when team members start using Styrby.'
               : 'Start a session with your AI coding agent to see it here.'}
           </p>
           {scope === 'mine' && (
-            <p className="mt-1 text-sm text-zinc-500">
+            <p className="mt-1 text-sm text-zinc-400">
               Run <code className="text-orange-500">styrby chat</code> to get
               started.
             </p>

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-account.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-account.tsx
@@ -115,7 +115,7 @@ export function SettingsAccount({ user, profile }: SettingsAccountProps) {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-zinc-100">Email</p>
-              <p className="text-sm text-zinc-500">{user.email}</p>
+              <p className="text-sm text-zinc-400">{user.email}</p>
             </div>
             <button
               onClick={() => setShowEmailDialog(!showEmailDialog)}
@@ -194,7 +194,7 @@ export function SettingsAccount({ user, profile }: SettingsAccountProps) {
                   }}
                 />
               ) : (
-                <p className="text-sm text-zinc-500">
+                <p className="text-sm text-zinc-400">
                   {profile?.display_name || 'Not set'}
                 </p>
               )}
@@ -247,7 +247,7 @@ export function SettingsAccount({ user, profile }: SettingsAccountProps) {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-zinc-100">Password</p>
-              <p className="text-sm text-zinc-500">
+              <p className="text-sm text-zinc-400">
                 {user.provider === 'github'
                   ? 'Signed in with GitHub'
                   : '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022'}

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-agents.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-agents.tsx
@@ -46,7 +46,7 @@ export function SettingsAgents({ agentConfigs }: SettingsAgentsProps) {
                 </div>
                 <div>
                   <p className="text-sm font-medium text-zinc-100 capitalize">{id}</p>
-                  <p className="text-sm text-zinc-500">
+                  <p className="text-sm text-zinc-400">
                     {config?.auto_approve_low_risk
                       ? 'Auto-approve low risk'
                       : 'Manual approval'}

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-appearance.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-appearance.tsx
@@ -20,7 +20,7 @@ export function SettingsAppearance() {
         <div className="px-4 py-4 flex items-center justify-between">
           <div>
             <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">Theme</p>
-            <p className="text-sm text-zinc-500 dark:text-zinc-500">
+            <p className="text-sm text-zinc-400 dark:text-zinc-400">
               Choose your preferred color scheme
             </p>
           </div>

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-danger-zone.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-danger-zone.tsx
@@ -25,7 +25,7 @@ export function SettingsDangerZone() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-zinc-100">Sign Out</p>
-                <p className="text-sm text-zinc-500">
+                <p className="text-sm text-zinc-400">
                   Sign out of your account on this device
                 </p>
               </div>
@@ -42,7 +42,7 @@ export function SettingsDangerZone() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-zinc-100">Delete Account</p>
-                <p className="text-sm text-zinc-500">
+                <p className="text-sm text-zinc-400">
                   Permanently delete your account and all data
                 </p>
               </div>

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-data-privacy.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-data-privacy.tsx
@@ -90,7 +90,7 @@ export function SettingsDataPrivacy() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-zinc-100">Export Your Data</p>
-              <p className="text-sm text-zinc-500">
+              <p className="text-sm text-zinc-400">
                 Download all your data in JSON format (GDPR Art. 15)
               </p>
             </div>
@@ -125,12 +125,12 @@ export function SettingsDataPrivacy() {
             <Shield className="h-4 w-4 text-blue-400" aria-hidden />
             <div>
               <p className="text-sm font-medium text-zinc-100">Privacy Control Center</p>
-              <p className="text-sm text-zinc-500">
+              <p className="text-sm text-zinc-400">
                 Retention policy, data map, encryption details, account deletion
               </p>
             </div>
           </div>
-          <ChevronRight className="h-4 w-4 text-zinc-500 group-hover:text-zinc-300 transition-colors" aria-hidden />
+          <ChevronRight className="h-4 w-4 text-zinc-400 group-hover:text-zinc-300 transition-colors" aria-hidden />
         </Link>
 
       </div>

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-link-row.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-link-row.tsx
@@ -10,7 +10,7 @@ import type { ReactNode } from 'react';
 function ChevronRight() {
   return (
     <svg
-      className="h-5 w-5 text-zinc-500"
+      className="h-5 w-5 text-zinc-400"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -73,7 +73,7 @@ export function SettingsLinkRow({
             {badge}
           </div>
           {description && (
-            <p className="text-sm text-zinc-500">{description}</p>
+            <p className="text-sm text-zinc-400">{description}</p>
           )}
         </div>
       </div>

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-notifications.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-notifications.tsx
@@ -183,7 +183,7 @@ export function SettingsNotifications({
         <div className="px-4 py-4 flex items-center justify-between">
           <div>
             <p className="text-sm font-medium text-zinc-100">Push Notifications</p>
-            <p className="text-sm text-zinc-500">
+            <p className="text-sm text-zinc-400">
               Get notified when agents need attention
             </p>
           </div>
@@ -208,7 +208,7 @@ export function SettingsNotifications({
                 <p className="text-sm font-medium text-zinc-100">
                   Browser Push Subscription
                 </p>
-                <p className="text-sm text-zinc-500">
+                <p className="text-sm text-zinc-400">
                   {webPush.subscribed
                     ? 'This browser is receiving push notifications.'
                     : webPush.permission === 'denied'
@@ -248,7 +248,7 @@ export function SettingsNotifications({
 
         {!webPush.supported && (
           <div className="px-4 py-4">
-            <p className="text-sm text-zinc-500">
+            <p className="text-sm text-zinc-400">
               Your browser does not support Web Push notifications. Try Chrome,
               Firefox, or Edge for push notification support.
             </p>
@@ -259,7 +259,7 @@ export function SettingsNotifications({
         <div className="px-4 py-4 flex items-center justify-between">
           <div>
             <p className="text-sm font-medium text-zinc-100">Email Notifications</p>
-            <p className="text-sm text-zinc-500">
+            <p className="text-sm text-zinc-400">
               Weekly summary and important alerts
             </p>
           </div>
@@ -281,7 +281,7 @@ export function SettingsNotifications({
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-zinc-100">Quiet Hours</p>
-              <p className="text-sm text-zinc-500">
+              <p className="text-sm text-zinc-400">
                 {notificationPrefs?.quiet_hours_start && notificationPrefs?.quiet_hours_end
                   ? `${notificationPrefs.quiet_hours_start} - ${notificationPrefs.quiet_hours_end}`
                   : 'Not configured'}
@@ -298,7 +298,7 @@ export function SettingsNotifications({
           {editingQuietHours && (
             <div className="mt-3 flex items-center gap-3">
               <div className="flex items-center gap-2">
-                <label htmlFor="quiet-start" className="text-xs text-zinc-500">
+                <label htmlFor="quiet-start" className="text-xs text-zinc-400">
                   From
                 </label>
                 <input
@@ -310,7 +310,7 @@ export function SettingsNotifications({
                 />
               </div>
               <div className="flex items-center gap-2">
-                <label htmlFor="quiet-end" className="text-xs text-zinc-500">
+                <label htmlFor="quiet-end" className="text-xs text-zinc-400">
                   To
                 </label>
                 <input
@@ -346,10 +346,10 @@ export function SettingsNotifications({
                   </span>
                 )}
               </div>
-              <p className="text-sm text-zinc-500">Filter notifications by importance</p>
+              <p className="text-sm text-zinc-400">Filter notifications by importance</p>
             </div>
             {prioritySaving && (
-              <span className="text-xs text-zinc-500">Saving...</span>
+              <span className="text-xs text-zinc-400">Saving...</span>
             )}
           </div>
           <div className={`${!isPaidTier ? 'opacity-50 pointer-events-none' : ''}`}>
@@ -364,13 +364,13 @@ export function SettingsNotifications({
               aria-label="Notification sensitivity slider"
             />
             <div className="flex justify-between mt-2">
-              <span className="text-xs text-zinc-500">Urgent only</span>
-              <span className="text-xs text-zinc-500">All</span>
+              <span className="text-xs text-zinc-400">Urgent only</span>
+              <span className="text-xs text-zinc-400">All</span>
             </div>
             <div className="mt-4 p-3 rounded-lg bg-zinc-800/50 border border-zinc-700">
               <p className="text-sm font-medium text-zinc-100 mb-1">{priorityCopy.title}</p>
               <p className="text-xs text-zinc-400 mb-2">{priorityCopy.summary}</p>
-              <div className="space-y-1 text-xs text-zinc-500">
+              <div className="space-y-1 text-xs text-zinc-400">
                 <p className="font-medium text-zinc-400">Examples at this level:</p>
                 {priorityCopy.examples.map((line) => (
                   <p key={line}>{line}</p>

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-subscription.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-subscription.tsx
@@ -51,7 +51,7 @@ export function SettingsSubscription({ subscription }: SettingsSubscriptionProps
               </span>
             </div>
             {subscription?.current_period_end && (
-              <p className="text-sm text-zinc-500 mt-1">
+              <p className="text-sm text-zinc-400 mt-1">
                 {subscription.cancel_at_period_end ? 'Cancels' : 'Renews'} on{' '}
                 {new Date(subscription.current_period_end).toLocaleDateString()}
               </p>
@@ -77,7 +77,7 @@ export function SettingsSubscription({ subscription }: SettingsSubscriptionProps
 
         {subscription && subscription.tier !== 'free' && monthlySpend !== null && (
           <div className="mt-4 pt-4 border-t border-zinc-800">
-            <p className="text-sm text-zinc-500">
+            <p className="text-sm text-zinc-400">
               This month&apos;s usage: ${monthlySpend.toFixed(2)}
             </p>
             <div className="mt-2 h-2 rounded-full bg-zinc-800 overflow-hidden">

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-support.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-support.tsx
@@ -58,7 +58,7 @@ export function SettingsSupport() {
           <div className="px-4 py-4 flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-zinc-100">Need Help?</p>
-              <p className="text-sm text-zinc-500">
+              <p className="text-sm text-zinc-400">
                 Submit a bug report, feature request, or question
               </p>
             </div>
@@ -77,7 +77,7 @@ export function SettingsSupport() {
           <div className="px-4 py-4 flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-zinc-100">Send Feedback</p>
-              <p className="text-sm text-zinc-500">
+              <p className="text-sm text-zinc-400">
                 Share ideas, report bugs, or tell us what you think
               </p>
             </div>

--- a/packages/styrby-web/src/app/dashboard/settings/api/api-keys-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/api/api-keys-client.tsx
@@ -247,7 +247,7 @@ export function ApiKeysClient({
         <div className="flex items-center gap-4">
           <p className="text-sm text-zinc-400">
             {keyCount} / {keyLimit} API keys used
-            <span className="text-zinc-500 ml-2">({tier} plan)</span>
+            <span className="text-zinc-400 ml-2">({tier} plan)</span>
           </p>
           <Link
             href="/dashboard/settings/api/docs"
@@ -288,7 +288,7 @@ export function ApiKeysClient({
               Upgrade to Power
             </Link>
           ) : (
-            <span className="text-sm text-zinc-500">Key limit reached</span>
+            <span className="text-sm text-zinc-400">Key limit reached</span>
           )}
         </div>
       </div>
@@ -331,7 +331,7 @@ export function ApiKeysClient({
         <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
           <div className="mx-auto h-16 w-16 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
             <svg
-              className="h-8 w-8 text-zinc-500"
+              className="h-8 w-8 text-zinc-400"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -346,7 +346,7 @@ export function ApiKeysClient({
             </svg>
           </div>
           <h3 className="text-lg font-medium text-zinc-100 mb-2">No API Keys</h3>
-          <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
+          <p className="text-zinc-400 mb-6 max-w-sm mx-auto">
             Create an API key to start accessing the Styrby API programmatically.
           </p>
           <button
@@ -384,7 +384,7 @@ export function ApiKeysClient({
                         </span>
                       )}
                     </div>
-                    <p className="text-xs text-zinc-500 mt-1 font-mono">
+                    <p className="text-xs text-zinc-400 mt-1 font-mono">
                       {key.key_prefix}{'*'.repeat(24)}
                     </p>
                   </div>
@@ -412,7 +412,7 @@ export function ApiKeysClient({
                 </div>
 
                 {/* Stats row */}
-                <div className="flex items-center gap-6 text-xs text-zinc-500">
+                <div className="flex items-center gap-6 text-xs text-zinc-400">
                   <span>
                     Created:{' '}
                     {new Date(key.created_at).toLocaleDateString('en-US', {
@@ -455,7 +455,7 @@ export function ApiKeysClient({
       {/* Revoked Keys */}
       {isPowerTier && revokedKeys.length > 0 && (
         <div className="space-y-4">
-          <h2 className="text-sm font-medium text-zinc-500">Revoked Keys</h2>
+          <h2 className="text-sm font-medium text-zinc-400">Revoked Keys</h2>
           {revokedKeys.map((key) => (
             <div
               key={key.id}
@@ -465,11 +465,11 @@ export function ApiKeysClient({
                 <div>
                   <div className="flex items-center gap-2">
                     <h3 className="text-sm font-semibold text-zinc-400">{key.name}</h3>
-                    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-zinc-800 text-zinc-500">
+                    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-zinc-800 text-zinc-400">
                       Revoked
                     </span>
                   </div>
-                  <p className="text-xs text-zinc-500 mt-1">
+                  <p className="text-xs text-zinc-400 mt-1">
                     Revoked on{' '}
                     {new Date(key.revoked_at!).toLocaleDateString('en-US', {
                       month: 'short',
@@ -617,7 +617,7 @@ export function ApiKeysClient({
                         </option>
                       ))}
                     </select>
-                    <p className="mt-1 text-xs text-zinc-500">
+                    <p className="mt-1 text-xs text-zinc-400">
                       For security, we recommend setting an expiration date
                     </p>
                   </div>

--- a/packages/styrby-web/src/app/dashboard/settings/api/docs/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/api/docs/page.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link';
 function CodeBlock({ language, code }: { language: string; code: string }) {
   return (
     <div className="relative rounded-lg bg-zinc-800 border border-zinc-700 overflow-hidden">
-      <div className="absolute top-0 right-0 px-2 py-1 text-xs text-zinc-500">
+      <div className="absolute top-0 right-0 px-2 py-1 text-xs text-zinc-400">
         {language}
       </div>
       <pre className="p-4 overflow-x-auto text-sm text-zinc-300">
@@ -90,7 +90,7 @@ function Endpoint({
                   <code className="text-xs bg-zinc-800 px-1.5 py-0.5 rounded text-orange-400">
                     {param.name}
                   </code>
-                  <span className="text-xs text-zinc-500">{param.type}</span>
+                  <span className="text-xs text-zinc-400">{param.type}</span>
                   {param.required && (
                     <span className="text-xs text-red-400">required</span>
                   )}
@@ -162,18 +162,18 @@ export default function ApiDocsPage() {
         <div className="flex items-center gap-3 mb-2">
           <Link
             href="/settings"
-            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="text-sm text-zinc-400 hover:text-zinc-300 transition-colors"
           >
             Settings
           </Link>
-          <span className="text-zinc-500">/</span>
+          <span className="text-zinc-400">/</span>
           <Link
             href="/settings/api"
-            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="text-sm text-zinc-400 hover:text-zinc-300 transition-colors"
           >
             API Keys
           </Link>
-          <span className="text-zinc-500">/</span>
+          <span className="text-zinc-400">/</span>
           <span className="text-sm text-zinc-300">Documentation</span>
         </div>
         <h1 className="text-2xl font-bold text-zinc-100 mb-2">API Documentation</h1>

--- a/packages/styrby-web/src/app/dashboard/settings/api/error.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/api/error.tsx
@@ -39,7 +39,7 @@ export default function Error({
 
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mb-6 p-3 rounded-lg bg-zinc-900 border border-zinc-800 text-left max-w-sm mx-auto">
-            <p className="text-xs text-zinc-500 mb-1">Dev only:</p>
+            <p className="text-xs text-zinc-400 mb-1">Dev only:</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">{error.message}</pre>
           </div>
         )}

--- a/packages/styrby-web/src/app/dashboard/settings/api/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/api/page.tsx
@@ -134,11 +134,11 @@ export default async function ApiKeysPage() {
         <div className="flex items-center gap-3 mb-2">
           <Link
             href="/dashboard/settings"
-            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="text-sm text-zinc-400 hover:text-zinc-300 transition-colors"
           >
             Settings
           </Link>
-          <span className="text-zinc-500">/</span>
+          <span className="text-zinc-400">/</span>
           <span className="text-sm text-zinc-300">API Keys</span>
         </div>
         <h1 className="text-2xl font-bold text-zinc-100 mb-8">API Keys</h1>

--- a/packages/styrby-web/src/app/dashboard/settings/error.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/error.tsx
@@ -46,12 +46,12 @@ export default function SettingsError({
         </p>
 
         {error.digest && (
-          <p className="text-xs text-zinc-500 mb-6">Error ID: {error.digest}</p>
+          <p className="text-xs text-zinc-400 mb-6">Error ID: {error.digest}</p>
         )}
 
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mb-6 p-3 rounded-lg bg-zinc-900 border border-zinc-800 text-left">
-            <p className="text-xs text-zinc-500 mb-1">Dev only:</p>
+            <p className="text-xs text-zinc-400 mb-1">Dev only:</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">{error.message}</pre>
           </div>
         )}

--- a/packages/styrby-web/src/app/dashboard/settings/loading.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/loading.tsx
@@ -13,7 +13,7 @@ export default function SettingsLoading() {
           role="status"
           aria-label="Loading settings"
         />
-        <p className="text-sm text-zinc-500">Loading Settings...</p>
+        <p className="text-sm text-zinc-400">Loading Settings...</p>
       </div>
     </div>
   );

--- a/packages/styrby-web/src/app/dashboard/settings/templates/__tests__/template-card.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/templates/__tests__/template-card.test.tsx
@@ -150,7 +150,7 @@ describe('TemplateCard', () => {
 
       expect(screen.getByText(/2 variables/)).toBeInTheDocument();
       // The variables badge section contains both variable names
-      const variableBadge = container.querySelector('.text-xs.text-zinc-500 span');
+      const variableBadge = container.querySelector('.text-xs.text-zinc-400 span');
       expect(variableBadge?.textContent).toContain('{{language}}');
       expect(variableBadge?.textContent).toContain('{{project_name}}');
     });

--- a/packages/styrby-web/src/app/dashboard/settings/templates/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/templates/page.tsx
@@ -91,7 +91,7 @@ export default async function TemplatesPage() {
             <Link href="/dashboard/settings" className="text-zinc-400 hover:text-zinc-100 transition-colors">
               Settings
             </Link>
-            <span className="text-zinc-500">/</span>
+            <span className="text-zinc-400">/</span>
             <span className="text-zinc-100">Templates</span>
           </nav>
         </div>

--- a/packages/styrby-web/src/app/dashboard/settings/templates/template-card.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/templates/template-card.tsx
@@ -188,7 +188,7 @@ export function TemplateCard({ template, onEdit, onDelete, onSetDefault }: Templ
             )}
           </div>
           {template.description && (
-            <p className="text-sm text-zinc-500 mt-1 line-clamp-2">{template.description}</p>
+            <p className="text-sm text-zinc-400 mt-1 line-clamp-2">{template.description}</p>
           )}
         </div>
       </div>
@@ -202,7 +202,7 @@ export function TemplateCard({ template, onEdit, onDelete, onSetDefault }: Templ
 
       {/* Variables badge */}
       {variableCount > 0 && (
-        <div className="flex items-center gap-1.5 text-xs text-zinc-500 mb-4">
+        <div className="flex items-center gap-1.5 text-xs text-zinc-400 mb-4">
           <VariableIcon className="h-3.5 w-3.5" />
           <span>
             {variableCount} variable{variableCount !== 1 ? 's' : ''}:{' '}

--- a/packages/styrby-web/src/app/dashboard/settings/templates/template-form.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/templates/template-form.tsx
@@ -360,7 +360,7 @@ export function TemplateForm({ isOpen, onClose, template, onSubmit }: TemplateFo
               >
                 Content <span className="text-red-400">*</span>
               </label>
-              <span className="text-xs text-zinc-500">
+              <span className="text-xs text-zinc-400">
                 Use {'{{variable_name}}'} for placeholders
               </span>
             </div>
@@ -407,7 +407,7 @@ export function TemplateForm({ isOpen, onClose, template, onSubmit }: TemplateFo
             </div>
 
             {formState.variables.length === 0 ? (
-              <p className="text-sm text-zinc-500 py-3 text-center border border-dashed border-zinc-700 rounded-lg">
+              <p className="text-sm text-zinc-400 py-3 text-center border border-dashed border-zinc-700 rounded-lg">
                 No variables defined. Add variables to make your template dynamic.
               </p>
             ) : (
@@ -469,7 +469,7 @@ export function TemplateForm({ isOpen, onClose, template, onSubmit }: TemplateFo
                       <button
                         type="button"
                         onClick={() => handleRemoveVariable(index)}
-                        className="mt-5 p-1.5 text-zinc-500 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+                        className="mt-5 p-1.5 text-zinc-400 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
                         aria-label={`Remove variable ${index + 1}`}
                       >
                         <TrashIcon className="h-4 w-4" />
@@ -485,7 +485,7 @@ export function TemplateForm({ isOpen, onClose, template, onSubmit }: TemplateFo
           <div className="flex items-center justify-between py-3 border-t border-zinc-800">
             <div>
               <p className="text-sm font-medium text-zinc-100">Set as Default</p>
-              <p className="text-xs text-zinc-500">
+              <p className="text-xs text-zinc-400">
                 Automatically apply this template to new sessions
               </p>
             </div>

--- a/packages/styrby-web/src/app/dashboard/settings/templates/templates-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/templates/templates-client.tsx
@@ -259,7 +259,7 @@ export function TemplatesClient({ initialTemplates, userId }: TemplatesClientPro
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-2xl font-bold text-zinc-100">Context Templates</h1>
-          <p className="text-sm text-zinc-500 mt-1">
+          <p className="text-sm text-zinc-400 mt-1">
             Create reusable context that can be injected into agent sessions.
           </p>
         </div>
@@ -283,9 +283,9 @@ export function TemplatesClient({ initialTemplates, userId }: TemplatesClientPro
       {/* Templates grid */}
       {templates.length === 0 ? (
         <div className="rounded-xl border border-dashed border-zinc-700 bg-zinc-900/50 p-12 text-center">
-          <DocumentTextIcon className="h-12 w-12 mx-auto text-zinc-500 mb-4" />
+          <DocumentTextIcon className="h-12 w-12 mx-auto text-zinc-400 mb-4" />
           <h3 className="text-lg font-medium text-zinc-300 mb-2">No templates yet</h3>
-          <p className="text-sm text-zinc-500 mb-6 max-w-md mx-auto">
+          <p className="text-sm text-zinc-400 mb-6 max-w-md mx-auto">
             Context templates let you define reusable project context with variables
             that get substituted at runtime.
           </p>

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/delivery-log-modal.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/delivery-log-modal.tsx
@@ -80,11 +80,11 @@ export function DeliveryLogModal({ webhook, onClose }: DeliveryLogModalProps) {
         <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
           <div>
             <h2 className="text-lg font-semibold text-zinc-100">Delivery Log</h2>
-            <p className="text-sm text-zinc-500">{webhook.name}</p>
+            <p className="text-sm text-zinc-400">{webhook.name}</p>
           </div>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
+            className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
             aria-label="Close delivery log"
           >
             <svg
@@ -119,8 +119,8 @@ export function DeliveryLogModal({ webhook, onClose }: DeliveryLogModalProps) {
 
           {!loading && !error && deliveries.length === 0 && (
             <div className="text-center py-8">
-              <p className="text-zinc-500">No deliveries yet</p>
-              <p className="text-sm text-zinc-500 mt-1">
+              <p className="text-zinc-400">No deliveries yet</p>
+              <p className="text-sm text-zinc-400 mt-1">
                 Deliveries will appear here once events are triggered
               </p>
             </div>
@@ -154,11 +154,11 @@ function DeliveryRow({ delivery }: { delivery: WebhookDelivery }) {
           </span>
           <span className="text-sm text-zinc-300">{delivery.event}</span>
         </div>
-        <span className="text-xs text-zinc-500">
+        <span className="text-xs text-zinc-400">
           {new Date(delivery.created_at).toLocaleString()}
         </span>
       </div>
-      <div className="text-xs text-zinc-500 flex items-center gap-3">
+      <div className="text-xs text-zinc-400 flex items-center gap-3">
         {delivery.response_status && <span>HTTP {delivery.response_status}</span>}
         {delivery.duration_ms !== null && <span>{delivery.duration_ms}ms</span>}
         <span>Attempts: {delivery.attempts}</span>

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-card.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-card.tsx
@@ -63,7 +63,7 @@ export function WebhookCard({
               </span>
             )}
           </div>
-          <p className="text-xs text-zinc-500 mt-1 truncate" title={webhook.url}>
+          <p className="text-xs text-zinc-400 mt-1 truncate" title={webhook.url}>
             {webhook.url}
           </p>
         </div>
@@ -98,7 +98,7 @@ export function WebhookCard({
 
       {/* Footer with status and actions */}
       <div className="flex items-center justify-between">
-        <div className="text-xs text-zinc-500">
+        <div className="text-xs text-zinc-400">
           {webhook.last_success_at ? (
             <span className="text-green-400">
               Last success: {formatLastSuccess(webhook.last_success_at)}

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-empty-state.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-empty-state.tsx
@@ -26,7 +26,7 @@ export function WebhookEmptyState({ webhookLimit, onCreate }: WebhookEmptyStateP
     <div className="rounded-xl bg-zinc-900 border border-zinc-800 px-4 py-16 text-center">
       <div className="mx-auto h-16 w-16 rounded-full bg-zinc-800 flex items-center justify-center mb-4">
         <svg
-          className="h-8 w-8 text-zinc-500"
+          className="h-8 w-8 text-zinc-400"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -43,7 +43,7 @@ export function WebhookEmptyState({ webhookLimit, onCreate }: WebhookEmptyStateP
       <h3 className="text-lg font-medium text-zinc-100 mb-2">No webhooks</h3>
       {webhookLimit > 0 ? (
         <>
-          <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
+          <p className="text-zinc-400 mb-6 max-w-sm mx-auto">
             Create webhooks to receive event notifications in Slack, Discord,
             or any custom endpoint.
           </p>
@@ -57,7 +57,7 @@ export function WebhookEmptyState({ webhookLimit, onCreate }: WebhookEmptyStateP
         </>
       ) : (
         <>
-          <p className="text-zinc-500 mb-6 max-w-sm mx-auto">
+          <p className="text-zinc-400 mb-6 max-w-sm mx-auto">
             Webhooks let you integrate Styrby with Slack, Discord, and more.
             Upgrade to Pro to create webhooks.
           </p>

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-form-modal.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-form-modal.tsx
@@ -194,7 +194,7 @@ function CreateEditPanel({
             placeholder="https://..."
             className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
           />
-          <p className="mt-1 text-xs text-zinc-500">Must be HTTPS for production use</p>
+          <p className="mt-1 text-xs text-zinc-400">Must be HTTPS for production use</p>
         </div>
 
         <div>
@@ -249,7 +249,7 @@ function CreateEditPanel({
                       >
                         {event.label}
                       </p>
-                      <p className="text-xs text-zinc-500">{event.description}</p>
+                      <p className="text-xs text-zinc-400">{event.description}</p>
                     </div>
                   </div>
                 </button>

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-header.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-header.tsx
@@ -41,7 +41,7 @@ export function WebhookHeader({
       <div className="flex items-center gap-4">
         <p className="text-sm text-zinc-400">
           {webhookCount} / {webhookLimit} webhooks used
-          <span className="text-zinc-500 ml-2">({tier} plan)</span>
+          <span className="text-zinc-400 ml-2">({tier} plan)</span>
         </p>
         <Link
           href="/dashboard/settings/webhooks/docs"

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-icon-button.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/_components/webhook-icon-button.tsx
@@ -51,7 +51,7 @@ export function WebhookIconButton({
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`p-1.5 rounded-lg text-zinc-500 transition-colors disabled:opacity-50 ${hoverClasses}`}
+      className={`p-1.5 rounded-lg text-zinc-400 transition-colors disabled:opacity-50 ${hoverClasses}`}
       aria-label={ariaLabel}
       title={title}
     >

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/docs/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/docs/page.tsx
@@ -75,18 +75,18 @@ export default async function WebhookDocsPage() {
         <div className="flex items-center gap-3 mb-2">
           <Link
             href="/settings"
-            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="text-sm text-zinc-400 hover:text-zinc-300 transition-colors"
           >
             Settings
           </Link>
-          <span className="text-zinc-500">/</span>
+          <span className="text-zinc-400">/</span>
           <Link
             href="/settings/webhooks"
-            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="text-sm text-zinc-400 hover:text-zinc-300 transition-colors"
           >
             Webhooks
           </Link>
-          <span className="text-zinc-500">/</span>
+          <span className="text-zinc-400">/</span>
           <span className="text-sm text-zinc-300">Documentation</span>
         </div>
 

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/error.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/error.tsx
@@ -68,7 +68,7 @@ export default function WebhooksError({ error, reset }: ErrorProps) {
         {/* Error details in development */}
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mt-8 p-4 rounded-lg bg-zinc-900 border border-zinc-800 text-left">
-            <p className="text-xs text-zinc-500 mb-2">Error details (development only):</p>
+            <p className="text-xs text-zinc-400 mb-2">Error details (development only):</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">
               {error.message}
             </pre>

--- a/packages/styrby-web/src/app/dashboard/settings/webhooks/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/webhooks/page.tsx
@@ -132,11 +132,11 @@ export default async function WebhooksPage() {
         <div className="flex items-center gap-3 mb-2">
           <Link
             href="/dashboard/settings"
-            className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="text-sm text-zinc-400 hover:text-zinc-300 transition-colors"
           >
             Settings
           </Link>
-          <span className="text-zinc-500">/</span>
+          <span className="text-zinc-400">/</span>
           <span className="text-sm text-zinc-300">Webhooks</span>
         </div>
         <h1 className="text-2xl font-bold text-zinc-100 mb-8">Webhooks</h1>

--- a/packages/styrby-web/src/app/dashboard/support/[id]/ticket-detail-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/support/[id]/ticket-detail-client.tsx
@@ -191,7 +191,7 @@ export function TicketDetailClient({ ticket, replies, userId }: TicketDetailClie
           {ticket.description}
         </p>
 
-        <p className="mt-4 text-xs text-zinc-500">
+        <p className="mt-4 text-xs text-zinc-400">
           Submitted {getRelativeTime(ticket.created_at)}
         </p>
       </div>
@@ -220,7 +220,7 @@ export function TicketDetailClient({ ticket, replies, userId }: TicketDetailClie
                   <p className="whitespace-pre-wrap text-sm text-zinc-200">
                     {reply.message}
                   </p>
-                  <p className="mt-2 text-xs text-zinc-500">
+                  <p className="mt-2 text-xs text-zinc-400">
                     {getRelativeTime(reply.created_at)}
                   </p>
                 </div>
@@ -263,7 +263,7 @@ export function TicketDetailClient({ ticket, replies, userId }: TicketDetailClie
         </div>
       ) : (
         <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 text-center">
-          <p className="text-sm text-zinc-500">
+          <p className="text-sm text-zinc-400">
             This ticket is closed. If you need further help, please open a new ticket.
           </p>
         </div>

--- a/packages/styrby-web/src/app/dashboard/support/support-list-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/support/support-list-client.tsx
@@ -115,7 +115,7 @@ export function SupportListClient({ tickets }: SupportListClientProps) {
         <div className="flex flex-col items-center justify-center rounded-xl border border-zinc-800 bg-zinc-900 py-16">
           <HelpCircle className="mb-4 h-12 w-12 text-zinc-400" />
           <p className="text-sm font-medium text-zinc-300">No tickets yet.</p>
-          <p className="mt-1 text-sm text-zinc-500">
+          <p className="mt-1 text-sm text-zinc-400">
             Need help? Submit a ticket and we will get back to you.
           </p>
           <button
@@ -156,7 +156,7 @@ export function SupportListClient({ tickets }: SupportListClientProps) {
                       {ticket.subject}
                     </p>
                   </div>
-                  <span className="shrink-0 text-xs text-zinc-500">
+                  <span className="shrink-0 text-xs text-zinc-400">
                     {getRelativeTime(ticket.created_at)}
                   </span>
                 </div>

--- a/packages/styrby-web/src/app/dashboard/team/[teamId]/members/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/[teamId]/members/page.tsx
@@ -196,7 +196,7 @@ export default async function MembersPage({ params }: MembersPageProps) {
       {/* Page header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
-          <div className="flex items-center gap-2 text-zinc-500 text-sm mb-1">
+          <div className="flex items-center gap-2 text-zinc-400 text-sm mb-1">
             <Link
               href={`/dashboard/team/${teamId}/invitations`}
               className="hover:text-zinc-300 transition-colors"

--- a/packages/styrby-web/src/app/dashboard/team/[teamId]/policies/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/[teamId]/policies/page.tsx
@@ -119,7 +119,7 @@ export default async function PoliciesPage({ params }: PoliciesPageProps) {
     <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
       {/* Page header */}
       <div>
-        <div className="flex items-center gap-2 text-zinc-500 text-sm mb-1">
+        <div className="flex items-center gap-2 text-zinc-400 text-sm mb-1">
           <Link
             href={`/dashboard/team/${teamId}/members`}
             className="hover:text-zinc-300 transition-colors"

--- a/packages/styrby-web/src/app/dashboard/team/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/page.tsx
@@ -177,7 +177,7 @@ export default async function TeamPage() {
               </Link>
             </div>
 
-            <p className="mt-6 text-sm text-zinc-500">
+            <p className="mt-6 text-sm text-zinc-400">
               Pro plan: ${TIERS.pro.price.monthly}/month · Growth plan: ${TIERS.growth.price.monthly}/month
             </p>
           </div>

--- a/packages/styrby-web/src/app/dashboard/team/team-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/team-client.tsx
@@ -294,7 +294,7 @@ export function TeamClient({
 
             <div>
               <label htmlFor="teamDescription" className="block text-sm font-medium text-zinc-300 mb-2">
-                Description <span className="text-zinc-500">(optional)</span>
+                Description <span className="text-zinc-400">(optional)</span>
               </label>
               <textarea
                 id="teamDescription"
@@ -347,7 +347,7 @@ export function TeamClient({
               {team.description && (
                 <p className="text-zinc-400 mt-1">{team.description}</p>
               )}
-              <div className="flex items-center gap-4 mt-2 text-sm text-zinc-500">
+              <div className="flex items-center gap-4 mt-2 text-sm text-zinc-400">
                 <span>{members.length} member{members.length !== 1 ? 's' : ''}</span>
                 <span>Created {formatDate(team.created_at)}</span>
               </div>
@@ -427,7 +427,7 @@ export function TeamClient({
                         {member.display_name || member.email}
                       </span>
                       {isCurrentUser && (
-                        <span className="text-xs text-zinc-500">(you)</span>
+                        <span className="text-xs text-zinc-400">(you)</span>
                       )}
                     </div>
                     <span className="text-sm text-zinc-400">{member.email}</span>
@@ -515,7 +515,7 @@ export function TeamClient({
                   </div>
                   <div>
                     <span className="font-medium text-zinc-100">{invite.email}</span>
-                    <div className="text-sm text-zinc-500">
+                    <div className="text-sm text-zinc-400">
                       Expires {formatDate(invite.expires_at)}
                     </div>
                   </div>

--- a/packages/styrby-web/src/app/dashboard/tools/tools-registry.tsx
+++ b/packages/styrby-web/src/app/dashboard/tools/tools-registry.tsx
@@ -110,7 +110,7 @@ function ToolCard({ tool }: { tool: MCPToolDescriptor }) {
           }`}
         >
           <Icon
-            className={`h-5 w-5 ${isAvailable ? 'text-amber-500' : 'text-zinc-500'}`}
+            className={`h-5 w-5 ${isAvailable ? 'text-amber-500' : 'text-zinc-400'}`}
             aria-hidden="true"
           />
         </div>

--- a/packages/styrby-web/src/app/dpa/page.tsx
+++ b/packages/styrby-web/src/app/dpa/page.tsx
@@ -115,7 +115,7 @@ export default function DpaPage() {
 
         <article className="prose prose-lg prose-invert max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-400 prose-a:no-underline hover:prose-a:text-orange-300 prose-strong:text-zinc-200">
           <h1>Data Processing Agreement</h1>
-          <p className="text-sm text-zinc-500">
+          <p className="text-sm text-zinc-400">
             Effective date: March 22, 2026. Last updated: March 22, 2026.
           </p>
 
@@ -459,7 +459,7 @@ export default function DpaPage() {
 
           {/* ── Related ──────────────────────────────────────── */}
           <hr />
-          <p className="dpa-related-links text-sm text-zinc-500">
+          <p className="dpa-related-links text-sm text-zinc-400">
             Related documents:{' '}
             <Link href="/privacy">Privacy Policy</Link>
             {' | '}

--- a/packages/styrby-web/src/app/global-error.tsx
+++ b/packages/styrby-web/src/app/global-error.tsx
@@ -63,7 +63,7 @@ export default function GlobalError({
             </button>
           </div>
           {error.digest && (
-            <p className="mt-6 text-xs text-zinc-500">Error ID: {error.digest}</p>
+            <p className="mt-6 text-xs text-zinc-400">Error ID: {error.digest}</p>
           )}
         </div>
       </body>

--- a/packages/styrby-web/src/app/legal/retention-proof/page.tsx
+++ b/packages/styrby-web/src/app/legal/retention-proof/page.tsx
@@ -272,7 +272,7 @@ export default async function RetentionProofPage() {
           <h1 className="text-3xl font-bold text-zinc-100">
             Data Retention - Target Policy and Live Proof
           </h1>
-          <p className="mt-2 text-sm text-zinc-500">
+          <p className="mt-2 text-sm text-zinc-400">
             Policy last audited: {POLICY_LAST_AUDITED}
           </p>
           <p className="mt-4 text-zinc-300 max-w-3xl">
@@ -359,7 +359,7 @@ export default async function RetentionProofPage() {
                     <td className="px-4 py-4 text-sm text-zinc-400 align-top max-w-xs">
                       {row.mechanism}
                     </td>
-                    <td className="px-4 py-4 text-sm text-zinc-500 align-top max-w-xs">
+                    <td className="px-4 py-4 text-sm text-zinc-400 align-top max-w-xs">
                       {row.gdprBasis}
                     </td>
                     <td className="px-4 py-4 align-top whitespace-nowrap">
@@ -411,7 +411,7 @@ export default async function RetentionProofPage() {
                 <p className="mt-1 text-3xl font-bold text-orange-400" data-testid="sessions-purged-count">
                   {liveCounts.sessions_purged_30d.toLocaleString()}
                 </p>
-                <p className="mt-2 text-xs text-zinc-500">
+                <p className="mt-2 text-xs text-zinc-400">
                   Source: sessions WHERE deleted_at IS NOT NULL AND deleted_at &gt; now() - 30 days
                 </p>
                 <p className="mt-1 text-xs text-emerald-500">
@@ -430,7 +430,7 @@ export default async function RetentionProofPage() {
                   })}{' '}
                   CT
                 </p>
-                <p className="mt-2 text-xs text-zinc-500">
+                <p className="mt-2 text-xs text-zinc-400">
                   Cached for up to 1 hour. Nightly cron runs at 03:00 CT.
                 </p>
               </div>
@@ -439,7 +439,7 @@ export default async function RetentionProofPage() {
         </section>
 
         {/* Footer */}
-        <div className="border-t border-zinc-800 pt-6 text-sm text-zinc-500">
+        <div className="border-t border-zinc-800 pt-6 text-sm text-zinc-400">
           <p className="mb-3 text-zinc-400">
             Target rules without automated enforcement will be backed by scheduled jobs in a future
             release. See{' '}

--- a/packages/styrby-web/src/app/legal/subprocessors/page.tsx
+++ b/packages/styrby-web/src/app/legal/subprocessors/page.tsx
@@ -101,7 +101,7 @@ export default function SubprocessorsPage() {
         {/* Page header */}
         <div className="mb-10">
           <h1 className="text-3xl font-bold text-zinc-100">Subprocessors</h1>
-          <p className="mt-2 text-sm text-zinc-500">
+          <p className="mt-2 text-sm text-zinc-400">
             Last updated: {SUBPROCESSORS_LAST_UPDATED}
           </p>
           <p className="mt-4 text-zinc-300 max-w-3xl">
@@ -222,7 +222,7 @@ export default function SubprocessorsPage() {
         </div>
 
         {/* Footer note */}
-        <div className="mt-8 border-t border-zinc-800 pt-6 text-sm text-zinc-500">
+        <div className="mt-8 border-t border-zinc-800 pt-6 text-sm text-zinc-400">
           <p>
             This list is kept current. For questions about sub-processor changes, data
             processing activities, or to request notification of future updates, email{' '}

--- a/packages/styrby-web/src/app/pricing/error.tsx
+++ b/packages/styrby-web/src/app/pricing/error.tsx
@@ -46,12 +46,12 @@ export default function PricingError({
         </p>
 
         {error.digest && (
-          <p className="text-xs text-zinc-500 mb-6">Error ID: {error.digest}</p>
+          <p className="text-xs text-zinc-400 mb-6">Error ID: {error.digest}</p>
         )}
 
         {process.env.NODE_ENV === 'development' && error.message && (
           <div className="mb-6 p-3 rounded-lg bg-zinc-900 border border-zinc-800 text-left">
-            <p className="text-xs text-zinc-500 mb-1">Dev only:</p>
+            <p className="text-xs text-zinc-400 mb-1">Dev only:</p>
             <pre className="text-xs text-red-400 whitespace-pre-wrap break-words">{error.message}</pre>
           </div>
         )}

--- a/packages/styrby-web/src/app/pricing/loading.tsx
+++ b/packages/styrby-web/src/app/pricing/loading.tsx
@@ -13,7 +13,7 @@ export default function PricingLoading() {
           role="status"
           aria-label="Loading pricing"
         />
-        <p className="text-sm text-zinc-500">Loading Pricing...</p>
+        <p className="text-sm text-zinc-400">Loading Pricing...</p>
       </div>
     </div>
   );

--- a/packages/styrby-web/src/app/pricing/pricing-cards.tsx
+++ b/packages/styrby-web/src/app/pricing/pricing-cards.tsx
@@ -22,7 +22,7 @@ export function PricingCards({ currentTier }: PricingCardsProps) {
       <div className="flex items-center justify-center gap-4 mb-10">
         <span
           className={`text-sm font-medium ${
-            billingCycle === 'monthly' ? 'text-zinc-100' : 'text-zinc-500'
+            billingCycle === 'monthly' ? 'text-zinc-100' : 'text-zinc-400'
           }`}
         >
           Monthly
@@ -41,7 +41,7 @@ export function PricingCards({ currentTier }: PricingCardsProps) {
         </button>
         <span
           className={`text-sm font-medium ${
-            billingCycle === 'annual' ? 'text-zinc-100' : 'text-zinc-500'
+            billingCycle === 'annual' ? 'text-zinc-100' : 'text-zinc-400'
           }`}
         >
           Annual
@@ -88,9 +88,9 @@ export function PricingCards({ currentTier }: PricingCardsProps) {
                 <span className="text-4xl font-bold text-zinc-100">
                   ${price}
                 </span>
-                <span className="text-zinc-500">{period}</span>
+                <span className="text-zinc-400">{period}</span>
                 {billingCycle === 'annual' && tierId !== 'free' && (
-                  <div className="text-sm text-zinc-500 mt-1">
+                  <div className="text-sm text-zinc-400 mt-1">
                     ${(tier.price.annual / 12).toFixed(2)}/month
                   </div>
                 )}

--- a/packages/styrby-web/src/app/privacy/page.tsx
+++ b/packages/styrby-web/src/app/privacy/page.tsx
@@ -52,7 +52,7 @@ export default function PrivacyPolicyPage() {
         <article className="prose prose-lg prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-500 prose-a:no-underline hover:prose-a:underline prose-strong:text-zinc-100">
           <h1>Privacy Policy</h1>
 
-          <p className="text-sm text-zinc-500">
+          <p className="text-sm text-zinc-400">
             Effective date: March 22, 2026. Last updated: March 22, 2026.
           </p>
 
@@ -534,7 +534,7 @@ export default function PrivacyPolicyPage() {
         </article>
 
         {/* Footer links */}
-        <div className="mt-12 pt-8 border-t border-zinc-800 flex items-center justify-between text-sm text-zinc-500">
+        <div className="mt-12 pt-8 border-t border-zinc-800 flex items-center justify-between text-sm text-zinc-400">
           <p>&copy; {new Date().getFullYear()} Steel Motion LLC. All rights reserved.</p>
           <div className="flex gap-6">
             <Link

--- a/packages/styrby-web/src/app/security/page.tsx
+++ b/packages/styrby-web/src/app/security/page.tsx
@@ -55,7 +55,7 @@ export default function SecurityPage() {
       <main id="main-content" tabIndex={-1} className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
         <article className="prose prose-lg prose-invert max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-400 prose-a:no-underline hover:prose-a:text-orange-300 prose-strong:text-zinc-200">
           <h1>Security</h1>
-          <p className="text-sm text-zinc-500">
+          <p className="text-sm text-zinc-400">
             Last updated: April 25, 2026
           </p>
 
@@ -244,7 +244,7 @@ export default function SecurityPage() {
 
           {/* ── Related ──────────────────────────────────────── */}
           <hr />
-          <p className="text-sm text-zinc-500">
+          <p className="text-sm text-zinc-400">
             Related documents:{' '}
             <Link href="/privacy">Privacy Policy</Link>
             {' | '}

--- a/packages/styrby-web/src/app/shared/[shareId]/shared-session-viewer.tsx
+++ b/packages/styrby-web/src/app/shared/[shareId]/shared-session-viewer.tsx
@@ -333,7 +333,7 @@ export function SharedSessionViewer({ shareId }: SharedSessionViewerProps) {
             <span className="text-sm font-semibold text-zinc-400">
               Styrby Session Replay
             </span>
-            <span className="text-xs text-zinc-500">
+            <span className="text-xs text-zinc-400">
               Shared {new Date(share.createdAt).toLocaleDateString()}
               {share.expiresAt && ` · Expires ${new Date(share.expiresAt).toLocaleDateString()}`}
             </span>
@@ -391,7 +391,7 @@ export function SharedSessionViewer({ shareId }: SharedSessionViewerProps) {
         {/* Message thread */}
         <div className="space-y-4" role="log" aria-label="Session messages">
           {messages.length === 0 && (
-            <p className="text-center text-zinc-500 py-12">No messages in this session.</p>
+            <p className="text-center text-zinc-400 py-12">No messages in this session.</p>
           )}
 
           {messages.map((message) => {
@@ -437,7 +437,7 @@ export function SharedSessionViewer({ shareId }: SharedSessionViewerProps) {
                   {/* Content */}
                   <div className="whitespace-pre-wrap break-words">
                     {isEncryptedUnreadable ? (
-                      <span className="inline-flex items-center gap-1.5 text-zinc-500 italic text-sm">
+                      <span className="inline-flex items-center gap-1.5 text-zinc-400 italic text-sm">
                         <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                         </svg>
@@ -472,7 +472,7 @@ export function SharedSessionViewer({ shareId }: SharedSessionViewerProps) {
         </div>
 
         {/* Footer branding */}
-        <div className="mt-12 text-center text-xs text-zinc-500">
+        <div className="mt-12 text-center text-xs text-zinc-400">
           Shared via{' '}
           <a href="https://styrby.com" className="hover:text-zinc-400 transition-colors">
             Styrby

--- a/packages/styrby-web/src/app/support/access/[grantId]/page.tsx
+++ b/packages/styrby-web/src/app/support/access/[grantId]/page.tsx
@@ -125,7 +125,7 @@ function GrantDetails({ grant }: { grant: GrantRow }) {
     <div className="space-y-4">
       {/* ── Reason card ─────────────────────────────────────────────────────── */}
       <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-        <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+        <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider text-zinc-400">
           Request details
         </h2>
 
@@ -133,14 +133,14 @@ function GrantDetails({ grant }: { grant: GrantRow }) {
           {/* Ticket subject — gives context to which ticket triggered this */}
           {grant.ticket_subject && (
             <div>
-              <dt className="text-xs text-zinc-500">Support ticket</dt>
+              <dt className="text-xs text-zinc-400">Support ticket</dt>
               <dd className="mt-0.5 text-sm text-zinc-200">{grant.ticket_subject}</dd>
             </div>
           )}
 
           {/* Session — show only last 8 chars so user can map it to their sessions */}
           <div>
-            <dt className="text-xs text-zinc-500">Session</dt>
+            <dt className="text-xs text-zinc-400">Session</dt>
             <dd className="mt-0.5 font-mono text-sm text-zinc-300">
               {shortSessionId(grant.session_id)}
             </dd>
@@ -148,19 +148,19 @@ function GrantDetails({ grant }: { grant: GrantRow }) {
 
           {/* Reason — admin-provided justification (required, non-empty) */}
           <div>
-            <dt className="text-xs text-zinc-500">Reason given</dt>
+            <dt className="text-xs text-zinc-400">Reason given</dt>
             <dd className="mt-0.5 text-sm leading-relaxed text-zinc-200">{grant.reason}</dd>
           </div>
 
           {/* Expiry — when the grant stops being usable even if approved */}
           <div>
-            <dt className="text-xs text-zinc-500">Access expires</dt>
+            <dt className="text-xs text-zinc-400">Access expires</dt>
             <dd className="mt-0.5 text-sm text-zinc-300">{formatDate(grant.expires_at)}</dd>
           </div>
 
           {/* Scope — what metadata fields the admin can see */}
           <div>
-            <dt className="text-xs text-zinc-500">Data visible to support</dt>
+            <dt className="text-xs text-zinc-400">Data visible to support</dt>
             <dd className="mt-0.5">
               <ul className="flex flex-wrap gap-1.5" aria-label="Accessible data fields">
                 {grant.scope.fields.map((field) => (
@@ -177,7 +177,7 @@ function GrantDetails({ grant }: { grant: GrantRow }) {
 
           {/* Requested at — when the admin made the request */}
           <div>
-            <dt className="text-xs text-zinc-500">Requested</dt>
+            <dt className="text-xs text-zinc-400">Requested</dt>
             <dd className="mt-0.5 text-sm text-zinc-300">{formatDate(grant.requested_at)}</dd>
           </div>
         </dl>
@@ -189,7 +189,7 @@ function GrantDetails({ grant }: { grant: GrantRow }) {
         scope of processing. This inline notice is lighter-weight than a modal
         and keeps the context visible during decision-making.
       */}
-      <p className="text-xs leading-relaxed text-zinc-500">
+      <p className="text-xs leading-relaxed text-zinc-400">
         A Styrby support staff member is requesting read-only access to session
         metadata (action names, tool names, timestamps, and token counts).
         Message content is never shared — your session data remains end-to-end
@@ -250,7 +250,7 @@ function RevokedPanel({ revokedAt }: { revokedAt: string }) {
       <ShieldOff className="mt-0.5 h-5 w-5 shrink-0 text-zinc-400" aria-hidden="true" />
       <div>
         <p className="text-sm font-medium text-zinc-300">Access revoked</p>
-        <p className="mt-1 text-sm text-zinc-500">
+        <p className="mt-1 text-sm text-zinc-400">
           You revoked this access on {formatDate(revokedAt)}.
           Support can no longer view the session.
         </p>
@@ -270,7 +270,7 @@ function ConsumedPanel({ lastAccessedAt }: { lastAccessedAt: string | null }) {
       <XCircle className="mt-0.5 h-5 w-5 shrink-0 text-zinc-400" aria-hidden="true" />
       <div>
         <p className="text-sm font-medium text-zinc-300">Access cap reached</p>
-        <p className="mt-1 text-sm text-zinc-500">
+        <p className="mt-1 text-sm text-zinc-400">
           The maximum number of views was used
           {lastAccessedAt ? ` at ${formatDate(lastAccessedAt)}` : ''}.
           No further access is possible.
@@ -291,7 +291,7 @@ function ExpiredPanel({ expiresAt }: { expiresAt: string }) {
       <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-zinc-400" aria-hidden="true" />
       <div>
         <p className="text-sm font-medium text-zinc-300">Access expired</p>
-        <p className="mt-1 text-sm text-zinc-500">
+        <p className="mt-1 text-sm text-zinc-400">
           This access grant expired on {formatDate(expiresAt)} without being used.
         </p>
       </div>
@@ -386,7 +386,7 @@ export default async function GrantApprovalPage({ params }: PageProps) {
     <div className="mx-auto max-w-lg px-4 py-10 sm:px-6">
       {/* Page header */}
       <div className="mb-6">
-        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-400">
           Styrby
         </p>
         <h1 className="text-xl font-bold text-zinc-100">Support Access Request</h1>
@@ -424,11 +424,11 @@ export default async function GrantApprovalPage({ params }: PageProps) {
       )}
 
       {/* Footer */}
-      <p className="mt-8 text-center text-xs text-zinc-500">
+      <p className="mt-8 text-center text-xs text-zinc-400">
         Grant ID {grantId} &middot; Questions?{' '}
         <a
           href="/dashboard/support"
-          className="text-zinc-500 underline-offset-2 hover:text-zinc-400 hover:underline"
+          className="text-zinc-400 underline-offset-2 hover:text-zinc-400 hover:underline"
         >
           Open a support ticket
         </a>

--- a/packages/styrby-web/src/app/terms/page.tsx
+++ b/packages/styrby-web/src/app/terms/page.tsx
@@ -53,7 +53,7 @@ export default function TermsOfServicePage() {
         <article className="prose prose-lg prose-invert prose-zinc max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-a:text-orange-500 prose-a:no-underline hover:prose-a:underline prose-strong:text-zinc-100">
           <h1>Terms of Service</h1>
 
-          <p className="text-sm text-zinc-500">
+          <p className="text-sm text-zinc-400">
             Effective date: March 22, 2026. Last updated: March 22, 2026.
           </p>
 
@@ -458,7 +458,7 @@ export default function TermsOfServicePage() {
         </article>
 
         {/* Footer links */}
-        <div className="mt-12 pt-8 border-t border-zinc-800 flex items-center justify-between text-sm text-zinc-500">
+        <div className="mt-12 pt-8 border-t border-zinc-800 flex items-center justify-between text-sm text-zinc-400">
           <p>&copy; {new Date().getFullYear()} Steel Motion LLC. All rights reserved.</p>
           <div className="flex gap-6">
             <Link

--- a/packages/styrby-web/src/components/admin/AuditLogTable.tsx
+++ b/packages/styrby-web/src/components/admin/AuditLogTable.tsx
@@ -88,7 +88,7 @@ function actionBadgeClass(action: string): string {
   if (action.startsWith('override')) return 'bg-orange-500/10 text-orange-400';
   if (action === 'reset_password') return 'bg-blue-500/10 text-blue-400';
   if (action.includes('consent')) return 'bg-purple-500/10 text-purple-400';
-  if (action.includes('expired')) return 'bg-zinc-700/50 text-zinc-500';
+  if (action.includes('expired')) return 'bg-zinc-700/50 text-zinc-400';
   return 'bg-zinc-700/50 text-zinc-400';
 }
 
@@ -136,7 +136,7 @@ export function AuditLogTable({ rows, nextCursor }: AuditLogTableProps) {
   if (rows.length === 0) {
     return (
       <div className="py-16 text-center" data-testid="audit-log-empty">
-        <p className="text-sm text-zinc-500">No admin audit log entries found.</p>
+        <p className="text-sm text-zinc-400">No admin audit log entries found.</p>
       </div>
     );
   }
@@ -168,7 +168,7 @@ export function AuditLogTable({ rows, nextCursor }: AuditLogTableProps) {
                 data-testid="audit-log-row"
               >
                 {/* ID column — monotonically increasing, useful for range queries */}
-                <td className="px-4 py-3 font-mono text-xs text-zinc-500">{row.id}</td>
+                <td className="px-4 py-3 font-mono text-xs text-zinc-400">{row.id}</td>
 
                 {/* Action badge */}
                 <td className="px-4 py-3">
@@ -226,7 +226,7 @@ export function AuditLogTable({ rows, nextCursor }: AuditLogTableProps) {
 
       {/* Pagination controls */}
       <div className="mt-4 flex items-center justify-between">
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-zinc-400">
           {rows.length} row{rows.length !== 1 ? 's' : ''} on this page
         </p>
 

--- a/packages/styrby-web/src/components/admin/IssueCreditForm.tsx
+++ b/packages/styrby-web/src/components/admin/IssueCreditForm.tsx
@@ -147,7 +147,7 @@ export function IssueCreditForm({ targetUserId, action }: IssueCreditFormProps) 
       <div className="flex flex-col gap-1">
         <label htmlFor="amount_dollars" className="text-sm font-medium text-zinc-300">
           Credit amount <span className="text-red-400">*</span>
-          <span className="ml-2 text-zinc-500 font-normal text-xs">$1.00 – $1,000.00</span>
+          <span className="ml-2 text-zinc-400 font-normal text-xs">$1.00 – $1,000.00</span>
         </label>
         <div className="relative">
           <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-zinc-400 text-sm">
@@ -224,7 +224,7 @@ export function IssueCreditForm({ targetUserId, action }: IssueCreditFormProps) 
       <div className="flex flex-col gap-1">
         <label htmlFor="expires_at" className="text-sm font-medium text-zinc-300">
           Expires at{' '}
-          <span className="text-zinc-500 font-normal">(optional — leave blank for no expiry)</span>
+          <span className="text-zinc-400 font-normal">(optional — leave blank for no expiry)</span>
         </label>
         <input
           id="expires_at"

--- a/packages/styrby-web/src/components/admin/IssueRefundForm.tsx
+++ b/packages/styrby-web/src/components/admin/IssueRefundForm.tsx
@@ -173,7 +173,7 @@ export function IssueRefundForm({
       <div className="flex flex-col gap-1">
         <label htmlFor="amount_dollars" className="text-sm font-medium text-zinc-300">
           Amount <span className="text-red-400">*</span>
-          <span className="ml-2 text-zinc-500 font-normal text-xs">Max $5,000.00</span>
+          <span className="ml-2 text-zinc-400 font-normal text-xs">Max $5,000.00</span>
         </label>
         <div className="relative">
           <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-zinc-400 text-sm">$</span>
@@ -197,7 +197,7 @@ export function IssueRefundForm({
             }
           />
         </div>
-        <p id="amount-hint" className="text-xs text-zinc-500">
+        <p id="amount-hint" className="text-xs text-zinc-400">
           Max $5,000 per refund (500,000 cents enforced server-side)
         </p>
         {state && !state.ok && state.field === 'amount_dollars' && (

--- a/packages/styrby-web/src/components/admin/OverrideTierForm.tsx
+++ b/packages/styrby-web/src/components/admin/OverrideTierForm.tsx
@@ -167,7 +167,7 @@ export function OverrideTierForm({ targetUserId, currentTier = 'free', action }:
       {/* Expires at (optional) */}
       <div className="flex flex-col gap-1">
         <label htmlFor="expiresAt" className="text-sm font-medium text-zinc-300">
-          Expires at <span className="text-zinc-500 font-normal">(optional — leave blank for permanent)</span>
+          Expires at <span className="text-zinc-400 font-normal">(optional — leave blank for permanent)</span>
         </label>
         <input
           id="expiresAt"

--- a/packages/styrby-web/src/components/admin/ResetPasswordForm.tsx
+++ b/packages/styrby-web/src/components/admin/ResetPasswordForm.tsx
@@ -120,7 +120,7 @@ export function ResetPasswordForm({ targetUserId, targetEmail, action }: ResetPa
           {/* WHY JSX text: React escapes user-supplied email — no XSS risk. */}
           {targetEmail}
         </p>
-        <p className="mt-1 text-xs text-zinc-500">
+        <p className="mt-1 text-xs text-zinc-400">
           The link expires after 24 hours. The admin_audit_log row is written
           before the email is sent — see Sentry if delivery fails.
         </p>

--- a/packages/styrby-web/src/components/admin/SendChurnSaveOfferForm.tsx
+++ b/packages/styrby-web/src/components/admin/SendChurnSaveOfferForm.tsx
@@ -178,7 +178,7 @@ export function SendChurnSaveOfferForm({ targetUserId, action }: SendChurnSaveOf
       <div className="flex flex-col gap-1">
         <label htmlFor="polar_discount_code" className="text-sm font-medium text-zinc-300">
           Polar discount code{' '}
-          <span className="text-zinc-500 font-normal">(optional — create in Polar dashboard first)</span>
+          <span className="text-zinc-400 font-normal">(optional — create in Polar dashboard first)</span>
         </label>
         <input
           id="polar_discount_code"

--- a/packages/styrby-web/src/components/admin/ToggleConsentForm.tsx
+++ b/packages/styrby-web/src/components/admin/ToggleConsentForm.tsx
@@ -92,7 +92,7 @@ export function ToggleConsentForm({
       ? 'text-green-400'
       : currentState === 'revoked'
         ? 'text-red-400'
-        : 'text-zinc-500';
+        : 'text-zinc-400';
 
   return (
     <form
@@ -109,7 +109,7 @@ export function ToggleConsentForm({
         className="rounded-lg border border-zinc-800 bg-zinc-900/50 px-4 py-3"
         data-testid="current-state-box"
       >
-        <p className="text-xs font-medium uppercase tracking-wide text-zinc-500">Current state</p>
+        <p className="text-xs font-medium uppercase tracking-wide text-zinc-400">Current state</p>
         <p className={`mt-1 text-sm font-semibold ${currentStateColor}`} data-testid="current-state-value">
           {currentState === 'granted'
             ? 'Granted'
@@ -177,7 +177,7 @@ export function ToggleConsentForm({
             aria-invalid={state && !state.ok && state.field === 'grant' ? true : undefined}
           />
           <span className="text-sm text-zinc-100">Grant</span>
-          <span className="ml-auto text-xs text-zinc-500">Sets granted_at, clears revoked_at</span>
+          <span className="ml-auto text-xs text-zinc-400">Sets granted_at, clears revoked_at</span>
         </label>
 
         <label
@@ -197,7 +197,7 @@ export function ToggleConsentForm({
             aria-invalid={state && !state.ok && state.field === 'grant' ? true : undefined}
           />
           <span className="text-sm text-zinc-100">Revoke</span>
-          <span className="ml-auto text-xs text-zinc-500">Sets revoked_at, preserves granted_at</span>
+          <span className="ml-auto text-xs text-zinc-400">Sets revoked_at, preserves granted_at</span>
         </label>
 
         {state && !state.ok && state.field === 'grant' && (

--- a/packages/styrby-web/src/components/admin/UserListTable.tsx
+++ b/packages/styrby-web/src/components/admin/UserListTable.tsx
@@ -167,7 +167,7 @@ export function UserListTable({ rows, query, page }: UserListTableProps) {
   if (rows.length === 0) {
     return (
       <div className="py-16 text-center" data-testid="user-list-empty">
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-zinc-400">
           {query
             // WHY truncate: an adversary (or accidental paste) could supply a very
             // long query string. Reflecting it verbatim risks layout break and a
@@ -212,7 +212,7 @@ export function UserListTable({ rows, query, page }: UserListTableProps) {
                 <td className="px-4 py-3">
                   <TierBadge tier={user.tier} overrideSource={user.override_source} />
                 </td>
-                <td className="px-4 py-3 text-xs text-zinc-500" title={user.created_at}>
+                <td className="px-4 py-3 text-xs text-zinc-400" title={user.created_at}>
                   {getRelativeTime(user.created_at)}
                 </td>
                 <td className="px-4 py-3 text-right">
@@ -233,7 +233,7 @@ export function UserListTable({ rows, query, page }: UserListTableProps) {
 
       {/* Pagination controls */}
       <div className="mt-4 flex items-center justify-between">
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-zinc-400">
           {rows.length} result{rows.length !== 1 ? 's' : ''} on this page
         </p>
 

--- a/packages/styrby-web/src/components/admin/UserSearchForm.tsx
+++ b/packages/styrby-web/src/components/admin/UserSearchForm.tsx
@@ -78,7 +78,7 @@ export function UserSearchForm({ defaultValue = '' }: UserSearchFormProps) {
     <form onSubmit={handleSubmit} className="flex gap-2" role="search" aria-label="Search users">
       <div className="relative flex-1">
         <Search
-          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500"
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400"
           aria-hidden="true"
         />
         <input

--- a/packages/styrby-web/src/components/admin/dossier/ProfileCard.tsx
+++ b/packages/styrby-web/src/components/admin/dossier/ProfileCard.tsx
@@ -116,12 +116,12 @@ export async function ProfileCard({ userId }: { userId: string }) {
 
       {/* Profile fields */}
       <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
-        <dt className="text-zinc-500">User ID</dt>
+        <dt className="text-zinc-400">User ID</dt>
         <dd className="font-mono text-xs text-zinc-300 break-all" data-testid="profile-user-id">
           {profile.id}
         </dd>
 
-        <dt className="text-zinc-500">Email</dt>
+        <dt className="text-zinc-400">Email</dt>
         <dd className="font-mono text-zinc-100" data-testid="profile-email">
           {/* WHY React JSX render: email from Supabase is rendered via JSX text
               nodes — React escapes all special characters automatically. We never
@@ -132,12 +132,12 @@ export async function ProfileCard({ userId }: { userId: string }) {
 
         {profile.full_name && (
           <>
-            <dt className="text-zinc-500">Name</dt>
+            <dt className="text-zinc-400">Name</dt>
             <dd className="text-zinc-100">{profile.full_name}</dd>
           </>
         )}
 
-        <dt className="text-zinc-500">Joined</dt>
+        <dt className="text-zinc-400">Joined</dt>
         <dd className="text-zinc-300" title={profile.created_at ?? ''}>
           {fmtDate(profile.created_at)}
         </dd>
@@ -146,7 +146,7 @@ export async function ProfileCard({ userId }: { userId: string }) {
       {/* Consent flags */}
       {consentFlags.length > 0 && (
         <div className="mt-5 border-t border-zinc-800 pt-4">
-          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-zinc-400">
             Consent Flags
           </h3>
           <table className="w-full text-xs" aria-label="Consent flags for this user">
@@ -168,10 +168,10 @@ export async function ProfileCard({ userId }: { userId: string }) {
                 return (
                   <tr key={flag.purpose} data-testid="consent-flag-row">
                     <td className="py-1.5 font-mono text-zinc-300">{flag.purpose}</td>
-                    <td className="py-1.5 text-zinc-500" title={flag.granted_at ?? ''}>
+                    <td className="py-1.5 text-zinc-400" title={flag.granted_at ?? ''}>
                       {fmtDate(flag.granted_at)}
                     </td>
-                    <td className="py-1.5 text-zinc-500" title={flag.revoked_at ?? ''}>
+                    <td className="py-1.5 text-zinc-400" title={flag.revoked_at ?? ''}>
                       {fmtDate(flag.revoked_at)}
                     </td>
                     <td className="py-1.5">
@@ -179,7 +179,7 @@ export async function ProfileCard({ userId }: { userId: string }) {
                         className={`inline-flex rounded-full px-1.5 py-0.5 text-xs font-medium ${
                           isGranted
                             ? 'bg-green-500/10 text-green-400'
-                            : 'bg-zinc-700/50 text-zinc-500'
+                            : 'bg-zinc-700/50 text-zinc-400'
                         }`}
                         data-testid={`consent-status-${flag.purpose}`}
                       >

--- a/packages/styrby-web/src/components/admin/dossier/RecentAuditCard.tsx
+++ b/packages/styrby-web/src/components/admin/dossier/RecentAuditCard.tsx
@@ -60,7 +60,7 @@ function actionBadgeClass(action: string): string {
   if (action.startsWith('override')) return 'bg-orange-500/10 text-orange-400';
   if (action === 'reset_password') return 'bg-blue-500/10 text-blue-400';
   if (action.includes('consent')) return 'bg-purple-500/10 text-purple-400';
-  if (action.includes('expired')) return 'bg-zinc-700/50 text-zinc-500';
+  if (action.includes('expired')) return 'bg-zinc-700/50 text-zinc-400';
   return 'bg-zinc-700/50 text-zinc-400';
 }
 
@@ -167,7 +167,7 @@ export async function RecentAuditCard({ userId }: { userId: string }) {
                   {row.actor_email}
                 </td>
                 <td
-                  className="max-w-[180px] truncate py-2 text-zinc-500"
+                  className="max-w-[180px] truncate py-2 text-zinc-400"
                   title={row.reason}
                   data-testid="audit-reason"
                 >
@@ -181,7 +181,7 @@ export async function RecentAuditCard({ userId }: { userId: string }) {
           </tbody>
         </table>
       ) : (
-        <p className="text-sm text-zinc-500" data-testid="no-audit-rows">
+        <p className="text-sm text-zinc-400" data-testid="no-audit-rows">
           No admin actions recorded for this user.
         </p>
       )}

--- a/packages/styrby-web/src/components/admin/dossier/SessionsCard.tsx
+++ b/packages/styrby-web/src/components/admin/dossier/SessionsCard.tsx
@@ -131,7 +131,7 @@ export async function SessionsCard({ userId }: { userId: string }) {
       <div className="mb-4 flex items-center gap-2">
         <Terminal className="h-4 w-4 text-zinc-400" aria-hidden="true" />
         <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-400">Sessions</h2>
-        <span className="ml-auto text-xs text-zinc-500">
+        <span className="ml-auto text-xs text-zinc-400">
           <span className="font-semibold text-zinc-100" data-testid="session-count-30d">
             {sessionCount30d}
           </span>{' '}
@@ -153,13 +153,13 @@ export async function SessionsCard({ userId }: { userId: string }) {
           <tbody className="divide-y divide-zinc-800/60">
             {recentSessions.map((s) => (
               <tr key={s.id} data-testid="session-row">
-                <td className="py-2 font-mono text-zinc-500" title={s.id}>
+                <td className="py-2 font-mono text-zinc-400" title={s.id}>
                   {/* WHY truncate: UUIDs are 36 chars — showing all in a dense table
                       breaks layout. Last 8 chars identify the row adequately for ops. */}
                   {s.id.slice(-8)}
                 </td>
                 <td className="py-2 text-zinc-300">{s.agent_type ?? '—'}</td>
-                <td className="py-2 text-zinc-500" title={s.started_at ?? ''}>
+                <td className="py-2 text-zinc-400" title={s.started_at ?? ''}>
                   {fmtDateTime(s.started_at)}
                 </td>
                 <td className="py-2 text-right font-mono text-zinc-300">
@@ -178,7 +178,7 @@ export async function SessionsCard({ userId }: { userId: string }) {
           </tbody>
         </table>
       ) : (
-        <p className="text-sm text-zinc-500" data-testid="no-sessions">
+        <p className="text-sm text-zinc-400" data-testid="no-sessions">
           No sessions found.
         </p>
       )}

--- a/packages/styrby-web/src/components/admin/dossier/SubscriptionCard.tsx
+++ b/packages/styrby-web/src/components/admin/dossier/SubscriptionCard.tsx
@@ -112,7 +112,7 @@ export async function SubscriptionCard({ userId }: { userId: string }) {
         )}
 
         {isManualOverride && overrideExpired && (
-          <span className="ml-auto inline-flex items-center rounded-full bg-zinc-700/50 px-2 py-0.5 text-xs font-medium text-zinc-500" data-testid="manual-override-expired-badge">
+          <span className="ml-auto inline-flex items-center rounded-full bg-zinc-700/50 px-2 py-0.5 text-xs font-medium text-zinc-400" data-testid="manual-override-expired-badge">
             Override expired
           </span>
         )}
@@ -120,7 +120,7 @@ export async function SubscriptionCard({ userId }: { userId: string }) {
 
       {sub ? (
         <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
-          <dt className="text-zinc-500">Tier</dt>
+          <dt className="text-zinc-400">Tier</dt>
           <dd>
             <span
               className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${tierBadgeClass}`}
@@ -130,14 +130,14 @@ export async function SubscriptionCard({ userId }: { userId: string }) {
             </span>
           </dd>
 
-          <dt className="text-zinc-500">Override source</dt>
+          <dt className="text-zinc-400">Override source</dt>
           <dd className="font-mono text-xs text-zinc-300" data-testid="override-source">
             {sub.override_source ?? '—'}
           </dd>
 
           {isManualOverride && (
             <>
-              <dt className="text-zinc-500">Override expires</dt>
+              <dt className="text-zinc-400">Override expires</dt>
               <dd
                 className="text-zinc-300"
                 data-testid="override-expires-at"
@@ -148,7 +148,7 @@ export async function SubscriptionCard({ userId }: { userId: string }) {
 
               {sub.override_reason && (
                 <>
-                  <dt className="text-zinc-500">Override reason</dt>
+                  <dt className="text-zinc-400">Override reason</dt>
                   <dd
                     className="text-zinc-300"
                     data-testid="override-reason"
@@ -163,23 +163,23 @@ export async function SubscriptionCard({ userId }: { userId: string }) {
             </>
           )}
 
-          <dt className="text-zinc-500">Billing cycle</dt>
+          <dt className="text-zinc-400">Billing cycle</dt>
           <dd className="text-zinc-300" data-testid="billing-cycle">
             {sub.billing_cycle ?? '—'}
           </dd>
 
-          <dt className="text-zinc-500">Period end</dt>
+          <dt className="text-zinc-400">Period end</dt>
           <dd className="text-zinc-300" title={sub.current_period_end ?? ''}>
             {fmtDate(sub.current_period_end)}
           </dd>
 
-          <dt className="text-zinc-500">Updated</dt>
-          <dd className="text-zinc-500 text-xs" title={sub.updated_at ?? ''}>
+          <dt className="text-zinc-400">Updated</dt>
+          <dd className="text-zinc-400 text-xs" title={sub.updated_at ?? ''}>
             {fmtDate(sub.updated_at)}
           </dd>
         </dl>
       ) : (
-        <p className="text-sm text-zinc-500" data-testid="no-subscription">
+        <p className="text-sm text-zinc-400" data-testid="no-subscription">
           No subscription record found.
         </p>
       )}

--- a/packages/styrby-web/src/components/admin/dossier/TeamsCard.tsx
+++ b/packages/styrby-web/src/components/admin/dossier/TeamsCard.tsx
@@ -143,7 +143,7 @@ export async function TeamsCard({ userId }: { userId: string }) {
                     {m.role}
                   </span>
                 </td>
-                <td className="py-2 text-xs text-zinc-500" title={m.joined_at ?? ''}>
+                <td className="py-2 text-xs text-zinc-400" title={m.joined_at ?? ''}>
                   {fmtDate(m.joined_at)}
                 </td>
               </tr>
@@ -151,7 +151,7 @@ export async function TeamsCard({ userId }: { userId: string }) {
           </tbody>
         </table>
       ) : (
-        <p className="text-sm text-zinc-500" data-testid="no-teams">
+        <p className="text-sm text-zinc-400" data-testid="no-teams">
           Not a member of any teams.
         </p>
       )}

--- a/packages/styrby-web/src/components/billing/ChurnSaveOfferCard.tsx
+++ b/packages/styrby-web/src/components/billing/ChurnSaveOfferCard.tsx
@@ -186,7 +186,7 @@ export function ChurnSaveOfferCard({
         )}
 
         {/* Expiry countdown */}
-        <p className="mt-3 text-center text-xs text-zinc-500">
+        <p className="mt-3 text-center text-xs text-zinc-400">
           Expires {formatDate(expiresAt)}
         </p>
       </div>
@@ -217,7 +217,7 @@ export function ChurnSaveOfferCard({
         {isPending ? 'Accepting...' : 'Accept offer'}
       </button>
 
-      <p className="text-center text-xs text-zinc-500">
+      <p className="text-center text-xs text-zinc-400">
         By accepting, you agree to the discounted subscription terms.
         You can cancel anytime after the promotional period.
       </p>

--- a/packages/styrby-web/src/components/cloud-tasks.tsx
+++ b/packages/styrby-web/src/components/cloud-tasks.tsx
@@ -40,7 +40,7 @@ const STATUS_CONFIG: Record<
   running:   { label: 'Running',   dotColor: '#3b82f6', badgeBg: 'bg-blue-500/10',    badgeText: 'text-blue-400' },
   completed: { label: 'Done',      dotColor: '#22c55e', badgeBg: 'bg-green-500/10',   badgeText: 'text-green-400' },
   failed:    { label: 'Failed',    dotColor: '#ef4444', badgeBg: 'bg-red-500/10',      badgeText: 'text-red-400' },
-  cancelled: { label: 'Cancelled', dotColor: '#71717a', badgeBg: 'bg-zinc-800',        badgeText: 'text-zinc-500' },
+  cancelled: { label: 'Cancelled', dotColor: '#71717a', badgeBg: 'bg-zinc-800',        badgeText: 'text-zinc-400' },
 };
 
 /**
@@ -200,7 +200,7 @@ function TaskRow({
             <StatusBadge status={task.status} />
 
             {task.metadata?.gitBranch && (
-              <span className="text-xs text-zinc-500 font-mono">
+              <span className="text-xs text-zinc-400 font-mono">
                 {task.metadata.gitBranch}
               </span>
             )}
@@ -442,7 +442,7 @@ export function CloudTasksPanel({ userId }: CloudTasksPanelProps) {
           ].map(({ label, value, color }) => (
             <div key={label} className="bg-zinc-900 rounded-lg p-3 text-center">
               <div className={`text-lg font-bold ${color}`}>{value}</div>
-              <div className="text-xs text-zinc-500">{label}</div>
+              <div className="text-xs text-zinc-400">{label}</div>
             </div>
           ))}
         </div>
@@ -452,7 +452,7 @@ export function CloudTasksPanel({ userId }: CloudTasksPanelProps) {
       {isLoading ? (
         <div className="flex items-center justify-center py-8">
           <div className="w-5 h-5 rounded-full border-2 border-orange-500 border-t-transparent animate-spin" />
-          <span className="ml-3 text-sm text-zinc-500">Loading tasks...</span>
+          <span className="ml-3 text-sm text-zinc-400">Loading tasks...</span>
         </div>
       ) : tasks.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
@@ -470,7 +470,7 @@ export function CloudTasksPanel({ userId }: CloudTasksPanelProps) {
               d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"
             />
           </svg>
-          <p className="text-sm text-zinc-500 mb-2">No cloud tasks yet</p>
+          <p className="text-sm text-zinc-400 mb-2">No cloud tasks yet</p>
           <p className="text-xs text-zinc-400 font-mono">
             styrby cloud submit &quot;Write tests for auth.ts&quot;
           </p>
@@ -495,7 +495,7 @@ export function CloudTasksPanel({ userId }: CloudTasksPanelProps) {
       {/* CLI hint */}
       <p className="text-xs text-zinc-400 text-center pt-1">
         Submit async tasks with{' '}
-        <code className="font-mono text-zinc-500">styrby cloud submit</code>
+        <code className="font-mono text-zinc-400">styrby cloud submit</code>
       </p>
     </div>
   );

--- a/packages/styrby-web/src/components/context-breakdown.tsx
+++ b/packages/styrby-web/src/components/context-breakdown.tsx
@@ -104,7 +104,7 @@ function FileContextRow({ entry, rank }: { entry: FileContextEntry; rank: number
       </td>
 
       {/* Last accessed */}
-      <td className="px-4 py-2.5 text-right text-xs text-zinc-500 whitespace-nowrap">
+      <td className="px-4 py-2.5 text-right text-xs text-zinc-400 whitespace-nowrap">
         {new Date(entry.lastAccessed).toLocaleTimeString('en-US', {
           hour: 'numeric',
           minute: '2-digit',
@@ -124,7 +124,7 @@ function EmptyBreakdown() {
       {/* Icon */}
       <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-zinc-800">
         <svg
-          className="h-5 w-5 text-zinc-500"
+          className="h-5 w-5 text-zinc-400"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -194,7 +194,7 @@ export function ContextBreakdown({ breakdown, className }: ContextBreakdownProps
         </div>
 
         {breakdown && (
-          <div className="flex items-center gap-3 text-xs text-zinc-500">
+          <div className="flex items-center gap-3 text-xs text-zinc-400">
             <span>
               <span className="font-semibold tabular-nums text-zinc-300">
                 {breakdown.totalTokens.toLocaleString()}
@@ -222,16 +222,16 @@ export function ContextBreakdown({ breakdown, className }: ContextBreakdownProps
           <table className="w-full text-left" aria-label="Files in context window">
             <thead>
               <tr className="border-b border-zinc-800/60">
-                <th className="px-4 py-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
+                <th className="px-4 py-2 text-xs font-medium uppercase tracking-wide text-zinc-400">
                   File
                 </th>
-                <th className="px-4 py-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
+                <th className="px-4 py-2 text-xs font-medium uppercase tracking-wide text-zinc-400">
                   Usage
                 </th>
-                <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">
+                <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-400">
                   Tokens
                 </th>
-                <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">
+                <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-zinc-400">
                   Last Read
                 </th>
               </tr>

--- a/packages/styrby-web/src/components/costs/CostSummaryCard.tsx
+++ b/packages/styrby-web/src/components/costs/CostSummaryCard.tsx
@@ -68,8 +68,8 @@ export function CostSummaryCard({
       }`}
     >
       <div className="flex items-center gap-2">
-        {icon && <span className="text-zinc-500">{icon}</span>}
-        <p className="text-sm text-zinc-500">{title}</p>
+        {icon && <span className="text-zinc-400">{icon}</span>}
+        <p className="text-sm text-zinc-400">{title}</p>
       </div>
 
       <p
@@ -81,11 +81,11 @@ export function CostSummaryCard({
       </p>
 
       <div className="flex items-center gap-2 mt-1">
-        <p className="text-xs text-zinc-500">{formatTokens(totalTokens)} tokens</p>
+        <p className="text-xs text-zinc-400">{formatTokens(totalTokens)} tokens</p>
         {summary.requestCount > 0 && (
           <>
             <span className="text-zinc-700">|</span>
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-zinc-400">
               {summary.requestCount.toLocaleString()} requests
             </p>
           </>

--- a/packages/styrby-web/src/components/costs/CostTable.tsx
+++ b/packages/styrby-web/src/components/costs/CostTable.tsx
@@ -129,7 +129,7 @@ export function CostTable({
         <div className="px-4 py-3 border-b border-zinc-800">
           <h3 className="font-semibold text-zinc-100">{title}</h3>
         </div>
-        <div className="px-4 py-8 text-center text-zinc-500">No cost data available</div>
+        <div className="px-4 py-8 text-center text-zinc-400">No cost data available</div>
       </div>
     );
   }

--- a/packages/styrby-web/src/components/costs/CostsByAgentChart.tsx
+++ b/packages/styrby-web/src/components/costs/CostsByAgentChart.tsx
@@ -117,7 +117,7 @@ export function CostsByAgentChart({
     return (
       <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
         <h3 className="text-lg font-semibold text-zinc-100 mb-4">{title}</h3>
-        <div className="py-8 text-center text-zinc-500">No agent data available</div>
+        <div className="py-8 text-center text-zinc-400">No agent data available</div>
       </div>
     );
   }
@@ -167,7 +167,7 @@ export function CostsByAgentChart({
                   <span className="text-sm font-semibold text-zinc-100">
                     {formatCost(agent.cost)}
                   </span>
-                  <span className="text-xs text-zinc-500">
+                  <span className="text-xs text-zinc-400">
                     ({agent.percentage.toFixed(1)}%)
                   </span>
                 </div>
@@ -193,7 +193,7 @@ export function CostsByAgentChart({
               )}
 
               {/* Token and request counts */}
-              <p className="text-xs text-zinc-500 mt-1">
+              <p className="text-xs text-zinc-400 mt-1">
                 {formatTokens(totalTokens)} tokens | {agent.requestCount.toLocaleString()}{' '}
                 requests
               </p>

--- a/packages/styrby-web/src/components/costs/DailyCostChart.tsx
+++ b/packages/styrby-web/src/components/costs/DailyCostChart.tsx
@@ -77,7 +77,7 @@ export function DailyCostChart({
     return (
       <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4">
         <h3 className="text-lg font-semibold text-zinc-100 mb-4">{title}</h3>
-        <div className="py-8 text-center text-zinc-500">No daily data available</div>
+        <div className="py-8 text-center text-zinc-400">No daily data available</div>
       </div>
     );
   }
@@ -128,7 +128,7 @@ export function DailyCostChart({
       </div>
 
       {/* X-axis labels showing date range */}
-      <div className="flex justify-between mt-2 text-xs text-zinc-500">
+      <div className="flex justify-between mt-2 text-xs text-zinc-400">
         {data.length > 0 && (
           <>
             <span>{formatDate(data[0].date)}</span>

--- a/packages/styrby-web/src/components/dashboard/digest-panel.tsx
+++ b/packages/styrby-web/src/components/dashboard/digest-panel.tsx
@@ -57,7 +57,7 @@ export function DigestPanel({ digest, userTier }: DigestPanelProps) {
       >
         <div>
           <p className="text-sm font-medium text-zinc-300">AI session digest</p>
-          <p className="text-xs text-zinc-500 mt-1">
+          <p className="text-xs text-zinc-400 mt-1">
             Get a weekly AI summary of your sessions on Pro, or daily on Growth.
           </p>
         </div>
@@ -80,7 +80,7 @@ export function DigestPanel({ digest, userTier }: DigestPanelProps) {
         className="mb-8 rounded-xl border border-zinc-800 bg-zinc-900 p-6"
       >
         <p className="text-sm font-medium text-zinc-300">Your AI session digest</p>
-        <p className="text-xs text-zinc-500 mt-2">
+        <p className="text-xs text-zinc-400 mt-2">
           Your first digest will appear here {upcomingLabel}.
         </p>
       </section>
@@ -100,16 +100,16 @@ export function DigestPanel({ digest, userTier }: DigestPanelProps) {
           <span className="inline-flex items-center rounded-full bg-orange-500/10 px-2 py-0.5 text-xs font-medium text-orange-400 mr-2">
             {periodLabel}
           </span>
-          <span className="text-xs text-zinc-500">{sessionLabel}</span>
+          <span className="text-xs text-zinc-400">{sessionLabel}</span>
         </div>
-        <span className="text-xs text-zinc-500">
+        <span className="text-xs text-zinc-400">
           {formatRelative(digest.generated_at)}
         </span>
       </div>
       {digest.content ? (
         <p className="text-sm leading-relaxed text-zinc-200">{digest.content}</p>
       ) : (
-        <p className="text-sm text-zinc-500 italic">
+        <p className="text-sm text-zinc-400 italic">
           Digest is being generated. Check back shortly.
         </p>
       )}

--- a/packages/styrby-web/src/components/dashboard/feedback-dialog.tsx
+++ b/packages/styrby-web/src/components/dashboard/feedback-dialog.tsx
@@ -212,7 +212,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           </h3>
           <button
             onClick={handleClose}
-            className="text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="text-zinc-400 hover:text-zinc-300 transition-colors"
             aria-label="Close feedback dialog"
           >
             <svg
@@ -255,7 +255,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
             </option>
           ))}
         </select>
-        <p className="text-xs text-zinc-500 mb-4">
+        <p className="text-xs text-zinc-400 mb-4">
           {FEEDBACK_CATEGORIES.find((c) => c.value === category)?.description}
         </p>
 
@@ -280,7 +280,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           disabled={isSubmitting}
           className="w-full rounded-lg border border-zinc-600 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 resize-none mb-1"
         />
-        <p className="text-xs text-zinc-500 text-right mb-4">
+        <p className="text-xs text-zinc-400 text-right mb-4">
           {message.length}/{MAX_MESSAGE_LENGTH}
         </p>
 
@@ -290,7 +290,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           className="block text-sm font-medium text-zinc-300 mb-2"
         >
           Email for follow-up{' '}
-          <span className="text-zinc-500 font-normal">(optional)</span>
+          <span className="text-zinc-400 font-normal">(optional)</span>
         </label>
         {/* WHY no aria-label: The <label htmlFor="feedback-email"> above
             already provides the accessible name. Redundant aria-label removed. */}

--- a/packages/styrby-web/src/components/dashboard/founder-feedback/GeneralTab.tsx
+++ b/packages/styrby-web/src/components/dashboard/founder-feedback/GeneralTab.tsx
@@ -66,14 +66,14 @@ export function GeneralTab({ initialItems, initialTotal }: GeneralTabProps) {
     return (
       <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-8 text-center">
         <MessageSquare className="mx-auto mb-2 h-8 w-8 text-zinc-400" />
-        <p className="text-sm text-zinc-500">No general feedback yet.</p>
+        <p className="text-sm text-zinc-400">No general feedback yet.</p>
       </div>
     );
   }
 
   return (
     <div className="space-y-3">
-      <p className="text-xs text-zinc-500">
+      <p className="text-xs text-zinc-400">
         Showing {items.length} of {total} submissions (latest first)
       </p>
       {items.map((item) => (
@@ -100,7 +100,7 @@ function FeedbackCard({ item }: { item: GeneralFeedbackItem }) {
 
   return (
     <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
-      <div className="mb-2 flex items-center gap-2 text-xs text-zinc-500">
+      <div className="mb-2 flex items-center gap-2 text-xs text-zinc-400">
         <span>User {userRef}</span>
         <span>-</span>
         <span className="capitalize">{platform}</span>

--- a/packages/styrby-web/src/components/dashboard/founder-feedback/NpsTab.tsx
+++ b/packages/styrby-web/src/components/dashboard/founder-feedback/NpsTab.tsx
@@ -123,15 +123,15 @@ export function NpsTab({ initialData, nps_window }: NpsTabProps) {
             <div className="mt-4 grid grid-cols-3 gap-2 text-center">
               <div>
                 <p className="text-xl font-bold text-green-400">{currentNps.promoters}</p>
-                <p className="text-xs text-zinc-500">Promoters</p>
+                <p className="text-xs text-zinc-400">Promoters</p>
               </div>
               <div>
                 <p className="text-xl font-bold text-yellow-400">{currentNps.passives}</p>
-                <p className="text-xs text-zinc-500">Passives</p>
+                <p className="text-xs text-zinc-400">Passives</p>
               </div>
               <div>
                 <p className="text-xl font-bold text-red-400">{currentNps.detractors}</p>
-                <p className="text-xs text-zinc-500">Detractors</p>
+                <p className="text-xs text-zinc-400">Detractors</p>
               </div>
             </div>
           )}
@@ -159,7 +159,7 @@ export function NpsTab({ initialData, nps_window }: NpsTabProps) {
                     {formatNpsScore(comment.score)}
                   </span>
                   {comment.nps_window && (
-                    <span className="text-xs text-zinc-500">
+                    <span className="text-xs text-zinc-400">
                       {comment.nps_window === '7d' ? '7-day survey' : '30-day survey'}
                     </span>
                   )}
@@ -176,7 +176,7 @@ export function NpsTab({ initialData, nps_window }: NpsTabProps) {
 
       {currentNps.total === 0 && (
         <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-8 text-center">
-          <p className="text-sm text-zinc-500">
+          <p className="text-sm text-zinc-400">
             No NPS responses yet.
             Prompts are scheduled for day 7 and day 30 after signup.
           </p>

--- a/packages/styrby-web/src/components/dashboard/founder-feedback/NpsTrendChart.tsx
+++ b/packages/styrby-web/src/components/dashboard/founder-feedback/NpsTrendChart.tsx
@@ -57,7 +57,7 @@ export function NpsTrendChart({ trend, height = 120 }: NpsTrendChartProps) {
 
   if (!trend.length) {
     return (
-      <div className="flex h-[120px] items-center justify-center rounded-lg bg-zinc-800/50 text-sm text-zinc-500">
+      <div className="flex h-[120px] items-center justify-center rounded-lg bg-zinc-800/50 text-sm text-zinc-400">
         No trend data yet
       </div>
     );

--- a/packages/styrby-web/src/components/dashboard/founder-feedback/PostmortemTab.tsx
+++ b/packages/styrby-web/src/components/dashboard/founder-feedback/PostmortemTab.tsx
@@ -171,13 +171,13 @@ export function PostmortemTab({ initialItems, initialTotal }: PostmortemTabProps
         </select>
 
         {loading && (
-          <span className="flex items-center text-xs text-zinc-500">
+          <span className="flex items-center text-xs text-zinc-400">
             <span className="mr-1 inline-block h-2 w-2 animate-pulse rounded-full bg-indigo-400" />
             Loading...
           </span>
         )}
 
-        <span className="ml-auto text-xs text-zinc-500">
+        <span className="ml-auto text-xs text-zinc-400">
           {items.length} of {total}
         </span>
       </div>
@@ -185,7 +185,7 @@ export function PostmortemTab({ initialItems, initialTotal }: PostmortemTabProps
       {/* List */}
       {items.length === 0 ? (
         <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-8 text-center">
-          <p className="text-sm text-zinc-500">No post-mortem data yet.</p>
+          <p className="text-sm text-zinc-400">No post-mortem data yet.</p>
         </div>
       ) : (
         <div className="space-y-2">
@@ -233,9 +233,9 @@ function PostmortemCard({ item }: { item: PostmortemItem }) {
         >
           {isUseful ? 'Useful' : 'Not useful'}
         </span>
-        <span className="text-xs text-zinc-500">{agentLabel}</span>
+        <span className="text-xs text-zinc-400">{agentLabel}</span>
         {dur != null && (
-          <span className="text-xs text-zinc-500">{dur} min</span>
+          <span className="text-xs text-zinc-400">{dur} min</span>
         )}
         <span className="ml-auto text-xs text-zinc-400">{date}</span>
       </div>

--- a/packages/styrby-web/src/components/dashboard/onboarding-banner.tsx
+++ b/packages/styrby-web/src/components/dashboard/onboarding-banner.tsx
@@ -149,7 +149,7 @@ export function OnboardingBanner({ onboardingState }: OnboardingBannerProps) {
                 <Circle className="h-3.5 w-3.5 shrink-0 text-amber-500" />
               )}
               {step.completed ? (
-                <span className="text-[11px] text-zinc-500 line-through">
+                <span className="text-[11px] text-zinc-400 line-through">
                   {step.label}
                 </span>
               ) : (

--- a/packages/styrby-web/src/components/dashboard/onboarding-modal.tsx
+++ b/packages/styrby-web/src/components/dashboard/onboarding-modal.tsx
@@ -120,7 +120,7 @@ export function OnboardingModal({ onboardingState, onDismiss }: OnboardingModalP
                     {step.label}
                   </Link>
                 )}
-                <p className="text-xs text-zinc-500 mt-0.5">{step.description}</p>
+                <p className="text-xs text-zinc-400 mt-0.5">{step.description}</p>
               </div>
             </div>
           ))}

--- a/packages/styrby-web/src/components/dashboard/support-modal.tsx
+++ b/packages/styrby-web/src/components/dashboard/support-modal.tsx
@@ -242,7 +242,7 @@ export function SupportModal({ open, onOpenChange }: SupportModalProps) {
                 maxLength={200}
                 className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
               />
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-zinc-400">
                 {subject.length}/200 characters
               </p>
             </div>
@@ -264,7 +264,7 @@ export function SupportModal({ open, onOpenChange }: SupportModalProps) {
                 maxLength={5000}
                 className="w-full resize-none rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
               />
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-zinc-400">
                 {description.length}/5,000 characters
               </p>
             </div>
@@ -307,10 +307,10 @@ export function SupportModal({ open, onOpenChange }: SupportModalProps) {
                 accept="image/*"
                 multiple
                 disabled
-                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-500 file:mr-3 file:rounded file:border-0 file:bg-zinc-700 file:px-3 file:py-1 file:text-sm file:text-zinc-300 disabled:opacity-50"
+                className="w-full rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-400 file:mr-3 file:rounded file:border-0 file:bg-zinc-700 file:px-3 file:py-1 file:text-sm file:text-zinc-300 disabled:opacity-50"
               />
               {/* File upload will be implemented once Supabase Storage integration ships. */}
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-zinc-400">
                 File upload coming soon. Max 3 images, 5MB each.
               </p>
             </div>

--- a/packages/styrby-web/src/components/landing/features-section.tsx
+++ b/packages/styrby-web/src/components/landing/features-section.tsx
@@ -210,7 +210,7 @@ export function FeaturesSection() {
               <div className="mt-auto pt-6">
                 <div className="rounded-xl border border-white/[0.06] bg-black/40 p-4">
                   <div className="mb-3 flex items-center justify-between">
-                    <span className="font-mono text-xs text-zinc-500">live agents</span>
+                    <span className="font-mono text-xs text-zinc-400">live agents</span>
                     <span className="flex items-center gap-1.5">
                       <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
                       <span className="font-mono text-xs text-emerald-400">3 active</span>
@@ -233,7 +233,7 @@ export function FeaturesSection() {
                         <span className="w-24 shrink-0 font-mono text-xs text-zinc-400">
                           {row.name}
                         </span>
-                        <span className="truncate font-mono text-xs text-zinc-500">
+                        <span className="truncate font-mono text-xs text-zinc-400">
                           {row.task}
                         </span>
                       </div>

--- a/packages/styrby-web/src/components/landing/footer.tsx
+++ b/packages/styrby-web/src/components/landing/footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
           </nav>
 
           {/* Credit + veteran badge */}
-          <div className="flex items-center gap-3 shrink-0 text-xs text-zinc-500">
+          <div className="flex items-center gap-3 shrink-0 text-xs text-zinc-400">
             <p>&copy; 2026 Steel Motion LLC</p>
             <span className="text-zinc-700" aria-hidden="true">·</span>
             <div className="flex items-center gap-1">

--- a/packages/styrby-web/src/components/landing/hero.tsx
+++ b/packages/styrby-web/src/components/landing/hero.tsx
@@ -193,7 +193,7 @@ export function Hero() {
           ].map(({ icon: Icon, text }) => (
             <div
               key={text}
-              className="flex items-center gap-2 text-[13px] text-zinc-500"
+              className="flex items-center gap-2 text-[13px] text-zinc-400"
             >
               {/* WHY aria-hidden: the adjacent <span> already conveys the
                   meaning verbatim ("E2E encrypted on your machine" etc.).

--- a/packages/styrby-web/src/components/landing/how-it-works.tsx
+++ b/packages/styrby-web/src/components/landing/how-it-works.tsx
@@ -39,7 +39,7 @@ function TerminalMockup() {
         <span className="h-3 w-3 rounded-full bg-red-500/70" />
         <span className="h-3 w-3 rounded-full bg-yellow-500/70" />
         <span className="h-3 w-3 rounded-full bg-emerald-500/70" />
-        <span className="ml-2 font-mono text-xs text-zinc-500">terminal</span>
+        <span className="ml-2 font-mono text-xs text-zinc-400">terminal</span>
       </div>
       {/* Body */}
       <div className="px-5 py-4">
@@ -47,7 +47,7 @@ function TerminalMockup() {
           <span className="font-mono text-xs text-emerald-400">$</span>
           <span className="font-mono text-xs text-zinc-200">npm install -g @styrby/cli</span>
         </div>
-        <div className="mt-2 font-mono text-xs text-zinc-500">
+        <div className="mt-2 font-mono text-xs text-zinc-400">
           added 1 package in 2.3s
         </div>
         <div className="mt-1 font-mono text-xs text-amber-400">
@@ -73,7 +73,7 @@ function PairingMockup() {
     <div className="flex w-full max-w-sm items-center justify-center gap-8">
       {/* QR code frame */}
       <div className="rounded-xl border border-white/[0.08] bg-zinc-950 p-4 shadow-[0_20px_60px_rgba(0,0,0,0.5)]">
-        <div className="mb-2 font-mono text-[10px] text-zinc-500">Scan to pair</div>
+        <div className="mb-2 font-mono text-[10px] text-zinc-400">Scan to pair</div>
         {/* QR grid - 5×5 block pattern suggesting a QR code */}
         <div className="grid grid-cols-7 gap-0.5">
           {[
@@ -91,7 +91,7 @@ function PairingMockup() {
             />
           ))}
         </div>
-        <div className="mt-2 font-mono text-[10px] text-zinc-500">expires in 2:00</div>
+        <div className="mt-2 font-mono text-[10px] text-zinc-400">expires in 2:00</div>
       </div>
 
       {/* Phone outline */}
@@ -143,7 +143,7 @@ function DashboardMockup() {
               />
               <div>
                 <div className="font-mono text-xs text-zinc-300">{agent.name}</div>
-                <div className="font-mono text-[10px] text-zinc-500">{agent.model}</div>
+                <div className="font-mono text-[10px] text-zinc-400">{agent.model}</div>
               </div>
             </div>
             <span className="font-mono text-xs text-amber-400">{agent.cost}</span>
@@ -152,7 +152,7 @@ function DashboardMockup() {
       </div>
       {/* Footer summary */}
       <div className="flex items-center justify-between border-t border-white/[0.06] px-5 py-3">
-        <span className="font-mono text-xs text-zinc-500">today</span>
+        <span className="font-mono text-xs text-zinc-400">today</span>
         <span className="font-mono text-xs text-amber-400">$0.67 total</span>
       </div>
     </div>

--- a/packages/styrby-web/src/components/landing/mobile-showcase.tsx
+++ b/packages/styrby-web/src/components/landing/mobile-showcase.tsx
@@ -27,8 +27,8 @@ function PermissionApprovalMockup() {
       <div className="min-h-[420px] bg-zinc-950 px-4 pb-6 pt-10">
         {/* Status bar */}
         <div className="mb-5 flex items-center justify-between px-1">
-          <span className="font-mono text-[9px] text-zinc-500">9:41</span>
-          <span className="font-mono text-[9px] text-zinc-500">styrby</span>
+          <span className="font-mono text-[9px] text-zinc-400">9:41</span>
+          <span className="font-mono text-[9px] text-zinc-400">styrby</span>
         </div>
 
         {/* Permission card */}
@@ -50,7 +50,7 @@ function PermissionApprovalMockup() {
           <span className="rounded-md border border-red-500/30 bg-red-500/10 px-2 py-0.5 font-mono text-[9px] text-red-400">
             HIGH RISK
           </span>
-          <span className="font-mono text-[9px] text-zinc-500">auth file modification</span>
+          <span className="font-mono text-[9px] text-zinc-400">auth file modification</span>
         </div>
 
         {/* Diff preview */}
@@ -99,8 +99,8 @@ function VoiceCommandMockup() {
       <div className="min-h-[420px] bg-zinc-950 px-4 pb-6 pt-10">
         {/* Status bar */}
         <div className="mb-5 flex items-center justify-between px-1">
-          <span className="font-mono text-[9px] text-zinc-500">9:41</span>
-          <span className="font-mono text-[9px] text-zinc-500">voice</span>
+          <span className="font-mono text-[9px] text-zinc-400">9:41</span>
+          <span className="font-mono text-[9px] text-zinc-400">voice</span>
         </div>
 
         {/* Mic circle */}
@@ -132,7 +132,7 @@ function VoiceCommandMockup() {
         {/* Transcript */}
         <div className="mt-4 space-y-2">
           <div className="rounded-lg border border-white/[0.05] bg-white/[0.03] px-3 py-2">
-            <p className="font-mono text-[9px] text-zinc-500">You said</p>
+            <p className="font-mono text-[9px] text-zinc-400">You said</p>
             <p className="mt-0.5 font-mono text-[10px] text-zinc-300">
               &ldquo;Stop the codex session&rdquo;
             </p>
@@ -163,8 +163,8 @@ function CodeReviewMockup() {
       <div className="min-h-[420px] bg-zinc-950 px-4 pb-6 pt-10">
         {/* Status bar */}
         <div className="mb-5 flex items-center justify-between px-1">
-          <span className="font-mono text-[9px] text-zinc-500">9:41</span>
-          <span className="font-mono text-[9px] text-zinc-500">diff</span>
+          <span className="font-mono text-[9px] text-zinc-400">9:41</span>
+          <span className="font-mono text-[9px] text-zinc-400">diff</span>
         </div>
 
         {/* File header */}
@@ -179,9 +179,9 @@ function CodeReviewMockup() {
         {/* Diff lines */}
         <div className="overflow-hidden rounded-lg border border-white/[0.06] bg-black/50">
           <div className="px-3 py-2 space-y-0.5">
-            <div className="font-mono text-[8px] text-zinc-500">@@ -24,7 +24,16 @@</div>
-            <div className="font-mono text-[9px] text-zinc-500"> export async function</div>
-            <div className="font-mono text-[9px] text-zinc-500">   getUser(id: string)</div>
+            <div className="font-mono text-[8px] text-zinc-400">@@ -24,7 +24,16 @@</div>
+            <div className="font-mono text-[9px] text-zinc-400"> export async function</div>
+            <div className="font-mono text-[9px] text-zinc-400">   getUser(id: string)</div>
             <div className="font-mono text-[9px] text-red-400/80">- &#47;&#47; TODO: add caching</div>
             <div className="font-mono text-[9px] text-emerald-400/80">+ const cached = await</div>
             <div className="font-mono text-[9px] text-emerald-400/80">+   redis.get(id)</div>
@@ -192,9 +192,9 @@ function CodeReviewMockup() {
 
         {/* Stats row */}
         <div className="mt-3 flex items-center gap-3">
-          <span className="font-mono text-[9px] text-zinc-500">4 files changed</span>
+          <span className="font-mono text-[9px] text-zinc-400">4 files changed</span>
           <span className="h-3 w-px bg-zinc-700" />
-          <span className="font-mono text-[9px] text-zinc-500">claude-code</span>
+          <span className="font-mono text-[9px] text-zinc-400">claude-code</span>
         </div>
 
         {/* Actions */}

--- a/packages/styrby-web/src/components/nps/NpsSurveyCard.tsx
+++ b/packages/styrby-web/src/components/nps/NpsSurveyCard.tsx
@@ -151,7 +151,7 @@ export function NpsSurveyCard({ window, promptId }: NpsSurveyCardProps) {
           </div>
 
           {/* Scale labels */}
-          <div className="flex justify-between px-1 text-xs text-zinc-500">
+          <div className="flex justify-between px-1 text-xs text-zinc-400">
             <span>Not likely</span>
             <span>Very likely</span>
           </div>
@@ -171,7 +171,7 @@ export function NpsSurveyCard({ window, promptId }: NpsSurveyCardProps) {
           <h2 className="mb-2 text-center text-lg font-bold text-zinc-100">
             {scoreLabel(selectedScore)}
           </h2>
-          <p className="mb-5 text-center text-sm text-zinc-500">Optional</p>
+          <p className="mb-5 text-center text-sm text-zinc-400">Optional</p>
 
           <textarea
             value={followup}

--- a/packages/styrby-web/src/components/referral/ReferralSection.tsx
+++ b/packages/styrby-web/src/components/referral/ReferralSection.tsx
@@ -147,14 +147,14 @@ export function ReferralSection({ referralCode, displayName }: ReferralSectionPr
 
           {/* Code display */}
           <div className="mt-4 flex items-center gap-2 border-t border-zinc-800 pt-4">
-            <span className="text-xs text-zinc-500">Your code:</span>
+            <span className="text-xs text-zinc-400">Your code:</span>
             <span className="font-mono text-xs font-semibold text-purple-400">
               {referralCode}
             </span>
           </div>
         </>
       ) : (
-        <p className="text-sm italic text-zinc-500">
+        <p className="text-sm italic text-zinc-400">
           Your invite link is being generated...
         </p>
       )}

--- a/packages/styrby-web/src/components/session-replay/controls.tsx
+++ b/packages/styrby-web/src/components/session-replay/controls.tsx
@@ -361,7 +361,7 @@ export function ReplayControls({
         {/* Right: Speed control and message counter */}
         <div className="flex items-center gap-4 min-w-[120px] justify-end">
           {/* Message counter */}
-          <span className="text-sm text-zinc-500">
+          <span className="text-sm text-zinc-400">
             {currentMessageIndex >= 0 ? currentMessageIndex + 1 : 0} /{' '}
             {totalMessages}
           </span>

--- a/packages/styrby-web/src/components/session-replay/player.tsx
+++ b/packages/styrby-web/src/components/session-replay/player.tsx
@@ -377,7 +377,7 @@ export function ReplayPlayer({
             </svg>
           </div>
           <span className="text-sm font-medium text-zinc-300">Session Replay</span>
-          <span className="text-xs text-zinc-500">
+          <span className="text-xs text-zinc-400">
             {messages.length} messages
           </span>
         </div>
@@ -414,7 +414,7 @@ export function ReplayPlayer({
         aria-label="Session replay messages"
       >
         {messages.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-zinc-500">
+          <div className="flex flex-col items-center justify-center h-full text-zinc-400">
             <svg
               className="h-12 w-12 mb-4"
               fill="none"

--- a/packages/styrby-web/src/components/team/invitations/InvitationsList.tsx
+++ b/packages/styrby-web/src/components/team/invitations/InvitationsList.tsx
@@ -215,7 +215,7 @@ export function InvitationsList({ invitations }: InvitationsListProps) {
                   {/* Email */}
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-2">
-                      <Mail className="w-4 h-4 text-zinc-500 flex-shrink-0" aria-hidden="true" />
+                      <Mail className="w-4 h-4 text-zinc-400 flex-shrink-0" aria-hidden="true" />
                       <span className="text-zinc-200 truncate max-w-[200px]">{inv.email}</span>
                     </div>
                   </td>

--- a/packages/styrby-web/src/components/team/invitations/InviteMemberModal.tsx
+++ b/packages/styrby-web/src/components/team/invitations/InviteMemberModal.tsx
@@ -169,7 +169,7 @@ export function InviteMemberModal({ isOpen, teamId, onClose, onSuccess }: Invite
           <button
             onClick={handleCancel}
             aria-label="Close modal"
-            className="absolute top-4 right-4 text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="absolute top-4 right-4 text-zinc-400 hover:text-zinc-300 transition-colors"
           >
             <X className="w-5 h-5" aria-hidden="true" />
           </button>

--- a/packages/styrby-web/src/components/team/members/MembersTable.tsx
+++ b/packages/styrby-web/src/components/team/members/MembersTable.tsx
@@ -296,7 +296,7 @@ export function MembersTable({
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <Users size={40} className="text-zinc-400 mb-3" aria-hidden />
         <p className="text-zinc-400 font-medium">No members yet</p>
-        <p className="text-zinc-500 text-sm mt-1">
+        <p className="text-zinc-400 text-sm mt-1">
           Invite your first team member from the Invitations panel.
         </p>
       </div>
@@ -355,10 +355,10 @@ export function MembersTable({
                       <div>
                         <div className="text-zinc-200 font-medium flex items-center gap-1.5">
                           {member.display_name ?? member.email}
-                          {isSelf && <span className="text-zinc-500 text-xs">(you)</span>}
+                          {isSelf && <span className="text-zinc-400 text-xs">(you)</span>}
                         </div>
                         {member.display_name && (
-                          <div className="text-zinc-500 text-xs">{member.email}</div>
+                          <div className="text-zinc-400 text-xs">{member.email}</div>
                         )}
                       </div>
                     </div>
@@ -386,7 +386,7 @@ export function MembersTable({
                       <RoleBadge role={member.role} />
                     )}
                     {isChangingRole && (
-                      <span className="text-zinc-500 text-xs ml-2">Saving...</span>
+                      <span className="text-zinc-400 text-xs ml-2">Saving...</span>
                     )}
                   </td>
 

--- a/packages/styrby-web/src/components/team/policies/PoliciesForm.tsx
+++ b/packages/styrby-web/src/components/team/policies/PoliciesForm.tsx
@@ -227,7 +227,7 @@ export function PoliciesForm({ initial, teamId, canEdit }: PoliciesFormProps) {
           <Shield size={16} className="text-green-400" aria-hidden />
           <h3 className="text-zinc-200 font-medium text-sm">Auto-approve rules</h3>
         </div>
-        <p className="text-zinc-500 text-xs mb-3">
+        <p className="text-zinc-400 text-xs mb-3">
           Tool names that are automatically allowed without requiring human review.
           Press Enter or comma to add a tool name.
         </p>
@@ -252,7 +252,7 @@ export function PoliciesForm({ initial, teamId, canEdit }: PoliciesFormProps) {
           <Shield size={16} className="text-red-400" aria-hidden />
           <h3 className="text-zinc-200 font-medium text-sm">Blocked tools</h3>
         </div>
-        <p className="text-zinc-500 text-xs mb-3">
+        <p className="text-zinc-400 text-xs mb-3">
           Tool names that are blocked outright. Takes precedence over auto-approve rules.
           Press Enter or comma to add.
         </p>
@@ -275,12 +275,12 @@ export function PoliciesForm({ initial, teamId, canEdit }: PoliciesFormProps) {
         <div className="flex items-center gap-2 mb-2">
           <h3 className="text-zinc-200 font-medium text-sm">Budget per seat (USD/month)</h3>
         </div>
-        <p className="text-zinc-500 text-xs mb-3">
+        <p className="text-zinc-400 text-xs mb-3">
           Monthly spend limit per member. Leave blank for no limit. Triggers an alert
           when any member exceeds this threshold.
         </p>
         <div className="relative max-w-40">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500 text-sm pointer-events-none">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm pointer-events-none">
             $
           </span>
           <input
@@ -325,7 +325,7 @@ export function PoliciesForm({ initial, teamId, canEdit }: PoliciesFormProps) {
       )}
 
       {!canEdit && (
-        <p className="text-zinc-500 text-xs pt-2 border-t border-zinc-800">
+        <p className="text-zinc-400 text-xs pt-2 border-t border-zinc-800">
           Only team owners and admins can edit policies.
         </p>
       )}

--- a/packages/styrby-web/src/components/theme-toggle.tsx
+++ b/packages/styrby-web/src/components/theme-toggle.tsx
@@ -62,7 +62,7 @@ export function ThemeToggle() {
             ${
               theme === value
                 ? 'bg-white text-zinc-900 shadow-sm dark:bg-zinc-900 dark:text-zinc-100'
-                : 'text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100'
+                : 'text-zinc-400 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100'
             }
           `}
           aria-label={label}


### PR DESCRIPTION
## Summary

axe-core CLI scan against production caught 29 color-contrast WCAG AA violations on the home page. 22/29 are \`text-zinc-500\` on the dark theme — fails the 4.5:1 ratio. Bumped to \`text-zinc-400\` (passes 6.1:1).

## What's in this PR

- **140 files, 474 zinc-500 → zinc-400 replacements** across web src
- **Email templates REVERTED** (separate background context — emails render on white where zinc-400 would FAIL but zinc-500 passes)
- **One test assertion updated** (CSS selector now references zinc-400)

## What's NOT in this PR

7 remaining axe violations on the home page — \`text-amber-500/20\`, \`text-amber-500/70\`, \`text-muted-foreground/50\` — are stylistic decorative-text choices. Need design-team review on intent vs a11y trade-off. Filed for post-launch.

## Verification

- \`pnpm typecheck\`: clean
- Test for touched test file: 22/22 pass
- Build: CI will verify
- **Post-merge:** re-run axe against the deployed prod URL to confirm 22 violations gone (will leave 7 decorative-amber findings)

🤖 Shipped via /a11y + /gh-ship