### PR TITLE
fix(a11y): aria-hidden decorative eyebrows + bump muted body text opacity

### DIFF
--- a/packages/styrby-web/src/app/pricing/page.tsx
+++ b/packages/styrby-web/src/app/pricing/page.tsx
@@ -71,7 +71,8 @@ export default function PricingPage() {
       {/* Hero */}
       <section className="pt-32 pb-16">
         <div className="mx-auto max-w-7xl px-6 text-center">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
+          {/* Decorative eyebrow; the h1 below is the accessible heading. */}
+          <p aria-hidden="true" className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
             Pricing
           </p>
           <h1 className="mt-3 text-balance text-4xl font-bold tracking-tight text-foreground md:text-5xl">
@@ -152,7 +153,8 @@ export default function PricingPage() {
       <section className="py-16 border-t border-zinc-800/40">
         <div className="mx-auto max-w-5xl px-6">
           <div className="mx-auto max-w-2xl text-center mb-10">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
+            {/* Decorative eyebrow; the h2 below is the accessible heading. */}
+            <p aria-hidden="true" className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
               ROI Estimator
             </p>
             <h2 className="mt-3 text-balance text-3xl font-bold tracking-tight text-foreground">
@@ -183,7 +185,8 @@ export default function PricingPage() {
       <section className="py-24 border-t border-zinc-800/40">
         <div className="mx-auto max-w-7xl px-6">
           <div className="mx-auto max-w-2xl text-center">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
+            {/* Decorative eyebrow; the h2 below is the accessible heading. */}
+            <p aria-hidden="true" className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
               FAQ
             </p>
             <h2 className="mt-3 text-balance text-3xl font-bold tracking-tight text-foreground">

--- a/packages/styrby-web/src/app/signup/page.tsx
+++ b/packages/styrby-web/src/app/signup/page.tsx
@@ -405,7 +405,7 @@ function SignUpPageInner() {
                   <p className="text-sm font-medium text-amber-400">
                     {decodeURIComponent(invitedBy)} invited you to Styrby
                   </p>
-                  <p className="mt-0.5 text-xs text-amber-500/70">
+                  <p className="mt-0.5 text-xs text-amber-400">
                     Create your account and pair your first agent in under a minute.
                   </p>
                 </div>

--- a/packages/styrby-web/src/components/landing/faq-section.tsx
+++ b/packages/styrby-web/src/components/landing/faq-section.tsx
@@ -140,7 +140,7 @@ export function FAQSection() {
             </div>
 
             {/* Mobile fallback: show all Q&A below the list on small screens */}
-            <p className="mt-4 text-xs text-muted-foreground/50 lg:hidden">
+            <p className="mt-4 text-xs text-muted-foreground lg:hidden">
               Tap a question above to read the answer here.
             </p>
           </div>

--- a/packages/styrby-web/src/components/landing/how-it-works.tsx
+++ b/packages/styrby-web/src/components/landing/how-it-works.tsx
@@ -231,8 +231,11 @@ export function HowItWorks() {
                   >
                     {/* Text block */}
                     <div className={isLeft ? "md:order-2" : "md:order-1"}>
-                      {/* Step number - mobile only */}
-                      <span className="mb-3 block font-mono text-4xl font-bold text-amber-500/20 md:hidden">
+                      {/* Step number - mobile only. Decorative duplicate of step.title heading; hidden from AT. */}
+                      <span
+                        aria-hidden="true"
+                        className="mb-3 block font-mono text-4xl font-bold text-amber-500/20 md:hidden"
+                      >
                         {step.number}
                       </span>
                       <h3 className="text-xl font-semibold text-foreground md:text-2xl">

--- a/packages/styrby-web/src/components/landing/pricing-section.tsx
+++ b/packages/styrby-web/src/components/landing/pricing-section.tsx
@@ -88,7 +88,8 @@ export function PricingSection() {
 
         {/* Section header */}
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
+          {/* Decorative eyebrow; the h2 below is the accessible section heading. */}
+          <p aria-hidden="true" className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500/70">
             Pricing
           </p>
           <h2 className="mt-3 text-balance text-3xl font-bold tracking-tight text-foreground md:text-4xl">
@@ -234,7 +235,7 @@ function PricingCard({
             ${plan.annual}/year (save ${plan.savings})
           </p>
         ) : plan.perSeatNote ? (
-          <p className="text-xs text-muted-foreground/50">{plan.perSeatNote}</p>
+          <p className="text-xs text-muted-foreground">{plan.perSeatNote}</p>
         ) : null}
       </div>
 


### PR DESCRIPTION
## Summary
- Targets the 6 remaining axe-core home-page violations from PR #307's post-deploy re-scan (option b: aria-hidden decorative duplicates + bump opacity on semantic body text)
- 7 element fixes across 5 files; visual identity preserved, AT semantics + contrast improved
- Sets up the home page for 100% axe-clean (29 -> 0 expected)

## Changes
- **how-it-works.tsx**: decorative mobile step-number numeral wrapped in `aria-hidden="true"` (step.title h3 follows immediately as the accessible heading)
- **pricing-section.tsx**: eyebrow "Pricing" before h2 wrapped in `aria-hidden="true"`; perSeatNote bumped from `text-muted-foreground/50` to full `text-muted-foreground`
- **pricing/page.tsx**: 3 eyebrows ("Pricing"/"ROI Estimator"/"FAQ") all wrapped in `aria-hidden="true"`
- **faq-section.tsx**: mobile FAQ hint bumped from `text-muted-foreground/50` to full `text-muted-foreground`
- **signup/page.tsx**: invitation sub-text changed from `text-amber-500/70` to `text-amber-400` (passes AA on dark zinc-950)

## Intentionally NOT changed
- `dashboard/costs/export-button.tsx` — already `aria-disabled="true"`; WCAG 1.4.3 exempts disabled controls
- `dashboard/otel-settings.tsx` — placeholder text; WCAG exempts placeholders from body-text contrast

## Test Plan
- [x] typecheck clean
- [x] pricing-section tests: 19/19 passing
- [ ] Post-deploy axe re-scan of home page shows 0 violations (down from 6)
- [ ] Visual regression: eyebrows + step numbers still render identically to sighted users
- [ ] VoiceOver: section headings announced once, not duplicated

Companion to PR #307 (text-zinc-500 -> text-zinc-400). Together these PRs complete the home page WCAG AA contrast pass; dashboard pages still pending (sub-agent scan in progress).

🤖 Shipped via /gh-ship