### PR TITLE
fix(a11y): dashboard progress aria-label + badge contrast (21 axe violations)

### DIFF
--- a/packages/styrby-web/src/app/dashboard/costs/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/costs/page.tsx
@@ -656,7 +656,7 @@ export default async function CostsPage({
           {Object.keys(tagTotals).length === 0 && (
             <div className="px-4 py-8 text-center">
               <p className="text-muted-foreground text-sm">No tagged sessions yet</p>
-              <p className="text-xs text-muted-foreground/60 mt-1">
+              <p className="text-xs text-muted-foreground/80 mt-1">
                 Add tags to sessions to see cost breakdowns by client or project.
               </p>
             </div>

--- a/packages/styrby-web/src/app/dashboard/privacy/_components/DataMapSection.tsx
+++ b/packages/styrby-web/src/app/dashboard/privacy/_components/DataMapSection.tsx
@@ -221,7 +221,7 @@ function DataMapRow({ entry }: { entry: DataMapEntry }) {
           className={`flex-shrink-0 flex items-center gap-1 text-xs px-2 py-0.5 rounded-full ${
             entry.encrypted
               ? 'bg-green-500/10 text-green-400'
-              : 'bg-zinc-700 text-zinc-400'
+              : 'bg-zinc-700 text-zinc-300'
           }`}
           aria-label={entry.encrypted ? 'Content encrypted' : 'Plaintext'}
         >

--- a/packages/styrby-web/src/app/dashboard/settings/_components/settings-subscription.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/settings-subscription.tsx
@@ -44,7 +44,7 @@ export function SettingsSubscription({ subscription }: SettingsSubscriptionProps
                     ? 'bg-green-500/10 text-green-400'
                     : subscription?.status === 'trialing'
                       ? 'bg-blue-500/10 text-blue-400'
-                      : 'bg-zinc-700 text-zinc-400'
+                      : 'bg-zinc-700 text-zinc-300'
                 }`}
               >
                 {subscription?.status || 'Free'}

--- a/packages/styrby-web/src/app/dashboard/team/team-client.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/team-client.tsx
@@ -442,7 +442,7 @@ export function TeamClient({
                         ? 'bg-orange-500/10 text-orange-400'
                         : member.role === 'admin'
                         ? 'bg-purple-500/10 text-purple-400'
-                        : 'bg-zinc-700 text-zinc-400'
+                        : 'bg-zinc-700 text-zinc-300'
                     }`}
                   >
                     {member.role.charAt(0).toUpperCase() + member.role.slice(1)}
@@ -525,7 +525,7 @@ export function TeamClient({
                   className={`px-3 py-1 rounded-full text-xs font-medium ${
                     invite.role === 'admin'
                       ? 'bg-purple-500/10 text-purple-400'
-                      : 'bg-zinc-700 text-zinc-400'
+                      : 'bg-zinc-700 text-zinc-300'
                   }`}
                 >
                   {invite.role.charAt(0).toUpperCase() + invite.role.slice(1)}

--- a/packages/styrby-web/src/components/cloud-tasks.tsx
+++ b/packages/styrby-web/src/components/cloud-tasks.tsx
@@ -150,7 +150,7 @@ function StatusBadge({ status }: { status: CloudTaskStatus }) {
  * @returns React element
  */
 function AgentBadge({ agentType }: { agentType: AgentType }) {
-  const classes = AGENT_COLORS[agentType] ?? 'bg-zinc-700 text-zinc-400';
+  const classes = AGENT_COLORS[agentType] ?? 'bg-zinc-700 text-zinc-300';
   return (
     <span
       className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-mono font-semibold ${classes}`}

--- a/packages/styrby-web/src/components/team/invitations/InvitationsList.tsx
+++ b/packages/styrby-web/src/components/team/invitations/InvitationsList.tsx
@@ -86,8 +86,8 @@ function statusBadgeClass(status: InvitationRow['status']): string {
     case 'pending': return 'bg-yellow-500/10 text-yellow-400';
     case 'accepted': return 'bg-green-500/10 text-green-400';
     case 'revoked': return 'bg-red-500/10 text-red-400';
-    case 'expired': return 'bg-zinc-700 text-zinc-400';
-    default: return 'bg-zinc-700 text-zinc-400';
+    case 'expired': return 'bg-zinc-700 text-zinc-300';
+    default: return 'bg-zinc-700 text-zinc-300';
   }
 }
 

--- a/packages/styrby-web/src/components/ui/progress.tsx
+++ b/packages/styrby-web/src/components/ui/progress.tsx
@@ -11,6 +11,7 @@ const Progress = React.forwardRef<
 >(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
+    aria-label="Progress"
     className={cn(
       'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
       className,


### PR DESCRIPTION
## Summary
- Authenticated dashboard a11y audit (sub-agent walked all 19 static dashboard routes against prod with provisioned-then-deleted Supabase test user) found 28 violations across 2 rules; this PR closes 21 of them
- One-line fix in `ui/progress.tsx` adds default `aria-label="Progress"` to the Radix primitive — kills 19 `aria-progressbar-name` violations across every dashboard route at once
- Bumped `bg-zinc-700 text-zinc-400` (4.07:1) to `text-zinc-300` (5.74:1) across 6 files; agent flagged 2 visible badges, grep found 5 more identical occurrences (boy-scout fix)
- Includes the agent's auto-fix on `dashboard/costs/page.tsx` (text-muted-foreground/60 -> /80)

## What's NOT in this PR (deferred)
6 orange/amber CTA buttons (`bg-orange-500`/`bg-amber-500` + `text-white`) at 2.80:1 across budget-alerts, team, support, settings/{api,templates,webhooks}. These are brand-color decisions affecting the marketing site too, so they need a design call:
- (a) darken to `bg-orange-700` (~5.0:1, passes AA)
- (b) keep brand color, bump to large-text threshold (>=18px, weight >=700)
- (c) introduce a darker text color

Filed as `A11Y-BRAND-CTA-CONTRAST` for design team.

## Test Plan
- [x] typecheck clean
- [x] 19 dashboard routes scanned against prod by Playwright + axe-core; baseline captured
- [x] Test user deleted; verified HTTP 404 on follow-up admin GET
- [ ] Post-deploy re-scan should show 7 / 28 violations remaining (only the 6 brand-color CTAs + 1 unrelated stragglers)
- [ ] VoiceOver: progress bars announced as "Progress" instead of "progressbar" (or whatever consumer label overrides)

Companion to #307 + #308. Together these PRs reduce ~50 axe violations across web (home page 29 -> 0 expected; dashboard 28 -> ~7).

🤖 Shipped via /gh-ship