### PR TITLE
fix(a11y): pricing page sliders + heading order + contrast (18 axe violations)

### DIFF
--- a/packages/styrby-web/src/app/pricing/page.tsx
+++ b/packages/styrby-web/src/app/pricing/page.tsx
@@ -132,6 +132,10 @@ export default function PricingPage() {
       {/* Pricing cards — 2-column grid (stacks on mobile) */}
       <section className="py-12">
         <div className="mx-auto max-w-4xl px-6">
+          {/* sr-only h2 satisfies WCAG heading-order between the page h1 and the
+              h3 inside each tier card; visually the section uses the cards as
+              its content, so no on-screen heading is shown. */}
+          <h2 className="sr-only">Available plans</h2>
           <div className="grid gap-6 md:grid-cols-2 md:items-stretch">
             <ProTierCard annual={annual} />
             <GrowthTierCard
@@ -143,7 +147,7 @@ export default function PricingPage() {
               }}
             />
           </div>
-          <p className="mt-8 text-center text-xs text-muted-foreground/60">
+          <p className="mt-8 text-center text-xs text-muted-foreground">
             Upgrade or downgrade in one click. Cancel anytime — no questions asked.
           </p>
         </div>

--- a/packages/styrby-web/src/components/pricing/ComparisonTable.tsx
+++ b/packages/styrby-web/src/components/pricing/ComparisonTable.tsx
@@ -33,7 +33,7 @@ function ComparisonCategory({
       <tr>
         <td
           colSpan={3}
-          className="pt-8 pb-3 text-center text-[10px] font-semibold uppercase tracking-[0.2em] text-amber-500/60"
+          className="pt-8 pb-3 text-center text-[10px] font-semibold uppercase tracking-[0.2em] text-amber-400"
         >
           {category.name}
         </td>

--- a/packages/styrby-web/src/components/pricing/ProTierCard.tsx
+++ b/packages/styrby-web/src/components/pricing/ProTierCard.tsx
@@ -133,7 +133,7 @@ export function ProTierCard({ annual }: ProTierCardProps) {
         </Button>
       </div>
 
-      <p className="mt-3 text-center text-[11px] text-muted-foreground/50">
+      <p className="mt-3 text-center text-[11px] text-muted-foreground">
         Cancel anytime. Upgrade to Growth in one click when your team grows.
       </p>
     </div>

--- a/packages/styrby-web/src/components/ui/slider.tsx
+++ b/packages/styrby-web/src/components/ui/slider.tsx
@@ -8,21 +8,36 @@ import { cn } from '@/lib/utils'
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      'relative flex w-full touch-none select-none items-center',
-      className,
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-))
+>(({ className, ...props }, ref) => {
+  // Radix Root accepts aria-label / aria-labelledby but does NOT forward them to
+  // the focusable Thumb element. Pull them off the spread and apply directly to
+  // the Thumb so screen readers announce the slider's accessible name (axe rule:
+  // aria-input-field-name on role="slider").
+  const {
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+    ...rootProps
+  } = props
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        'relative flex w-full touch-none select-none items-center',
+        className,
+      )}
+      {...rootProps}
+    >
+      <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+      />
+    </SliderPrimitive.Root>
+  )
+})
 Slider.displayName = SliderPrimitive.Root.displayName
 
 export { Slider }


### PR DESCRIPTION
## Summary
- Post-deploy axe scan after #310 surfaced 18 pricing-page violations (page never previously scanned standalone)
- This PR closes ~14 of 18; remaining ~4 are 3 aria-hidden eyebrows axe over-reports + 1 brand CTA tracked in #100
- Highest-leverage fix: Radix Slider primitive now forwards aria-labelledby/aria-label to the focusable Thumb (fixes 5 ROI Calculator sliders that already had labels prepared but couldn't deliver them)

## Changes
- **ui/slider.tsx**: pull aria-label/aria-labelledby off Root spread, apply directly to Thumb. Primitive-level fix that cascades to every Slider consumer in the app.
- **pricing/page.tsx**: added `<h2 className="sr-only">Available plans</h2>` between page h1 and tier-card h3s (closes heading-order violation without visual change). Also bumped trust-footnote from `text-muted-foreground/60` to full opacity.
- **ProTierCard.tsx**: "Cancel anytime" sub-text bumped from `text-muted-foreground/50` to full.
- **ComparisonTable.tsx**: 7 feature-category section labels bumped from `text-amber-500/60` to `text-amber-400` (matches #308 amber pattern).

## NOT in this PR
- 3 aria-hidden decorative eyebrows axe still complains about (spec-compliant per WCAG aria-hidden exemption — see #310 commit msg for the explainer)
- Pricing-card brand CTAs (orange/amber + white text at 2.80:1) — design call deferred to task #100

## Test Plan
- [x] typecheck clean
- [x] pricing-section tests: 19/19 passing
- [ ] Post-deploy axe re-scan: pricing 18 -> ~4
- [ ] Manual: focus into ROI Calculator sliders with keyboard, VoiceOver should announce the slider's purpose ("Number of developers", "Hours saved per week", etc.)

5th in the a11y wave (#307 home contrast, #308 eyebrows, #309 dashboard, #310 follow-ups, this PR pricing).

🤖 Shipped via /gh-ship