### PR TITLE
fix(mobile): singleflight on getOrCreateKeyPair race window (#98)

### DIFF
--- a/packages/styrby-mobile/src/services/__tests__/encryption.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/encryption.test.ts
@@ -178,6 +178,62 @@ describe('Encryption Service', () => {
       expect(keypair.publicKey.length).toBe(32);
       expect(keypair.secretKey.length).toBe(32);
     });
+
+    it('singleflight: concurrent callers share one SecureStore read + one keypair generation', async () => {
+      // Simulate cold start (empty cache, empty SecureStore) with a non-trivial
+      // SecureStore latency so three callers overlap in the in-flight window.
+      let resolveStored: (v: string | null) => void = () => {};
+      (SecureStore.getItemAsync as jest.Mock).mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveStored = resolve;
+        })
+      );
+
+      // Fire three concurrent callers BEFORE the SecureStore read resolves.
+      const p1 = getOrCreateKeyPair();
+      const p2 = getOrCreateKeyPair();
+      const p3 = getOrCreateKeyPair();
+
+      // Now release the SecureStore read with no stored value, forcing
+      // the singleflight to call regenerateKeyPair() exactly once.
+      resolveStored(null);
+
+      const [k1, k2, k3] = await Promise.all([p1, p2, p3]);
+
+      // All three callers received the SAME keypair object reference.
+      expect(k1).toBe(k2);
+      expect(k2).toBe(k3);
+
+      // SecureStore was read exactly once across all three callers
+      // (the second + third callers awaited the in-flight promise).
+      expect(SecureStore.getItemAsync).toHaveBeenCalledTimes(1);
+
+      // generateKeyPair() was invoked exactly once — the race scenario
+      // (3 parallel regenerations with last-writer-wins) is closed.
+      expect(generateKeyPair).toHaveBeenCalledTimes(1);
+
+      // SecureStore.setItemAsync was written exactly once.
+      expect(SecureStore.setItemAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('singleflight: clears in-flight slot on failure so retries can succeed', async () => {
+      // First call fails on SecureStore read.
+      (SecureStore.getItemAsync as jest.Mock).mockRejectedValueOnce(
+        new Error('SecureStore unavailable')
+      );
+
+      await expect(getOrCreateKeyPair()).rejects.toThrow('SecureStore unavailable');
+
+      // Second call: SecureStore now works (no stored value -> regenerate).
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(null);
+
+      const keypair = await getOrCreateKeyPair();
+
+      // The retry succeeded — the failed first attempt did not poison
+      // subsequent calls by leaving a rejected promise in the in-flight slot.
+      expect(keypair).toBeDefined();
+      expect(keypair.publicKey.length).toBe(32);
+    });
   });
 
   // ==========================================================================

--- a/packages/styrby-mobile/src/services/encryption.ts
+++ b/packages/styrby-mobile/src/services/encryption.ts
@@ -78,6 +78,26 @@ interface StoredKeyPair {
 let cachedKeyPair: NaClKeyPair | null = null;
 
 /**
+ * In-flight singleflight promise for getOrCreateKeyPair().
+ *
+ * WHY: getOrCreateKeyPair() is called from multiple hot paths (encryptMessage,
+ * decryptMessage, registerPublicKey) that can fire concurrently — a fresh
+ * launch where the user taps Send while the relay is reconnecting and
+ * decrypting a buffered message hits all three at once. If the in-memory
+ * cache is empty AND SecureStore is empty (first launch / post-logout / stale
+ * data), each concurrent caller would fall through to regenerateKeyPair() in
+ * parallel. The last writer to SecureStore wins; earlier writers' keypairs
+ * become orphaned despite already being used to encrypt outgoing messages,
+ * so any reply to those messages decrypts to garbage on the device.
+ *
+ * The singleflight pattern: the first caller starts the work and stores the
+ * pending promise here; concurrent callers await this same promise instead
+ * of starting their own. Cleared in finally so a failed first attempt
+ * doesn't permanently poison subsequent calls.
+ */
+let inFlight: Promise<NaClKeyPair> | null = null;
+
+/**
  * Cached recipient public keys indexed by machine ID.
  * WHY Map: We look up keys by machine_id on every encrypt/decrypt call.
  * A Map gives O(1) lookup vs repeated Supabase queries.
@@ -123,37 +143,54 @@ export async function getOrCreateKeyPair(): Promise<NaClKeyPair> {
     return cachedKeyPair;
   }
 
-  // Check SecureStore for a persisted keypair
-  const stored = await SecureStore.getItemAsync(KEYPAIR_STORAGE_KEY);
-
-  if (stored) {
-    try {
-      const parsed: StoredKeyPair = JSON.parse(stored);
-      const keypair: NaClKeyPair = {
-        publicKey: await decodeBase64(parsed.publicKey),
-        secretKey: await decodeBase64(parsed.secretKey),
-      };
-
-      // Validate key lengths before caching
-      if (keypair.publicKey.length !== 32 || keypair.secretKey.length !== 32) {
-        logger.error('Stored keypair has invalid key lengths, regenerating');
-        return await regenerateKeyPair();
-      }
-
-      cachedKeyPair = keypair;
-      logger.log('Loaded existing keypair from SecureStore');
-      return keypair;
-    } catch (parseError) {
-      // WHY: If the stored data is corrupted, generate a fresh keypair
-      // rather than failing. The old public key in machine_keys will be
-      // overwritten during the next pairing or registerPublicKey call.
-      logger.error('Failed to parse stored keypair, regenerating:', parseError);
-      return await regenerateKeyPair();
-    }
+  // Singleflight: if another caller is already loading/generating, await
+  // their result instead of racing to SecureStore + regenerateKeyPair.
+  if (inFlight) {
+    return inFlight;
   }
 
-  // No stored keypair -- generate a new one
-  return await regenerateKeyPair();
+  inFlight = (async (): Promise<NaClKeyPair> => {
+    try {
+      // Check SecureStore for a persisted keypair
+      const stored = await SecureStore.getItemAsync(KEYPAIR_STORAGE_KEY);
+
+      if (stored) {
+        try {
+          const parsed: StoredKeyPair = JSON.parse(stored);
+          const keypair: NaClKeyPair = {
+            publicKey: await decodeBase64(parsed.publicKey),
+            secretKey: await decodeBase64(parsed.secretKey),
+          };
+
+          // Validate key lengths before caching
+          if (keypair.publicKey.length !== 32 || keypair.secretKey.length !== 32) {
+            logger.error('Stored keypair has invalid key lengths, regenerating');
+            return await regenerateKeyPair();
+          }
+
+          cachedKeyPair = keypair;
+          logger.log('Loaded existing keypair from SecureStore');
+          return keypair;
+        } catch (parseError) {
+          // WHY: If the stored data is corrupted, generate a fresh keypair
+          // rather than failing. The old public key in machine_keys will be
+          // overwritten during the next pairing or registerPublicKey call.
+          logger.error('Failed to parse stored keypair, regenerating:', parseError);
+          return await regenerateKeyPair();
+        }
+      }
+
+      // No stored keypair -- generate a new one
+      return await regenerateKeyPair();
+    } finally {
+      // Clear the in-flight slot so a subsequent call re-checks cache /
+      // SecureStore freshly. On failure this lets callers retry; on success
+      // cachedKeyPair is set so the next call short-circuits at the top.
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
 }
 
 /**
@@ -403,6 +440,10 @@ export async function registerPublicKey(userId: string): Promise<void> {
  */
 export function clearEncryptionCache(): void {
   cachedKeyPair = null;
+  // Defensive: drop any in-flight singleflight promise so a post-logout
+  // call to getOrCreateKeyPair() does NOT receive a keypair that was being
+  // generated for the previous session.
+  inFlight = null;
   recipientKeyCache.clear();
   logger.log('Cleared encryption cache');
 }


### PR DESCRIPTION
## Summary
Closes #98. Closes a real race window in `packages/styrby-mobile/src/services/encryption.ts` that could orphan freshly-generated keypairs and silently break decryption of replies.

## The bug
`getOrCreateKeyPair()` is the entry point for every encrypt/decrypt/registerPublicKey operation. Hot-path callers (chat-session.ts:142,302, useChatSend.ts:131, useRelayMessageHandler.ts:182, pairing.ts:188) can fire concurrently — a fresh launch where the user taps Send while the relay is reconnecting and decrypting buffered messages hits all three at once.

If the in-memory cache is empty AND SecureStore is empty (first launch / post-logout / corrupted-stored-data path), the original code allowed concurrent callers to all fall through to `regenerateKeyPair()` in parallel. Each writes to SecureStore; last writer wins. Earlier writers' keypairs are now orphaned despite already being used to encrypt outgoing messages — any reply to those messages decrypts to garbage on the device.

## The fix
Module-level singleflight pattern. The first caller stores the in-flight Promise; concurrent callers await that same Promise instead of starting their own work. Cleared in `finally` so a failed first attempt doesn't permanently poison subsequent calls. Also cleared from `clearEncryptionCache()` so a post-logout call doesn't receive a keypair generated for the previous session.

## Changes
- `packages/styrby-mobile/src/services/encryption.ts` — new `inFlight` module state + wrapped `getOrCreateKeyPair` body in singleflight IIFE; defensive reset in `clearEncryptionCache`
- `packages/styrby-mobile/src/services/__tests__/encryption.test.ts` — 2 new regression tests:
  1. **Concurrent callers**: 3 simultaneous `getOrCreateKeyPair()` calls during a slow SecureStore read → exactly 1 SecureStore.getItemAsync, 1 generateKeyPair, 1 SecureStore.setItemAsync; all 3 promises resolve to the same keypair object reference.
  2. **Failure recovery**: a first call that fails on SecureStore read does NOT poison the in-flight slot — the second call retries cleanly.

## Test Plan
- [x] 22/22 encryption tests passing (was 20, +2 new)
- [x] typecheck clean
- [ ] Manual: cold-launch app + send message immediately while relay catches up — messages encrypt/decrypt successfully without orphaned-keypair warnings in dev logs

🤖 Shipped via /gh-ship