### PR TITLE
feat(mobile): wire CloudTasks screen + Power-tier gate (#97 PR-1)

### DIFF
--- a/packages/styrby-mobile/app/(tabs)/index.tsx
+++ b/packages/styrby-mobile/app/(tabs)/index.tsx
@@ -522,6 +522,36 @@ export default function DashboardScreen() {
         })}
       </View>
 
+      {/* Cloud Tasks — Power-tier feature for monitoring async agent jobs.
+          The destination screen handles tier gating (free/pro see upgrade
+          prompt, power see the live task list), so the link is unconditional
+          here for discoverability. */}
+      <View className="mx-4 mt-6">
+        <Text className="text-zinc-400 text-sm font-medium mb-3">CLOUD</Text>
+        <Pressable
+          onPress={() => router.push('/cloud-tasks')}
+          className="bg-background-secondary rounded-xl overflow-hidden"
+          accessibilityRole="button"
+          accessibilityLabel="Cloud Tasks. Monitor long-running agent jobs from your CLI."
+        >
+          <View className="flex-row items-center p-4">
+            <View
+              style={{ backgroundColor: 'rgba(249, 115, 22, 0.1)' }}
+              className="w-12 h-12 rounded-xl items-center justify-center"
+            >
+              <Ionicons name="cloud" size={24} color="#f97316" />
+            </View>
+            <View className="flex-1 ml-4">
+              <Text className="text-zinc-100 font-semibold text-base">Cloud Tasks</Text>
+              <Text className="text-zinc-500 text-sm mt-0.5">
+                Monitor async agent jobs from your CLI
+              </Text>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color="#71717a" />
+          </View>
+        </Pressable>
+      </View>
+
       {/* Activity Graph — 52-week coding activity heatmap */}
       <View className="mx-4 mt-6">
         <Text className="text-zinc-400 text-sm font-medium mb-3">ACTIVITY</Text>

--- a/packages/styrby-mobile/app/__tests__/cloud-tasks-screen.test.tsx
+++ b/packages/styrby-mobile/app/__tests__/cloud-tasks-screen.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Cloud Tasks Screen Render Tests
+ *
+ * Verifies that app/cloud-tasks.tsx routes correctly through its three
+ * primary states:
+ *   1. Loading (auth + tier in flight)
+ *   2. Tier gate (free / pro user)
+ *   3. Authenticated Power user (renders the CloudTasks component)
+ * Plus the defensive unauthenticated branch.
+ *
+ * Uses react-test-renderer (node environment, no DOM).
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { renderAsync } from '../../__tests__/utils/renderAsync';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function collectText(
+  node: renderer.ReactTestRendererJSON | renderer.ReactTestRendererJSON[] | null,
+): string[] {
+  if (!node) return [];
+  if (Array.isArray(node)) return node.flatMap(collectText);
+  const texts: string[] = [];
+  if (typeof node === 'string') return [node];
+  if (node.children) {
+    for (const child of node.children) {
+      if (typeof child === 'string') texts.push(child);
+      else texts.push(...collectText(child));
+    }
+  }
+  return texts;
+}
+
+function hasText(
+  tree: renderer.ReactTestRendererJSON | renderer.ReactTestRendererJSON[] | null,
+  text: string,
+): boolean {
+  return collectText(tree).some((t) => t.includes(text));
+}
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  Stack: { Screen: 'StackScreen' },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('styrby-shared', () => ({}));
+
+// platform-billing: returns deterministic upgrade copy for assertions.
+jest.mock('@/lib/platform-billing', () => ({
+  getUpgradeMessage: jest.fn((feature: string) => `${feature} is part of the Power plan.`),
+  getUpgradeButtonLabel: jest.fn(() => 'Upgrade to Power'),
+  getIosManageNote: jest.fn(() => null),
+  POLAR_CUSTOMER_PORTAL_URL: 'https://example.test/portal',
+}));
+
+// CloudTasks component: replaced with a string sentinel so we can assert it
+// rendered without exercising its Supabase realtime subscription internals.
+jest.mock('@/components/CloudTasks', () => ({
+  CloudTasks: 'CloudTasks',
+}));
+
+// useSubscriptionTier: per-test override via a mutable mock value.
+const mockTierValue: { tier: string; isLoading: boolean; isPaid: boolean; error: Error | null } = {
+  tier: 'free',
+  isLoading: false,
+  isPaid: false,
+  error: null,
+};
+
+jest.mock('@/hooks/useSubscriptionTier', () => ({
+  useSubscriptionTier: jest.fn(() => mockTierValue),
+}));
+
+// supabase auth: per-test override via a mutable mock value.
+const mockAuthValue: { data: { user: { id: string } | null }; error: Error | null } = {
+  data: { user: { id: 'test-user-id' } },
+  error: null,
+};
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(async () => mockAuthValue),
+    },
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn(async () => ({ data: null, error: null })),
+      update: jest.fn().mockReturnThis(),
+    })),
+  },
+}));
+
+// cloud-tasks service: replace cancelCloudTask with a no-op so wiring is
+// covered without exercising the Supabase mutation path (covered by its
+// own unit test in src/services/__tests__/cloud-tasks.test.ts).
+jest.mock('@/services/cloud-tasks', () => ({
+  cancelCloudTask: jest.fn(async () => {}),
+  CANCELLABLE_STATUSES: ['queued', 'running'] as const,
+}));
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+import CloudTasksScreen from '../cloud-tasks';
+
+describe('CloudTasksScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTierValue.tier = 'free';
+    mockTierValue.isLoading = false;
+    mockTierValue.isPaid = false;
+    mockAuthValue.data = { user: { id: 'test-user-id' } };
+  });
+
+  it('renders the Power-tier upgrade gate for a free user', async () => {
+    mockTierValue.tier = 'free';
+    const tree = await renderAsync(<CloudTasksScreen />);
+    expect(tree).toBeTruthy();
+    // Standard gate header
+    expect(hasText(tree, 'Power Plan Required')).toBe(true);
+    // Feature-specific copy threaded through the gate's `feature` prop
+    expect(hasText(tree, 'Cloud Tasks is part of the Power plan.')).toBe(true);
+  });
+
+  it('renders the Power-tier upgrade gate for a pro user', async () => {
+    mockTierValue.tier = 'pro';
+    const tree = await renderAsync(<CloudTasksScreen />);
+    expect(hasText(tree, 'Power Plan Required')).toBe(true);
+  });
+
+  it('renders the CloudTasks component for a power user', async () => {
+    mockTierValue.tier = 'power';
+    const tree = await renderAsync(<CloudTasksScreen />);
+    expect(tree).toBeTruthy();
+    // The CloudTasks mock is a string sentinel; serialize the JSON to verify
+    // the component element appears somewhere in the tree.
+    const serialized = JSON.stringify(tree);
+    expect(serialized).toContain('CloudTasks');
+    // Power user should NOT see the gate
+    expect(hasText(tree, 'Power Plan Required')).toBe(false);
+  });
+
+  it('renders the sign-in prompt when no authenticated user', async () => {
+    mockAuthValue.data = { user: null };
+    const tree = await renderAsync(<CloudTasksScreen />);
+    expect(hasText(tree, 'Sign in to view cloud tasks')).toBe(true);
+    expect(hasText(tree, 'Sign in')).toBe(true);
+  });
+});

--- a/packages/styrby-mobile/app/api-keys.tsx
+++ b/packages/styrby-mobile/app/api-keys.tsx
@@ -32,18 +32,12 @@ import {
   RefreshControl,
   KeyboardAvoidingView,
   Platform,
-  Linking,
   Share,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import { z } from 'zod';
-import {
-  getUpgradeMessage,
-  getUpgradeButtonLabel,
-  getIosManageNote,
-  POLAR_CUSTOMER_PORTAL_URL,
-} from '../src/lib/platform-billing';
+import { PowerTierGate } from '../src/components/tier/PowerTierGate';
 import {
   useApiKeys,
   type ApiKey,
@@ -543,61 +537,6 @@ function SecretRevealModal({ secret, keyName, onClose }: SecretModalProps) {
 }
 
 // ============================================================================
-// Power Tier Gate
-// ============================================================================
-
-/**
- * Full-screen upgrade prompt shown to non-Power-tier users.
- *
- * WHY platform-conditional rendering:
- * Apple App Store §3.1.3(a) classifies Styrby as a Reader App and prohibits
- * showing upgrade buttons, pricing, or links to external payment flows on iOS.
- * Android shows the full upgrade CTA with a direct link to the Polar portal.
- *
- * @returns React element
- */
-function PowerTierGate() {
-  const upgradeButtonLabel = getUpgradeButtonLabel('power');
-  const iosManageNote = getIosManageNote();
-
-  return (
-    <View className="flex-1 bg-background items-center justify-center px-8">
-      <View className="w-20 h-20 rounded-3xl bg-orange-500/15 items-center justify-center mb-6">
-        <Ionicons name="code-slash" size={40} color="#f97316" />
-      </View>
-      <Text className="text-white text-2xl font-bold text-center mb-2">
-        Power Plan Required
-      </Text>
-      <Text className="text-zinc-400 text-center mb-6">
-        {getUpgradeMessage('API Keys', 'power')}
-        {'\n\n'}Build integrations and automate your Styrby workflow with direct
-        API access.
-      </Text>
-
-      {/* WHY: Only render upgrade button on Android. Apple Reader App rules
-          (§3.1.3(a)) prohibit purchase CTAs or external payment links on iOS. */}
-      {upgradeButtonLabel !== null ? (
-        <Pressable
-          className="bg-brand px-8 py-4 rounded-2xl active:opacity-80"
-          onPress={() =>
-            Linking.openURL(POLAR_CUSTOMER_PORTAL_URL).catch(() => null)
-          }
-          accessibilityRole="button"
-          accessibilityLabel={upgradeButtonLabel}
-        >
-          <Text className="text-white font-bold text-base">{upgradeButtonLabel}</Text>
-        </Pressable>
-      ) : (
-        // iOS: informational note only — no button, no price, no external link
-        iosManageNote !== null && (
-          <Text className="text-zinc-500 text-sm text-center">{iosManageNote}</Text>
-        )
-      )}
-    </View>
-  );
-}
-
-// ============================================================================
 // Screen
 // ============================================================================
 
@@ -721,7 +660,13 @@ export default function ApiKeysScreen() {
   // --------------------------------------------------------------------------
 
   if (!isPowerTier) {
-    return <PowerTierGate />;
+    return (
+      <PowerTierGate
+        feature="API Keys"
+        description="Build integrations and automate your Styrby workflow with direct API access."
+        icon="code-slash"
+      />
+    );
   }
 
   // --------------------------------------------------------------------------

--- a/packages/styrby-mobile/app/cloud-tasks.tsx
+++ b/packages/styrby-mobile/app/cloud-tasks.tsx
@@ -1,0 +1,138 @@
+/**
+ * Cloud Tasks Screen
+ *
+ * Full-screen Power-tier feature for monitoring async cloud agent tasks.
+ *
+ * What it does:
+ * - Lists the user's most-recent cloud tasks (queued / running / completed /
+ *   failed / cancelled) with live status updates via Supabase Realtime
+ * - Tapping a task opens a detail sheet with the full prompt, result, error,
+ *   and cost
+ * - Active tasks (queued, running) can be cancelled directly from the list
+ *   or detail sheet — the cancel handler updates `cloud_tasks.status` to
+ *   'cancelled' and the relay infrastructure terminates the agent execution
+ *
+ * Tier gate:
+ * - Free and Pro users see the PowerTierGate upgrade prompt
+ * - Power users see the live task list
+ *
+ * Navigated to from the Dashboard's "Cloud Tasks" card link.
+ *
+ * Backend wiring:
+ * - cloud_tasks Supabase table (migration 063)
+ * - Realtime channel filtered by user_id
+ * - Cancel via Supabase UPDATE; the relay watches for status='cancelled'
+ *   transitions and terminates the running agent (CLI side: cloud.ts:496)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { View, Text, ActivityIndicator, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router, Stack } from 'expo-router';
+import { supabase } from '../src/lib/supabase';
+import { CloudTasks } from '../src/components/CloudTasks';
+import { PowerTierGate } from '../src/components/tier/PowerTierGate';
+import { useSubscriptionTier } from '../src/hooks/useSubscriptionTier';
+import { cancelCloudTask } from '../src/services/cloud-tasks';
+
+/**
+ * Renders the Cloud Tasks screen.
+ *
+ * Behavior:
+ * 1. Resolves the authenticated user (auth.getUser).
+ * 2. Looks up subscription tier via useSubscriptionTier.
+ * 3. While loading: spinner.
+ * 4. Non-Power: PowerTierGate upgrade prompt.
+ * 5. Power: <CloudTasks userId={user.id} onCancelTask={cancelCloudTask} />.
+ *
+ * @returns React element
+ */
+export default function CloudTasksScreen() {
+  const [userId, setUserId] = useState<string | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!cancelled) setUserId(user?.id ?? null);
+      } finally {
+        if (!cancelled) setAuthLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const { tier, isLoading: tierLoading } = useSubscriptionTier(userId);
+
+  // Stable callback so CloudTasks's useCallback deps don't rebuild every render.
+  const handleCancel = useCallback(async (taskId: string) => {
+    await cancelCloudTask(taskId);
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
+  // Loading: auth check OR tier check still in flight
+  if (authLoading || (userId !== null && tierLoading)) {
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Cloud Tasks' }} />
+        <View className="flex-1 bg-background items-center justify-center">
+          <ActivityIndicator size="large" color="#f97316" />
+          <Text className="text-zinc-500 mt-4">Loading…</Text>
+        </View>
+      </>
+    );
+  }
+
+  // Not authenticated — defensive; the route group should already enforce auth
+  // but render a clear state if we ever land here without a session.
+  if (userId === null) {
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Cloud Tasks' }} />
+        <View className="flex-1 bg-background items-center justify-center px-8">
+          <Ionicons name="lock-closed-outline" size={40} color="#71717a" />
+          <Text className="text-white text-lg font-semibold mt-4 text-center">
+            Sign in to view cloud tasks
+          </Text>
+          <Pressable
+            onPress={() => router.replace('/(auth)/login')}
+            className="bg-brand px-6 py-3 rounded-xl mt-6 active:opacity-80"
+            accessibilityRole="button"
+            accessibilityLabel="Go to sign-in screen"
+          >
+            <Text className="text-white font-bold">Sign in</Text>
+          </Pressable>
+        </View>
+      </>
+    );
+  }
+
+  // Tier gate: free + pro users get the upgrade prompt
+  if (tier !== 'power') {
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Cloud Tasks' }} />
+        <PowerTierGate
+          feature="Cloud Tasks"
+          description="Submit long-running agent jobs from your CLI and monitor them live from the phone — code reviews, refactors, and any async task with real-time status, cost tracking, and one-tap cancellation."
+          icon="cloud"
+        />
+      </>
+    );
+  }
+
+  // Power tier: render the task list
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Cloud Tasks' }} />
+      <View className="flex-1 bg-background">
+        <CloudTasks userId={userId} onCancelTask={handleCancel} />
+      </View>
+    </>
+  );
+}

--- a/packages/styrby-mobile/src/components/tier/PowerTierGate.tsx
+++ b/packages/styrby-mobile/src/components/tier/PowerTierGate.tsx
@@ -1,0 +1,96 @@
+/**
+ * PowerTierGate
+ *
+ * Generic full-screen upgrade prompt for any Power-tier-only feature.
+ *
+ * Replaces two near-identical copies that previously lived in
+ * `src/components/webhooks/power-tier-gate.tsx` (icon: key) and
+ * `app/api-keys.tsx` (icon: code-slash). Consolidating them prevents
+ * future drift between the two surfaces and makes new gated features
+ * (Cloud Tasks, future Power-only modules) trivial to add.
+ */
+
+import { View, Text, Pressable, Linking } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  getUpgradeMessage,
+  getUpgradeButtonLabel,
+  getIosManageNote,
+  POLAR_CUSTOMER_PORTAL_URL,
+} from '../../lib/platform-billing';
+
+/**
+ * Props for the PowerTierGate component.
+ */
+export interface PowerTierGateProps {
+  /**
+   * Human-readable feature name shown in the upgrade copy
+   * (e.g., "Webhooks", "API Keys", "Cloud Tasks").
+   */
+  feature: string;
+
+  /**
+   * One-to-two sentence pitch that explains what unlocks at the Power tier.
+   * Rendered below the standard "{feature} is part of the Power plan" line.
+   */
+  description: string;
+
+  /**
+   * Optional Ionicons glyph name shown in the colored hero badge.
+   * Defaults to 'key' to match the previous Webhooks gate.
+   */
+  icon?: keyof typeof Ionicons.glyphMap;
+}
+
+/**
+ * Renders the Power-tier upgrade prompt.
+ *
+ * WHY platform-conditional rendering:
+ * Apple App Store §3.1.3(a) classifies Styrby as a Reader App and prohibits
+ * showing upgrade buttons, pricing, or links to external payment flows on iOS.
+ * Android shows the full upgrade CTA with a direct link to the Polar portal.
+ * `getUpgradeButtonLabel` returns `null` on iOS so we can fall back to the
+ * informational `getIosManageNote()` instead of a CTA.
+ *
+ * @param props - PowerTierGateProps
+ * @returns React element
+ */
+export function PowerTierGate({ feature, description, icon = 'key' }: PowerTierGateProps) {
+  const upgradeButtonLabel = getUpgradeButtonLabel('power');
+  const iosManageNote = getIosManageNote();
+
+  return (
+    <View className="flex-1 bg-background items-center justify-center px-8">
+      <View className="w-20 h-20 rounded-3xl bg-orange-500/15 items-center justify-center mb-6">
+        <Ionicons name={icon} size={40} color="#f97316" />
+      </View>
+      <Text className="text-white text-2xl font-bold text-center mb-2">
+        Power Plan Required
+      </Text>
+      <Text className="text-zinc-400 text-center mb-6">
+        {getUpgradeMessage(feature, 'power')}
+        {'\n\n'}{description}
+      </Text>
+
+      {/* WHY: Only render upgrade button on Android. Apple Reader App rules
+          (§3.1.3(a)) prohibit purchase CTAs or external payment links on iOS. */}
+      {upgradeButtonLabel !== null ? (
+        <Pressable
+          className="bg-brand px-8 py-4 rounded-2xl active:opacity-80"
+          onPress={() =>
+            Linking.openURL(POLAR_CUSTOMER_PORTAL_URL).catch(() => null)
+          }
+          accessibilityRole="button"
+          accessibilityLabel={upgradeButtonLabel}
+        >
+          <Text className="text-white font-bold text-base">{upgradeButtonLabel}</Text>
+        </Pressable>
+      ) : (
+        // iOS: informational note only - no button, no price, no external link
+        iosManageNote !== null && (
+          <Text className="text-zinc-500 text-sm text-center">{iosManageNote}</Text>
+        )
+      )}
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/components/webhooks/power-tier-gate.tsx
+++ b/packages/styrby-mobile/src/components/webhooks/power-tier-gate.tsx
@@ -1,68 +1,29 @@
 /**
- * PowerTierGate
+ * Webhooks-specific re-export of the generic PowerTierGate.
  *
- * Full-screen upgrade prompt shown to non-Power-tier users when they reach
- * the Webhooks screen.
+ * Kept as a thin wrapper so existing `import { PowerTierGate } from
+ * '../src/components/webhooks'` paths keep working after the consolidation.
+ * The generic component now lives at `src/components/tier/PowerTierGate.tsx`.
  */
 
-import { View, Text, Pressable, Linking } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
-import {
-  getUpgradeMessage,
-  getUpgradeButtonLabel,
-  getIosManageNote,
-  POLAR_CUSTOMER_PORTAL_URL,
-} from '../../lib/platform-billing';
+import { PowerTierGate as GenericPowerTierGate } from '../tier/PowerTierGate';
 
 /**
- * Renders the Power-tier upgrade prompt.
+ * Webhooks-tier gate. Pre-configured with the feature name + description for
+ * the Webhooks screen so existing call sites (`<PowerTierGate />`) keep
+ * rendering the same content they always did.
  *
- * WHY platform-conditional rendering:
- * Apple App Store §3.1.3(a) classifies Styrby as a Reader App and prohibits
- * showing upgrade buttons, pricing, or links to external payment flows on iOS.
- * Android shows the full upgrade CTA with a direct link to the Polar portal.
- * `getUpgradeButtonLabel` returns `null` on iOS so we can fall back to the
- * informational `getIosManageNote()` instead of a CTA.
+ * For new screens, prefer importing the generic component directly from
+ * `src/components/tier/PowerTierGate` and passing your own props.
  *
  * @returns React element
  */
 export function PowerTierGate() {
-  const upgradeButtonLabel = getUpgradeButtonLabel('power');
-  const iosManageNote = getIosManageNote();
-
   return (
-    <View className="flex-1 bg-background items-center justify-center px-8">
-      <View className="w-20 h-20 rounded-3xl bg-orange-500/15 items-center justify-center mb-6">
-        <Ionicons name="key" size={40} color="#f97316" />
-      </View>
-      <Text className="text-white text-2xl font-bold text-center mb-2">
-        Power Plan Required
-      </Text>
-      <Text className="text-zinc-400 text-center mb-6">
-        {getUpgradeMessage('Webhooks', 'power')}
-        {'\n\n'}Automate your workflow by receiving real-time event notifications
-        to any HTTPS endpoint.
-      </Text>
-
-      {/* WHY: Only render upgrade button on Android. Apple Reader App rules
-          (§3.1.3(a)) prohibit purchase CTAs or external payment links on iOS. */}
-      {upgradeButtonLabel !== null ? (
-        <Pressable
-          className="bg-brand px-8 py-4 rounded-2xl active:opacity-80"
-          onPress={() =>
-            Linking.openURL(POLAR_CUSTOMER_PORTAL_URL).catch(() => null)
-          }
-          accessibilityRole="button"
-          accessibilityLabel={upgradeButtonLabel}
-        >
-          <Text className="text-white font-bold text-base">{upgradeButtonLabel}</Text>
-        </Pressable>
-      ) : (
-        // iOS: informational note only - no button, no price, no external link
-        iosManageNote !== null && (
-          <Text className="text-zinc-500 text-sm text-center">{iosManageNote}</Text>
-        )
-      )}
-    </View>
+    <GenericPowerTierGate
+      feature="Webhooks"
+      description="Automate your workflow by receiving real-time event notifications to any HTTPS endpoint."
+      icon="key"
+    />
   );
 }

--- a/packages/styrby-mobile/src/services/__tests__/cloud-tasks.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/cloud-tasks.test.ts
@@ -1,0 +1,139 @@
+/**
+ * cloud-tasks service test suite
+ *
+ * Covers the cancelCloudTask helper that backs the mobile Cloud Tasks
+ * screen's onCancelTask prop.
+ */
+
+// ============================================================================
+// Mock Setup
+// ============================================================================
+
+// styrby-shared: import only the type, no runtime values needed.
+jest.mock('styrby-shared', () => ({}));
+
+// Supabase chain mock — captures the full call shape so we can assert on it.
+type ChainResult = { data?: unknown; error?: { message: string } | null };
+
+const mockMaybeSingle = jest.fn<Promise<ChainResult>, []>();
+const mockUpdateChain = {
+  eq: jest.fn<Promise<ChainResult>, [string, string]>(),
+};
+const mockUpdate = jest.fn(() => mockUpdateChain);
+const mockSelectEq = {
+  maybeSingle: mockMaybeSingle,
+};
+const mockSelect = jest.fn(() => ({ eq: jest.fn(() => mockSelectEq) }));
+const mockFrom = jest.fn(() => ({
+  select: mockSelect,
+  update: mockUpdate,
+}));
+
+jest.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args as []),
+  },
+}));
+
+import { cancelCloudTask, CANCELLABLE_STATUSES } from '../cloud-tasks';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('cloud-tasks service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('CANCELLABLE_STATUSES', () => {
+    it('matches the CLI cancel whitelist (queued + running only)', () => {
+      // Mirrors packages/styrby-cli/src/commands/cloud.ts:484 — drift here
+      // means UI offers a Cancel button the backend will reject.
+      expect(CANCELLABLE_STATUSES).toEqual(['queued', 'running']);
+    });
+  });
+
+  describe('cancelCloudTask()', () => {
+    it('updates status to cancelled when task is queued', async () => {
+      mockMaybeSingle.mockResolvedValueOnce({ data: { status: 'queued' }, error: null });
+      mockUpdateChain.eq.mockResolvedValueOnce({ data: null, error: null });
+
+      await cancelCloudTask('task-1');
+
+      expect(mockFrom).toHaveBeenCalledWith('cloud_tasks');
+      expect(mockUpdate).toHaveBeenCalledWith({ status: 'cancelled' });
+      expect(mockUpdateChain.eq).toHaveBeenCalledWith('id', 'task-1');
+    });
+
+    it('updates status to cancelled when task is running', async () => {
+      mockMaybeSingle.mockResolvedValueOnce({ data: { status: 'running' }, error: null });
+      mockUpdateChain.eq.mockResolvedValueOnce({ data: null, error: null });
+
+      await cancelCloudTask('task-2');
+
+      expect(mockUpdate).toHaveBeenCalledWith({ status: 'cancelled' });
+    });
+
+    it('rejects when task is already completed', async () => {
+      mockMaybeSingle.mockResolvedValueOnce({ data: { status: 'completed' }, error: null });
+
+      await expect(cancelCloudTask('task-3')).rejects.toThrow(
+        'Cannot cancel task with status "completed"'
+      );
+      // CRITICAL: no UPDATE was issued — preventing the silent "succeeds-on-
+      // a-finished-task" footgun the pre-flight SELECT exists to prevent.
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects when task is already failed', async () => {
+      mockMaybeSingle.mockResolvedValueOnce({ data: { status: 'failed' }, error: null });
+
+      await expect(cancelCloudTask('task-4')).rejects.toThrow(
+        'Cannot cancel task with status "failed"'
+      );
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects when task is already cancelled', async () => {
+      mockMaybeSingle.mockResolvedValueOnce({ data: { status: 'cancelled' }, error: null });
+
+      await expect(cancelCloudTask('task-5')).rejects.toThrow(
+        'Cannot cancel task with status "cancelled"'
+      );
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects with task-not-found message when SELECT returns no rows', async () => {
+      mockMaybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+      await expect(cancelCloudTask('missing-task')).rejects.toThrow(
+        'Task missing-task not found'
+      );
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects when SELECT itself errors', async () => {
+      mockMaybeSingle.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'connection timeout' },
+      });
+
+      await expect(cancelCloudTask('task-6')).rejects.toThrow('connection timeout');
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects when UPDATE itself errors (after passing the gate)', async () => {
+      mockMaybeSingle.mockResolvedValueOnce({ data: { status: 'queued' }, error: null });
+      mockUpdateChain.eq.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'permission denied' },
+      });
+
+      await expect(cancelCloudTask('task-7')).rejects.toThrow('permission denied');
+      // UPDATE was attempted — this distinguishes "RLS rejected" from the
+      // "wrong-status" rejection that should never reach the UPDATE call.
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/styrby-mobile/src/services/cloud-tasks.ts
+++ b/packages/styrby-mobile/src/services/cloud-tasks.ts
@@ -1,0 +1,84 @@
+/**
+ * Cloud Tasks Service
+ *
+ * Mobile-side helpers for the cloud_tasks Supabase table — the backing store
+ * for the Power-tier "Cloud Monitoring" and "Code Review From Mobile"
+ * features.
+ *
+ * What lives here:
+ * - cancelCloudTask: matches the `styrby cloud cancel` CLI command's
+ *   semantics (pre-flight status check + UPDATE to 'cancelled')
+ *
+ * The CloudTasks UI component (`src/components/CloudTasks.tsx`) handles its
+ * own SELECT and Realtime subscription — those are display concerns. This
+ * module owns mutation operations the screen wires into the component's
+ * onCancelTask prop.
+ *
+ * @see packages/styrby-cli/src/commands/cloud.ts for the CLI counterpart
+ * @see supabase/migrations/063_cloud_tasks.sql for the schema
+ */
+
+import { supabase } from '../lib/supabase';
+import type { CloudTaskStatus } from 'styrby-shared';
+
+/**
+ * Statuses from which a cloud task may be cancelled.
+ *
+ * WHY: Mirrors the CLI's whitelist (`packages/styrby-cli/src/commands/cloud.ts:484`)
+ * so the mobile cancel flow has identical semantics. Completed/failed/already-
+ * cancelled tasks should never present a Cancel button in the UI, but this
+ * server-side check is the authoritative gate.
+ */
+export const CANCELLABLE_STATUSES: readonly CloudTaskStatus[] = ['queued', 'running'];
+
+/**
+ * Updates a cloud task's status to 'cancelled' after verifying the task is
+ * in a cancellable state. Mirrors `styrby cloud cancel <taskId>`.
+ *
+ * Pre-flight SELECT (matching cli/cloud.ts:471):
+ * Without it, an UPDATE on a 'completed'/'failed'/'cancelled' task succeeds
+ * silently (RLS allows it) and we'd give the user false confidence that an
+ * already-finished task was cancelled.
+ *
+ * Cancellation propagation:
+ * The relay infrastructure subscribes to cloud_tasks and terminates the
+ * agent execution when status flips to 'cancelled' (per migration 063
+ * comment + CLI cancel command).
+ *
+ * @param taskId - UUID of the task to cancel
+ * @throws {Error} If the task is not found, not owned by the caller (RLS),
+ *                 already in a non-cancellable terminal state, or if the
+ *                 Supabase request itself fails
+ *
+ * @example
+ * try {
+ *   await cancelCloudTask(task.id);
+ * } catch (e) {
+ *   Alert.alert('Could not cancel', e instanceof Error ? e.message : 'Unknown error');
+ * }
+ */
+export async function cancelCloudTask(taskId: string): Promise<void> {
+  const { data: task, error: fetchError } = await supabase
+    .from('cloud_tasks')
+    .select('status')
+    .eq('id', taskId)
+    .maybeSingle();
+
+  if (fetchError) throw new Error(fetchError.message);
+  if (!task) throw new Error(`Task ${taskId} not found`);
+
+  const currentStatus = task.status as CloudTaskStatus;
+  if (!CANCELLABLE_STATUSES.includes(currentStatus)) {
+    throw new Error(
+      `Cannot cancel task with status "${currentStatus}". ` +
+      `Only queued or running tasks can be cancelled.`
+    );
+  }
+
+  const { error: updateError } = await supabase
+    .from('cloud_tasks')
+    .update({ status: 'cancelled' as CloudTaskStatus })
+    .eq('id', taskId);
+
+  if (updateError) throw new Error(updateError.message);
+}


### PR DESCRIPTION
## Summary
PR-1 of the CloudTasks full integration sequence. Closes the **watch** half of task #97 — Power users can now monitor their CLI-dispatched cloud agent tasks live from the mobile app.

## What's in this PR
1. **New screen** `app/cloud-tasks.tsx` — orchestrator that resolves auth + tier and routes to: spinner / PowerTierGate / live CloudTasks list / sign-in prompt
2. **New service** `src/services/cloud-tasks.ts` — `cancelCloudTask(taskId)` mirrors CLI's `styrby cloud cancel` semantics (pre-flight status check + UPDATE)
3. **Consolidated PowerTierGate** to `src/components/tier/PowerTierGate.tsx` — generic + parameterized; replaces 2 near-duplicate copies (webhooks + api-keys). webhooks wrapper kept for backward-compat
4. **Dashboard card** linking to /cloud-tasks (unconditional; gating happens on the destination)
5. **Tests** — 9 service tests + 4 screen tests, all passing

## What's NOT in this PR (sequence)
- PR-2: code-review dispatcher ("Choose from recent sessions" UX)
- PR-3: push-on-completion Edge Function + DB trigger
- PR-4: real-device walkthrough doc

## Test Plan
- [x] typecheck clean
- [x] 13/13 new tests pass (9 service + 4 screen)
- [x] Full mobile suite: no new failures introduced (3 pre-existing auth/passkey test failures unrelated, verified on main)
- [ ] Manual: cold-launch as Power user → tap Dashboard's Cloud Tasks card → see live tasks (or empty state)
- [ ] Manual: same flow as free/pro user → see PowerTierGate
- [ ] Manual: tap Cancel on an active task → status flips to 'cancelled'

🤖 Shipped via /gh-ship