### PR TITLE
feat(cloud-tasks): push notification on terminal status (#97 PR-3)

### DIFF
--- a/packages/styrby-mobile/src/hooks/__tests__/useNotifications.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useNotifications.test.ts
@@ -389,6 +389,30 @@ describe('useNotifications', () => {
     expect(mockRouterPush).toHaveBeenCalledWith('/(tabs)/settings');
   });
 
+  it('navigates to /cloud-tasks when screen=cloud-tasks (#97 PR-3)', async () => {
+    renderHook(() => useNotifications());
+
+    await waitFor(() => expect(mockResponseCallback).not.toBeNull());
+
+    // cloud_task_completed / cloud_task_failed pushes from migration 092
+    // carry data.screen='cloud-tasks' + data.taskId. The route is unparametrized
+    // (the screen ranks tasks by startedAt DESC so the just-finished one
+    // surfaces at the top automatically).
+    // taskId currently informational (the screen ranks tasks by startedAt
+    // DESC so the just-finished task lands on top automatically). Included
+    // here to lock in the Zod schema accepting non-strict-UUID strings.
+    const response = makeNotificationResponse({
+      screen: 'cloud-tasks',
+      taskId: '11111111-1111-1111-1111-111111111111',
+    });
+
+    await act(async () => {
+      mockResponseCallback!(response);
+    });
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/cloud-tasks');
+  });
+
   // --------------------------------------------------------------------------
   // Type-Based Navigation (Strategy 2 - Backwards Compatibility)
   // --------------------------------------------------------------------------

--- a/packages/styrby-mobile/src/hooks/useNotifications.ts
+++ b/packages/styrby-mobile/src/hooks/useNotifications.ts
@@ -45,7 +45,12 @@ type NotificationScreen =
   // push trigger fans out to the user's devices with data.screen='mcp_approval'
   // and data.approvalId so this hook can deep-link straight to the
   // /mcp-approval/[approvalId] screen for sub-second decision UX.
-  | 'mcp_approval';
+  | 'mcp_approval'
+  // WHY cloud-tasks added in #97 PR-3: the cloud_tasks status trigger
+  // (migration 092) fires data.screen='cloud-tasks' on terminal status
+  // transitions. Tap routes the user to /cloud-tasks where they can see
+  // the just-finished task at the top of the list.
+  | 'cloud-tasks';
 
 /**
  * Shape of the `data` payload attached to Styrby push notifications.
@@ -69,6 +74,13 @@ interface NotificationData {
    * audit_log row.
    */
   approvalId?: string;
+  /**
+   * Task ID for screen='cloud-tasks' deep links. Currently informational —
+   * the destination screen ranks tasks by startedAt DESC so the just-
+   * finished task surfaces at the top automatically. Preserved here so a
+   * future iteration can auto-open its detail sheet on launch.
+   */
+  taskId?: string;
   /**
    * MCP-approval-only flag. When the audit_log push trigger fires for
    * action='mcp_approval_requested' the payload carries action='mcp_approval'
@@ -99,9 +111,17 @@ const NotificationDataSchema = z.object({
     'budget_alert',
     'daemon_reconnected',
   ]).optional(),
-  screen: z.enum(['chat', 'dashboard', 'sessions', 'costs', 'settings', 'mcp_approval']).optional(),
+  screen: z.enum(['chat', 'dashboard', 'sessions', 'costs', 'settings', 'mcp_approval', 'cloud-tasks']).optional(),
   sessionId: z.string().optional(),
   approvalId: z.string().uuid().optional(),
+  // taskId routes the user to /cloud-tasks for screen='cloud-tasks' deep-links
+  // (cloud_task_completed / cloud_task_failed push events from migration 092).
+  // WHY z.string() rather than .uuid(): Zod's uuid() validator rejects some
+  // valid UUID variants (notably non-v4 hex strings used in test fixtures)
+  // and a strict failure would cause the WHOLE payload to be discarded —
+  // breaking routing too. Validation here is opt-in to type safety, not a
+  // security boundary; the cloud_tasks RLS policy is the actual gate.
+  taskId: z.string().optional(),
   action: z.string().optional(),
 }).passthrough();
 
@@ -200,6 +220,18 @@ export function useNotifications(): UseNotificationsResult {
 
         case 'settings':
           router.push('/(tabs)/settings');
+          return true;
+
+        case 'cloud-tasks':
+          // WHY just push the screen route: cloud_task_completed /
+          // cloud_task_failed pushes carry a taskId in the data payload, but
+          // the screen's <CloudTasks/> list already auto-loads the most recent
+          // 25 tasks and ranks them by startedAt DESC, so the just-completed
+          // task is virtually guaranteed to be at the top of the list when the
+          // user lands. A deep-link to the detail sheet would be a useful
+          // follow-up, but for now landing on the list satisfies the
+          // "tap notification -> see the task that finished" UX promise.
+          router.push('/cloud-tasks');
           return true;
 
         default:

--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -47,7 +47,13 @@ type NotificationEventType =
   // Phase 2.4 — team approval request notification
   // Sent to all eligible approvers when the CLI submits a review-class command.
   // The mobile app surfaces "Approve / Deny / View diff" action buttons.
-  | 'approval_request';
+  | 'approval_request'
+  // #97 PR-3 — cloud task lifecycle notifications
+  // Fired by the notify_push_for_cloud_task trigger (migration 092) on
+  // terminal status transitions of public.cloud_tasks. cancelled tasks
+  // intentionally skip the push (user-initiated, no need to re-notify).
+  | 'cloud_task_completed'
+  | 'cloud_task_failed';
 
 /**
  * Data payload included with the notification event.
@@ -91,6 +97,16 @@ interface NotificationEventData {
 
   /** Session duration in milliseconds (for session completion events) */
   sessionDurationMs?: number;
+
+  // #97 PR-3 — cloud task fields
+  /** UUID of the cloud_tasks row (for deep-link to task detail). */
+  taskId?: string;
+  /**
+   * First ~80 chars of the task prompt — used in the notification body so
+   * the user knows which task finished without opening the app. The trigger
+   * (migration 092) already truncates to 80 chars on the server side.
+   */
+  prompt?: string;
 }
 
 /**
@@ -206,7 +222,9 @@ const VALID_EVENT_TYPES: NotificationEventType[] = [
   'session_error',
   'budget_warning',
   'budget_exceeded',
-  'approval_request',  // Phase 2.4
+  'approval_request',         // Phase 2.4
+  'cloud_task_completed',     // #97 PR-3
+  'cloud_task_failed',        // #97 PR-3
 ];
 
 /**
@@ -223,6 +241,13 @@ const BASE_PRIORITY_BY_EVENT: Record<NotificationEventType, number> = {
   // WHY priority 1 for approval_request: team members are blocked at the CLI
   // waiting for this notification to be acted on. Maximum urgency is appropriate.
   approval_request: 1,
+  // WHY priority 4 for cloud_task_completed: a cloud task finishing is
+  // structurally the same as a session completing — informational, not
+  // urgent. Same priority as session_completed.
+  cloud_task_completed: 4,
+  // WHY priority 2 for cloud_task_failed: agent error is actionable; the
+  // user may need to retry or investigate. Same priority as session_error.
+  cloud_task_failed: 2,
 };
 
 /**
@@ -551,6 +576,16 @@ function isTypeAllowed(
       // approver assignment — that's an admin-level change, not a preference
       // toggle. (SOC2 CC6.3 — governance controls must not be user-bypassable.)
       return true;
+    case 'cloud_task_completed':
+      // WHY reuse push_session_complete: structurally the same kind of event
+      // (an agent finished a job). Reusing the existing toggle avoids a
+      // schema migration and keeps the settings UI from growing yet another
+      // checkbox. Default = false (per migration 001), matching session_completed.
+      return prefs.push_session_complete;
+    case 'cloud_task_failed':
+      // WHY reuse push_session_errors: cloud-task failure is structurally the
+      // same as session error (agent ran into a problem). Default = true.
+      return prefs.push_session_errors;
     default:
       return true;
   }
@@ -704,6 +739,48 @@ function buildNotificationPayload(
           screen: 'chat',
           sessionId: data.sessionId,
           type: 'session_error',
+        },
+        sound: 'default',
+        priority: 'high',
+      };
+
+    case 'cloud_task_completed':
+      // WHY: tap takes user to the cloud-tasks screen (where the task list
+      // and detail sheet live); the taskId is forwarded so the screen can
+      // optionally auto-open the matching task on launch.
+      return {
+        title: data.title || 'Cloud Task Complete',
+        body:
+          data.body ||
+          (data.prompt && data.prompt.length > 0
+            ? `${data.agentType || 'Agent'}: ${data.prompt}`
+            : data.costUsd !== undefined
+              ? `Task finished — cost $${data.costUsd.toFixed(4)}`
+              : 'Cloud task finished'),
+        data: {
+          screen: 'cloud-tasks',
+          taskId: data.taskId,
+          type: 'cloud_task_completed',
+        },
+        sound: 'default',
+        priority: 'default',
+      };
+
+    case 'cloud_task_failed':
+      // WHY priority 'high' on the Expo channel: matches session_error so
+      // the OS surfaces it more prominently — a failed cloud task is
+      // actionable (user may need to retry from the dispatcher).
+      return {
+        title: data.title || 'Cloud Task Failed',
+        body:
+          data.body ||
+          (data.prompt && data.prompt.length > 0
+            ? `${data.agentType || 'Agent'} failed on: ${data.prompt}`
+            : `${data.agentType || 'Agent'} encountered an error`),
+        data: {
+          screen: 'cloud-tasks',
+          taskId: data.taskId,
+          type: 'cloud_task_failed',
         },
         sound: 'default',
         priority: 'high',

--- a/supabase/migrations/092_cloud_tasks_push_trigger.sql
+++ b/supabase/migrations/092_cloud_tasks_push_trigger.sql
@@ -1,0 +1,202 @@
+-- ============================================================================
+-- Migration 092: Push notification trigger on cloud_tasks terminal transitions
+-- ============================================================================
+--
+-- WHY this trigger exists:
+--   The Power-tier "Cloud Monitoring" feature (per docstring on
+--   packages/styrby-mobile/src/components/CloudTasks.tsx) promises live status
+--   for long-running cloud agent tasks. PR-1 of #97 wired the screen to
+--   Supabase Realtime so logged-in mobile users see status flips live; PR-2
+--   added the dispatcher. This migration closes the loop by sending a push
+--   notification when a task reaches a terminal state, so the user gets
+--   notified even when the app is backgrounded.
+--
+--   The relay infrastructure (CLI side) updates cloud_tasks.status when a
+--   task finishes. This trigger fires on those UPDATEs, calls the existing
+--   send-push-notification edge function via pg_net, and the function
+--   delivers via Expo Push (handling rate limits, quiet hours, per-type
+--   prefs, invalid-token deactivation).
+--
+-- Pattern reuse:
+--   This is a near-clone of migration 019's notify_push_for_message trigger
+--   on session_messages, applied to cloud_tasks. The pg_net plumbing,
+--   vault.decrypted_secrets lookup, hardcoded edge function URL (per 019's
+--   header — Supabase managed Postgres denies ALTER DATABASE ... SET
+--   app.supabase_url), and EXCEPTION-WHEN-OTHERS error handling all match.
+--
+-- Event type mapping:
+--   cloud_tasks.status='completed' -> send-push-notification 'cloud_task_completed'
+--   cloud_tasks.status='failed'    -> send-push-notification 'cloud_task_failed'
+--   cloud_tasks.status='cancelled' -> NO push (user-initiated; they already know)
+--
+-- Preference reuse (no schema change):
+--   - cloud_task_completed reuses push_session_complete (semantically same:
+--     "agent finished a job"; same opt-in default = false)
+--   - cloud_task_failed reuses push_session_errors (semantically same: agent
+--     failure; default = true)
+--   See send-push-notification/index.ts isTypeAllowed() switch for the wiring.
+--
+-- ROLLBACK:
+--   DROP TRIGGER IF EXISTS notify_push_for_cloud_task ON public.cloud_tasks;
+--   DROP FUNCTION IF EXISTS public.notify_push_for_cloud_task();
+--
+-- Risk class: SAFE — additive only (new trigger + new function, both with
+-- robust EXCEPTION-WHEN-OTHERS so any pg_net hiccup degrades to a WARNING
+-- and the cloud_tasks UPDATE itself proceeds).
+-- ============================================================================
+
+-- pg_net is already enabled (migration 017), so we don't re-create the extension.
+
+-- ============================================================================
+-- §1. Trigger function
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.notify_push_for_cloud_task()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_event_type    TEXT;
+  v_payload       JSONB;
+  v_service_key   TEXT;
+  v_edge_fn_url   TEXT;
+BEGIN
+  -- Only fire on terminal transitions FROM a non-terminal state. This prevents
+  -- duplicate pushes if a downstream system writes status='completed' twice
+  -- (idempotent UPDATEs are common in retry paths).
+  IF NEW.status = OLD.status THEN
+    RETURN NEW;
+  END IF;
+
+  -- Map terminal states to push event types. cancelled is a deliberate
+  -- skip — the user issued the cancel from the UI, so re-notifying them is
+  -- noise. Non-terminal transitions (queued -> running) also skip; we only
+  -- push when the agent has stopped.
+  v_event_type := CASE NEW.status
+    WHEN 'completed' THEN 'cloud_task_completed'
+    WHEN 'failed'    THEN 'cloud_task_failed'
+    ELSE NULL
+  END;
+
+  IF v_event_type IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Build the edge function payload. Mirrors the shape send-push-notification
+  -- expects (type/userId/data) and includes enough metadata for the mobile
+  -- notification template to render a useful body without a follow-up DB hit.
+  v_payload := jsonb_build_object(
+    'type',   v_event_type,
+    'userId', NEW.user_id::TEXT,
+    'data',   jsonb_build_object(
+      'taskId',    NEW.id::TEXT,
+      'agentType', NEW.agent_type,
+      'sessionId', NEW.session_id::TEXT,
+      'costUsd',   NEW.cost_usd,
+      -- Include first 80 chars of prompt so the body can preview it. The
+      -- function defaults to a generic message if this is missing.
+      'prompt',    LEFT(COALESCE(NEW.prompt, ''), 80)
+    )
+  );
+
+  -- Look up the service role key from vault.decrypted_secrets. Same pattern
+  -- as migration 019. If the secret is missing, log a warning and proceed —
+  -- the cloud_tasks UPDATE shouldn't fail because of a push delivery issue.
+  BEGIN
+    SELECT decrypted_secret
+      INTO v_service_key
+      FROM vault.decrypted_secrets
+     WHERE name = 'supabase_functions_api_key'
+     LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING '[notify_push_for_cloud_task] vault.decrypted_secrets not accessible: %', SQLERRM;
+    RETURN NEW;
+  END;
+
+  IF v_service_key IS NULL THEN
+    RAISE WARNING '[notify_push_for_cloud_task] Secret "supabase_functions_api_key" not found in vault. Push skipped for task %.', NEW.id;
+    RETURN NEW;
+  END IF;
+
+  -- WHY hardcoded URL: See migration 019's header. Supabase managed Postgres
+  -- denies ALTER DATABASE ... SET app.supabase_url, so current_setting()
+  -- returned NULL/empty in earlier attempts. Project ref akmtmxunjhsgldjztdtt
+  -- is stable for the lifetime of the project.
+  v_edge_fn_url := 'https://akmtmxunjhsgldjztdtt.supabase.co/functions/v1/send-push-notification';
+
+  PERFORM net.http_post(
+    url     := v_edge_fn_url,
+    body    := v_payload::TEXT,
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'Authorization', 'Bearer ' || v_service_key
+    )
+  );
+
+  RETURN NEW;
+
+EXCEPTION WHEN OTHERS THEN
+  -- Final safety net: any unexpected failure in the trigger logs a warning
+  -- but does NOT abort the cloud_tasks UPDATE. A failed push is better than
+  -- a failed status update — the realtime subscription still delivers the
+  -- new status to any open mobile/web client.
+  RAISE WARNING '[notify_push_for_cloud_task] Unexpected error for task %: %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.notify_push_for_cloud_task() IS
+  'Fires after UPDATE on cloud_tasks when status transitions to a terminal '
+  'state (completed, failed). Calls send-push-notification edge function via '
+  'pg_net to deliver a push to the task owner. cancelled status skips the '
+  'push because the user issued the cancel themselves. Push delivery '
+  'failures are logged as WARNINGs and never abort the UPDATE. '
+  'Companion to migration 019 (sessions_messages push trigger).';
+
+-- ============================================================================
+-- §2. Trigger registration
+-- ============================================================================
+
+DROP TRIGGER IF EXISTS notify_push_for_cloud_task ON public.cloud_tasks;
+
+CREATE TRIGGER notify_push_for_cloud_task
+  AFTER UPDATE OF status ON public.cloud_tasks
+  FOR EACH ROW
+  WHEN (NEW.status IS DISTINCT FROM OLD.status)
+  EXECUTE FUNCTION public.notify_push_for_cloud_task();
+
+COMMENT ON TRIGGER notify_push_for_cloud_task ON public.cloud_tasks IS
+  'Sends a push to the task owner when cloud_tasks.status transitions. '
+  'Filtered to UPDATE OF status with WHEN clause so unrelated column updates '
+  '(e.g. updated_at, cost_usd) do not invoke the edge function unnecessarily.';
+
+-- ============================================================================
+-- POST-DEPLOY VERIFICATION
+-- ============================================================================
+--
+-- 1. Confirm the trigger function exists:
+--    SELECT proname FROM pg_proc WHERE proname = 'notify_push_for_cloud_task';
+--    Expected: 1 row.
+--
+-- 2. Confirm the trigger is registered:
+--    SELECT tgname, tgrelid::regclass
+--      FROM pg_trigger
+--     WHERE tgname = 'notify_push_for_cloud_task';
+--    Expected: 1 row, tgrelid = public.cloud_tasks
+--
+-- 3. End-to-end smoke test (requires a real cloud_tasks row + device_token):
+--    -- Insert a queued task as a test user, then transition status:
+--    UPDATE public.cloud_tasks SET status = 'completed' WHERE id = '<task-id>';
+--    -- Within ~5 seconds, expect a push notification on the device.
+--    -- If no push arrives, check:
+--    --   * supabase_functions_api_key exists in vault.decrypted_secrets
+--    --   * notification_preferences.push_session_complete = true for the user
+--    --   * device_tokens has an active row for the user
+--    --   * pg_net._http_response shows a 200 from the edge function
+--
+-- 4. Rollback:
+--    DROP TRIGGER IF EXISTS notify_push_for_cloud_task ON public.cloud_tasks;
+--    DROP FUNCTION IF EXISTS public.notify_push_for_cloud_task();
+-- ============================================================================


### PR DESCRIPTION
## Summary
PR-3 of the CloudTasks full integration. Closes the **notify** half — when a cloud task reaches a terminal state (completed/failed), the task owner receives a push on their mobile device. Combined with PR-1 (screen + tier gate) and PR-2 (dispatcher), this delivers the marketed "Cloud Monitoring" experience end to end.

## Changes
- **`supabase/migrations/092_cloud_tasks_push_trigger.sql`** — pg_net trigger on `cloud_tasks` UPDATE OF status. Fires on terminal transitions (completed → `cloud_task_completed`; failed → `cloud_task_failed`). Cancelled is deliberately skipped (user already knows). Mirrors migration 019's vault-secret + hardcoded-URL pattern.
- **`supabase/functions/send-push-notification/index.ts`** — adds the two new event types (priority 4 / 2), templates, and preference mapping (reuses existing `push_session_complete` / `push_session_errors` toggles to avoid a schema migration + settings UI change).
- **`src/hooks/useNotifications.ts`** — extends `NotificationScreen`, `NotificationData`, and the Zod schema with `cloud-tasks` + `taskId`. Adds `case 'cloud-tasks'` route handler. taskId uses `z.string()` not `.uuid()` so a malformed taskId doesn't discard the whole payload.

## Tests
- 60/60 passing (33 useNotifications + 18 service + 5 sheet + 4 screen)
- typecheck clean
- Migration includes post-deploy verification block (queries + smoke test)

## Test Plan (manual, after migration applies)
- [ ] Run migration 092
- [ ] As Power user with `push_session_complete=true`, dispatch a cloud task from the mobile dispatcher (PR-2)
- [ ] When the relay marks `status='completed'`, expect a push within ~5s
- [ ] Tap notification → app routes to `/cloud-tasks` → just-finished task at top of list
- [ ] Cancel a task → no push fires (cancelled deliberately skipped)
- [ ] Force a failure → expect "Cloud Task Failed" push with prompt preview

## Next
- PR-4: real-device walkthrough doc covering the full integration flow

🤖 Shipped via /gh-ship