### PR TITLE
test(push): extract notification templates + 33 tests for cloud_task_* + all event types

### DIFF
--- a/packages/styrby-web/src/__tests__/notification-templates.test.ts
+++ b/packages/styrby-web/src/__tests__/notification-templates.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Notification templates test suite
+ *
+ * Unit tests for the pure logic in
+ * `supabase/functions/_shared/notification-templates.ts`. The shared module
+ * was extracted from `send-push-notification/index.ts` (1375 LOC, zero
+ * existing tests) so its template/preference/priority logic could be tested
+ * from Vitest without standing up a Deno test runner.
+ *
+ * Coverage focus:
+ * - All 9 NotificationEventType cases produce a payload with the correct
+ *   title, body, screen routing, sound, and priority.
+ * - Default-fallback bodies fire when title/body overrides are absent.
+ * - isTypeAllowed maps each event type to the correct preference column,
+ *   in particular cloud_task_* reuse of session_complete / session_errors
+ *   (the #97 PR-3 design choice that avoided a schema migration).
+ * - BASE_PRIORITY_BY_EVENT has an entry for every event type with a
+ *   semantically-correct value.
+ * - VALID_EVENT_TYPES matches the NotificationEventType union exactly
+ *   (drift here means a payload validator rejects events the templates
+ *   actually handle, or vice versa).
+ *
+ * Pre-existing event types are tested too — this is the first test of the
+ * function's logic, period, so we lock in current behavior as the
+ * regression baseline.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+// Relative path to the shared module under supabase/functions/_shared/.
+// Vitest resolves this fine from styrby-web's src/__tests__/ directory.
+import {
+  buildNotificationPayload,
+  isTypeAllowed,
+  BASE_PRIORITY_BY_EVENT,
+  VALID_EVENT_TYPES,
+  type NotificationEventType,
+  type NotificationPreferences,
+} from '../../../../supabase/functions/_shared/notification-templates';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build a NotificationPreferences row with every column set to true unless
+ * overridden. Use the override to flip a single field for negative tests.
+ */
+function prefs(overrides: Partial<NotificationPreferences> = {}): NotificationPreferences {
+  return {
+    push_permission_requests: true,
+    push_session_errors: true,
+    push_budget_alerts: true,
+    push_session_complete: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// VALID_EVENT_TYPES & BASE_PRIORITY_BY_EVENT — registry consistency
+// ============================================================================
+
+describe('Event type registry', () => {
+  it('VALID_EVENT_TYPES contains every event type in NotificationEventType', () => {
+    // The union has 9 members; the array must match exactly.
+    expect(VALID_EVENT_TYPES.length).toBe(9);
+    expect(VALID_EVENT_TYPES).toEqual([
+      'permission_request',
+      'session_started',
+      'session_completed',
+      'session_error',
+      'budget_warning',
+      'budget_exceeded',
+      'approval_request',
+      'cloud_task_completed',
+      'cloud_task_failed',
+    ]);
+  });
+
+  it('BASE_PRIORITY_BY_EVENT has an entry for every event type', () => {
+    for (const t of VALID_EVENT_TYPES) {
+      expect(BASE_PRIORITY_BY_EVENT[t]).toBeDefined();
+      expect(typeof BASE_PRIORITY_BY_EVENT[t]).toBe('number');
+    }
+  });
+
+  it('priority semantics: critical events have lower numbers than informational', () => {
+    // Approval is the most urgent (1); session_started is the least (5).
+    expect(BASE_PRIORITY_BY_EVENT.approval_request).toBe(1);
+    expect(BASE_PRIORITY_BY_EVENT.budget_exceeded).toBe(1);
+    expect(BASE_PRIORITY_BY_EVENT.session_started).toBe(5);
+
+    // Cloud task priorities mirror their session counterparts (PR-3 design).
+    expect(BASE_PRIORITY_BY_EVENT.cloud_task_completed).toBe(
+      BASE_PRIORITY_BY_EVENT.session_completed,
+    );
+    expect(BASE_PRIORITY_BY_EVENT.cloud_task_failed).toBe(
+      BASE_PRIORITY_BY_EVENT.session_error,
+    );
+  });
+});
+
+// ============================================================================
+// isTypeAllowed — preference mapping
+// ============================================================================
+
+describe('isTypeAllowed()', () => {
+  it('permission_request honors push_permission_requests', () => {
+    expect(isTypeAllowed(prefs({ push_permission_requests: true }), 'permission_request')).toBe(true);
+    expect(isTypeAllowed(prefs({ push_permission_requests: false }), 'permission_request')).toBe(false);
+  });
+
+  it('session_error honors push_session_errors', () => {
+    expect(isTypeAllowed(prefs({ push_session_errors: true }), 'session_error')).toBe(true);
+    expect(isTypeAllowed(prefs({ push_session_errors: false }), 'session_error')).toBe(false);
+  });
+
+  it('session_completed honors push_session_complete', () => {
+    expect(isTypeAllowed(prefs({ push_session_complete: true }), 'session_completed')).toBe(true);
+    expect(isTypeAllowed(prefs({ push_session_complete: false }), 'session_completed')).toBe(false);
+  });
+
+  it('budget events honor push_budget_alerts', () => {
+    expect(isTypeAllowed(prefs({ push_budget_alerts: true }), 'budget_warning')).toBe(true);
+    expect(isTypeAllowed(prefs({ push_budget_alerts: false }), 'budget_warning')).toBe(false);
+    expect(isTypeAllowed(prefs({ push_budget_alerts: true }), 'budget_exceeded')).toBe(true);
+    expect(isTypeAllowed(prefs({ push_budget_alerts: false }), 'budget_exceeded')).toBe(false);
+  });
+
+  it('session_started is always allowed (no dedicated toggle)', () => {
+    // Even with every other toggle off, session_started fires.
+    const allOff: NotificationPreferences = {
+      push_permission_requests: false,
+      push_session_errors: false,
+      push_budget_alerts: false,
+      push_session_complete: false,
+    };
+    expect(isTypeAllowed(allOff, 'session_started')).toBe(true);
+  });
+
+  it('approval_request is always allowed (SOC2 CC6.3 governance non-bypassable)', () => {
+    // Approval pushes cannot be opted out at the type level — disabling
+    // them would let an approver dodge governance reviews.
+    const allOff: NotificationPreferences = {
+      push_permission_requests: false,
+      push_session_errors: false,
+      push_budget_alerts: false,
+      push_session_complete: false,
+    };
+    expect(isTypeAllowed(allOff, 'approval_request')).toBe(true);
+  });
+
+  describe('cloud_task_* preference reuse (#97 PR-3 design)', () => {
+    it('cloud_task_completed reuses push_session_complete (default false in DB)', () => {
+      expect(isTypeAllowed(prefs({ push_session_complete: true }), 'cloud_task_completed')).toBe(true);
+      expect(isTypeAllowed(prefs({ push_session_complete: false }), 'cloud_task_completed')).toBe(false);
+    });
+
+    it('cloud_task_failed reuses push_session_errors (default true in DB)', () => {
+      expect(isTypeAllowed(prefs({ push_session_errors: true }), 'cloud_task_failed')).toBe(true);
+      expect(isTypeAllowed(prefs({ push_session_errors: false }), 'cloud_task_failed')).toBe(false);
+    });
+
+    it('cloud_task_completed and session_completed share the same gate', () => {
+      // Drift here would mean toggling "Session complete pushes" in the
+      // settings UI no longer affects cloud-task pushes — broken UX.
+      const off = prefs({ push_session_complete: false });
+      expect(isTypeAllowed(off, 'session_completed')).toBe(false);
+      expect(isTypeAllowed(off, 'cloud_task_completed')).toBe(false);
+    });
+
+    it('cloud_task_failed and session_error share the same gate', () => {
+      const off = prefs({ push_session_errors: false });
+      expect(isTypeAllowed(off, 'session_error')).toBe(false);
+      expect(isTypeAllowed(off, 'cloud_task_failed')).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// buildNotificationPayload — template rendering per event type
+// ============================================================================
+
+describe('buildNotificationPayload()', () => {
+  describe('permission_request', () => {
+    it('routes to chat screen with sessionId + permissions channel', () => {
+      const p = buildNotificationPayload('permission_request', {
+        sessionId: 'sess-1',
+        agentType: 'Claude',
+        permissionType: 'write files',
+      });
+      expect(p.title).toBe('Permission Required');
+      expect(p.body).toContain('Claude');
+      expect(p.body).toContain('write files');
+      expect(p.data.screen).toBe('chat');
+      expect(p.data.sessionId).toBe('sess-1');
+      expect(p.priority).toBe('high');
+      expect(p.channelId).toBe('permissions');
+    });
+
+    it('honors title/body overrides', () => {
+      const p = buildNotificationPayload('permission_request', {
+        title: 'Custom title',
+        body: 'Custom body',
+      });
+      expect(p.title).toBe('Custom title');
+      expect(p.body).toBe('Custom body');
+    });
+
+    it('falls back when agentType/permissionType absent', () => {
+      const p = buildNotificationPayload('permission_request', {});
+      expect(p.body).toBe('Agent wants to perform an action');
+    });
+  });
+
+  describe('session_started', () => {
+    it('routes to dashboard with default priority', () => {
+      const p = buildNotificationPayload('session_started', {
+        sessionId: 'sess-2',
+        agentType: 'Codex',
+      });
+      expect(p.title).toBe('Codex Session Started');
+      expect(p.data.screen).toBe('dashboard');
+      expect(p.priority).toBe('default');
+    });
+  });
+
+  describe('session_completed', () => {
+    it('shows cost in body when costUsd present', () => {
+      const p = buildNotificationPayload('session_completed', {
+        sessionId: 'sess-3',
+        costUsd: 0.1234,
+      });
+      expect(p.body).toBe('Cost: $0.1234');
+      expect(p.data.screen).toBe('sessions');
+    });
+
+    it('falls back to "Session finished" when costUsd absent', () => {
+      const p = buildNotificationPayload('session_completed', {});
+      expect(p.body).toBe('Session finished');
+    });
+  });
+
+  describe('session_error', () => {
+    it('routes to chat with high priority', () => {
+      const p = buildNotificationPayload('session_error', {
+        agentType: 'Gemini',
+        sessionId: 'sess-4',
+      });
+      expect(p.title).toBe('Session Error');
+      expect(p.body).toBe('Gemini encountered an error');
+      expect(p.data.screen).toBe('chat');
+      expect(p.priority).toBe('high');
+    });
+  });
+
+  describe('cloud_task_completed (#97 PR-3)', () => {
+    it('routes to /cloud-tasks with taskId + default priority', () => {
+      const p = buildNotificationPayload('cloud_task_completed', {
+        taskId: 'task-99',
+        agentType: 'Claude Code',
+        prompt: 'echo hello',
+      });
+      expect(p.title).toBe('Cloud Task Complete');
+      expect(p.data.screen).toBe('cloud-tasks');
+      expect(p.data.taskId).toBe('task-99');
+      expect(p.data.type).toBe('cloud_task_completed');
+      expect(p.priority).toBe('default');
+    });
+
+    it('body shows agent + prompt preview when prompt present', () => {
+      const p = buildNotificationPayload('cloud_task_completed', {
+        agentType: 'Codex',
+        prompt: 'list open issues',
+      });
+      expect(p.body).toBe('Codex: list open issues');
+    });
+
+    it('body falls back to cost when prompt absent and costUsd present', () => {
+      const p = buildNotificationPayload('cloud_task_completed', {
+        costUsd: 0.0567,
+      });
+      expect(p.body).toBe('Task finished — cost $0.0567');
+    });
+
+    it('body falls back to generic message when both prompt and cost absent', () => {
+      const p = buildNotificationPayload('cloud_task_completed', {});
+      expect(p.body).toBe('Cloud task finished');
+    });
+  });
+
+  describe('cloud_task_failed (#97 PR-3)', () => {
+    it('routes to /cloud-tasks with high priority', () => {
+      const p = buildNotificationPayload('cloud_task_failed', {
+        taskId: 'task-100',
+        agentType: 'Aider',
+        prompt: 'refactor auth',
+      });
+      expect(p.title).toBe('Cloud Task Failed');
+      expect(p.body).toBe('Aider failed on: refactor auth');
+      expect(p.data.screen).toBe('cloud-tasks');
+      expect(p.data.taskId).toBe('task-100');
+      expect(p.priority).toBe('high');
+    });
+
+    it('body falls back to "{agent} encountered an error" when prompt absent', () => {
+      const p = buildNotificationPayload('cloud_task_failed', {
+        agentType: 'Goose',
+      });
+      expect(p.body).toBe('Goose encountered an error');
+    });
+
+    it('body uses "Agent" when agentType also absent', () => {
+      const p = buildNotificationPayload('cloud_task_failed', {});
+      expect(p.body).toBe('Agent encountered an error');
+    });
+  });
+
+  describe('budget_warning', () => {
+    it('shows percentage when costUsd + budgetThreshold present', () => {
+      const p = buildNotificationPayload('budget_warning', {
+        costUsd: 75,
+        budgetThreshold: 100,
+      });
+      expect(p.body).toBe('Spending at 75% of $100.00');
+      expect(p.data.screen).toBe('costs');
+      expect(p.priority).toBe('high');
+    });
+
+    it('falls back when costUsd absent', () => {
+      const p = buildNotificationPayload('budget_warning', {
+        budgetThreshold: 100,
+      });
+      expect(p.body).toBe('Approaching budget threshold of $100.00');
+    });
+  });
+
+  describe('budget_exceeded', () => {
+    it('shows the threshold in body', () => {
+      const p = buildNotificationPayload('budget_exceeded', {
+        budgetThreshold: 50,
+      });
+      expect(p.title).toBe('Budget Exceeded');
+      expect(p.body).toBe('Spending exceeded $50.00');
+      expect(p.priority).toBe('high');
+    });
+  });
+
+  describe('approval_request (Phase 2.4)', () => {
+    it('routes to approvals with default actions array + permissions channel', () => {
+      const p = buildNotificationPayload('approval_request', {
+        approvalId: 'apr-1',
+        toolName: 'bash',
+        riskLevel: 'high',
+        requesterUserId: 'user-2',
+      });
+      expect(p.title).toBe('Approval Required: bash');
+      expect(p.body).toContain('Approve, Deny, or View diff');
+      expect(p.data.screen).toBe('approvals');
+      expect(p.data.approvalId).toBe('apr-1');
+      expect(p.data.actions).toEqual(['approve', 'deny', 'view_diff']);
+      expect(p.channelId).toBe('permissions');
+    });
+
+    it('honors caller-supplied actions array', () => {
+      const p = buildNotificationPayload('approval_request', {
+        approvalId: 'apr-2',
+        actions: ['approve', 'view_diff'],
+      });
+      expect(p.data.actions).toEqual(['approve', 'view_diff']);
+    });
+  });
+
+  describe('exhaustiveness', () => {
+    it('throws for unhandled type (compile-time guard but defensive runtime check)', () => {
+      // The cast bypasses TS narrowing so we can hit the default branch at
+      // runtime. The exhaustive `never` check inside the function is the
+      // compile-time guard; this proves the runtime safety net also works.
+      expect(() =>
+        buildNotificationPayload('not_a_real_type' as NotificationEventType, {}),
+      ).toThrow(/Unhandled notification type/);
+    });
+  });
+});

--- a/supabase/functions/_shared/notification-templates.ts
+++ b/supabase/functions/_shared/notification-templates.ts
@@ -1,0 +1,396 @@
+/**
+ * Notification Templates Shared Module
+ *
+ * Pure-function templates and lookup tables for the send-push-notification
+ * edge function. Extracted out of `send-push-notification/index.ts` so that:
+ *
+ * 1. The pure logic (no I/O, no Supabase, no Deno globals) can be unit-tested
+ *    from Node/Vitest without standing up a Deno test runner.
+ * 2. Multiple call sites (the function body, future test consumers, possible
+ *    future API routes) reference the same source of truth for event types
+ *    and per-event behavior.
+ *
+ * What lives here:
+ * - `NotificationEventType` — union of all push event types
+ * - `NotificationEventData` — per-event data payload shape
+ * - `NotificationPayload` — return shape from buildNotificationPayload
+ * - `NotificationPreferences` — user-pref row shape (subset relevant here)
+ * - `BASE_PRIORITY_BY_EVENT` — 1-5 urgency lookup
+ * - `VALID_EVENT_TYPES` — runtime allowlist used for payload validation
+ * - `isTypeAllowed()` — maps event type → relevant `push_*` preference toggle
+ * - `buildNotificationPayload()` — title/body/data/priority template per type
+ *
+ * What does NOT live here:
+ * - The Deno HTTP handler (auth, rate limit, audit log, Expo HTTP call)
+ * - Smart-priority scoring (cost thresholds, risk adjustments) — those live
+ *   in index.ts because they read from auxiliary lookups not relevant to
+ *   template rendering itself.
+ *
+ * @see supabase/functions/send-push-notification/index.ts for the consumer
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Notification event types accepted by send-push-notification.
+ *
+ * Each type maps to a specific notification template (title + body), a base
+ * priority score, and a preference column in `notification_preferences` that
+ * gates whether the push fires. Adding a new event type requires updating:
+ *   1. This union
+ *   2. `VALID_EVENT_TYPES` runtime allowlist
+ *   3. `BASE_PRIORITY_BY_EVENT` priority lookup
+ *   4. `isTypeAllowed()` preference mapping
+ *   5. `buildNotificationPayload()` template
+ * The exhaustive `never` check at the bottom of buildNotificationPayload
+ * makes step 5 a compile error if forgotten.
+ */
+export type NotificationEventType =
+  | 'permission_request'
+  | 'session_started'
+  | 'session_completed'
+  | 'session_error'
+  | 'budget_warning'
+  | 'budget_exceeded'
+  | 'approval_request'
+  | 'cloud_task_completed'
+  | 'cloud_task_failed';
+
+/**
+ * Per-event data payload. Not all fields apply to every event — the template
+ * builder pulls only what it needs and falls back to defaults.
+ */
+export interface NotificationEventData {
+  sessionId?: string;
+  agentType?: string;
+  approvalId?: string;
+  requesterUserId?: string;
+  actions?: string[];
+  title?: string;
+  body?: string;
+  costUsd?: number;
+  budgetThreshold?: number;
+  permissionType?: string;
+  riskLevel?: 'low' | 'medium' | 'high';
+  toolName?: string;
+  sessionDurationMs?: number;
+  // #97 PR-3 — cloud_task_* fields
+  taskId?: string;
+  prompt?: string;
+}
+
+/**
+ * The Expo push payload shape returned by `buildNotificationPayload`.
+ */
+export interface NotificationPayload {
+  title: string;
+  body: string;
+  data: Record<string, unknown>;
+  sound: 'default' | null;
+  priority: 'default' | 'high';
+  /** Optional Android notification channel ID for routing to specific UX */
+  channelId?: string;
+}
+
+/**
+ * Subset of `notification_preferences` columns relevant to template logic.
+ * The full row shape lives in index.ts — duplicating here would be drift
+ * risk; importing from index.ts would create a circular boundary. The
+ * compromise: declare the minimum surface needed here, callers populate
+ * from the full row.
+ */
+export interface NotificationPreferences {
+  push_permission_requests: boolean;
+  push_session_errors: boolean;
+  push_budget_alerts: boolean;
+  push_session_complete: boolean;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Runtime allowlist for incoming `type` field validation. Mirrors
+ * `NotificationEventType` exactly. Drift is caught by `as const` + the
+ * type-level satisfies check in the consumer.
+ */
+export const VALID_EVENT_TYPES: readonly NotificationEventType[] = [
+  'permission_request',
+  'session_started',
+  'session_completed',
+  'session_error',
+  'budget_warning',
+  'budget_exceeded',
+  'approval_request',
+  'cloud_task_completed',
+  'cloud_task_failed',
+] as const;
+
+/**
+ * Base priority scores by event type.
+ * Scale: 1 (most urgent) to 5 (informational only).
+ *
+ * Smart-priority logic in index.ts adjusts these by risk level, cost, and
+ * session duration before comparing against the user's `priority_threshold`.
+ */
+export const BASE_PRIORITY_BY_EVENT: Record<NotificationEventType, number> = {
+  permission_request: 2,
+  session_started: 5,
+  session_completed: 4,
+  session_error: 2,
+  budget_warning: 2,
+  budget_exceeded: 1,
+  // approval_request: maximum urgency — team members are blocked at the CLI
+  approval_request: 1,
+  // cloud_task_completed: structurally same as session_completed
+  cloud_task_completed: 4,
+  // cloud_task_failed: agent error is actionable — same priority as session_error
+  cloud_task_failed: 2,
+};
+
+// ============================================================================
+// Preference mapping
+// ============================================================================
+
+/**
+ * Returns whether the user's preferences allow this notification type.
+ *
+ * Maps each event type to its corresponding `push_*` column. Types without
+ * a dedicated toggle (session_started, approval_request) are always allowed
+ * because they're either informational or governance-critical.
+ *
+ * @param prefs - The user's notification_preferences row (partial shape)
+ * @param eventType - The event type to check
+ * @returns true if the user has opted in (or no opt-out exists)
+ */
+export function isTypeAllowed(
+  prefs: NotificationPreferences,
+  eventType: NotificationEventType,
+): boolean {
+  switch (eventType) {
+    case 'permission_request':
+      return prefs.push_permission_requests;
+    case 'session_error':
+      return prefs.push_session_errors;
+    case 'session_completed':
+      return prefs.push_session_complete;
+    case 'budget_warning':
+    case 'budget_exceeded':
+      return prefs.push_budget_alerts;
+    case 'session_started':
+      // No dedicated preference column — informational, low frequency.
+      return true;
+    case 'approval_request':
+      // Cannot be opted out at the type level; SOC2 CC6.3 governance
+      // controls must not be user-bypassable.
+      return true;
+    case 'cloud_task_completed':
+      // Reuses push_session_complete. Default false (matches session_completed).
+      return prefs.push_session_complete;
+    case 'cloud_task_failed':
+      // Reuses push_session_errors. Default true.
+      return prefs.push_session_errors;
+    default: {
+      // Exhaustive check — adding a new event type without a case is a
+      // compile error here.
+      const _exhaustive: never = eventType;
+      return _exhaustive;
+    }
+  }
+}
+
+// ============================================================================
+// Template builder
+// ============================================================================
+
+/**
+ * Builds the notification payload (title, body, data, priority) based on
+ * the event type and associated data.
+ *
+ * Each event type has a pre-defined template that creates user-friendly
+ * notification text and includes routing data so the mobile app can navigate
+ * to the relevant screen when the notification is tapped.
+ *
+ * @param type - The notification event type
+ * @param data - Event-specific data for template interpolation
+ * @returns The constructed notification payload
+ */
+export function buildNotificationPayload(
+  type: NotificationEventType,
+  data: NotificationEventData,
+): NotificationPayload {
+  switch (type) {
+    case 'permission_request':
+      return {
+        title: data.title || 'Permission Required',
+        body:
+          data.body ||
+          `${data.agentType || 'Agent'} wants to ${data.permissionType || 'perform an action'}`,
+        data: {
+          screen: 'chat',
+          sessionId: data.sessionId,
+          type: 'permission_request',
+        },
+        sound: 'default',
+        priority: 'high',
+        channelId: 'permissions',
+      };
+
+    case 'session_started':
+      return {
+        title: data.title || `${data.agentType || 'Agent'} Session Started`,
+        body: data.body || 'New coding session active',
+        data: {
+          screen: 'dashboard',
+          sessionId: data.sessionId,
+          type: 'session_started',
+        },
+        sound: 'default',
+        priority: 'default',
+      };
+
+    case 'session_completed':
+      return {
+        title: data.title || 'Session Complete',
+        body:
+          data.body ||
+          (data.costUsd !== undefined
+            ? `Cost: $${data.costUsd.toFixed(4)}`
+            : 'Session finished'),
+        data: {
+          screen: 'sessions',
+          sessionId: data.sessionId,
+          type: 'session_completed',
+        },
+        sound: 'default',
+        priority: 'default',
+      };
+
+    case 'session_error':
+      return {
+        title: data.title || 'Session Error',
+        body:
+          data.body ||
+          `${data.agentType || 'Agent'} encountered an error`,
+        data: {
+          screen: 'chat',
+          sessionId: data.sessionId,
+          type: 'session_error',
+        },
+        sound: 'default',
+        priority: 'high',
+      };
+
+    case 'cloud_task_completed':
+      // Tap takes user to the cloud-tasks screen (where the task list and
+      // detail sheet live); the taskId is forwarded so the screen can
+      // optionally auto-open the matching task on launch.
+      return {
+        title: data.title || 'Cloud Task Complete',
+        body:
+          data.body ||
+          (data.prompt && data.prompt.length > 0
+            ? `${data.agentType || 'Agent'}: ${data.prompt}`
+            : data.costUsd !== undefined
+              ? `Task finished — cost $${data.costUsd.toFixed(4)}`
+              : 'Cloud task finished'),
+        data: {
+          screen: 'cloud-tasks',
+          taskId: data.taskId,
+          type: 'cloud_task_completed',
+        },
+        sound: 'default',
+        priority: 'default',
+      };
+
+    case 'cloud_task_failed':
+      // Priority 'high' on the Expo channel matches session_error so the
+      // OS surfaces it more prominently — a failed cloud task is actionable.
+      return {
+        title: data.title || 'Cloud Task Failed',
+        body:
+          data.body ||
+          (data.prompt && data.prompt.length > 0
+            ? `${data.agentType || 'Agent'} failed on: ${data.prompt}`
+            : `${data.agentType || 'Agent'} encountered an error`),
+        data: {
+          screen: 'cloud-tasks',
+          taskId: data.taskId,
+          type: 'cloud_task_failed',
+        },
+        sound: 'default',
+        priority: 'high',
+      };
+
+    case 'budget_warning': {
+      const percentage =
+        data.costUsd !== undefined && data.budgetThreshold
+          ? Math.round((data.costUsd / data.budgetThreshold) * 100)
+          : null;
+
+      return {
+        title: data.title || 'Budget Warning',
+        body:
+          data.body ||
+          (percentage !== null
+            ? `Spending at ${percentage}% of $${data.budgetThreshold?.toFixed(2)}`
+            : `Approaching budget threshold of $${data.budgetThreshold?.toFixed(2) || '?'}`),
+        data: {
+          screen: 'costs',
+          type: 'budget_warning',
+          budgetThreshold: data.budgetThreshold,
+        },
+        sound: 'default',
+        priority: 'high',
+      };
+    }
+
+    case 'budget_exceeded':
+      return {
+        title: data.title || 'Budget Exceeded',
+        body:
+          data.body ||
+          `Spending exceeded $${data.budgetThreshold?.toFixed(2) || '?'}`,
+        data: {
+          screen: 'costs',
+          type: 'budget_exceeded',
+          budgetThreshold: data.budgetThreshold,
+        },
+        sound: 'default',
+        priority: 'high',
+      };
+
+    // Phase 2.4 — approval_request notification.
+    // Sent to eligible approvers when the CLI pauses on a review-class command.
+    // "Approve / Deny / View diff" is spelled out in the body so notifications
+    // remain scannable on watches / previews where action buttons don't appear.
+    case 'approval_request':
+      return {
+        title: data.title || `Approval Required: ${data.toolName || 'Tool call'}`,
+        body:
+          data.body ||
+          `A team member is waiting. Tap to Approve, Deny, or View diff.`,
+        data: {
+          screen: 'approvals',
+          approvalId: data.approvalId,
+          requesterUserId: data.requesterUserId,
+          toolName: data.toolName,
+          riskLevel: data.riskLevel,
+          actions: data.actions ?? ['approve', 'deny', 'view_diff'],
+          type: 'approval_request',
+        },
+        sound: 'default',
+        priority: 'high',
+        channelId: 'permissions',
+      };
+
+    default: {
+      // Exhaustive check ensures every NotificationEventType is handled.
+      const _exhaustiveCheck: never = type;
+      throw new Error(`Unhandled notification type: ${String(_exhaustiveCheck)}`);
+    }
+  }
+}

--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -27,87 +27,19 @@ import {
   isExpoPushToken,
   type ExpoPushSendResult,
 } from '../_shared/expo-push.ts';
+import {
+  buildNotificationPayload,
+  isTypeAllowed,
+  BASE_PRIORITY_BY_EVENT,
+  VALID_EVENT_TYPES,
+  type NotificationEventType,
+  type NotificationEventData,
+  type NotificationPayload,
+} from '../_shared/notification-templates.ts';
 
 // ============================================================================
 // Types
 // ============================================================================
-
-/**
- * Notification event types that this function handles.
- * Each type maps to a specific notification template with pre-defined
- * title, body, and routing behavior in the mobile app.
- */
-type NotificationEventType =
-  | 'permission_request'
-  | 'session_started'
-  | 'session_completed'
-  | 'session_error'
-  | 'budget_warning'
-  | 'budget_exceeded'
-  // Phase 2.4 — team approval request notification
-  // Sent to all eligible approvers when the CLI submits a review-class command.
-  // The mobile app surfaces "Approve / Deny / View diff" action buttons.
-  | 'approval_request'
-  // #97 PR-3 — cloud task lifecycle notifications
-  // Fired by the notify_push_for_cloud_task trigger (migration 092) on
-  // terminal status transitions of public.cloud_tasks. cancelled tasks
-  // intentionally skip the push (user-initiated, no need to re-notify).
-  | 'cloud_task_completed'
-  | 'cloud_task_failed';
-
-/**
- * Data payload included with the notification event.
- * Not all fields are required for every event type.
- */
-interface NotificationEventData {
-  /** Session UUID for navigation to specific session */
-  sessionId?: string;
-
-  /** Which AI agent triggered the event (e.g., "Claude", "Codex") */
-  agentType?: string;
-
-  // Phase 2.4 — approval_request specific fields
-  /** Approval row UUID (for deep-link to approval detail screen) */
-  approvalId?: string;
-  /** User ID of the team member who submitted the approval request */
-  requesterUserId?: string;
-  /** Action buttons to surface in the notification (mobile): approve, deny, view_diff */
-  actions?: string[];
-
-  /** Custom notification title override */
-  title?: string;
-
-  /** Custom notification body override */
-  body?: string;
-
-  /** Cost in USD for session completion events */
-  costUsd?: number;
-
-  /** Budget threshold in USD for budget events */
-  budgetThreshold?: number;
-
-  /** Type of permission being requested (e.g., "write files") */
-  permissionType?: string;
-
-  /** Risk level for permission requests (low, medium, high) */
-  riskLevel?: 'low' | 'medium' | 'high';
-
-  /** Tool name for permission requests (e.g., "bash", "write") */
-  toolName?: string;
-
-  /** Session duration in milliseconds (for session completion events) */
-  sessionDurationMs?: number;
-
-  // #97 PR-3 — cloud task fields
-  /** UUID of the cloud_tasks row (for deep-link to task detail). */
-  taskId?: string;
-  /**
-   * First ~80 chars of the task prompt — used in the notification body so
-   * the user knows which task finished without opening the app. The trigger
-   * (migration 092) already truncates to 80 chars on the server side.
-   */
-  prompt?: string;
-}
 
 /**
  * The incoming request payload from internal services.
@@ -123,32 +55,10 @@ interface NotificationRequest {
   data: NotificationEventData;
 }
 
-/**
- * Notification template built from the event type and data.
- * Used to construct the Expo push message.
- */
-interface NotificationPayload {
-  /** Notification title displayed in the notification shade */
-  title: string;
-
-  /** Notification body text */
-  body: string;
-
-  /** Data payload delivered to the app for navigation routing */
-  data: Record<string, unknown>;
-
-  /** Sound to play ("default" or null for silent) */
-  sound: 'default' | null;
-
-  /** Delivery priority ("high" for time-sensitive like permissions) */
-  priority: 'default' | 'high';
-
-  /**
-   * Android notification channel ID.
-   * "permissions" channel has more aggressive vibration pattern.
-   */
-  channelId?: string;
-}
+// NOTE: NotificationEventType, NotificationEventData, NotificationPayload,
+// VALID_EVENT_TYPES, BASE_PRIORITY_BY_EVENT, isTypeAllowed, and
+// buildNotificationPayload are imported from `../_shared/notification-templates.ts`
+// so they can be unit-tested from Vitest without standing up a Deno test runner.
 
 /**
  * Row shape from the notification_preferences table.
@@ -210,45 +120,6 @@ interface NotificationResponse {
  * coding session generates 10-30 notifications; 100 provides generous headroom.
  */
 const RATE_LIMIT_PER_HOUR = 100;
-
-/**
- * Valid notification event types for payload validation.
- * Used to reject requests with unknown event types before processing.
- */
-const VALID_EVENT_TYPES: NotificationEventType[] = [
-  'permission_request',
-  'session_started',
-  'session_completed',
-  'session_error',
-  'budget_warning',
-  'budget_exceeded',
-  'approval_request',         // Phase 2.4
-  'cloud_task_completed',     // #97 PR-3
-  'cloud_task_failed',        // #97 PR-3
-];
-
-/**
- * Base priority scores by event type.
- * Scale: 1 (most urgent) to 5 (informational only).
- */
-const BASE_PRIORITY_BY_EVENT: Record<NotificationEventType, number> = {
-  permission_request: 2,
-  session_started: 5,
-  session_completed: 4,
-  session_error: 2,
-  budget_warning: 2,
-  budget_exceeded: 1,
-  // WHY priority 1 for approval_request: team members are blocked at the CLI
-  // waiting for this notification to be acted on. Maximum urgency is appropriate.
-  approval_request: 1,
-  // WHY priority 4 for cloud_task_completed: a cloud task finishing is
-  // structurally the same as a session completing — informational, not
-  // urgent. Same priority as session_completed.
-  cloud_task_completed: 4,
-  // WHY priority 2 for cloud_task_failed: agent error is actionable; the
-  // user may need to retry or investigate. Same priority as session_error.
-  cloud_task_failed: 2,
-};
 
 /**
  * Risk level adjustments for permission requests.
@@ -538,58 +409,11 @@ async function checkNotificationPreferences(
   };
 }
 
-/**
- * Checks whether a specific notification type is enabled in user preferences.
- *
- * Maps each event type to its corresponding preference column.
- * Types not explicitly mapped (like session_started) are always allowed
- * because they don't have a dedicated preference toggle.
- *
- * @param prefs - The user's notification preferences
- * @param eventType - The notification event type to check
- * @returns True if the user has enabled notifications for this type
- */
-function isTypeAllowed(
-  prefs: NotificationPreferences,
-  eventType: NotificationEventType
-): boolean {
-  switch (eventType) {
-    case 'permission_request':
-      return prefs.push_permission_requests;
-    case 'session_error':
-      return prefs.push_session_errors;
-    case 'session_completed':
-      return prefs.push_session_complete;
-    case 'budget_warning':
-    case 'budget_exceeded':
-      return prefs.push_budget_alerts;
-    case 'session_started':
-      // WHY no preference column: session_started is a low-frequency,
-      // informational notification. It was intentionally omitted from
-      // per-type preferences to keep the settings UI simple. If users
-      // don't want it, they can disable push entirely.
-      return true;
-    case 'approval_request':
-      // WHY always true: approval_request notifications cannot be opted out
-      // of at the type level. An approver who disabled push cannot fulfil
-      // their governance role. If they want no push, they must disable their
-      // approver assignment — that's an admin-level change, not a preference
-      // toggle. (SOC2 CC6.3 — governance controls must not be user-bypassable.)
-      return true;
-    case 'cloud_task_completed':
-      // WHY reuse push_session_complete: structurally the same kind of event
-      // (an agent finished a job). Reusing the existing toggle avoids a
-      // schema migration and keeps the settings UI from growing yet another
-      // checkbox. Default = false (per migration 001), matching session_completed.
-      return prefs.push_session_complete;
-    case 'cloud_task_failed':
-      // WHY reuse push_session_errors: cloud-task failure is structurally the
-      // same as session error (agent ran into a problem). Default = true.
-      return prefs.push_session_errors;
-    default:
-      return true;
-  }
-}
+// isTypeAllowed lives in ../_shared/notification-templates.ts (imported above).
+// The shared module's NotificationPreferences declares the subset of columns
+// it reads from; the wider local NotificationPreferences interface is
+// structurally compatible (excess properties allowed when narrowing by
+// assignment).
 
 /**
  * Determines whether the current time falls within the user's quiet hours.
@@ -658,212 +482,9 @@ function timeToMinutes(time: string): number {
   return hours * 60 + minutes;
 }
 
-// ============================================================================
-// Notification Payload Builder
-// ============================================================================
-
-/**
- * Builds the notification payload (title, body, data, priority) based on
- * the event type and associated data.
- *
- * Each event type has a pre-defined template that creates user-friendly
- * notification text and includes routing data so the mobile app can navigate
- * to the relevant screen when the notification is tapped.
- *
- * @param type - The notification event type
- * @param data - Event-specific data for template interpolation
- * @returns The constructed notification payload
- */
-function buildNotificationPayload(
-  type: NotificationEventType,
-  data: NotificationEventData
-): NotificationPayload {
-  switch (type) {
-    case 'permission_request':
-      return {
-        title: data.title || 'Permission Required',
-        body:
-          data.body ||
-          `${data.agentType || 'Agent'} wants to ${data.permissionType || 'perform an action'}`,
-        data: {
-          screen: 'chat',
-          sessionId: data.sessionId,
-          type: 'permission_request',
-        },
-        sound: 'default',
-        priority: 'high',
-        // WHY "permissions" channel: The mobile app registers this Android
-        // channel with a more aggressive vibration pattern and red LED color
-        // to distinguish urgent permission requests from informational
-        // notifications. See notifications.ts line 79.
-        channelId: 'permissions',
-      };
-
-    case 'session_started':
-      return {
-        title: data.title || `${data.agentType || 'Agent'} Session Started`,
-        body: data.body || 'New coding session active',
-        data: {
-          screen: 'dashboard',
-          sessionId: data.sessionId,
-          type: 'session_started',
-        },
-        sound: 'default',
-        priority: 'default',
-      };
-
-    case 'session_completed':
-      return {
-        title: data.title || 'Session Complete',
-        body:
-          data.body ||
-          (data.costUsd !== undefined
-            ? `Cost: $${data.costUsd.toFixed(4)}`
-            : 'Session finished'),
-        data: {
-          screen: 'sessions',
-          sessionId: data.sessionId,
-          type: 'session_completed',
-        },
-        sound: 'default',
-        priority: 'default',
-      };
-
-    case 'session_error':
-      return {
-        title: data.title || 'Session Error',
-        body:
-          data.body ||
-          `${data.agentType || 'Agent'} encountered an error`,
-        data: {
-          screen: 'chat',
-          sessionId: data.sessionId,
-          type: 'session_error',
-        },
-        sound: 'default',
-        priority: 'high',
-      };
-
-    case 'cloud_task_completed':
-      // WHY: tap takes user to the cloud-tasks screen (where the task list
-      // and detail sheet live); the taskId is forwarded so the screen can
-      // optionally auto-open the matching task on launch.
-      return {
-        title: data.title || 'Cloud Task Complete',
-        body:
-          data.body ||
-          (data.prompt && data.prompt.length > 0
-            ? `${data.agentType || 'Agent'}: ${data.prompt}`
-            : data.costUsd !== undefined
-              ? `Task finished — cost $${data.costUsd.toFixed(4)}`
-              : 'Cloud task finished'),
-        data: {
-          screen: 'cloud-tasks',
-          taskId: data.taskId,
-          type: 'cloud_task_completed',
-        },
-        sound: 'default',
-        priority: 'default',
-      };
-
-    case 'cloud_task_failed':
-      // WHY priority 'high' on the Expo channel: matches session_error so
-      // the OS surfaces it more prominently — a failed cloud task is
-      // actionable (user may need to retry from the dispatcher).
-      return {
-        title: data.title || 'Cloud Task Failed',
-        body:
-          data.body ||
-          (data.prompt && data.prompt.length > 0
-            ? `${data.agentType || 'Agent'} failed on: ${data.prompt}`
-            : `${data.agentType || 'Agent'} encountered an error`),
-        data: {
-          screen: 'cloud-tasks',
-          taskId: data.taskId,
-          type: 'cloud_task_failed',
-        },
-        sound: 'default',
-        priority: 'high',
-      };
-
-    case 'budget_warning': {
-      // Calculate percentage if both current cost and threshold are available
-      const percentage =
-        data.costUsd !== undefined && data.budgetThreshold
-          ? Math.round((data.costUsd / data.budgetThreshold) * 100)
-          : null;
-
-      return {
-        title: data.title || 'Budget Warning',
-        body:
-          data.body ||
-          (percentage !== null
-            ? `Spending at ${percentage}% of $${data.budgetThreshold?.toFixed(2)}`
-            : `Approaching budget threshold of $${data.budgetThreshold?.toFixed(2) || '?'}`),
-        data: {
-          screen: 'costs',
-          type: 'budget_warning',
-          budgetThreshold: data.budgetThreshold,
-        },
-        sound: 'default',
-        priority: 'high',
-      };
-    }
-
-    case 'budget_exceeded':
-      return {
-        title: data.title || 'Budget Exceeded',
-        body:
-          data.body ||
-          `Spending exceeded $${data.budgetThreshold?.toFixed(2) || '?'}`,
-        data: {
-          screen: 'costs',
-          type: 'budget_exceeded',
-          budgetThreshold: data.budgetThreshold,
-        },
-        sound: 'default',
-        priority: 'high',
-      };
-
-    // Phase 2.4 — approval_request notification
-    // Sent to eligible approvers when the CLI pauses on a review-class command.
-    // WHY "Approve / Deny / View diff" in the body: these are the three actions
-    // the mobile app surfaces in the notification tray (via actions[] in data).
-    // Spelling them out in the body text makes the notification scannable even
-    // on watches / notification previews where action buttons don't appear.
-    case 'approval_request':
-      return {
-        title: data.title || `Approval Required: ${data.toolName || 'Tool call'}`,
-        body:
-          data.body ||
-          `A team member is waiting. Tap to Approve, Deny, or View diff.`,
-        data: {
-          screen: 'approvals',
-          approvalId: data.approvalId,
-          requesterUserId: data.requesterUserId,
-          toolName: data.toolName,
-          riskLevel: data.riskLevel,
-          // Action buttons rendered by the mobile notification handler
-          actions: data.actions ?? ['approve', 'deny', 'view_diff'],
-          type: 'approval_request',
-        },
-        sound: 'default',
-        priority: 'high',
-        // WHY "permissions" channel: reuse the existing high-urgency Android
-        // notification channel (aggressive vibration, red LED) — approval
-        // requests are at least as urgent as permission_request notifications.
-        channelId: 'permissions',
-      };
-
-    default: {
-      // WHY exhaustive check: TypeScript's never type ensures we handle every
-      // NotificationEventType. If a new type is added to the union without
-      // adding a case here, the build will fail at compile time.
-      const _exhaustiveCheck: never = type;
-      throw new Error(`Unhandled notification type: ${_exhaustiveCheck}`);
-    }
-  }
-}
+// buildNotificationPayload lives in ../_shared/notification-templates.ts
+// (imported above). All title/body/screen-routing logic for every event type
+// is in one place so it can be unit-tested from Vitest.
 
 // ============================================================================
 // Device Token Lookup


### PR DESCRIPTION
## Summary
Closes the unit-test gap on `send-push-notification`. The function was **1375 LOC with ZERO existing tests**; this PR extracts the pure template/preference/priority logic into a shared module and adds 33 Vitest tests that run in existing CI.

## Why this exists
After #316 added `cloud_task_completed` / `cloud_task_failed`, the only verification was the manual real-device walkthrough (#317). Unit tests catch regressions earlier — and protect every existing event type (permission_request, session_*, budget_*, approval_request) which previously had **0 coverage**.

## Changes
- **New** `supabase/functions/_shared/notification-templates.ts` — pure types + `VALID_EVENT_TYPES` + `BASE_PRIORITY_BY_EVENT` + `isTypeAllowed` + `buildNotificationPayload`. Mirrors the existing `_shared/expo-push.ts` convention.
- **Refactored** `send-push-notification/index.ts` to import from the shared module (~280 LOC deletion). Single source of truth.
- **New** `packages/styrby-web/src/__tests__/notification-templates.test.ts` — 33 tests across registry consistency, preference mapping, and template rendering for all 9 event types. Picked up automatically by the existing `src/**/*.test.{ts,tsx}` include glob.

## Coverage delta
| Surface | Before | After |
|---|---|---|
| send-push-notification template logic | 0 tests | 33 tests |
| cloud_task_completed/_failed rendering | manual walkthrough only | unit-tested |
| preference-mapping for ALL types | none | full positive + negative |
| Exhaustiveness guard | TS-level only | runtime-tested too |

## Test Plan
- [x] typecheck clean
- [x] 33/33 new tests passing locally
- [x] Existing styrby-web suite unaffected
- [ ] CI confirms the new test file is discovered + runs

🤖 Shipped via /gh-ship