### PR TITLE
fix(mobile): repair expo-passkey/native mocks + add missing test-mobile CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,43 @@ jobs:
       - name: Run web unit tests
         run: pnpm --filter styrby-web run test
 
+  test-mobile:
+    name: Mobile Unit Tests
+    runs-on: ubuntu-latest
+    needs: [changes, build-shared]
+    # WHY this job exists: the mobile Jest suite (96 suites / ~1680 tests) had no
+    # CI gate before — only `build-mobile` (lint + expo export) and `perf-budgets`
+    # (cold-start-proxy only) touched the mobile package. That gap let the SDK 54
+    # upgrade silently break 3 passkey/auth suites (expo-passkey/native mock
+    # specifier mismatch) without CI catching it. This job runs the full suite.
+    # Skip on PRs that don't touch mobile or shared (e.g., web-only or cli-only).
+    if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.shared == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@cb9c4fdd700176d874d52d64ce3b7418842cf6d3 # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # WHY download shared build: the mobile jest.config maps most styrby-shared
+      # specifiers to source, but any unmapped @styrby/shared subpath resolves to
+      # the package's dist/. Download it so resolution never falls through to a
+      # missing build dir. Mirrors the perf-budgets job's mobile-mapper download.
+      - name: Download shared build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: shared-build
+          path: packages/styrby-shared/dist/
+
+      - name: Run mobile unit tests
+        run: pnpm --filter styrby-mobile run test
+
   # ─── Security scanning ───
   security:
     name: Security Audit
@@ -901,7 +938,7 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [changes, quality, test-shared, test-cli, test-web, security, build-shared, build-cli, build-web, build-mobile, e2e, bundle-size, perf-budgets]
+    needs: [changes, quality, test-shared, test-cli, test-web, test-mobile, security, build-shared, build-cli, build-web, build-mobile, e2e, bundle-size, perf-budgets]
     if: always()
     steps:
       - name: Evaluate results
@@ -929,6 +966,7 @@ jobs:
           check_job "Shared Tests" "${{ needs.test-shared.result }}"
           check_job "CLI Tests" "${{ needs.test-cli.result }}"
           check_job "Web Tests" "${{ needs.test-web.result }}"
+          check_job "Mobile Tests" "${{ needs.test-mobile.result }}"
           # Security job now hard-fails on high CVEs (continue-on-error removed 2026-03-27).
           check_job "Security" "${{ needs.security.result }}"
           check_job "Build Shared" "${{ needs.build-shared.result }}"

--- a/packages/styrby-mobile/app/__tests__/auth-screens.test.tsx
+++ b/packages/styrby-mobile/app/__tests__/auth-screens.test.tsx
@@ -61,6 +61,11 @@ jest.mock('@expo/vector-icons', () => ({
   Ionicons: 'Ionicons',
 }));
 
+// NOTE: this suite renders app/(auth)/login.tsx (imports `expo-passkey/native`),
+// but needs no local passkey mock — the global stub in jest.setup.js handles it.
+// Local overrides are only needed by suites that assert on passkey calls
+// (login-passkey, passkeys).
+
 jest.mock('styrby-shared', () => ({
   decodePairingUrl: jest.fn(() => ({
     channelId: 'test-channel',

--- a/packages/styrby-mobile/app/__tests__/login-passkey.test.tsx
+++ b/packages/styrby-mobile/app/__tests__/login-passkey.test.tsx
@@ -38,7 +38,13 @@ jest.mock('../../src/lib/config', () => ({
   getApiBaseUrl: jest.fn(() => 'http://localhost:3000'),
 }));
 
-jest.mock('expo-passkey', () => ({
+// WHY 'expo-passkey/native' (not bare 'expo-passkey'): app/(auth)/login.tsx
+// imports the platform-specific `expo-passkey/native` subpath (SDK 54 / Metro
+// 0.82+ honors the exports map). Mocking the bare specifier leaves the real Expo
+// native module (`requireNativeModule`) to load, which throws "Cannot use import
+// statement outside a module" under the pure-node jest env. Mock what the source
+// actually imports.
+jest.mock('expo-passkey/native', () => ({
   __esModule: true,
   default: {
     authenticateWithPasskey: jest.fn(),

--- a/packages/styrby-mobile/app/settings/__tests__/passkeys.test.tsx
+++ b/packages/styrby-mobile/app/settings/__tests__/passkeys.test.tsx
@@ -74,7 +74,11 @@ jest.mock('../../../src/lib/config', () => ({
 
 const mockPasskeyCreate = jest.fn();
 const mockPasskeyAuthenticate = jest.fn();
-jest.mock('expo-passkey', () => ({
+// WHY 'expo-passkey/native' (not bare 'expo-passkey'): app/settings/passkeys.tsx
+// imports the platform-specific `expo-passkey/native` subpath. Mocking the bare
+// specifier leaves the real Expo native module to load and throw under the
+// pure-node jest env. Mock what the source actually imports.
+jest.mock('expo-passkey/native', () => ({
   __esModule: true,
   default: {
     createPasskey: mockPasskeyCreate,

--- a/packages/styrby-mobile/jest.config.js
+++ b/packages/styrby-mobile/jest.config.js
@@ -72,6 +72,13 @@ module.exports = {
     // optional.) Surfaced during the SDK 52→54 upgrade when
     // `expo/virtual/env.js` (a new internal SDK 54 module) failed to
     // transpile and broke ~20 test suites.
+    //
+    // NOTE on expo-passkey: it is deliberately NOT in this allow-list. It is an
+    // Expo *native* module (`requireNativeModule`) that cannot load in this
+    // pure-node test environment regardless of transpilation. The suites that
+    // touch it mock the `expo-passkey/native` subpath the source actually
+    // imports (see app/__tests__/login-passkey, app/settings/__tests__/passkeys,
+    // app/__tests__/auth-screens) rather than transforming it.
     'node_modules/(?!(\\.pnpm/.*/node_modules/)?((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|native-base|react-native-svg|styrby-shared|@styrby/shared|@supabase)/)',
   ],
   setupFiles: ['./jest.setup.js'],

--- a/packages/styrby-mobile/jest.setup.js
+++ b/packages/styrby-mobile/jest.setup.js
@@ -179,12 +179,17 @@ jest.mock('expo-camera', () => ({
  * shape (default export with createPasskey / authenticateWithPasskey) and
  * returns JSON strings, matching the production contract.
  * Tests that exercise enrollment/authentication override these with
- * jest.mock('expo-passkey', ...) locally.
+ * jest.mock('expo-passkey/native', ...) locally.
  */
-// WHY mocking 'expo-passkey' (not '/native'): Metro resolves the bare package
-// name on native platforms to build/index.native.js via platform-aware
-// resolution. Our app code imports from 'expo-passkey' to match that.
-jest.mock('expo-passkey', () => ({
+// WHY mocking 'expo-passkey/native' (the subpath, not bare): since PR #295 the
+// app code imports `ExpoPasskey from 'expo-passkey/native'` (SDK 54 / Metro
+// 0.82+ honors the package exports map; the bare import broke on-device — see
+// app/(auth)/login.tsx). This global stub MUST target the same specifier the
+// source imports, otherwise the real native module loads and throws
+// "Cannot use import statement outside a module". (Was bare 'expo-passkey'
+// pre-fix, which silently went dead when the source switched to the subpath and
+// broke the login-passkey / passkeys / auth-screens suites.)
+jest.mock('expo-passkey/native', () => ({
   __esModule: true,
   default: {
     isPasskeySupported: jest.fn(() => true),


### PR DESCRIPTION
## Summary
- The styrby-mobile Jest suite was **RED on main** (3 auth/passkey suites failed to run) but had **no CI job** — so it slipped past the gate undetected.
- Root cause: PR #295 switched the source to `import from 'expo-passkey/native'`, but the global stub + per-test mocks still targeted bare `'expo-passkey'`. The stub went dead, the real Expo native module loaded under pure-node jest, and threw `Cannot use import statement outside a module`.
- Fix retargets the mocks to the `/native` specifier the source actually imports, **and adds a `test-mobile` CI job** so mobile Jest is gated going forward.

## Changes
- `packages/styrby-mobile/jest.setup.js` — global stub `expo-passkey` → `expo-passkey/native` (+ corrected stale WHY comment)
- `packages/styrby-mobile/app/__tests__/login-passkey.test.tsx`, `app/settings/__tests__/passkeys.test.tsx` — local assertion-bearing mocks → `/native`
- `packages/styrby-mobile/app/__tests__/auth-screens.test.tsx` — drop redundant local mock (relies on global stub)
- `packages/styrby-mobile/jest.config.js` — NOTE clarifying expo-passkey is mocked, not transformed
- `.github/workflows/ci.yml` — new `test-mobile` job (mirrors `test-web`, gated on mobile||shared), wired into `summary` aggregator

## Test Plan
- [x] Mobile suite: 96/96 suites, 1690 passed / 6 skipped / **0 failed** (was 3 suites + 9 tests failing)
- [x] Mobile lint 0, typecheck 0
- [x] ci.yml valid YAML; `summary` job exits 1 on any red check (real gate)
- [ ] CI passes (incl. the new test-mobile job self-validating on this PR)

No source/runtime changes — test infra + CI only.

🤖 Shipped via /gh-ship