### PR TITLE
fix(tier): align mobile + shared to canonical Free/Pro/Growth model (unblocks Growth customers)

### DIFF
--- a/packages/styrby-mobile/app/__tests__/cloud-tasks-screen.test.tsx
+++ b/packages/styrby-mobile/app/__tests__/cloud-tasks-screen.test.tsx
@@ -56,7 +56,13 @@ jest.mock('@expo/vector-icons', () => ({
   Ionicons: 'Ionicons',
 }));
 
-jest.mock('styrby-shared', () => ({}));
+// Provide the real isPremiumTier contract so the tier gate behaves correctly.
+// (growth + power are premium; free + pro are not.) An empty stub previously
+// left isPremiumTier undefined, throwing on render.
+jest.mock('styrby-shared', () => ({
+  isPremiumTier: (tier: string | null | undefined) =>
+    tier === 'growth' || tier === 'power',
+}));
 
 // platform-billing: returns deterministic upgrade copy for assertions.
 jest.mock('@/lib/platform-billing', () => ({
@@ -149,7 +155,7 @@ describe('CloudTasksScreen', () => {
     expect(hasText(tree, 'Power Plan Required')).toBe(true);
   });
 
-  it('renders the CloudTasks component for a power user', async () => {
+  it('renders the CloudTasks component for a power user (legacy premium)', async () => {
     mockTierValue.tier = 'power';
     const tree = await renderAsync(<CloudTasksScreen />);
     expect(tree).toBeTruthy();
@@ -159,6 +165,22 @@ describe('CloudTasksScreen', () => {
     expect(serialized).toContain('CloudTasks');
     // Power user should NOT see the gate
     expect(hasText(tree, 'Power Plan Required')).toBe(false);
+  });
+
+  it('renders the CloudTasks component for a growth user (current premium)', async () => {
+    // Regression: the gate used `tier !== 'power'`, which wrongly blocked
+    // paying Growth customers. Now gated via isPremiumTier(growth) === true.
+    mockTierValue.tier = 'growth';
+    const tree = await renderAsync(<CloudTasksScreen />);
+    expect(tree).toBeTruthy();
+    expect(JSON.stringify(tree)).toContain('CloudTasks');
+    expect(hasText(tree, 'Power Plan Required')).toBe(false);
+  });
+
+  it('renders the upgrade gate for a free user', async () => {
+    mockTierValue.tier = 'free';
+    const tree = await renderAsync(<CloudTasksScreen />);
+    expect(hasText(tree, 'Power Plan Required')).toBe(true);
   });
 
   it('renders the sign-in prompt when no authenticated user', async () => {

--- a/packages/styrby-mobile/app/__tests__/settings-screen.test.tsx
+++ b/packages/styrby-mobile/app/__tests__/settings-screen.test.tsx
@@ -201,6 +201,9 @@ jest.mock('styrby-shared', () => ({
   formatTime: jest.fn((t: string | null, fallback: string) => fallback ?? t),
   getThresholdDescription: jest.fn(() => 'Medium priority'),
   getEstimatedNotificationPercentage: jest.fn(() => 50),
+  // Tier entitlement helper used by the Metrics Export row gate.
+  isPremiumTier: (tier: string | null | undefined) =>
+    tier === 'growth' || tier === 'power',
 }));
 
 // ============================================================================

--- a/packages/styrby-mobile/app/__tests__/tab-screens.test.tsx
+++ b/packages/styrby-mobile/app/__tests__/tab-screens.test.tsx
@@ -108,6 +108,9 @@ jest.mock('styrby-shared', () => ({
   ],
   PROVIDER_DISPLAY_NAMES: { anthropic: 'Anthropic', openai: 'OpenAI', google: 'Google' },
   STATIC_PRICING_LAST_VERIFIED: '2026-03-15',
+  // Tier entitlement helper used by costs.tsx gates (ExportButton, TeamCostSection).
+  isPremiumTier: (tier: string | null | undefined) =>
+    tier === 'growth' || tier === 'power',
 }));
 
 // -- Supabase client --

--- a/packages/styrby-mobile/app/cloud-tasks.tsx
+++ b/packages/styrby-mobile/app/cloud-tasks.tsx
@@ -35,6 +35,7 @@ import { CloudTaskSubmitSheet } from '../src/components/cloud-tasks/CloudTaskSub
 import { PowerTierGate } from '../src/components/tier/PowerTierGate';
 import { useSubscriptionTier } from '../src/hooks/useSubscriptionTier';
 import { cancelCloudTask } from '../src/services/cloud-tasks';
+import { isPremiumTier } from 'styrby-shared';
 
 /**
  * Renders the Cloud Tasks screen.
@@ -114,8 +115,12 @@ export default function CloudTasksScreen() {
     );
   }
 
-  // Tier gate: free + pro users get the upgrade prompt
-  if (tier !== 'power') {
+  // Tier gate: Cloud Tasks is a PREMIUM feature. Only growth (current premium)
+  // and power (legacy premium, grandfathered) are entitled; free + pro see the
+  // upgrade prompt. WHY isPremiumTier (not `tier !== 'power'`): the bare 'power'
+  // check wrongly blocked paying Growth customers — see the canonical tier model
+  // in docs/planning/styrby-tiers-canonical.md.
+  if (!isPremiumTier(tier)) {
     return (
       <>
         <Stack.Screen options={{ title: 'Cloud Tasks' }} />

--- a/packages/styrby-mobile/app/session/[id].tsx
+++ b/packages/styrby-mobile/app/session/[id].tsx
@@ -141,7 +141,7 @@ type ViewMode = 'details' | 'replay';
 export default function SessionDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [session, setSession] = useState<SessionData | null>(null);
-  const [userTier, setUserTier] = useState<'free' | 'pro' | 'power'>('free');
+  const [userTier, setUserTier] = useState<'free' | 'pro' | 'power' | 'growth'>('free');
 
   /**
    * Bookmark hook — provides the user's bookmarked session IDs and toggle fn.
@@ -233,7 +233,7 @@ export default function SessionDetailScreen() {
           .eq('user_id', user.id)
           .single();
 
-        setUserTier((subscription?.tier as 'free' | 'pro' | 'power') || 'free');
+        setUserTier((subscription?.tier as 'free' | 'pro' | 'power' | 'growth') || 'free');
 
         // Fetch billing model metadata for this session's cost records.
         // WHY: The sessions table stores total_cost_usd but not billing_model

--- a/packages/styrby-mobile/app/settings/__tests__/index.test.tsx
+++ b/packages/styrby-mobile/app/settings/__tests__/index.test.tsx
@@ -48,6 +48,14 @@ function hasText(
 // Global Mocks
 // ============================================================================
 
+// -- styrby-shared: provide the tier entitlement helper the hub imports.
+// (Every mobile test mocks styrby-shared; the real ESM barrel can't load under
+// jest's CJS resolver.) growth + power are premium.
+jest.mock('styrby-shared', () => ({
+  isPremiumTier: (tier: string | null | undefined) =>
+    tier === 'growth' || tier === 'power',
+}));
+
 // -- expo-router --
 const mockRouterPush = jest.fn();
 jest.mock('expo-router', () => ({

--- a/packages/styrby-mobile/app/settings/__tests__/metrics.test.tsx
+++ b/packages/styrby-mobile/app/settings/__tests__/metrics.test.tsx
@@ -53,6 +53,14 @@ function hasText(
 // Global Mocks
 // ============================================================================
 
+// -- styrby-shared: provide the tier entitlement helper the screen imports.
+// (Every mobile test mocks styrby-shared; the real ESM barrel can't load under
+// jest's CJS resolver.) growth + power are premium.
+jest.mock('styrby-shared', () => ({
+  isPremiumTier: (tier: string | null | undefined) =>
+    tier === 'growth' || tier === 'power',
+}));
+
 // -- @expo/vector-icons --
 jest.mock('@expo/vector-icons', () => ({
   Ionicons: 'Ionicons',

--- a/packages/styrby-mobile/app/settings/index.tsx
+++ b/packages/styrby-mobile/app/settings/index.tsx
@@ -31,6 +31,7 @@ import * as SecureStore from 'expo-secure-store';
 import { supabase } from '../../src/lib/supabase';
 import { useCurrentUser } from '../../src/hooks/useCurrentUser';
 import { useSubscriptionTier } from '../../src/hooks/useSubscriptionTier';
+import { isPremiumTier } from 'styrby-shared';
 import { SectionHeader, SettingRow } from '../../src/components/ui';
 import { THEME_PREFERENCE_KEY } from '../../src/contexts/ThemeContext';
 
@@ -226,7 +227,7 @@ export default function SettingsHubScreen() {
           icon="pulse"
           iconColor="#8b5cf6"
           title="Metrics Export"
-          subtitle={tier === 'power' ? 'OTEL export' : 'Power plan required'}
+          subtitle={isPremiumTier(tier) ? 'OTEL export' : 'Growth plan required'}
           onPress={() => router.push('/settings/metrics')}
         />
         <SettingRow

--- a/packages/styrby-mobile/app/settings/metrics.tsx
+++ b/packages/styrby-mobile/app/settings/metrics.tsx
@@ -37,6 +37,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../../src/lib/supabase';
 import { useCurrentUser } from '../../src/hooks/useCurrentUser';
 import { useSubscriptionTier } from '../../src/hooks/useSubscriptionTier';
+import { isPremiumTier } from 'styrby-shared';
 import { SectionHeader, SettingRow } from '../../src/components/ui';
 import {
   type OtelUserConfig,
@@ -62,7 +63,9 @@ import {
 export default function MetricsScreen() {
   const { user } = useCurrentUser();
   const { tier } = useSubscriptionTier(user?.id ?? null);
-  const isPowerTier = tier === 'power';
+  // Premium = growth (current) or power (legacy). OTEL export is a premium
+  // feature; the old `tier === 'power'` check wrongly excluded Growth customers.
+  const isPremium = isPremiumTier(tier);
 
   /**
    * Current OTEL configuration loaded from profiles.otel_config JSONB column.
@@ -287,7 +290,7 @@ export default function MetricsScreen() {
         keyboardShouldPersistTaps="handled"
       >
         {/* Power tier gate banner */}
-        {!isPowerTier && (
+        {!isPremium && (
           <>
             <SectionHeader title="Requirements" />
             <View className="mx-4 my-2 px-3 py-3 rounded-lg bg-purple-500/10 border border-purple-500/20">
@@ -308,7 +311,7 @@ export default function MetricsScreen() {
             iconColor="#8b5cf6"
             title="Enable OTEL Export"
             subtitle={
-              !isPowerTier
+              !isPremium
                 ? 'Power plan required'
                 : otelConfig.enabled
                   ? 'Exporting to ' + (otelConfig.endpoint
@@ -318,11 +321,11 @@ export default function MetricsScreen() {
             }
             trailing={
               <Switch
-                value={otelConfig.enabled && isPowerTier}
+                value={otelConfig.enabled && isPremium}
                 onValueChange={(v) => void handleEnabledToggle(v)}
-                disabled={!isPowerTier}
+                disabled={!isPremium}
                 trackColor={{ false: '#3f3f46', true: '#8b5cf650' }}
-                thumbColor={otelConfig.enabled && isPowerTier ? '#8b5cf6' : '#71717a'}
+                thumbColor={otelConfig.enabled && isPremium ? '#8b5cf6' : '#71717a'}
                 accessibilityRole="switch"
                 accessibilityLabel="Toggle OTEL metrics export"
               />
@@ -331,7 +334,7 @@ export default function MetricsScreen() {
         </View>
 
         {/* Configuration form — only shown for Power users */}
-        {isPowerTier && (
+        {isPremium && (
           <>
             <SectionHeader title="Provider Preset" />
             <View className="bg-background-secondary px-4 py-3">

--- a/packages/styrby-mobile/src/components/OnboardingModal.tsx
+++ b/packages/styrby-mobile/src/components/OnboardingModal.tsx
@@ -57,6 +57,8 @@ interface OnboardingModalProps {
 const TIER_DISPLAY_NAMES: Record<SubscriptionTier, string> = {
   free: 'Free',
   pro: 'Pro',
+  growth: 'Growth',
+  // Legacy values mapped to the current display name at the boundary.
   power: 'Growth',
   team: 'Growth',
 };

--- a/packages/styrby-mobile/src/components/SessionReplay.tsx
+++ b/packages/styrby-mobile/src/components/SessionReplay.tsx
@@ -65,7 +65,7 @@ interface SessionReplayProps {
   /** All messages in the session, sorted by createdAt */
   messages: ReplayMessageData[];
   /** User's subscription tier */
-  userTier: 'free' | 'pro' | 'power';
+  userTier: 'free' | 'pro' | 'power' | 'growth';
   /** Callback when replay completes */
   onComplete?: () => void;
   /** Callback when user exits replay */

--- a/packages/styrby-mobile/src/components/SessionSummary.tsx
+++ b/packages/styrby-mobile/src/components/SessionSummary.tsx
@@ -19,6 +19,7 @@ import {
   getIosManageNote,
   POLAR_CUSTOMER_PORTAL_URL,
 } from '../lib/platform-billing';
+import { isPremiumTier } from 'styrby-shared';
 
 /* ──────────────────────────── Types ──────────────────────────── */
 
@@ -36,7 +37,7 @@ export interface SessionSummaryProps {
   sessionStatus: string;
 
   /** The user's subscription tier */
-  userTier: 'free' | 'pro' | 'power';
+  userTier: 'free' | 'pro' | 'power' | 'growth';
 }
 
 /* ──────────────────────────── Helper ──────────────────────────── */
@@ -83,8 +84,10 @@ export function SessionSummary({
   const isSessionCompleted = ['stopped', 'expired', 'error'].includes(sessionStatus);
   const isSessionActive = ['starting', 'running', 'idle', 'paused'].includes(sessionStatus);
 
-  // Check if user has access to summaries
-  const hasSummaryAccess = userTier === 'pro' || userTier === 'power';
+  // Session summaries are available to all paid tiers: pro (individual) plus
+  // the premium tiers (growth/power). Previously omitted 'growth', blocking
+  // paying Growth customers.
+  const hasSummaryAccess = userTier === 'pro' || isPremiumTier(userTier);
 
   // ──────────────────────────────────────────
   // Render: Free tier upgrade prompt

--- a/packages/styrby-mobile/src/components/costs/ExportButton.tsx
+++ b/packages/styrby-mobile/src/components/costs/ExportButton.tsx
@@ -9,6 +9,7 @@
 import { Pressable, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { ExportButtonProps } from '../../types/costs';
+import { isPremiumTier } from 'styrby-shared';
 
 /**
  * Renders the export button. The orchestrator owns the format-picker logic
@@ -18,19 +19,20 @@ import type { ExportButtonProps } from '../../types/costs';
  * @returns Rendered pressable button
  */
 export function ExportButton({ tier, isExporting, onPress }: ExportButtonProps) {
-  const isPower = tier === 'power';
+  // Cost export is a premium (growth/power) feature — not just legacy 'power'.
+  const isPremium = isPremiumTier(tier);
   return (
     <Pressable
-      onPress={isPower ? onPress : undefined}
-      disabled={isExporting || !isPower}
+      onPress={isPremium ? onPress : undefined}
+      disabled={isExporting || !isPremium}
       className={`flex-row items-center px-3 py-1.5 rounded-lg border gap-1.5 active:opacity-80 ${
-        isPower
+        isPremium
           ? 'border-zinc-700 bg-zinc-800'
           : 'border-zinc-800/50 opacity-40'
       }`}
       accessibilityRole="button"
       accessibilityLabel={
-        !isPower
+        !isPremium
           ? 'Export costs, requires Power plan'
           : isExporting
             ? 'Exporting...'
@@ -45,7 +47,7 @@ export function ExportButton({ tier, isExporting, onPress }: ExportButtonProps) 
       <Text className="text-zinc-400 text-xs font-medium">
         {isExporting ? 'Exporting…' : 'Export'}
       </Text>
-      {!isPower && <Ionicons name="lock-closed" size={10} color="#52525b" />}
+      {!isPremium && <Ionicons name="lock-closed" size={10} color="#52525b" />}
     </Pressable>
   );
 }

--- a/packages/styrby-mobile/src/components/costs/TeamCostSection.tsx
+++ b/packages/styrby-mobile/src/components/costs/TeamCostSection.tsx
@@ -12,6 +12,7 @@ import { View, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { MemberCostRow } from '../../hooks/useTeamCosts';
 import type { TeamCostSectionProps } from '../../types/costs';
+import { isPremiumTier } from 'styrby-shared';
 
 /**
  * Three skeleton rows shown while team cost data is loading.
@@ -117,7 +118,9 @@ export function TeamCostSection({
 }: TeamCostSectionProps) {
   if (isLoading) return <LoadingSkeleton />;
 
-  if (userTier !== 'power') {
+  // Team Costs is a premium (growth/power) feature. The bare `!== 'power'`
+  // check wrongly gated out paying Growth customers.
+  if (!isPremiumTier(userTier)) {
     return (
       <GateMessage
         iconBgClass="bg-orange-500/15"

--- a/packages/styrby-mobile/src/hooks/__tests__/useSubscriptionTier.test.ts
+++ b/packages/styrby-mobile/src/hooks/__tests__/useSubscriptionTier.test.ts
@@ -31,12 +31,17 @@ import { useSubscriptionTier } from '../useSubscriptionTier';
 // Helpers
 // ============================================================================
 
-function mockSupabaseTier(plan: string | null, error: unknown = null) {
+// WHY the row shape is `{ tier }` (not `{ plan }`): the production column is
+// `subscriptions.tier`. The earlier mock returned `{ plan }`, mirroring the
+// hook's buggy `.select('plan')` — so the test agreed with the bug and passed
+// while every real user was silently coerced to 'free'. This mock now reflects
+// the real column, and the dedicated test below asserts `.select('tier')`.
+function mockSupabaseTier(tier: string | null, error: unknown = null) {
   const chain = {
     select: jest.fn().mockReturnThis(),
     eq: jest.fn().mockReturnThis(),
     maybeSingle: jest.fn().mockResolvedValue({
-      data: plan !== null ? { plan } : null,
+      data: tier !== null ? { tier } : null,
       error,
     }),
   };
@@ -72,7 +77,19 @@ describe('useSubscriptionTier', () => {
     expect(result.current.isPaid).toBe(false);
   });
 
-  it('returns power tier when subscription row has plan=power', async () => {
+  it('queries the `tier` column (regression: was the non-existent `plan`)', async () => {
+    const chain = mockSupabaseTier('growth');
+
+    renderHook(() => useSubscriptionTier('user-1'));
+    await act(async () => {});
+
+    expect(mockFrom).toHaveBeenCalledWith('subscriptions');
+    expect(chain.select).toHaveBeenCalledWith('tier');
+    // Guard against regressing to the broken column name.
+    expect(chain.select).not.toHaveBeenCalledWith('plan');
+  });
+
+  it('returns power tier when subscription row has tier=power', async () => {
     mockSupabaseTier('power');
 
     const { result } = renderHook(() => useSubscriptionTier('user-1'));
@@ -82,13 +99,25 @@ describe('useSubscriptionTier', () => {
     expect(result.current.isPaid).toBe(true);
   });
 
-  it('returns pro tier when subscription row has plan=pro', async () => {
+  it('returns pro tier when subscription row has tier=pro', async () => {
     mockSupabaseTier('pro');
 
     const { result } = renderHook(() => useSubscriptionTier('user-1'));
     await act(async () => {});
 
     expect(result.current.tier).toBe('pro');
+    expect(result.current.isPaid).toBe(true);
+  });
+
+  it('returns growth tier and isPaid=true (regression: Growth read as free)', async () => {
+    // 'growth' is the current premium tier (4 live subs). Before the column fix
+    // this resolved to 'free', blocking paying Growth customers everywhere.
+    mockSupabaseTier('growth');
+
+    const { result } = renderHook(() => useSubscriptionTier('user-1'));
+    await act(async () => {});
+
+    expect(result.current.tier).toBe('growth');
     expect(result.current.isPaid).toBe(true);
   });
 

--- a/packages/styrby-mobile/src/hooks/useBudgetAlerts.ts
+++ b/packages/styrby-mobile/src/hooks/useBudgetAlerts.ts
@@ -217,6 +217,8 @@ export interface UseBudgetAlertsReturn {
 const TIER_ALERT_LIMITS: Record<SubscriptionTier, number> = {
   free: 0,
   pro: 3,
+  growth: 5,
+  // Legacy premium aliases — same limit as growth.
   power: 5,
   team: 5,
 };

--- a/packages/styrby-mobile/src/hooks/useOnboarding.ts
+++ b/packages/styrby-mobile/src/hooks/useOnboarding.ts
@@ -126,6 +126,8 @@ const ALL_STEPS: Omit<ChecklistStep, 'completed'>[] = [
 const TIER_INCLUDES: Record<SubscriptionTier, SubscriptionTier[]> = {
   free: ['free'],
   pro: ['free', 'pro'],
+  // growth is the current premium tier — sees all paid steps (incl. legacy power).
+  growth: ['free', 'pro', 'power', 'growth'],
   power: ['free', 'pro', 'power'],
   team: ['free', 'pro', 'power', 'team'],
 };

--- a/packages/styrby-mobile/src/hooks/useSubscriptionTier.ts
+++ b/packages/styrby-mobile/src/hooks/useSubscriptionTier.ts
@@ -16,11 +16,13 @@ import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
 
 /**
- * Subscription tier values as stored in `subscriptions.plan`.
- * WHY string alias rather than enum: Supabase returns raw strings and we
- * want graceful handling of unknown / future tiers without throwing.
+ * Subscription tier values as stored in the `subscriptions.tier` column.
+ * Canonical model: docs/planning/styrby-tiers-canonical.md. Active tiers are
+ * 'free' | 'pro' | 'growth'; 'power' is the legacy premium tier (grandfathered).
+ * WHY the `| string` tail: Supabase returns raw strings and we want graceful
+ * handling of unknown / never-shipped enum values ('team', etc.) without throwing.
  */
-export type SubscriptionTier = 'free' | 'pro' | 'power' | string;
+export type SubscriptionTier = 'free' | 'pro' | 'power' | 'growth' | string;
 
 /**
  * Hook: fetches the user's current subscription tier.
@@ -29,7 +31,7 @@ export type SubscriptionTier = 'free' | 'pro' | 'power' | string;
  * existing settings-screen behavior.
  *
  * @param userId - Authenticated Supabase user id (pass null while unknown)
- * @returns `{ tier, isLoading, error, isPaid }` — `isPaid` is true for pro+power
+ * @returns `{ tier, isLoading, error, isPaid }` — `isPaid` is true for pro/power/growth
  *
  * @example
  * const { user } = useCurrentUser();
@@ -56,9 +58,15 @@ export function useSubscriptionTier(userId: string | null): {
     setIsLoading(true);
     (async () => {
       try {
+        // WHY 'tier' (not 'plan'): the column is `subscriptions.tier`
+        // (subscription_tier enum). There is NO `plan` column — selecting it
+        // returned a PostgREST 42703 error that the catch below swallowed to
+        // 'free', so EVERY mobile user (including paying Pro/Growth customers)
+        // was treated as free and locked out of paid features. See
+        // docs/planning/styrby-tiers-canonical.md.
         const { data, error: subError } = await supabase
           .from('subscriptions')
-          .select('plan')
+          .select('tier')
           .eq('user_id', userId)
           .maybeSingle();
 
@@ -70,7 +78,7 @@ export function useSubscriptionTier(userId: string | null): {
           setError(subError instanceof Error ? subError : new Error(String(subError)));
           setTier('free');
         } else {
-          setTier((data?.plan as SubscriptionTier | undefined) ?? 'free');
+          setTier((data?.tier as SubscriptionTier | undefined) ?? 'free');
         }
       } catch (err) {
         if (!isMounted) return;
@@ -86,7 +94,9 @@ export function useSubscriptionTier(userId: string | null): {
     };
   }, [userId]);
 
-  const isPaid = tier === 'pro' || tier === 'power';
+  // Paid = any non-free tier. Includes 'growth' (the current premium tier) —
+  // omitting it previously made Growth customers read as unpaid.
+  const isPaid = tier === 'pro' || tier === 'power' || tier === 'growth';
 
   return { tier, isLoading, error, isPaid };
 }

--- a/packages/styrby-mobile/src/hooks/useTeamCosts.ts
+++ b/packages/styrby-mobile/src/hooks/useTeamCosts.ts
@@ -16,6 +16,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
+import { isPremiumTier } from 'styrby-shared';
 
 // ============================================================================
 // Types
@@ -124,7 +125,9 @@ export function useTeamCosts(rangeStartDate: string): UseTeamCostsReturn {
       .eq('user_id', user.id)
       .single();
 
-    if (subscription?.tier !== 'power') {
+    // Team cost rollup is a premium (growth/power) feature. The old
+    // `!== 'power'` check made paying Growth customers ineligible.
+    if (!isPremiumTier(subscription?.tier)) {
       setIsEligible(false);
       return null;
     }

--- a/packages/styrby-shared/src/billing/__tests__/tier-logic.test.ts
+++ b/packages/styrby-shared/src/billing/__tests__/tier-logic.test.ts
@@ -9,6 +9,7 @@ import {
   isTierFeatureEnabled,
   getFeatureLimitFor,
   normalizeTier,
+  isPremiumTier,
 } from '../tier-logic.js';
 
 describe('isTierFeatureEnabled', () => {
@@ -77,10 +78,54 @@ describe('normalizeTier', () => {
     expect(normalizeTier('team')).toBe('team');
   });
 
+  it('passes through growth (regression: was silently coerced to free)', () => {
+    // WHY: 'growth' is the current premium tier (4 live subscriptions). Before
+    // this fix normalizeTier lacked a 'growth' case, so a Growth customer's
+    // tier read from the DB was coerced to 'free', locking them out of paid
+    // features. Canonical model: docs/planning/styrby-tiers-canonical.md.
+    expect(normalizeTier('growth')).toBe('growth');
+  });
+
   it('defaults to free for null / undefined / unknown', () => {
     expect(normalizeTier(null)).toBe('free');
     expect(normalizeTier(undefined)).toBe('free');
     expect(normalizeTier('enterprise')).toBe('free');
     expect(normalizeTier('')).toBe('free');
+  });
+});
+
+describe('isPremiumTier', () => {
+  it('is true for the premium tiers (growth + legacy power)', () => {
+    expect(isPremiumTier('growth')).toBe(true);
+    expect(isPremiumTier('power')).toBe(true);
+  });
+
+  it('is false for free and paid-individual pro', () => {
+    // 'pro' is paid but NOT premium — premium features (Cloud Tasks, smart
+    // filter, OTEL export) require growth/power.
+    expect(isPremiumTier('pro')).toBe(false);
+    expect(isPremiumTier('free')).toBe(false);
+  });
+
+  it('is false (fail-closed) for never-shipped / unknown / nullish tiers', () => {
+    expect(isPremiumTier('team')).toBe(false);
+    expect(isPremiumTier('business')).toBe(false);
+    expect(isPremiumTier('enterprise')).toBe(false);
+    expect(isPremiumTier(null)).toBe(false);
+    expect(isPremiumTier(undefined)).toBe(false);
+    expect(isPremiumTier('mystery')).toBe(false);
+  });
+});
+
+describe('growth tier feature gating (TIER_LIMITS coverage)', () => {
+  it('grants growth the full premium feature set including teamFeatures', () => {
+    expect(isTierFeatureEnabled('growth', 'teamFeatures')).toBe(true);
+    expect(isTierFeatureEnabled('growth', 'apiAccess')).toBe(true);
+    expect(isTierFeatureEnabled('growth', 'budgetAlerts')).toBe(true);
+    expect(isTierFeatureEnabled('growth', 'costDashboard')).toBe(true);
+  });
+
+  it('keeps pro NON-team (teamFeatures false) — premium ≠ pro', () => {
+    expect(isTierFeatureEnabled('pro', 'teamFeatures')).toBe(false);
   });
 });

--- a/packages/styrby-shared/src/billing/tier-logic.ts
+++ b/packages/styrby-shared/src/billing/tier-logic.ts
@@ -19,12 +19,38 @@
 import { TIER_LIMITS } from '../constants.js';
 
 /**
- * The four tier identifiers that exist anywhere in the system.
+ * The subscription tier identifiers. See the canonical tier model in
+ * `docs/planning/styrby-tiers-canonical.md` (verified live 2026-06-08).
  *
- * `'team'` is reserved for the Teams plan that is not yet GA; helpers below
- * recognise it but mobile/web should not surface it until billing ships it.
+ * ACTIVE (sold today): `'free'`, `'pro'`, `'growth'`.
+ * LEGACY: `'power'` — the pre-cutover premium tier, replaced by `'growth'`;
+ *   one grandfathered customer remains in production, so it must keep working,
+ *   but never offer it to new users.
+ * `'team'` is a never-shipped placeholder retained only because `TIER_LIMITS`
+ *   and the DB enum still carry it; do not surface it.
  */
-export type TierId = 'free' | 'pro' | 'power' | 'team';
+export type TierId = 'free' | 'pro' | 'power' | 'growth' | 'team';
+
+/**
+ * Returns true when the tier grants PREMIUM (top-tier) features — Cloud Tasks,
+ * Notifications smart-filter, Metrics OTEL export, etc.
+ *
+ * Premium = `'growth'` (current premium tier) OR `'power'` (legacy premium,
+ * grandfathered). `'pro'` is a paid INDIVIDUAL tier and is NOT premium;
+ * `'free'` is not premium. This is the single entitlement gate every premium
+ * feature should call — never compare against a bare tier string.
+ *
+ * @param tier - The user's resolved subscription tier.
+ * @returns `true` when the tier is `'growth'` or `'power'`.
+ *
+ * @example
+ * ```ts
+ * if (!isPremiumTier(tier)) return <UpgradePrompt feature="Cloud Tasks" />;
+ * ```
+ */
+export function isPremiumTier(tier: TierId | string | null | undefined): boolean {
+  return tier === 'growth' || tier === 'power';
+}
 
 /**
  * The set of features that are gated by tier. Each entry maps to a property
@@ -113,9 +139,12 @@ export function normalizeTier(raw: string | null | undefined): TierId {
   switch (raw) {
     case 'pro':
     case 'power':
+    case 'growth':
     case 'team':
       return raw;
     default:
+      // WHY fail-closed to 'free': unknown / legacy-unused values
+      // ('business', 'enterprise') and typos must never grant a paid tier.
       return 'free';
   }
 }

--- a/packages/styrby-shared/src/types.ts
+++ b/packages/styrby-shared/src/types.ts
@@ -45,8 +45,14 @@ export interface SessionCost {
   model: string;
 }
 
-/** User subscription tier */
-export type SubscriptionTier = 'free' | 'pro' | 'power' | 'team';
+/**
+ * User subscription tier. Canonical model: `docs/planning/styrby-tiers-canonical.md`.
+ * Active (sold): 'free' | 'pro' | 'growth'. Legacy: 'power' (1 grandfathered
+ * customer). 'team' is a never-shipped placeholder retained for the DB enum.
+ * Prefer the {@link TierId} union + {@link isPremiumTier} helper from
+ * `billing/tier-logic` for gating decisions.
+ */
+export type SubscriptionTier = 'free' | 'pro' | 'power' | 'growth' | 'team';
 
 // ============================================================================
 // Phase 7.14 — Contribution/Activity Graph

--- a/supabase/migrations/093_subscription_tier_add_growth.sql
+++ b/supabase/migrations/093_subscription_tier_add_growth.sql
@@ -1,0 +1,30 @@
+-- Migration 093: Record 'growth' in the subscription_tier enum.
+--
+-- SCHEMA-DRIFT CLOSED:
+--   `subscription_tier` (migration 001 line 59, extended by 055) is the
+--   enum ['free','pro','power','team','business','enterprise']. The Growth
+--   tier shipped in Phase 5 and the Polar webhook (getTierFromProductId)
+--   writes 'growth' to subscriptions.tier — yet no tracked migration ever
+--   added 'growth' to the enum. Production already contains the value (it was
+--   added directly via the Management API: live introspection on 2026-06-08
+--   shows the enum as ['free','pro','power','team','business','enterprise',
+--   'growth'], with 4 live subscriptions on tier='growth'). This migration
+--   records that change in the schema files so they match production reality.
+--
+-- WHY this matters: without the value in the migration history, a fresh
+--   environment (local reset, new preview branch, DR rebuild) would recreate
+--   the enum WITHOUT 'growth', and the first Growth checkout webhook would
+--   raise SQLSTATE 22P02 ("invalid input value for enum subscription_tier").
+--
+-- CANONICAL MODEL: docs/planning/styrby-tiers-canonical.md
+--   Active tiers: free | pro | growth. Legacy: power (1 grandfathered
+--   customer). team/business/enterprise: never shipped (enum-only).
+--
+-- CONSTRAINT: Postgres cannot reference a newly-added enum value in the same
+--   transaction (SQLSTATE 55P04). This migration only ADDs the value; any code
+--   needing to CAST to it must do so in a later migration. (Idempotent — no-op
+--   in production where the value already exists.)
+--
+-- Governing: SOC2 CC7.2 (data integrity — schema-of-record matches runtime).
+
+ALTER TYPE public.subscription_tier ADD VALUE IF NOT EXISTS 'growth';


### PR DESCRIPTION
## Summary
PR **1 of 2** implementing the canonical tier remediation (`docs/planning/styrby-tiers-canonical.md`, verified live against Polar + DB + website). Fixes a **systemic entitlement bug**: the codebase carried the abandoned `'power'`-only premium taxonomy and never handled `'growth'` (the current premium tier — **4 live subs**), so paying Growth customers were locked out of premium features on mobile. The mobile tier hook also read a **non-existent column**, treating every mobile user as free.

## Changes (23 files + 1 migration)
**shared**
- `SubscriptionTier` (types.ts) + `TierId`/`normalizeTier` (tier-logic.ts): add `'growth'` (normalizeTier previously coerced `growth`→`free`)
- New **`isPremiumTier()`** helper (premium = growth|power) — the single entitlement gate. +12 tests

**mobile** (web already correct via `toLegacyTierId`)
- `useSubscriptionTier`: **BUG FIX** — `.select('tier')` not the non-existent `.select('plan')` (which errored → caught → `'free'` for everyone). Existing test mocked the same wrong column (`{plan}`), masking it — now `{tier}` and asserts `.select('tier')`. +growth test
- Replaced **7** bare `tier === 'power'` gates with `isPremiumTier` (cloud-tasks, settings/metrics, settings/index, TeamCostSection, ExportButton, SessionSummary, useTeamCosts)
- Added `'growth'` to 3 `Record<SubscriptionTier,_>` maps + 3 inline unions; updated 4 test mocks
- `platform-billing` left as-is (required-tier→label mapper, callers pass constants — not buggy)

**db**: migration 093 — idempotent `ADD VALUE IF NOT EXISTS 'growth'` (records the value already live in prod; prevents fresh-rebuild 22P02 on first Growth checkout)

## Test Plan
- [x] typecheck 5/5 · lint 0 errors · build shared+cli+web 3/3
- [x] mobile 96/96 suites (1694 pass / 0 fail) · shared 1450 · cli 2931
- [x] web 3853/3854 — the 1 fail is the **pre-existing LAUNCH-2 ChurnSaveOfferCard timing flake** (untouched here; passes 15/15 isolated)
- [ ] CI passes

> Note for CI: the ChurnSaveOfferCard flake may surface under full-suite parallelism on web-test. Pre-existing + unrelated — a re-run clears it.

Follow-up **PR 2** adds `cloud_tasks` RLS server-side premium enforcement (split: production data-access policy change, different risk).

🤖 Shipped via /gh-ship