### PR TITLE
fix(db): make audit_trigger_fn FK-safe on profile deletion (root-cause)

### DIFF
--- a/supabase/migrations/096_audit_trigger_profile_delete_fk_safe.sql
+++ b/supabase/migrations/096_audit_trigger_profile_delete_fk_safe.sql
@@ -1,0 +1,99 @@
+-- Migration 096: Make audit_trigger_fn FK-safe on profile deletion.
+--
+-- ROOT-CAUSE BUG:
+--   audit_log.user_id has FK -> profiles(id) ON DELETE SET NULL (migration 001).
+--   audit_trigger_fn (migration 053) fires AFTER DELETE on profiles and inserts
+--   an audit row with user_id = COALESCE((OLD).user_id, auth.uid()). For a
+--   profiles DELETE the resolved id is the profile being deleted (profiles.id ==
+--   the user id; and during a GoTrue admin/self delete auth.uid() is that same
+--   id). The profile row is already gone by the time the AFTER-DELETE trigger
+--   inserts, so the new audit row references a non-existent profile and the
+--   INSERT raises SQLSTATE 23503 (audit_log_user_id_fkey) — which ABORTS the
+--   whole deletion.
+--
+--   Impact: ANY profile deletion 500s — admin user deletion AND, critically,
+--   the self-service GDPR "delete my account" flow. (Surfaced 2026-06-09 while
+--   removing leaked e2e test users from production.)
+--
+--   This is profiles-specific: for every other audited table a DELETE's
+--   user_id points at the OWNER's profile, and in an auth.users cascade the
+--   child rows are deleted BEFORE the parent profile, so the owner still
+--   exists when their audit row is written. profiles is the only table whose
+--   audited row IS the FK target.
+--
+-- FIX:
+--   On a profiles DELETE, set the audit row's user_id to
+--   NULLIF(auth.uid(), OLD.id):
+--     - admin deletes another user  -> auth.uid() = admin (a live profile) -> recorded
+--     - user deletes own account    -> auth.uid() = OLD.id                 -> NULL
+--     - service-role cascade delete -> auth.uid() = NULL                   -> NULL
+--   user_id = NULL is permitted by the column + FK. The deleted profile's id
+--   and full snapshot are still captured in resource_id + metadata.record, and
+--   the acting principal is recorded in metadata.actor — so the deletion audit
+--   is preserved without a dangling FK.
+--
+--   All non-profiles behavior is unchanged.
+--
+-- Governing: SOC2 CC7.2 (audit completeness) + GDPR Art.17 (erasure must work).
+
+CREATE OR REPLACE FUNCTION public.audit_trigger_fn()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_record jsonb;
+  v_user_id uuid;       -- subject (owner) id read off the row, if it has one
+  v_final_user_id uuid; -- FK-safe value actually written to audit_log.user_id
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_record := to_jsonb(OLD);
+    BEGIN
+      v_user_id := (OLD).user_id;
+    EXCEPTION WHEN others THEN
+      v_user_id := NULL;
+    END;
+  ELSE
+    v_record := to_jsonb(NEW);
+    BEGIN
+      v_user_id := (NEW).user_id;
+    EXCEPTION WHEN others THEN
+      v_user_id := NULL;
+    END;
+  END IF;
+
+  IF TG_OP = 'DELETE' AND TG_TABLE_NAME = 'profiles' THEN
+    -- The subject profile is being deleted; never reference it. Record the
+    -- actor only when it is a DIFFERENT, still-existing user (admin delete);
+    -- otherwise NULL (self-deletion / service-role cascade). FK-safe always.
+    v_final_user_id := NULLIF(auth.uid(), (v_record->>'id')::uuid);
+  ELSE
+    v_final_user_id := COALESCE(v_user_id, auth.uid());
+  END IF;
+
+  INSERT INTO public.audit_log (
+    user_id,
+    action,
+    resource_type,
+    resource_id,
+    metadata,
+    created_at
+  ) VALUES (
+    v_final_user_id,
+    'record_mutated'::audit_action,
+    TG_TABLE_NAME,
+    (v_record->>'id')::uuid,
+    jsonb_build_object(
+      'operation', TG_OP,
+      'table', TG_TABLE_NAME,
+      'record', v_record,
+      'actor', auth.uid(),
+      'control_ref', 'SOC2 CC7.2'
+    ),
+    now()
+  );
+
+  RETURN NULL;
+END;
+$$;

--- a/supabase/tests/rls/096_audit_trigger_profile_delete.sql
+++ b/supabase/tests/rls/096_audit_trigger_profile_delete.sql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- BEHAVIOR TEST: Migration 096 (audit_trigger_fn FK-safe on profile delete)
+-- ============================================================================
+-- Proves a profile can be DELETEd without the audit trigger raising
+-- 23503 (audit_log_user_id_fkey), across the three real paths, and that the
+-- deletion is still audited correctly.
+--
+-- USAGE (local):
+--   supabase db reset
+--   psql "$DB_URL" -f supabase/tests/rls/096_audit_trigger_profile_delete.sql
+--
+-- Invariants:
+--   1. Self-service delete (auth.uid() == the profile) succeeds; audit row has
+--      user_id = NULL, resource_id = deleted id, metadata.actor = self.
+--   2. Admin delete (auth.uid() = a different, live user) succeeds; audit row
+--      has user_id = the admin (FK-valid), resource_id = the deleted profile.
+--   3. Cascade delete via auth.users (no auth.uid()) succeeds; no 23503.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION _set_uid(p_uid uuid) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub', COALESCE(p_uid::text,''), true);
+  PERFORM set_config('request.jwt.claims',
+    CASE WHEN p_uid IS NULL THEN '' ELSE json_build_object('sub',p_uid::text,'role','authenticated')::text END, true);
+END;$$;
+
+BEGIN;
+
+-- Test 1: self-service account deletion (the GDPR path that used to 500)
+DO $$
+DECLARE u uuid := gen_random_uuid(); n int; logged record;
+BEGIN
+  INSERT INTO auth.users (id, email) VALUES (u, 'selfdel96@test.local');
+  INSERT INTO profiles (id) VALUES (u) ON CONFLICT DO NOTHING;
+  PERFORM _set_uid(u);                         -- acting as myself
+  DELETE FROM public.profiles WHERE id = u;    -- must NOT raise 23503
+  PERFORM _set_uid(NULL);
+  SELECT count(*) INTO n FROM profiles WHERE id = u;
+  IF n <> 0 THEN RAISE EXCEPTION 'TEST 1 FAILED: profile not deleted'; END IF;
+  SELECT user_id, resource_id INTO logged FROM audit_log
+    WHERE resource_type='profiles' AND resource_id=u ORDER BY created_at DESC LIMIT 1;
+  IF logged.resource_id <> u THEN RAISE EXCEPTION 'TEST 1 FAILED: deletion not audited'; END IF;
+  IF logged.user_id IS NOT NULL THEN RAISE EXCEPTION 'TEST 1 FAILED: self-delete audit user_id should be NULL, got %', logged.user_id; END IF;
+  RAISE NOTICE 'TEST 1 PASS: self-service profile delete works + audited (user_id NULL)';
+END;$$;
+
+ROLLBACK; BEGIN;
+
+-- Test 2: admin deletes another user — actor recorded, FK-valid
+DO $$
+DECLARE admin uuid := gen_random_uuid(); target uuid := gen_random_uuid(); logged record;
+BEGIN
+  INSERT INTO auth.users (id, email) VALUES (admin,'admin96@test.local'),(target,'target96@test.local');
+  INSERT INTO profiles (id) VALUES (admin) ON CONFLICT DO NOTHING;
+  INSERT INTO profiles (id) VALUES (target) ON CONFLICT DO NOTHING;
+  PERFORM _set_uid(admin);                       -- admin is the actor
+  DELETE FROM public.profiles WHERE id = target; -- must NOT raise 23503
+  PERFORM _set_uid(NULL);
+  SELECT user_id, resource_id INTO logged FROM audit_log
+    WHERE resource_type='profiles' AND resource_id=target ORDER BY created_at DESC LIMIT 1;
+  IF logged.user_id <> admin THEN RAISE EXCEPTION 'TEST 2 FAILED: expected actor=admin in user_id, got %', logged.user_id; END IF;
+  RAISE NOTICE 'TEST 2 PASS: admin profile delete works + records live actor';
+END;$$;
+
+ROLLBACK; BEGIN;
+
+-- Test 3: cascade delete via auth.users (service-role path, no auth.uid())
+DO $$
+DECLARE u uuid := gen_random_uuid(); n int;
+BEGIN
+  INSERT INTO auth.users (id, email) VALUES (u,'cascade96@test.local');
+  INSERT INTO profiles (id) VALUES (u) ON CONFLICT DO NOTHING;
+  PERFORM _set_uid(NULL);
+  DELETE FROM auth.users WHERE id = u;        -- cascades to profiles; must NOT raise 23503
+  SELECT count(*) INTO n FROM profiles WHERE id = u;
+  IF n <> 0 THEN RAISE EXCEPTION 'TEST 3 FAILED: cascade did not remove profile'; END IF;
+  RAISE NOTICE 'TEST 3 PASS: auth.users cascade delete works (no FK abort)';
+END;$$;
+
+ROLLBACK;
+
+DROP FUNCTION IF EXISTS _set_uid(uuid);
+
+DO $$ BEGIN
+  RAISE NOTICE '================================================================';
+  RAISE NOTICE 'ALL TESTS PASSED — migration 096 profile-delete audit is FK-safe';
+  RAISE NOTICE '================================================================';
+END;$$;


### PR DESCRIPTION
## Summary
Root-cause fix for the audit-trigger bug that **500'd every profile deletion** — including the self-service **GDPR "delete my account"** flow. Surfaced while removing leaked e2e test users (all 196 admin-API deletes returned 500).

**Cause:** `audit_log.user_id` has FK → `profiles(id)`. `audit_trigger_fn` (053) fires AFTER DELETE on profiles and inserts an audit row with `user_id` = the profile being deleted — but it's already gone, so the FK fails (`23503`) and aborts the delete. profiles is the only self-referential case (other tables' DELETE audit references the still-present owner; cascades delete children before the parent profile — which is why bulk subscription deletes worked).

**Fix:** on a `profiles` DELETE, write `user_id = NULLIF(auth.uid(), OLD.id)` — the actor when it's a different live user (admin delete), NULL for self-deletion / service-role cascade. FK-safe everywhere. The deleted id + snapshot stay in `resource_id` + `metadata.record`, actor in `metadata.actor`, so the audit is preserved (SOC2 CC7.2).

## Changes
- `supabase/migrations/096_audit_trigger_profile_delete_fk_safe.sql` — `CREATE OR REPLACE audit_trigger_fn`
- `supabase/tests/rls/096_audit_trigger_profile_delete.sql` — behavior test (self / admin / cascade)

## Test Plan
- [x] Behavior test 3/3 on real Postgres (full 001–096 stack): self-delete → `user_id` NULL; admin-delete → live actor recorded; `auth.users` cascade → no 23503
- [x] **Applied to production**; verified the exact prior failure (admin-API user delete) now returns **200 OK**
- [ ] CI passes (migrations `db reset` re-validates the stack)

🤖 Shipped via /gh-ship