### PR TITLE
chore(web): clear 96 pre-existing lint warnings (dead code + a11y + hooks-dep)

### DIFF
--- a/packages/styrby-web/src/__tests__/admin/middleware.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/middleware.integration.test.ts
@@ -376,7 +376,7 @@ describe('admin middleware integration', () => {
       // WHY: startsWith('/dashboard/admin') would match /dashboardfake if the
       // boundary check is wrong. Verify the gate is exact-boundary only.
       const req = makeRequest('/dashboardfake', false);
-      const response = await middleware(req);
+      await middleware(req);
 
       // Middleware should NOT gate this path as an admin path.
       // No env configured, so if the guard fired we'd get 404.

--- a/packages/styrby-web/src/__tests__/admin/webhook-override.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/webhook-override.integration.test.ts
@@ -102,33 +102,6 @@ function signPayload(payload: string): string {
 }
 
 /**
- * Creates a mock Polar webhook Request with a valid HMAC signature.
- *
- * @param body - Event payload object.
- * @param overrideSignature - If provided, use this signature instead of a valid one.
- */
-function createWebhookRequest(
-  body: Record<string, unknown>,
-  overrideSignature?: string,
-): Request {
-  const payload   = JSON.stringify(body);
-  const signature = overrideSignature ?? signPayload(payload);
-
-  const headersMock = new Headers();
-  headersMock.set('polar-signature', signature);
-  headersMock.set('x-forwarded-for', '1.2.3.4');
-
-  return new Request('http://localhost:3000/api/webhooks/polar', {
-    method: 'POST',
-    headers: {
-      'Content-Type':    'application/json',
-      'x-forwarded-for': '1.2.3.4',
-    },
-    body: payload,
-  });
-}
-
-/**
  * Standard subscription.created/updated event payload.
  *
  * @param overrides - Fields to merge into the data object.

--- a/packages/styrby-web/src/__tests__/billing-ops/credit-lifecycle.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/billing-ops/credit-lifecycle.integration.test.ts
@@ -256,7 +256,7 @@ describe('Credit lifecycle — issue + revoke + RLS', () => {
     mockRpc.mockResolvedValueOnce({ data: { audit_id: 150 }, error: null });
 
     const supabase = await createClient();
-    const { data, error } = await supabase.rpc('admin_revoke_credit', {
+    const { error } = await supabase.rpc('admin_revoke_credit', {
       p_credit_id: CREDIT_ID_1,
       p_reason:    'admin correction — credit issued in error',
     });

--- a/packages/styrby-web/src/__tests__/handoff-route.test.ts
+++ b/packages/styrby-web/src/__tests__/handoff-route.test.ts
@@ -149,7 +149,7 @@ function buildChain(
    * `maybeSingle` and `single` which return the real resolvers.
    */
   function makeChain(): Record<string, unknown> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     const proxy: any = new Proxy(
       {},
       {
@@ -185,7 +185,7 @@ vi.mock('@/lib/supabase/server', () => ({
 
 describe('GET /api/sessions/[id]/handoff', () => {
   // Dynamically import the route handler AFTER mocks are set up.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   
   let GET: (...args: any[]) => Promise<NextResponse>;
 
   beforeEach(async () => {

--- a/packages/styrby-web/src/__tests__/support-access/expiry.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/support-access/expiry.integration.test.ts
@@ -76,7 +76,7 @@ vi.mock('next/headers', () => ({
 const mockSentryCapture = vi.fn();
 vi.mock('@sentry/nextjs', () => ({
   captureException: (...args: unknown[]) => mockSentryCapture(...args),
-  captureMessage:   (...args: unknown[]) => void 0,
+  captureMessage:   (..._args: unknown[]) => void 0,
 }));
 
 const mockRpc = vi.fn();

--- a/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/support-access/full-approval-flow.integration.test.ts
@@ -106,7 +106,7 @@ vi.mock('next/headers', () => ({
 const mockSentryCapture = vi.fn();
 vi.mock('@sentry/nextjs', () => ({
   captureException: (...args: unknown[]) => mockSentryCapture(...args),
-  captureMessage:   (...args: unknown[]) => void 0,
+  captureMessage:   (..._args: unknown[]) => void 0,
 }));
 
 // ── Supabase ──────────────────────────────────────────────────────────────────
@@ -594,7 +594,7 @@ describe('Audit side effects — RPC is the sole audit channel', () => {
     const mockUpdate = vi.fn();
     const ticketChain = makeTicketFromChain();
     // Augment the chain with insert/update spies to detect any rogue DML.
-    mockFrom.mockImplementation((table: string) => ({
+    mockFrom.mockImplementation((_table: string) => ({
       ...ticketChain,
       insert: mockInsert,
       update: mockUpdate,

--- a/packages/styrby-web/src/__tests__/support-access/revoke-after-approve.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/support-access/revoke-after-approve.integration.test.ts
@@ -63,7 +63,7 @@ vi.mock('next/headers', () => ({
 const mockSentryCapture = vi.fn();
 vi.mock('@sentry/nextjs', () => ({
   captureException: (...args: unknown[]) => mockSentryCapture(...args),
-  captureMessage:   (...args: unknown[]) => void 0,
+  captureMessage:   (..._args: unknown[]) => void 0,
 }));
 
 const mockRpc  = vi.fn();

--- a/packages/styrby-web/src/app/api/account/retention/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/account/retention/__tests__/route.test.ts
@@ -12,7 +12,6 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NextRequest } from 'next/server';
 
 // ============================================================================
 // Mocks
@@ -20,9 +19,6 @@ import { NextRequest } from 'next/server';
 
 const mockGetUser = vi.fn();
 const mockFrom = vi.fn();
-const mockAuditInsert = vi.fn();
-const mockProfileUpdate = vi.fn();
-const mockProfileSelect = vi.fn();
 
 /**
  * Build a minimal Supabase chain mock.
@@ -71,23 +67,6 @@ function setupProfileSelect(retentionDays: number | null) {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     single: vi.fn().mockResolvedValue({ data: { retention_days: retentionDays }, error: null }),
-  };
-  return chain;
-}
-
-function setupProfileUpdate(success = true) {
-  const chain = {
-    update: vi.fn().mockReturnThis(),
-    eq: vi.fn().mockResolvedValue({
-      error: success ? null : { message: 'DB error' },
-    }),
-  };
-  return chain;
-}
-
-function setupAuditInsert() {
-  const chain = {
-    insert: vi.fn().mockResolvedValue({ error: null }),
   };
   return chain;
 }
@@ -185,7 +164,6 @@ describe('PUT /api/account/retention', () => {
     setupAuthUser();
 
     const auditInsertSpy = vi.fn().mockResolvedValue({ error: null });
-    const profileUpdateSpy = vi.fn().mockReturnThis();
     const profileEqSpy = vi.fn().mockResolvedValue({ error: null });
 
     const callOrder: string[] = [];

--- a/packages/styrby-web/src/app/api/admin/founder-error-histogram/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-error-histogram/route.ts
@@ -61,18 +61,6 @@ type HistogramDay = {
   date: string;
 } & Record<ErrorClass, number>;
 
-/**
- * Raw row from the Supabase audit_log aggregation query.
- */
-interface AuditLogRow {
-  /** ISO date string (YYYY-MM-DD) from DATE_TRUNC('day', created_at) */
-  record_date: string;
-  /** error_class value (one of ERROR_CLASSES) */
-  error_class: string;
-  /** Count of rows for this (date, error_class) combination */
-  count: number;
-}
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/packages/styrby-web/src/app/api/admin/founder-team-metrics/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-team-metrics/route.ts
@@ -59,12 +59,6 @@ interface TeamDbRow {
   created_at: string;
 }
 
-/** team_members aggregation row. */
-interface MemberCountRow {
-  team_id: string;
-  count: number;
-}
-
 /** Subscription row for owner tier. */
 interface SubscriptionRow {
   user_id: string;

--- a/packages/styrby-web/src/app/api/cron/openrouter-credit-monitor/route.ts
+++ b/packages/styrby-web/src/app/api/cron/openrouter-credit-monitor/route.ts
@@ -111,7 +111,6 @@ interface OpenRouterAuthKeyResponse {
 import {
   computeCycleMetrics,
   formatCentralTimestamp,
-  type CycleMetrics,
 } from './cycle-metrics';
 
 export async function GET(request: NextRequest) {

--- a/packages/styrby-web/src/app/api/sessions/[id]/replay/[tokenId]/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/sessions/[id]/replay/[tokenId]/__tests__/route.test.ts
@@ -82,7 +82,7 @@ describe('DELETE /api/sessions/[id]/replay/[tokenId]', () => {
         getUser: vi.fn(async () => ({ data: { user: null }, error: new Error('no auth') })),
       },
       from: vi.fn(),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     } as any);
 
     const res = await makeDeleteRequest('session-1', 'token-1');

--- a/packages/styrby-web/src/app/api/sessions/[id]/replay/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/sessions/[id]/replay/__tests__/route.test.ts
@@ -109,7 +109,7 @@ describe('POST /api/sessions/[id]/replay', () => {
         getUser: vi.fn(async () => ({ data: { user: null }, error: new Error('not auth') })),
       },
       from: vi.fn(),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     } as any);
 
     const res = await makeRequest('session-123', validBody);

--- a/packages/styrby-web/src/app/api/teams/[id]/costs/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/costs/__tests__/route.test.ts
@@ -87,21 +87,6 @@ function setupAuthUser() {
   });
 }
 
-/**
- * Creates a chainable from() mock that resolves with the given result.
- *
- * WHY this helper: The route calls supabase.from('team_members').select().eq().eq().maybeSingle()
- * which requires a chainable mock that returns the result only on maybeSingle().
- */
-function makeFromChain(result: { data?: unknown; error?: unknown }) {
-  const chain: Record<string, unknown> = {};
-  for (const method of ['select', 'eq', 'gte', 'lte', 'order', 'limit', 'not', 'maybeSingle']) {
-    chain[method] = vi.fn().mockReturnValue(chain);
-  }
-  (chain['maybeSingle'] as ReturnType<typeof vi.fn>).mockResolvedValue(result);
-  return vi.fn().mockReturnValue(chain);
-}
-
 // ============================================================================
 // Tests
 // ============================================================================

--- a/packages/styrby-web/src/app/api/teams/[id]/sso/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/sso/__tests__/route.test.ts
@@ -23,13 +23,6 @@ import { NextRequest } from 'next/server';
 // ============================================================================
 
 const mockGetUser = vi.fn();
-const mockInsert = vi.fn();
-const mockUpdate = vi.fn();
-const mockSelect = vi.fn();
-const mockSingle = vi.fn();
-const mockEq = vi.fn();
-const mockIn = vi.fn();
-const mockContains = vi.fn();
 const mockRpc = vi.fn();
 
 /**

--- a/packages/styrby-web/src/app/api/v1/account/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/account/__tests__/route.test.ts
@@ -546,7 +546,7 @@ describe('GET /api/v1/account', () => {
     // TypeScript's structural check on withApiAuthAndRateLimit's overloaded
     // signature is too narrow to accept { keyExpiresAt: null }. The cast is safe
     // here because the handler receives the context directly at runtime.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     (withApiAuthAndRateLimit as any).mockImplementationOnce(
       (handler: (req: NextRequest, ctx: Record<string, unknown>) => Promise<NextResponse>) => {
         return async (request: NextRequest) =>

--- a/packages/styrby-web/src/app/api/v1/auth/oauth/callback/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/auth/oauth/callback/__tests__/route.test.ts
@@ -171,7 +171,6 @@ import { POST } from '../route';
 import { OAUTH_CALLBACK_RATE_LIMIT, KEY_TTL_DAYS } from '@/lib/auth/api-config';
 import * as Sentry from '@sentry/nextjs';
 import { rateLimit } from '@/lib/rateLimit';
-import { generateApiKey } from '@styrby/shared';
 import { hashApiKey } from '@/lib/api-keys';
 
 // ============================================================================

--- a/packages/styrby-web/src/app/api/v1/auth/oauth/start/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/auth/oauth/start/__tests__/route.test.ts
@@ -104,7 +104,7 @@ vi.mock('@/lib/supabase/server', () => ({
 // ============================================================================
 
 import { POST } from '../route';
-import { OAUTH_START_RATE_LIMIT, OAUTH_ALLOWED_REDIRECT_ORIGINS, MAX_REDIRECT_URL_LENGTH, isAllowedRedirectOrigin, extractStateFromAuthUrl } from '@/lib/auth/api-config';
+import { OAUTH_START_RATE_LIMIT, MAX_REDIRECT_URL_LENGTH, isAllowedRedirectOrigin, extractStateFromAuthUrl } from '@/lib/auth/api-config';
 import * as Sentry from '@sentry/nextjs';
 import { rateLimit } from '@/lib/rateLimit';
 

--- a/packages/styrby-web/src/app/api/v1/auth/oauth/start/route.ts
+++ b/packages/styrby-web/src/app/api/v1/auth/oauth/start/route.ts
@@ -71,7 +71,6 @@ import { createAdminClient } from '@/lib/supabase/server';
 import { rateLimit, rateLimitResponse } from '@/lib/rateLimit';
 import {
   OAUTH_START_RATE_LIMIT,
-  OAUTH_ALLOWED_REDIRECT_ORIGINS,
   MAX_REDIRECT_URL_LENGTH,
   isAllowedRedirectOrigin,
   extractStateFromAuthUrl,

--- a/packages/styrby-web/src/app/api/v1/auth/otp/send/route.ts
+++ b/packages/styrby-web/src/app/api/v1/auth/otp/send/route.ts
@@ -50,7 +50,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import * as Sentry from '@sentry/nextjs';
 import { createAdminClient } from '@/lib/supabase/server';
-import { rateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { rateLimit } from '@/lib/rateLimit';
 import { OTP_SEND_RATE_LIMIT, hashEmail, MAX_EMAIL_LENGTH } from '@/lib/auth/api-config';
 
 // ============================================================================

--- a/packages/styrby-web/src/app/api/v1/auth/otp/verify/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/auth/otp/verify/__tests__/route.test.ts
@@ -177,7 +177,6 @@ import { OTP_VERIFY_RATE_LIMIT, KEY_TTL_DAYS } from '@/lib/auth/api-config';
 const handlePost = POST;
 import * as Sentry from '@sentry/nextjs';
 import { rateLimit } from '@/lib/rateLimit';
-import { generateApiKey } from '@styrby/shared';
 import { hashApiKey } from '@/lib/api-keys';
 
 // ============================================================================

--- a/packages/styrby-web/src/app/api/v1/auth/otp/verify/route.ts
+++ b/packages/styrby-web/src/app/api/v1/auth/otp/verify/route.ts
@@ -73,7 +73,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import * as Sentry from '@sentry/nextjs';
 import { createAdminClient } from '@/lib/supabase/server';
-import { rateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { rateLimit } from '@/lib/rateLimit';
 import { hashApiKey } from '@/lib/api-keys';
 import { generateApiKey } from '@styrby/shared';
 // WHY import from lib/auth/api-config (not send/route): Next.js 16 forbids non-HTTP-method

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/summary/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/summary/route.ts
@@ -49,7 +49,7 @@ import {
 } from '@/middleware/api-auth';
 import { createAdminClient, createClient } from '@/lib/supabase/server';
 import { resolveEffectiveTier } from '@/lib/tier-enforcement';
-import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
+import { rateLimit, rateLimitResponse } from '@/lib/rateLimit';
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/packages/styrby-web/src/app/api/v1/sessions/groups/[id]/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/groups/[id]/__tests__/route.test.ts
@@ -109,7 +109,6 @@ import { DELETE } from '../route';
 // ============================================================================
 
 const VALID_GROUP_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
-const VALID_BASE_URL = `http://localhost:3000/api/v1/sessions/groups/${VALID_GROUP_ID}`;
 
 /**
  * Creates a NextRequest for DELETE /api/v1/sessions/groups/[id].

--- a/packages/styrby-web/src/app/api/webhooks/polar/__tests__/team-subscription.test.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/__tests__/team-subscription.test.ts
@@ -43,7 +43,7 @@ const mockSingle = vi.fn();
 
 vi.mock('@/lib/supabase/server', () => ({
   createAdminClient: vi.fn(() => ({
-    from: vi.fn((table: string) => {
+    from: vi.fn((_table: string) => {
       return {
         upsert: mockUpsert,
         update: mockUpdate,

--- a/packages/styrby-web/src/app/billing/offer/[offerId]/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/billing/offer/[offerId]/__tests__/actions.test.ts
@@ -58,7 +58,7 @@ const mockSentryCaptureException = vi.fn();
 
 vi.mock('@sentry/nextjs', () => ({
   captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
-  captureMessage: (...args: unknown[]) => void 0,
+  captureMessage: (..._args: unknown[]) => void 0,
 }));
 
 // ─── Supabase mock ────────────────────────────────────────────────────────────

--- a/packages/styrby-web/src/app/billing/offer/[offerId]/page.tsx
+++ b/packages/styrby-web/src/app/billing/offer/[offerId]/page.tsx
@@ -37,6 +37,7 @@
  */
 
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { Tag, CheckCircle, ShieldOff, Clock, AlertTriangle } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import { acceptOfferAction } from './actions';
@@ -396,12 +397,12 @@ export default async function ChurnSaveOfferPage({ params }: PageProps) {
       {/* Footer */}
       <p className="mt-8 text-center text-xs text-zinc-400">
         Offer ID {offerId} &middot; Questions?{' '}
-        <a
+        <Link
           href="/dashboard/support"
           className="text-zinc-400 underline-offset-2 hover:text-zinc-400 hover:underline"
         >
           Contact support
-        </a>
+        </Link>
       </p>
     </div>
   );

--- a/packages/styrby-web/src/app/dashboard/admin/__tests__/page.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/__tests__/page.test.tsx
@@ -129,7 +129,7 @@ describe('UserListTable', () => {
 
     const link = screen.getByRole('link', { name: /view dossier for user0@example.com/i });
     expect(link).toBeDefined();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     expect((link as any).href).toContain(`/dashboard/admin/users/user-id-0`);
   });
 
@@ -140,9 +140,9 @@ describe('UserListTable', () => {
     expect(nextLink).toBeDefined();
     // WHY: Next page URL must carry the query param forward so the new page
     // returns results for the same search.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     expect((nextLink as any).href).toContain('q=foo');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     expect((nextLink as any).href).toContain('page=2');
   });
 
@@ -158,7 +158,7 @@ describe('UserListTable', () => {
     const prevLink = screen.getByTestId('prev-page-link');
     expect(prevLink).toBeDefined();
     // Previous should go to page 1 (no page param needed)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     const href = (prevLink as any).href as string;
     expect(href).toContain('q=foo');
     expect(href).not.toContain('page=2');

--- a/packages/styrby-web/src/app/dashboard/admin/audit/__tests__/page.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/audit/__tests__/page.test.tsx
@@ -213,7 +213,7 @@ describe('AuditLogTable', () => {
     render(<AuditLogTable rows={makeAuditRows(50)} nextCursor={500} />);
     const nextLink = screen.getByTestId('audit-next-page-link');
     expect(nextLink).toBeDefined();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     const href = (nextLink as any).href as string;
     expect(href).toContain('cursor=500');
   });

--- a/packages/styrby-web/src/app/dashboard/admin/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/page.tsx
@@ -44,32 +44,6 @@ import { createAdminClient } from '@/lib/supabase/server';
 import { UserSearchForm } from '@/components/admin/UserSearchForm';
 import { UserListTable, type AdminUserRow } from '@/components/admin/UserListTable';
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/**
- * @deprecated H27: escapeIlike is no longer used now that the admin user search
- * goes through the search_users_by_email_for_admin RPC (migration 062), which
- * handles ILIKE escaping internally. Kept here temporarily in case other callers
- * exist; will be removed in the next cleancode pass.
- *
- * Escapes ILIKE metacharacters so a search string is treated as a literal.
- *
- * WHY: Without escaping, a query like "%" matches all rows (full-table scan),
- * which is both a cost-risk (unbounded result) and a data enumeration vector.
- * Even though the admin is a trusted actor, defense-in-depth matters here.
- * Supabase PostgREST passes the escape character to Postgres ILIKE correctly
- * when the `\` escape prefix is used. See quality review T4 #1.
- *
- * Characters escaped: `%` (any-string wildcard), `_` (single-char wildcard),
- * and `\` (the escape character itself).
- *
- * @param s - Raw search string from user input
- * @returns String safe to embed inside `%...%` ILIKE pattern
- */
-function escapeIlike(s: string): string {
-  return s.replace(/[%_\\]/g, '\\$&');
-}
-
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface AdminPageProps {

--- a/packages/styrby-web/src/app/dashboard/admin/support/session/[sessionId]/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/support/session/[sessionId]/page.tsx
@@ -41,7 +41,7 @@ import { notFound } from 'next/navigation';
 import { headers } from 'next/headers';
 import { z } from 'zod';
 import { createClient } from '@/lib/supabase/server';
-import { rateLimit, RATE_LIMITS, rateLimitResponse } from '@/lib/rateLimit';
+import { rateLimit } from '@/lib/rateLimit';
 
 // ============================================================================
 // Constants

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/__tests__/actions.test.ts
@@ -145,7 +145,7 @@ vi.mock('@/lib/supabase/server', () => ({
 // Import mocked modules so tests can assert on them.
 // WHY import after vi.mock: Vitest hoists vi.mock calls to the top, so these
 // imports get the mocked versions regardless of declaration order in the file.
-import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import type { Mock } from 'vitest';
 

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/actions.ts
@@ -295,7 +295,7 @@ export async function overrideTierAction(
     }
   }
 
-  const { data: auditId, error } = await supabase.rpc('admin_override_tier', {
+  const { error } = await supabase.rpc('admin_override_tier', {
     p_target_user_id: parsed.data.targetUserId,
     p_new_tier: parsed.data.newTier,
     p_expires_at: parsed.data.expiresAt ?? null,

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/__tests__/actions.test.ts
@@ -160,7 +160,7 @@ vi.mock('@/lib/billing/polar-refund', () => {
 });
 
 // Import mocked modules so tests can assert on them.
-import { createClient, createAdminClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 import { RefundError } from '@/lib/billing/polar-refund';
 import { assertAdminMfa, AdminMfaRequiredError } from '@/lib/admin/mfa-gate';
 import type { Mock } from 'vitest';

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/page.tsx
@@ -312,7 +312,6 @@ async function CreditsSection({ userId }: { userId: string }) {
             </thead>
             <tbody>
               {credits.map((c) => {
-                const isActive = c.applied_at === null && c.revoked_at === null;
                 const stateLabel = c.revoked_at
                   ? 'Revoked'
                   : c.applied_at

--- a/packages/styrby-web/src/app/dashboard/founder/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/founder/page.tsx
@@ -68,7 +68,6 @@ export default async function FounderPage() {
   // consumed by external tooling (e.g. a scheduled Slack digest). We call it
   // from the page server component rather than duplicating the logic here.
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  let metrics: Awaited<typeof import('@/app/api/admin/founder-metrics/route').GET> extends Promise<Response> ? Record<string, unknown> : never;
 
   type FounderMetrics = {
     mrrUsd: number;

--- a/packages/styrby-web/src/app/dashboard/privacy/__tests__/privacy-components.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/privacy/__tests__/privacy-components.test.tsx
@@ -19,7 +19,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // Components under test

--- a/packages/styrby-web/src/app/dashboard/settings/_components/__tests__/use-monthly-spend.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/__tests__/use-monthly-spend.test.tsx
@@ -22,7 +22,7 @@ function makeSupabase(rows: FakeRow[] | null) {
   const gte = vi.fn().mockResolvedValue({ data: rows, error: null });
   const select = vi.fn().mockReturnValue({ gte });
   const from = vi.fn().mockReturnValue({ select });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   
   return { client: { from } as any, gte, select, from };
 }
 

--- a/packages/styrby-web/src/app/dashboard/settings/_components/__tests__/use-web-push.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/__tests__/use-web-push.test.tsx
@@ -14,8 +14,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useWebPush } from '../use-web-push';
 
-type WritableNav = Navigator & { serviceWorker?: unknown };
-
 describe('useWebPush', () => {
   const originalPushManager = (globalThis as unknown as { PushManager?: unknown })
     .PushManager;
@@ -33,7 +31,7 @@ describe('useWebPush', () => {
       originalPushManager;
     (globalThis as unknown as { Notification?: unknown }).Notification =
       originalNotification;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     delete (navigator as any).serviceWorker;
   });
 
@@ -57,7 +55,7 @@ describe('useWebPush', () => {
       getSubscription: vi.fn().mockResolvedValue(null),
       subscribe: vi.fn().mockResolvedValue(fakeSubscription),
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     (navigator as any).serviceWorker = {
       ready: Promise.resolve({ pushManager }),
     };
@@ -101,7 +99,7 @@ describe('useWebPush', () => {
       getSubscription: vi.fn().mockResolvedValue(existing),
       subscribe: vi.fn(),
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     (navigator as any).serviceWorker = {
       ready: Promise.resolve({ pushManager }),
     };
@@ -132,7 +130,7 @@ describe('useWebPush', () => {
 
   it('subscribe surfaces a missing-VAPID-key as an error without calling fetch', async () => {
     (globalThis as unknown as { PushManager: unknown }).PushManager = class {};
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     (navigator as any).serviceWorker = {
       ready: Promise.resolve({
         pushManager: { getSubscription: vi.fn().mockResolvedValue(null) },

--- a/packages/styrby-web/src/app/dashboard/settings/_components/use-web-push.ts
+++ b/packages/styrby-web/src/app/dashboard/settings/_components/use-web-push.ts
@@ -49,8 +49,7 @@ export function useWebPush(deps?: {
   getVapidKey?: () => string | undefined;
 }): UseWebPushResult {
   const fetchImpl = deps?.fetchImpl ?? (typeof fetch !== 'undefined' ? fetch : undefined);
-  const getVapidKey =
-    deps?.getVapidKey ?? (() => process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY);
+  const depsGetVapidKey = deps?.getVapidKey;
 
   const [supported, setSupported] = useState(false);
   const [permission, setPermission] = useState<NotificationPermission>('default');
@@ -100,6 +99,11 @@ export function useWebPush(deps?: {
         return;
       }
       const registration = await navigator.serviceWorker.ready;
+      // WHY: Resolve the VAPID key inside the callback (not at hook-body scope)
+      // so a new `?? () => ...` fallback closure isn't created every render,
+      // which would change this useCallback's identity on every render.
+      const getVapidKey =
+        depsGetVapidKey ?? (() => process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY);
       const vapidPublicKey = getVapidKey();
       if (!vapidPublicKey) {
         setError('Push notification configuration is missing. Please contact support.');
@@ -131,7 +135,7 @@ export function useWebPush(deps?: {
     } finally {
       setLoading(false);
     }
-  }, [fetchImpl, getVapidKey]);
+  }, [fetchImpl, depsGetVapidKey]);
 
   const unsubscribe = useCallback(async () => {
     setLoading(true);

--- a/packages/styrby-web/src/app/dashboard/team/[teamId]/sso/sso-settings-panel.tsx
+++ b/packages/styrby-web/src/app/dashboard/team/[teamId]/sso/sso-settings-panel.tsx
@@ -22,7 +22,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Shield, Lock, Mail, Users, AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
+import { Shield, Lock, Users, AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/packages/styrby-web/src/app/legal/retention-proof/__tests__/page.test.tsx
+++ b/packages/styrby-web/src/app/legal/retention-proof/__tests__/page.test.tsx
@@ -209,7 +209,7 @@ describe('/legal/retention-proof page', () => {
     it('Sessions row has enforced status', async () => {
       mockApiSuccess({ sessions_purged_30d: 0, as_of: new Date().toISOString() });
       const Page = RetentionProofPage as () => Promise<React.ReactElement>;
-      const { container } = render(await Page());
+      render(await Page());
 
       // Find the Sessions row and check its badge
       const table = screen.getByRole('table', { name: 'Styrby data retention policy' });
@@ -222,7 +222,7 @@ describe('/legal/retention-proof page', () => {
     it('Audit log entries row has target status', async () => {
       mockApiSuccess({ sessions_purged_30d: 0, as_of: new Date().toISOString() });
       const Page = RetentionProofPage as () => Promise<React.ReactElement>;
-      const { container } = render(await Page());
+      render(await Page());
 
       const table = screen.getByRole('table', { name: 'Styrby data retention policy' });
       const rows = table.querySelectorAll('tbody tr');
@@ -234,7 +234,7 @@ describe('/legal/retention-proof page', () => {
     it('Cost records row has target status', async () => {
       mockApiSuccess({ sessions_purged_30d: 0, as_of: new Date().toISOString() });
       const Page = RetentionProofPage as () => Promise<React.ReactElement>;
-      const { container } = render(await Page());
+      render(await Page());
 
       const table = screen.getByRole('table', { name: 'Styrby data retention policy' });
       const rows = table.querySelectorAll('tbody tr');

--- a/packages/styrby-web/src/app/login/page.tsx
+++ b/packages/styrby-web/src/app/login/page.tsx
@@ -7,38 +7,6 @@ import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Github, Mail, KeyRound } from 'lucide-react';
 
-/**
- * Google logo SVG icon.
- * WHY inline: lucide-react does not include Google as an icon.
- * We use a minimal, accessible SVG matching Google brand guidelines.
- */
-function GoogleIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      className={className}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-        fill="#4285F4"
-      />
-      <path
-        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-        fill="#34A853"
-      />
-      <path
-        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-        fill="#FBBC05"
-      />
-      <path
-        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-        fill="#EA4335"
-      />
-    </svg>
-  );
-}
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { isDisposableEmail, DISPOSABLE_EMAIL_ERROR } from '@/lib/disposable-emails';
@@ -220,36 +188,6 @@ function LoginForm() {
       provider: 'github',
       options: {
         redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirect)}`,
-      },
-    });
-
-    if (error) {
-      setMessage({ type: 'error', text: error.message });
-      setLoading(false);
-    }
-  }
-
-  /**
-   * Initiates Google OAuth flow.
-   *
-   * WHY queryParams hd: We pass `hd` as an empty string to *not* restrict to a
-   * specific domain at the OAuth prompt level — team-level domain enforcement
-   * happens server-side in the auth callback. If we hardcoded a domain here,
-   * solo users (non-Workspace) could not use Google sign-in at all.
-   *
-   * The auth callback extracts the `hd` claim from the verified session metadata
-   * after Google populates it, giving us the authoritative domain per team.
-   */
-  async function handleGoogleLogin() {
-    setLoading(true);
-    setMessage(null);
-
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirect)}`,
-        // access_type=offline ensures we get a refresh token (needed for session persistence)
-        queryParams: { access_type: 'offline', prompt: 'select_account' },
       },
     });
 

--- a/packages/styrby-web/src/app/signup/page.tsx
+++ b/packages/styrby-web/src/app/signup/page.tsx
@@ -8,25 +8,6 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Github, Mail } from 'lucide-react';
 
-/**
- * Google logo SVG icon.
- * WHY inline: lucide-react does not include Google as an icon.
- */
-function GoogleIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      className={className}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
-      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
-      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
-      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
-    </svg>
-  );
-}
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -303,38 +284,6 @@ function SignUpPageInner() {
       provider: 'github',
       options: {
         redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`,
-      },
-    });
-
-    if (error) {
-      setMessage({ type: 'error', text: error.message });
-      setLoading(false);
-    }
-  }
-
-  /**
-   * Google OAuth signup.
-   *
-   * WHY hd not set: Same reasoning as login page - domain enforcement happens
-   * server-side in the auth callback using the verified hd claim from Google.
-   * Not restricting at the prompt level allows both personal and Workspace
-   * Google accounts to sign up. The team auto-enroll only fires for accounts
-   * whose hd matches a configured team sso_domain.
-   */
-  async function handleGoogleSignUp() {
-    if (!agreed) {
-      setMessage({ type: 'error', text: 'Please agree to the Terms of Service and Privacy Policy.' });
-      return;
-    }
-
-    setLoading(true);
-    setMessage(null);
-
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`,
-        queryParams: { access_type: 'offline', prompt: 'select_account' },
       },
     });
 

--- a/packages/styrby-web/src/app/support/access/[grantId]/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/support/access/[grantId]/__tests__/actions.test.ts
@@ -59,7 +59,7 @@ const mockSentryCaptureException = vi.fn();
 
 vi.mock('@sentry/nextjs', () => ({
   captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
-  captureMessage: (...args: unknown[]) => void 0,
+  captureMessage: (..._args: unknown[]) => void 0,
 }));
 
 // ─── Supabase mock ────────────────────────────────────────────────────────────

--- a/packages/styrby-web/src/app/support/access/[grantId]/__tests__/page.test.tsx
+++ b/packages/styrby-web/src/app/support/access/[grantId]/__tests__/page.test.tsx
@@ -342,7 +342,7 @@ describe('GrantApprovalPage', () => {
     // WHY: token_hash is the SHA-256 of the raw access token. It must never
     // be sent to the client — including in the rendered HTML. Verifying it is
     // excluded from the select query is the correct enforcement point.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     const selectArg: string = (mockSelect.mock.calls as any)[0]?.[0] ?? '';
     expect(selectArg).not.toContain('token_hash');
     // granted_by (admin UUID) is also excluded per spec §4.3.

--- a/packages/styrby-web/src/app/support/access/[grantId]/page.tsx
+++ b/packages/styrby-web/src/app/support/access/[grantId]/page.tsx
@@ -38,6 +38,7 @@
  */
 
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { CheckCircle, Clock, ShieldOff, XCircle, AlertTriangle } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import { approveAction, revokeAction } from './actions';
@@ -426,12 +427,12 @@ export default async function GrantApprovalPage({ params }: PageProps) {
       {/* Footer */}
       <p className="mt-8 text-center text-xs text-zinc-400">
         Grant ID {grantId} &middot; Questions?{' '}
-        <a
+        <Link
           href="/dashboard/support"
           className="text-zinc-400 underline-offset-2 hover:text-zinc-400 hover:underline"
         >
           Open a support ticket
-        </a>
+        </Link>
       </p>
     </div>
   );

--- a/packages/styrby-web/src/components/admin/OverrideTierForm.tsx
+++ b/packages/styrby-web/src/components/admin/OverrideTierForm.tsx
@@ -24,7 +24,7 @@
  * @param currentTier - Current tier shown as the default select value.
  */
 
-import { useActionState, useRef, useCallback } from 'react';
+import { useActionState, useCallback } from 'react';
 import type { AdminActionResult } from '@/app/dashboard/admin/users/[userId]/actions';
 
 // ─── Datetime helpers ─────────────────────────────────────────────────────────

--- a/packages/styrby-web/src/components/dashboard/AgentWeeklySparklines.tsx
+++ b/packages/styrby-web/src/components/dashboard/AgentWeeklySparklines.tsx
@@ -100,7 +100,7 @@ export function AgentWeeklySparklines({ rows }: AgentWeeklySparklinesProps) {
                   const barH = Math.max(Math.round(frac * BAR_HEIGHT_PX), 2);
                   return (
                     <div
-                      // eslint-disable-next-line react/no-array-index-key -- i is stable for a fixed 7-element array
+                       
                       key={i}
                       title={`$${cost.toFixed(4)}`}
                       style={{

--- a/packages/styrby-web/src/components/dashboard/team-costs/TeamMemberCostTable.tsx
+++ b/packages/styrby-web/src/components/dashboard/team-costs/TeamMemberCostTable.tsx
@@ -201,7 +201,6 @@ export function TeamMemberCostTable({
           <tbody className="divide-y divide-border/20">
             {sorted.map((member) => {
               const pct = teamTotal > 0 ? (member.totalCostUsd / teamTotal) * 100 : 0;
-              const totalTokens = member.totalInputTokens + member.totalOutputTokens;
 
               return (
                 <tr key={member.userId} className="hover:bg-secondary/10 transition-colors">

--- a/packages/styrby-web/src/components/team/members/MembersTable.tsx
+++ b/packages/styrby-web/src/components/team/members/MembersTable.tsx
@@ -28,7 +28,6 @@ import {
 import {
   canRevokeMember,
   parseDbRole,
-  TEAM_ADMIN_AUDIT_ACTIONS,
 } from '@styrby/shared';
 import type { TeamMemberAdminRow } from '@styrby/shared';
 

--- a/packages/styrby-web/src/lib/admin/__tests__/guard.test.ts
+++ b/packages/styrby-web/src/lib/admin/__tests__/guard.test.ts
@@ -82,7 +82,7 @@ describe('requireSiteAdmin', () => {
     });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -97,7 +97,7 @@ describe('requireSiteAdmin', () => {
     });
 
     await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -116,7 +116,7 @@ describe('requireSiteAdmin', () => {
     });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -133,7 +133,7 @@ describe('requireSiteAdmin', () => {
     });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -149,7 +149,7 @@ describe('requireSiteAdmin', () => {
     });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -165,7 +165,7 @@ describe('requireSiteAdmin', () => {
     });
 
     await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -184,7 +184,7 @@ describe('requireSiteAdmin', () => {
     });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -212,7 +212,7 @@ describe('requireSiteAdmin', () => {
     };
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       throwingSupabase as any,
       makeRequest()
     );
@@ -227,7 +227,7 @@ describe('requireSiteAdmin', () => {
     const supabase = makeMockSupabase({ user: null });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -244,7 +244,7 @@ describe('requireSiteAdmin', () => {
     });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -260,7 +260,7 @@ describe('requireSiteAdmin', () => {
     });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -277,7 +277,7 @@ describe('requireSiteAdmin', () => {
     const supabase = makeMockSupabase({ user: null });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest()
     );
@@ -302,7 +302,7 @@ describe('requireSiteAdmin', () => {
     });
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       supabase as any,
       makeRequest('/dashboardfake') // guard is path-agnostic; middleware filters before calling it
     );
@@ -322,7 +322,7 @@ describe('requireSiteAdmin', () => {
     };
 
     const result = await requireSiteAdmin(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       
       throwingAuthSupabase as any,
       makeRequest()
     );

--- a/packages/styrby-web/src/lib/email/lifecycle.ts
+++ b/packages/styrby-web/src/lib/email/lifecycle.ts
@@ -49,7 +49,7 @@ function getResendClient(): Resend | null {
   if (!resendClient) {
     if (!process.env.RESEND_API_KEY) {
       if (!warnedMissingKey) {
-        // eslint-disable-next-line no-console
+         
         console.warn(
           '[email/lifecycle] RESEND_API_KEY is not set - lifecycle emails are disabled.'
         );
@@ -209,7 +209,7 @@ async function safeSend(params: {
       text: params.text,
     });
     if (error) {
-      // eslint-disable-next-line no-console
+       
       console.error('[email/lifecycle] send failed', {
         kind: params.kind,
         to: params.to,
@@ -218,7 +218,7 @@ async function safeSend(params: {
       });
     }
   } catch (err) {
-    // eslint-disable-next-line no-console
+     
     console.error('[email/lifecycle] send threw', {
       kind: params.kind,
       to: params.to,

--- a/packages/styrby-web/src/lib/middleware/__tests__/idempotency.test.ts
+++ b/packages/styrby-web/src/lib/middleware/__tests__/idempotency.test.ts
@@ -212,9 +212,6 @@ describe('checkIdempotency', () => {
     expect(result1).toEqual({ replayed: false });
     expect(result2).toEqual({ replayed: false });
 
-    // Verify the eq() call received different user IDs on each invocation
-    // (the second .eq() call on the chain is the user_id filter)
-    const allEqCalls = mockFrom.mock.results.flatMap(() => []);
     // The key assertion is that both calls reached the DB independently
     expect(mockFrom).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## Summary
Boy-scout cleanup of **all** pre-existing ESLint warnings in `styrby-web` (**96 → 0**), each fixed genuinely — no `eslint-disable` comments, no `_`-prefixing of real vars/imports, **zero behavior change**.

## What changed
- **34 dead `// eslint-disable` directives** removed (they reported "no problems").
- **~55 unused imports/vars/types deleted outright** across source + test files (dead interfaces `AuditLogRow`/`MemberCountRow`/`CycleMetrics`, unused `rateLimitResponse`/`RATE_LIMITS` imports, dead test mocks). Git history preserves.
- **Google OAuth dead code removed** from `login`/`signup` pages (`GoogleIcon` + `handleGoogleLogin`/`handleGoogleSignUp`) — parked-for-reuse code preserved by git history + `runbooks/enable-google-oauth.md`.
- **a11y/perf:** 2 `<a href="/dashboard/support">` → `<Link>` (`next/no-html-link-for-pages`) in billing/offer + support/access pages.
- **react-hooks/exhaustive-deps** in `use-web-push.ts`: moved the VAPID-key fallback resolution **inside** the `subscribe` useCallback (it was creating a new closure every render, churning the callback identity); dep is now the stable `deps` ref.
- Unused positional mock-callback params `_`-prefixed (the only allowed `_`-prefix per the rule).

## Test Plan
- [x] `pnpm lint` → **0 warnings, 0 errors**
- [x] Typecheck 7/7 · web build clean
- [x] web **3841** tests pass (221 files, unchanged)
- [ ] CI green

54 files, net **−236 lines**. Pure hygiene — no runtime behavior change.

🤖 Shipped via /gh-ship