### PR TITLE
fix(audit): bug-hunt batch 1 — migration 096 regression + 13 verified bugs

### DIFF
--- a/packages/styrby-mobile/app/__tests__/accept-invite-screen.test.tsx
+++ b/packages/styrby-mobile/app/__tests__/accept-invite-screen.test.tsx
@@ -141,6 +141,9 @@ jest.mock('@/lib/supabase', () => ({
       })),
     },
     from: jest.fn(() => mockSupabaseChain()),
+    // Accept now goes through the atomic accept_team_invitation RPC (WAVE-E-002
+    // fix). Default to success; tests override per-case via rpc.mockResolvedValueOnce.
+    rpc: jest.fn(async () => ({ data: null, error: null })),
     channel: jest.fn(() => ({
       on: jest.fn().mockReturnThis(),
       subscribe: jest.fn(),
@@ -170,6 +173,7 @@ function getMockSupabase() {
   return require('@/lib/supabase').supabase as {
     auth: { getUser: jest.Mock };
     from: jest.Mock;
+    rpc: jest.Mock;
   };
 }
 
@@ -494,16 +498,14 @@ describe('AcceptInviteScreen', () => {
   /**
    * After tapping Accept the component calls:
    * 1. auth.getUser()
-   * 2. supabase.from('team_invitations').update(...)
-   * 3. supabase.from('team_members').upsert(...)
+   * 2. supabase.rpc('accept_team_invitation', ...) — atomic accept (WAVE-E-002)
    *
-   * All succeed → state transitions to 'accepted' and shows the success screen.
+   * The RPC succeeds → state transitions to 'accepted' and shows the success screen.
    */
   it('shows accepted confirmation after successfully accepting the invitation', async () => {
     Object.assign(mockLocalSearchParams, { token: VALID_INVITATION.token });
     setupFromSuccess(VALID_INVITATION); // validateToken
-    setupFromEmpty();                   // update team_invitations → accepted
-    setupFromEmpty();                   // upsert team_members
+    // rpc defaults to success ({ data: null, error: null }) — no override needed.
 
     const instance = await mountAndSettle();
 
@@ -521,6 +523,60 @@ describe('AcceptInviteScreen', () => {
     expect(hasText(tree, 'Welcome to the Team!')).toBe(true);
     expect(hasText(tree, 'successfully joined')).toBe(true);
     expect(hasText(tree, 'View Team')).toBe(true);
+  });
+
+  /**
+   * Regression (WAVE-E-002 + bug #17): accept must go through the single atomic
+   * accept_team_invitation RPC — NOT two separate PostgREST writes. The RPC
+   * receives the invitation id + user id and handles role mapping + invited_by
+   * server-side. A two-write flow could strand the invitation 'accepted' with
+   * no membership row on a partial failure / seat race.
+   */
+  it('calls the atomic accept_team_invitation RPC with invitation + user id', async () => {
+    Object.assign(mockLocalSearchParams, { token: VALID_INVITATION.token });
+    setupFromSuccess(VALID_INVITATION); // validateToken
+
+    const instance = await mountAndSettle();
+    const acceptButton = instance.root.findAll(
+      (node) => node.props.accessibilityLabel === 'Accept team invitation',
+    )[0];
+
+    await act(async () => {
+      acceptButton?.props.onPress?.();
+    });
+
+    expect(getMockSupabase().rpc).toHaveBeenCalledWith('accept_team_invitation', {
+      p_invitation_id: VALID_INVITATION.id,
+      p_user_id: 'user-uuid-test',
+    });
+    // The mobile path must NOT issue a direct team_members write during accept.
+    const fromCalls = getMockSupabase().from.mock.calls.map((c) => c[0]);
+    expect(fromCalls).not.toContain('team_members');
+  });
+
+  /**
+   * Regression: the RPC's typed P0001 (invitation_already_resolved) exception
+   * maps to the screen's 'invalid' state, not a generic error.
+   */
+  it('maps a P0001 already-resolved RPC error to the invalid state', async () => {
+    Object.assign(mockLocalSearchParams, { token: VALID_INVITATION.token });
+    setupFromSuccess(VALID_INVITATION); // validateToken
+    getMockSupabase().rpc.mockResolvedValueOnce({
+      data: null,
+      error: { code: 'P0001', message: 'invitation_already_resolved' },
+    });
+
+    const instance = await mountAndSettle();
+    const acceptButton = instance.root.findAll(
+      (node) => node.props.accessibilityLabel === 'Accept team invitation',
+    )[0];
+
+    await act(async () => {
+      acceptButton?.props.onPress?.();
+    });
+
+    const tree = instance.toJSON();
+    expect(hasText(tree, 'already been accepted')).toBe(true);
   });
 
   // --------------------------------------------------------------------------
@@ -580,13 +636,16 @@ describe('AcceptInviteScreen', () => {
   // --------------------------------------------------------------------------
 
   /**
-   * If the team_invitations update returns an error during accept, the
-   * component transitions to 'error' rather than 'accepted'.
+   * If the accept_team_invitation RPC returns a generic (untyped) error during
+   * accept, the component transitions to 'error' rather than 'accepted'.
    */
   it('shows error state when the accept mutation fails', async () => {
     Object.assign(mockLocalSearchParams, { token: VALID_INVITATION.token });
     setupFromSuccess(VALID_INVITATION);          // validateToken succeeds
-    setupFromError({ message: 'Permission denied' }); // update fails
+    getMockSupabase().rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'Permission denied' },
+    }); // RPC fails with a non-typed error
 
     const instance = await mountAndSettle();
 
@@ -704,8 +763,7 @@ describe('AcceptInviteScreen', () => {
   it('calls router.replace to team tab when View Team is pressed after accepting', async () => {
     Object.assign(mockLocalSearchParams, { token: VALID_INVITATION.token });
     setupFromSuccess(VALID_INVITATION); // validateToken
-    setupFromEmpty();                   // update team_invitations
-    setupFromEmpty();                   // upsert team_members
+    // rpc defaults to success — atomic accept.
 
     const instance = await mountAndSettle();
 

--- a/packages/styrby-mobile/app/_layout.tsx
+++ b/packages/styrby-mobile/app/_layout.tsx
@@ -218,10 +218,18 @@ export default function RootLayout() {
           onboarded = true;
           // Also update React state so subsequent renders skip the disk read.
           setHasOnboarded(true);
-        } else if (session) {
+        } else if (session && !inShared && !inInvite) {
           // Auto-mark: once a Supabase session exists, treat the user as
           // onboarded. Covers returning users whose old build did not write
           // ONBOARDING_KEY.
+          //
+          // WHY exclude inShared / inInvite: those are PUBLIC deep-link entry
+          // points. A brand-new user who arrives via /shared/[shareId] or
+          // /invite/[token] may already hold a session, but they have NOT seen
+          // onboarding. Auto-marking them here would silently flag them
+          // onboarded forever, so they'd skip onboarding on first real app
+          // entry. We only auto-mark inside the authenticated-app flow (i.e.
+          // when not sitting on an exempt public route).
           await SecureStore.setItemAsync(ONBOARDING_KEY, 'true');
           onboarded = true;
           setHasOnboarded(true);

--- a/packages/styrby-mobile/app/budget-alerts.tsx
+++ b/packages/styrby-mobile/app/budget-alerts.tsx
@@ -92,6 +92,32 @@ function AlertCard({ alert, onToggle, onDelete }: AlertCardProps) {
   };
 
   /**
+   * Format a budget amount according to the alert's type.
+   *
+   * WHY: currentSpend / threshold carry DIFFERENT units per alertType:
+   *   - subscription_quota → a fraction in [0,1] (render as a percentage)
+   *   - credits            → an integer credit count (render as "N credits")
+   *   - cost_usd           → a USD dollar amount (render via formatCost)
+   * Formatting a quota fraction or credit count as USD produced nonsense like
+   * "$0.15" for 15% quota used. This branches on alertType so each unit is
+   * rendered in its own scale.
+   *
+   * @param value - The amount in the alert's native unit.
+   * @returns A human-readable string in the correct unit.
+   */
+  const formatAmount = (value: number): string => {
+    switch (alert.alertType) {
+      case 'subscription_quota':
+        return `${(value * 100).toFixed(0)}%`;
+      case 'credits':
+        return `${Math.round(value)} credits`;
+      case 'cost_usd':
+      default:
+        return formatCost(value);
+    }
+  };
+
+  /**
    * Confirm before deleting an alert.
    */
   const handleDeletePress = () => {
@@ -110,7 +136,7 @@ function AlertCard({ alert, onToggle, onDelete }: AlertCardProps) {
       className="bg-zinc-900 rounded-2xl p-4 mb-3"
       style={{ opacity: alert.enabled ? 1 : 0.6 }}
       accessibilityRole="summary"
-      accessibilityLabel={`Budget alert: ${alert.name}, ${formatCost(alert.currentSpend)} of ${formatCost(alert.threshold)} ${getPeriodLabel(alert.period)}, ${alert.percentUsed.toFixed(0)}% used`}
+      accessibilityLabel={`Budget alert: ${alert.name}, ${formatAmount(alert.currentSpend)} of ${formatAmount(alert.threshold)} ${getPeriodLabel(alert.period)}, ${alert.percentUsed.toFixed(0)}% used`}
     >
       {/* Header: Name + Toggle + Delete */}
       <View className="flex-row items-center justify-between mb-3">
@@ -173,10 +199,10 @@ function AlertCard({ alert, onToggle, onDelete }: AlertCardProps) {
       <View className="flex-row items-center justify-between">
         <Text className="text-zinc-400 text-sm">
           <Text style={{ color: progressColor, fontWeight: '600' }}>
-            {formatCost(alert.currentSpend)}
+            {formatAmount(alert.currentSpend)}
           </Text>
           {' / '}
-          {formatCost(alert.threshold)} {getPeriodLabel(alert.period)}
+          {formatAmount(alert.threshold)} {getPeriodLabel(alert.period)}
         </Text>
         <Text
           className="text-sm font-semibold"
@@ -191,7 +217,7 @@ function AlertCard({ alert, onToggle, onDelete }: AlertCardProps) {
         <View className="flex-row items-center mt-2 bg-red-500/10 rounded-lg px-3 py-2">
           <Ionicons name="warning" size={14} color="#ef4444" />
           <Text className="text-red-400 text-xs ml-1.5 font-medium">
-            Budget exceeded by {formatCost(alert.currentSpend - alert.threshold)}
+            Budget exceeded by {formatAmount(alert.currentSpend - alert.threshold)}
           </Text>
         </View>
       )}

--- a/packages/styrby-mobile/app/team/accept-invite.tsx
+++ b/packages/styrby-mobile/app/team/accept-invite.tsx
@@ -221,13 +221,22 @@ export default function AcceptInviteScreen() {
   // --------------------------------------------------------------------------
 
   /**
-   * Accepts the invitation by:
-   * 1. Updating team_invitations.status → 'accepted'
-   * 2. Upserting a team_members row with the current user
+   * Accepts the invitation atomically via the accept_team_invitation RPC.
    *
-   * WHY upsert: The user may already have a membership row from a previous
-   * invitation. Upsert avoids a unique constraint error while keeping the
-   * role current.
+   * WHY a single RPC (WAVE-E-002 fix, mirrors the web path at
+   * packages/styrby-web/src/app/api/invitations/accept/route.ts):
+   *   The previous implementation issued TWO independent PostgREST writes —
+   *   UPDATE team_invitations SET status='accepted', then a separate
+   *   team_members upsert. If the second write failed (or two requests raced),
+   *   the invitation was stranded 'accepted' with NO membership row, silently
+   *   inflating the seat count and locking the user out of the team. The RPC
+   *   wraps both writes in one Postgres transaction (row-locked FOR UPDATE), so
+   *   a partial failure rolls back BOTH. It also handles role mapping
+   *   (viewer → member) and copies invited_by, which the old upsert dropped
+   *   (bug #17). The function raises typed exceptions we map to screen states:
+   *     - P0002 invitation_not_found       → invalid
+   *     - P0001 invitation_already_resolved → invalid
+   *     - P0003 invitation_expired          → invalid (expired reason)
    *
    * @param invitation - The validated invitation to accept
    */
@@ -242,32 +251,43 @@ export default function AcceptInviteScreen() {
         return;
       }
 
-      // Update invitation status first
-      const { error: updateError } = await supabase
-        .from('team_invitations')
-        .update({ status: 'accepted' })
-        .eq('id', invitation.id);
+      // Single atomic accept: inserts the team_members row (with role mapping +
+      // invited_by) and flips the invitation to 'accepted' in one transaction.
+      const { error: rpcError } = await supabase.rpc('accept_team_invitation', {
+        p_invitation_id: invitation.id,
+        p_user_id: user.id,
+      });
 
-      if (updateError) {
-        throw new Error(updateError.message);
-      }
+      if (rpcError) {
+        // Map the function's typed PostgreSQL exceptions to user-facing states.
+        // PostgREST surfaces the RAISE EXCEPTION code on `.code` and the text on
+        // `.message`; match on both for resilience across postgrest-js versions.
+        const code = (rpcError as { code?: string }).code ?? '';
+        const msg = (rpcError as { message?: string }).message ?? '';
 
-      // Add user to team members
-      // WHY upsert with onConflict: prevents a duplicate row error if the
-      // user was previously removed and re-invited.
-      const { error: memberError } = await supabase
-        .from('team_members')
-        .upsert(
-          {
-            team_id: invitation.team_id,
-            user_id: user.id,
-            role: invitation.role,
-          },
-          { onConflict: 'team_id,user_id' }
-        );
+        if (code === 'P0003' || /invitation_expired/.test(msg)) {
+          setState({
+            status: 'invalid',
+            reason: 'This invitation has expired. Please ask the team admin to send a new invitation.',
+          });
+          return;
+        }
+        if (code === 'P0001' || /invitation_already_resolved/.test(msg)) {
+          setState({
+            status: 'invalid',
+            reason: 'This invitation has already been accepted or revoked.',
+          });
+          return;
+        }
+        if (code === 'P0002' || /invitation_not_found/.test(msg)) {
+          setState({
+            status: 'invalid',
+            reason: 'This invitation link is invalid or has been revoked.',
+          });
+          return;
+        }
 
-      if (memberError) {
-        throw new Error(memberError.message);
+        throw new Error(msg || 'Failed to accept invitation.');
       }
 
       setState({ status: 'accepted' });

--- a/packages/styrby-mobile/jest.config.js
+++ b/packages/styrby-mobile/jest.config.js
@@ -46,6 +46,19 @@ module.exports = {
     // babel-jest can transform it in CJS mode. The package.json exports field
     // points at dist/logging/index.js (ESM) which Jest cannot consume directly.
     '^@styrby/shared/logging$': '<rootDir>/../styrby-shared/src/logging/index.ts',
+    // WHY: Map @styrby/shared/billing subpath to source so babel-jest can
+    // transform it in CJS mode. The package.json exports field points at
+    // dist/billing/index.js (ESM) which Jest cannot consume directly. Consumed
+    // by useSubscriptionTier / useBudgetAlerts (normalizeTier tier-gate fixes).
+    '^@styrby/shared/billing$': '<rootDir>/../styrby-shared/src/billing/index.ts',
+    // WHY strip the .js extension on RELATIVE imports: the shared source is
+    // authored ESM-style ('./tier-logic.js') but the files on disk are .ts.
+    // When we map a subpath barrel (billing/index.ts) to source, Jest resolves
+    // that barrel's own './tier-logic.js' literally and fails. Rewriting any
+    // relative '*.js' import back to extensionless lets Jest's default resolver
+    // find the .ts/.tsx source. Scoped to ./ and ../ so it never touches
+    // package or absolute-path mappings above.
+    '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   transform: {
     // Use babel-jest with Expo's Babel config for TypeScript support

--- a/packages/styrby-mobile/src/components/VoiceInput.tsx
+++ b/packages/styrby-mobile/src/components/VoiceInput.tsx
@@ -433,6 +433,31 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
     transcribeAudioRef.current = transcribeAudio;
   });
 
+  // WHY (unmount safety): if the user navigates away mid-recording, neither the
+  // auto-stop timer nor the AudioRecorder were ever torn down — the mic stayed
+  // engaged after the screen left. This unmount-only effect (empty deps, so the
+  // cleanup runs exactly once on teardown) clears the pending auto-stop timer
+  // and stops the recorder if one is still live. We read the refs at cleanup
+  // time so we always act on the latest instances.
+  useEffect(() => {
+    return () => {
+      if (autoStopTimerRef.current) {
+        clearTimeout(autoStopTimerRef.current);
+        autoStopTimerRef.current = null;
+      }
+      const recorder = recordingRef.current as { stop?: () => unknown } | null;
+      // Best-effort stop; ignore errors during teardown (instance may already
+      // be stopped/unloaded). Optional-chaining the method guards against
+      // expo-audio shape differences across versions.
+      try {
+        recorder?.stop?.();
+      } catch {
+        // Swallow: teardown must never throw.
+      }
+      recordingRef.current = null;
+    };
+  }, []);
+
   // --------------------------------------------------------------------------
   // Confirmation Modal Actions
   // --------------------------------------------------------------------------

--- a/packages/styrby-mobile/src/components/cloud-tasks/CloudTaskSubmitSheet.tsx
+++ b/packages/styrby-mobile/src/components/cloud-tasks/CloudTaskSubmitSheet.tsx
@@ -171,9 +171,26 @@ export function CloudTaskSubmitSheet({
     setSessionsError(null);
 
     void (async () => {
+      // WHY explicit user scope: on a team, sessions RLS permits reading
+      // teammates' rows. The recent-sessions picker is a PERSONAL convenience
+      // list, so without .eq('user_id', ...) it leaked other members' session
+      // titles / project_path / git_branch. Scope to the authed user explicitly
+      // (defence in depth — do not rely on RLS alone for this UI affordance).
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (cancelled) return;
+      if (!user) {
+        setSessions([]);
+        setSessionsLoading(false);
+        return;
+      }
+
       const { data, error } = await supabase
         .from('sessions')
         .select('id, title, project_path, git_branch, agent_type, started_at')
+        .eq('user_id', user.id)
         .order('started_at', { ascending: false })
         .limit(10);
 

--- a/packages/styrby-mobile/src/components/cloud-tasks/__tests__/CloudTaskSubmitSheet.test.tsx
+++ b/packages/styrby-mobile/src/components/cloud-tasks/__tests__/CloudTaskSubmitSheet.test.tsx
@@ -56,14 +56,24 @@ const mockSessionFetch: SessionFetchResult = { data: [], error: null };
 
 jest.mock('@/lib/supabase', () => ({
   supabase: {
+    // The recent-sessions query is now user-scoped: it resolves the authed user
+    // and adds .eq('user_id', ...) so teammates' sessions don't leak (bug #10).
+    auth: {
+      getUser: jest.fn(async () => ({
+        data: { user: { id: 'user-uuid-test' } },
+        error: null,
+      })),
+    },
     from: jest.fn(() => {
       const chain: {
         select: jest.Mock;
+        eq: jest.Mock;
         order: jest.Mock;
         limit: jest.Mock;
         then: (resolve: (v: unknown) => void) => Promise<unknown>;
       } = {
         select: jest.fn(() => chain),
+        eq: jest.fn(() => chain),
         order: jest.fn(() => chain),
         limit: jest.fn(() => chain),
         then: (resolve: (v: unknown) => void) =>

--- a/packages/styrby-mobile/src/hooks/useBudgetAlerts.ts
+++ b/packages/styrby-mobile/src/hooks/useBudgetAlerts.ts
@@ -26,6 +26,7 @@ import {
   safeParseSingle,
 } from '../lib/schemas';
 import type { AgentType, SubscriptionTier } from 'styrby-shared';
+import { normalizeTier } from '@styrby/shared/billing';
 
 // ============================================================================
 // Types
@@ -494,7 +495,12 @@ export function useBudgetAlerts(): UseBudgetAlertsReturn {
   const [tier, setTier] = useState<SubscriptionTier>('free');
   const [refreshKey, setRefreshKey] = useState(0);
 
-  const alertLimit = TIER_ALERT_LIMITS[tier];
+  // Normalize the raw tier BEFORE the limit lookup. A stray legacy 'power'
+  // value has no key in TIER_ALERT_LIMITS, which would yield `undefined` and
+  // make `alerts.length >= undefined` always false (unintended unlimited
+  // alerts). normalizeTier folds 'power' → 'growth' (cap 5) and fail-closes
+  // unknown values to 'free' (cap 0). Every TierId it returns is a valid key.
+  const alertLimit = TIER_ALERT_LIMITS[normalizeTier(tier)];
 
   /**
    * Fetch all budget alerts and compute their current spend.

--- a/packages/styrby-mobile/src/hooks/useCosts.ts
+++ b/packages/styrby-mobile/src/hooks/useCosts.ts
@@ -668,6 +668,14 @@ export function useCosts(): UseCostsReturn {
    * is filtered by the user's auth to respect RLS.
    */
   useEffect(() => {
+    // WHY this flag: setupRealtime awaits getUser() before it can create the
+    // channel and store it in realtimeChannelRef. If the component unmounts
+    // during that await, the cleanup below runs while the ref is still null and
+    // cannot remove the channel — so the channel created AFTER the await would
+    // leak its WebSocket subscription forever. We track cancellation in the
+    // effect closure and tear down (or never create) the channel post-await.
+    let cancelled = false;
+
     /**
      * Set up the Realtime subscription after initial data load completes.
      */
@@ -677,6 +685,9 @@ export function useCosts(): UseCostsReturn {
       } = await supabase.auth.getUser();
 
       if (!user) return;
+
+      // Unmounted while awaiting getUser(): do not subscribe.
+      if (cancelled) return;
 
       const channel = supabase
         .channel('cost-records-realtime')
@@ -727,6 +738,15 @@ export function useCosts(): UseCostsReturn {
           setIsRealtimeConnected(status === 'SUBSCRIBED');
         });
 
+      // Defensive double-check: if the effect was cleaned up between the
+      // post-await guard and here (e.g. a synchronous-looking but reentrant
+      // unmount), remove the channel immediately rather than storing a ref the
+      // cleanup already ran past.
+      if (cancelled) {
+        supabase.removeChannel(channel);
+        return;
+      }
+
       realtimeChannelRef.current = channel;
     };
 
@@ -734,6 +754,7 @@ export function useCosts(): UseCostsReturn {
 
     // Cleanup on unmount
     return () => {
+      cancelled = true;
       if (realtimeChannelRef.current) {
         supabase.removeChannel(realtimeChannelRef.current);
         realtimeChannelRef.current = null;

--- a/packages/styrby-mobile/src/hooks/useNotifications.ts
+++ b/packages/styrby-mobile/src/hooks/useNotifications.ts
@@ -167,6 +167,13 @@ export function useNotifications(): UseNotificationsResult {
   const notificationListener = useRef<Notifications.Subscription | undefined>(undefined);
   const responseListener = useRef<Notifications.Subscription | undefined>(undefined);
 
+  // WHY: On a cold start triggered by a notification tap, BOTH
+  // getLastNotificationResponseAsync() and the response listener deliver the
+  // SAME launching response, so handleNotificationResponse would fire twice
+  // (double navigation, double badge clear). Track already-handled response
+  // identifiers and ignore repeats — mirrors the useInviteLinkHandler dedupe.
+  const handledResponseIds = useRef<Set<string>>(new Set());
+
   /**
    * Navigates to a screen based on the explicit `screen` field in the
    * notification data payload.
@@ -255,6 +262,14 @@ export function useNotifications(): UseNotificationsResult {
    */
   const handleNotificationResponse = useCallback(
     (response: Notifications.NotificationResponse) => {
+      // Dedupe: the cold-start launching response can arrive twice (last-response
+      // API + listener). Ignore an identifier we've already routed.
+      const responseId = response.notification.request.identifier;
+      if (responseId) {
+        if (handledResponseIds.current.has(responseId)) return;
+        handledResponseIds.current.add(responseId);
+      }
+
       const rawData = response.notification.request.content.data;
 
       // Clear badge when user interacts with any notification

--- a/packages/styrby-mobile/src/hooks/useSessions.ts
+++ b/packages/styrby-mobile/src/hooks/useSessions.ts
@@ -280,7 +280,11 @@ export function useSessions(): UseSessionsReturn {
         // state (stopped, error, expired).
         query = query.in('status', ['starting', 'running', 'idle', 'paused']);
       } else if (currentFilters.status === 'completed') {
-        query = query.in('status', ['stopped', 'expired']);
+        // WHY 'error' is included: 'error' is a TERMINAL session_status (see
+        // migration 001 enum + the 004_webhooks terminal-transition trigger).
+        // Excluding it from both the active AND completed filters made errored
+        // sessions vanish from the UI entirely. Terminal = stopped|error|expired.
+        query = query.in('status', ['stopped', 'error', 'expired']);
       }
 
       // ---- Agent filter ----

--- a/packages/styrby-mobile/src/hooks/useSubscriptionTier.ts
+++ b/packages/styrby-mobile/src/hooks/useSubscriptionTier.ts
@@ -13,6 +13,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { normalizeTier } from '@styrby/shared/billing';
 import { supabase } from '../lib/supabase';
 
 /**
@@ -94,9 +95,12 @@ export function useSubscriptionTier(userId: string | null): {
     };
   }, [userId]);
 
-  // Paid = any non-free tier. Includes 'growth' (the current premium tier) —
-  // omitting it previously made Growth customers read as unpaid.
-  const isPaid = tier === 'pro' || tier === 'growth';
+  // Paid = any non-free tier. Normalize FIRST so a stray legacy 'power' value
+  // (which folds to 'growth') is recognized as paid rather than falling through
+  // a hardcoded pro/growth check. normalizeTier also fail-closes unknown values
+  // to 'free', so behavior for pro/growth/free is unchanged.
+  const normalized = normalizeTier(tier);
+  const isPaid = normalized !== 'free';
 
   return { tier, isLoading, error, isPaid };
 }

--- a/packages/styrby-shared/src/context-sync/summarizer.ts
+++ b/packages/styrby-shared/src/context-sync/summarizer.ts
@@ -244,6 +244,29 @@ export function extractPathsFromToolCall(
   return [...new Set(paths)];
 }
 
+/**
+ * Scrubs an absolute filesystem path down to its basename-only masked form.
+ *
+ * WHY: ContextFileRef.path is propagated cross-agent (possibly different
+ * owners). Emitting the full absolute path leaks the user's directory tree.
+ * The module's documented contract (FULL_SCRUB_MASK / file_paths rule, and the
+ * ContextFileRef type doc) is basename-only: `/Users/alice/src/auth.ts` →
+ * `[PATH]/auth.ts`. We reuse the SAME scrub engine the rest of the module uses
+ * (scrubMessage with file_paths) so the masking is identical everywhere and
+ * there is a single source of truth for the ABSOLUTE_PATH_PATTERN.
+ *
+ * @param path - The raw (possibly absolute) file path extracted from a tool call.
+ * @returns The basename-only masked path (e.g. `[PATH]/auth.ts`). Non-absolute
+ *          inputs pass through unchanged.
+ */
+function scrubFileRefPath(path: string): string {
+  const scrubbed = scrubMessage(
+    { role: 'tool', content: path },
+    { secrets: false, file_paths: true, commands: false }
+  );
+  return scrubbed.content;
+}
+
 // ============================================================================
 // Relevance scoring
 // ============================================================================
@@ -538,7 +561,10 @@ export function buildFileRefs(
   const maxMentions = Math.max(...[...pathData.values()].map((d) => d.mentionCount));
 
   const refs: ContextFileRef[] = [...pathData.entries()].map(([path, data]) => ({
-    path,
+    // Scrub to basename-only BEFORE storing so the leaked directory tree never
+    // reaches the DB, the summary markdown (line ~469), or the injection prompt
+    // (line ~686). This enforces the ContextFileRef.path contract at the source.
+    path: scrubFileRefPath(path),
     lastTouchedAt: data.lastTouchedAt,
     relevance: computeRelevance(data.lastTouchedAt, data.mentionCount, maxMentions, now),
   }));

--- a/packages/styrby-shared/src/session-handoff/device-id.ts
+++ b/packages/styrby-shared/src/session-handoff/device-id.ts
@@ -24,33 +24,38 @@
 export function generateDeviceId(): string {
   const nowMs = Date.now();
 
-  // 48-bit timestamp (ms since epoch) as big-endian hex
-  const timeLo = (nowMs & 0xffffffff) >>> 0;
-  const timeHi = Math.floor(nowMs / 0x100000000) & 0xffff;
+  // RFC 9562 §5.7 field layout (big-endian, most-significant timestamp bits
+  // FIRST so that lexicographic string order matches chronological order):
+  //
+  //   unix_ts_ms : 48-bit big-endian millisecond timestamp
+  //     ├─ top 32 bits  → first group  (8 hex)  "time_high"
+  //     └─ low 16 bits  → second group (4 hex)  "time_low"
+  //   ver (4) + rand_a (12) → third group  (4 hex)
+  //   var (2) + rand_b high (14) → fourth group (4 hex)
+  //   rand_b low (48) → fifth group (12 hex)
+  //
+  // WHY DIVISION not bit-shift: JavaScript bitwise operators (>>, &) coerce
+  // their operands to 32-bit signed integers. A 48-bit ms timestamp (>2^32)
+  // would be truncated by `>>`/`&`, scrambling the high bits and breaking
+  // chronological ordering. Math.floor(nowMs / 0x10000) computes the true top
+  // 32 bits across the full 53-bit safe-integer range.
+  const timeHigh = (Math.floor(nowMs / 0x10000) >>> 0).toString(16).padStart(8, '0');
+  const timeLow = (nowMs & 0xffff).toString(16).padStart(4, '0');
 
-  // 12-bit random (rand_a, lower 12 bits of the version nibble word)
+  // 12-bit random (rand_a) packed with the version nibble (0111 = 7).
   const randA = crypto.getRandomValues(new Uint16Array(1))[0] & 0x0fff;
+  const verRandA = (0x7000 | randA).toString(16).padStart(4, '0');
 
-  // 62-bit random split across two 32-bit words (rand_b)
+  // 62-bit random (rand_b) split across two 32-bit words.
   const [randB1, randB2] = Array.from(crypto.getRandomValues(new Uint32Array(2)));
 
-  // Assemble per RFC 9562 §5.7
-  // time_high (16 bits) | time_mid (16 bits) | time_low (32 bits)
-  const p1 = timeHi.toString(16).padStart(4, '0');
-  const p2 = ((nowMs >> 16) & 0xffff).toString(16).padStart(4, '0');
-  const p3 = timeLo.toString(16).padStart(8, '0');
+  // Variant bits: force top two bits to 10 (RFC 9562 variant), 14 random bits follow.
+  const variantRand = (0x8000 | ((randB1 >>> 16) & 0x3fff)).toString(16).padStart(4, '0');
 
-  // Version nibble: 0111 = 7
-  const p4 = (0x7000 | randA).toString(16).padStart(4, '0');
+  // Final 48 random bits: low 16 of randB1 + all 32 of randB2.
+  const tail = (randB1 & 0xffff).toString(16).padStart(4, '0') + randB2.toString(16).padStart(8, '0');
 
-  // Variant nibble: 10xx = 8-b (force two high bits to 10)
-  const variantBits = (randB1 >>> 16) & 0x3fff;
-  const p5 = (0x8000 | variantBits).toString(16).padStart(4, '0');
-
-  const p6 = (randB1 & 0xffff).toString(16).padStart(4, '0');
-  const p7 = randB2.toString(16).padStart(8, '0');
-
-  return `${p3}-${p2}-${p4}-${p5}-${p6}${p7}`;
+  return `${timeHigh}-${timeLow}-${verRandA}-${variantRand}-${tail}`;
 }
 
 /**

--- a/packages/styrby-shared/tests/context-sync/summarizer.test.ts
+++ b/packages/styrby-shared/tests/context-sync/summarizer.test.ts
@@ -539,7 +539,8 @@ describe('buildFileRefs', () => {
     ];
     const refs = buildFileRefs(msgs, FIXED_NOW);
     expect(refs).toHaveLength(1);
-    expect(refs[0]!.path).toBe('/Users/alice/src/auth.ts');
+    // Path is scrubbed to basename-only before storage (cross-agent leak fix).
+    expect(refs[0]!.path).toBe('[PATH]/auth.ts');
   });
 
   it('deduplicates identical paths across multiple tool calls', () => {
@@ -559,7 +560,7 @@ describe('buildFileRefs', () => {
     ];
     const refs = buildFileRefs(msgs, FIXED_NOW);
     // new.ts is mentioned twice → higher frequency → higher relevance
-    expect(refs[0]!.path).toBe('/Users/alice/new.ts');
+    expect(refs[0]!.path).toBe('[PATH]/new.ts');
   });
 
   it('ignores tool calls for non-allowlisted tools', () => {
@@ -582,7 +583,7 @@ describe('buildFileRefs', () => {
       },
     ];
     const refs = buildFileRefs(msgs, FIXED_NOW);
-    expect(refs.some((r) => r.path === '/Users/alice/json-arg.ts')).toBe(true);
+    expect(refs.some((r) => r.path === '[PATH]/json-arg.ts')).toBe(true);
   });
 
   it('skips tool calls with invalid JSON string arguments', () => {
@@ -715,6 +716,24 @@ describe('summarize', () => {
     ];
     const out = summarize({ messages }, FIXED_NOW);
     expect(out.fileRefs.length).toBeGreaterThan(0);
+  });
+
+  it('never leaks the absolute directory tree in fileRefs or summaryMarkdown', () => {
+    // Regression: fileRefs previously emitted FULL absolute paths cross-agent,
+    // leaking the user's directory layout. Paths must be basename-only.
+    const messages = [
+      toolMsg('Read', 'read_file', { path: '/Users/alice/projects/secret-app/src/auth.ts' }),
+    ];
+    const out = summarize({ messages }, FIXED_NOW);
+    // No stored ref retains the parent directories.
+    for (const ref of out.fileRefs) {
+      expect(ref.path).not.toContain('/Users/alice');
+      expect(ref.path).not.toContain('secret-app');
+      expect(ref.path).toBe('[PATH]/auth.ts');
+    }
+    // The rendered summary must not echo the directory tree either.
+    expect(out.summaryMarkdown).not.toContain('/Users/alice');
+    expect(out.summaryMarkdown).not.toContain('secret-app');
   });
 });
 

--- a/packages/styrby-shared/tests/session-handoff/device-id.test.ts
+++ b/packages/styrby-shared/tests/session-handoff/device-id.test.ts
@@ -5,7 +5,7 @@
  * the isValidDeviceId guard function.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { generateDeviceId, isValidDeviceId } from '../../src/session-handoff/device-id';
 
 // UUID canonical format regex (any version)
@@ -26,6 +26,40 @@ describe('generateDeviceId', () => {
   it('returns a 36-character string', () => {
     expect(generateDeviceId()).toHaveLength(36);
   });
+
+  it('sorts chronologically by timestamp (UUID v7 time-ordering)', () => {
+    // Regression: a prior impl placed the timestamp bytes incorrectly and
+    // truncated via 32-bit shift, so IDs did NOT sort by creation time.
+    // Increasing timestamps must produce lexicographically increasing IDs,
+    // including across the 32-bit boundary in the 48-bit ms field.
+    const nowSpy = vi.spyOn(Date, 'now');
+    const timestamps = [
+      0x0000_0000_0001, // tiny
+      0x0000_ffff_ffff, // just below 2^32
+      0x0001_0000_0000, // just above 2^32 (would break under a 32-bit shift)
+      0x0001_0000_0001,
+      0x018f_1234_5678, // a realistic 2026-era ms timestamp
+      0x018f_1234_5679,
+    ];
+
+    const ids = timestamps.map((ts) => {
+      nowSpy.mockReturnValue(ts);
+      return generateDeviceId();
+    });
+
+    const sorted = [...ids].sort();
+    expect(ids).toEqual(sorted);
+
+    // First group (top 32 timestamp bits) must be strictly non-decreasing.
+    const prefixes = ids.map((id) => id.slice(0, 13)); // time_high + '-' + time_low
+    expect([...prefixes].sort()).toEqual(prefixes);
+
+    nowSpy.mockRestore();
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('isValidDeviceId', () => {

--- a/packages/styrby-web/src/lib/resend.ts
+++ b/packages/styrby-web/src/lib/resend.ts
@@ -168,7 +168,10 @@ export async function sendSubscriptionConfirmedEmail({
   billingCycle: 'monthly' | 'annual';
   nextBillingDate: string;
 }) {
-  const tierName = tier === 'pro' ? 'Pro' : 'Power';
+  // Canonical tiers are Free/Pro/Growth (power retired). The param type is
+  // 'pro' | 'growth', so the non-pro branch is always Growth — labeling it
+  // 'Power' sent every Growth subscriber a "You're now on Styrby Power!" email.
+  const tierName = tier === 'pro' ? 'Pro' : 'Growth';
   return sendEmail({
     to: email,
     subject: `You're now on Styrby ${tierName}!`,

--- a/supabase/migrations/097_audit_trigger_restore_defensive_blocks.sql
+++ b/supabase/migrations/097_audit_trigger_restore_defensive_blocks.sql
@@ -1,0 +1,116 @@
+-- Migration 097: Restore the audit_trigger_fn defensive blocks that migration
+-- 096 dropped when it rewrote the function body from scratch.
+--
+-- REGRESSION (introduced by migration 096, found 2026-06-09 by the bug-hunt audit):
+--   096 reimplemented audit_trigger_fn to make profile deletion FK-safe, but in
+--   rewriting the whole body it silently dropped two defensive blocks that
+--   migrations 058 + 059 had added:
+--
+--     1. (058 — SEC-MIG-R2-001, HIGH) bigserial-PK compatibility. resource_id
+--        was cast `(v_record->>'id')::uuid` INSIDE a BEGIN/EXCEPTION wrapper,
+--        because billing_credits, churn_save_offers, and support_access_grants
+--        have `id bigserial` PRIMARY KEYs (migrations 048/050) and are audited
+--        (migration 056). 096 cast inline with NO guard, so the first write to
+--        any of those tables raises SQLSTATE 22P02 (invalid_text_representation,
+--        "invalid input syntax for type uuid") and ABORTS the host transaction.
+--        Impact: admin_issue_credit, admin_send_churn_save_offer, and every
+--        support_access_grant flow (request/approve/revoke/consume) 500.
+--
+--     2. (059 — SEC-ADV-R2-003, HIGH) PII scrub. churn_save_offers.polar_discount_code
+--        was stripped from metadata.record BEFORE the INSERT, because audit_log
+--        is owner-readable (RLS) and is exported verbatim via
+--        GET /api/account/export. 096 dropped the scrub, so every churn-save-offer
+--        mutation leaks the raw Polar coupon code into the user-accessible audit
+--        trail + GDPR export.
+--
+--   096 also narrowed search_path from (public, extensions, pg_temp) to
+--   (public, pg_temp); this migration restores `extensions` to match 059.
+--
+-- FIX: re-merge BOTH defensive blocks while PRESERVING 096's profile-delete
+-- FK-safe user_id handling (user_id = NULLIF(auth.uid(), OLD.id) on a profiles
+-- DELETE, so the audit row never references the just-deleted profile).
+--
+-- Governing: SOC2 CC7.2 (audit completeness/integrity) + GDPR Art.17 (erasure)
+-- + the SEC-MIG-R2-001 / SEC-ADV-R2-003 controls 058/059 established.
+
+CREATE OR REPLACE FUNCTION public.audit_trigger_fn()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_record jsonb;
+  v_user_id uuid;        -- subject (owner) id read off the row, if it has one
+  v_final_user_id uuid;  -- FK-safe value written to audit_log.user_id (096)
+  v_resource_id uuid;    -- bigserial-safe value written to audit_log.resource_id (058)
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_record := to_jsonb(OLD);
+    BEGIN
+      v_user_id := (OLD).user_id;
+    EXCEPTION WHEN others THEN
+      v_user_id := NULL;
+    END;
+  ELSE
+    v_record := to_jsonb(NEW);
+    BEGIN
+      v_user_id := (NEW).user_id;
+    EXCEPTION WHEN others THEN
+      v_user_id := NULL;
+    END;
+  END IF;
+
+  -- (096) profiles is the only audited table whose row IS the FK target of
+  -- audit_log.user_id. On a profiles DELETE never reference the just-deleted
+  -- profile: record the actor only when it is a DIFFERENT, still-existing user
+  -- (admin delete); otherwise NULL (self-deletion / service-role cascade).
+  IF TG_OP = 'DELETE' AND TG_TABLE_NAME = 'profiles' THEN
+    v_final_user_id := NULLIF(auth.uid(), (v_record->>'id')::uuid);
+  ELSE
+    v_final_user_id := COALESCE(v_user_id, auth.uid());
+  END IF;
+
+  -- (058) bigserial-PK compatibility. billing_credits / churn_save_offers /
+  -- support_access_grants have `id bigserial` PKs; casting a bigint id's text
+  -- to uuid raises 22P02. Guard the cast and store NULL for non-uuid PKs so the
+  -- audit INSERT never aborts the host transaction.
+  BEGIN
+    v_resource_id := (v_record->>'id')::uuid;
+  EXCEPTION WHEN invalid_text_representation THEN
+    v_resource_id := NULL;
+  END;
+
+  -- (059, SEC-ADV-R2-003) scrub sensitive columns from the per-table allowlist
+  -- BEFORE the metadata.record INSERT, since audit_log is owner-readable (RLS)
+  -- and is exported via GET /api/account/export.
+  --   * churn_save_offers.polar_discount_code — Polar coupon code.
+  IF TG_TABLE_NAME = 'churn_save_offers' THEN
+    v_record := v_record - 'polar_discount_code';
+  END IF;
+
+  INSERT INTO public.audit_log (
+    user_id,
+    action,
+    resource_type,
+    resource_id,
+    metadata,
+    created_at
+  ) VALUES (
+    v_final_user_id,
+    'record_mutated'::audit_action,
+    TG_TABLE_NAME,
+    v_resource_id,
+    jsonb_build_object(
+      'operation', TG_OP,
+      'table', TG_TABLE_NAME,
+      'record', v_record,
+      'actor', auth.uid(),
+      'control_ref', 'SOC2 CC7.2'
+    ),
+    now()
+  );
+
+  RETURN NULL;
+END;
+$$;

--- a/supabase/tests/rls/097_audit_trigger_bigserial_and_scrub.sql
+++ b/supabase/tests/rls/097_audit_trigger_bigserial_and_scrub.sql
@@ -1,0 +1,90 @@
+-- ============================================================================
+-- BEHAVIOR TEST: Migration 097 (audit_trigger_fn defensive blocks restored)
+-- ============================================================================
+-- Guards against the regression migration 096 introduced: rewriting
+-- audit_trigger_fn from scratch dropped (a) the bigserial-PK cast guard and
+-- (b) the churn_save_offers PII scrub. This test exercises a bigserial-PK
+-- audited table AND the scrub so any future from-scratch rewrite that drops
+-- them fails CI (096's test only covered profiles, which is why it regressed).
+--
+-- USAGE (local):
+--   supabase db reset
+--   psql "$DB_URL" -f supabase/tests/rls/097_audit_trigger_bigserial_and_scrub.sql
+--
+-- Invariants:
+--   1. INSERT into billing_credits (id bigserial) does NOT raise 22P02; the
+--      audit row is written with resource_id = NULL (bigint PK can't be uuid).
+--   2. INSERT into churn_save_offers does NOT raise; the audit row's
+--      metadata.record has polar_discount_code SCRUBBED.
+--   3. profiles self-delete still works + audit user_id = NULL (096 preserved).
+-- ============================================================================
+
+BEGIN;
+
+-- Test 1: bigserial-PK audited table no longer 22P02-aborts (SEC-MIG-R2-001).
+DO $$
+DECLARE u uuid := gen_random_uuid(); a uuid := gen_random_uuid(); v_res uuid; n int;
+BEGIN
+  INSERT INTO auth.users (id, email) VALUES (u,'bc097@test.local'),(a,'adm097@test.local');
+  INSERT INTO profiles (id) VALUES (u),(a) ON CONFLICT DO NOTHING;
+
+  -- Pre-097 this raised SQLSTATE 22P02 (bigint id text -> uuid) and aborted.
+  INSERT INTO billing_credits (user_id, amount_cents, currency, reason, granted_by, granted_at)
+    VALUES (u, 500, 'usd', 'test097', a, now());
+
+  SELECT count(*) INTO n FROM audit_log WHERE resource_type='billing_credits';
+  IF n < 1 THEN RAISE EXCEPTION 'TEST 1 FAILED: billing_credits insert not audited'; END IF;
+
+  SELECT resource_id INTO v_res FROM audit_log WHERE resource_type='billing_credits' ORDER BY created_at DESC LIMIT 1;
+  IF v_res IS NOT NULL THEN RAISE EXCEPTION 'TEST 1 FAILED: bigserial PK should map to NULL resource_id, got %', v_res; END IF;
+
+  RAISE NOTICE 'TEST 1 PASS: bigserial-PK insert succeeds (no 22P02), audit resource_id NULL';
+END;$$;
+
+ROLLBACK; BEGIN;
+
+-- Test 2: churn_save_offers.polar_discount_code scrubbed from audit_log (SEC-ADV-R2-003).
+DO $$
+DECLARE u uuid := gen_random_uuid(); a uuid := gen_random_uuid(); rec jsonb;
+BEGIN
+  INSERT INTO auth.users (id, email) VALUES (u,'churn097@test.local'),(a,'adm097b@test.local');
+  INSERT INTO profiles (id) VALUES (u),(a) ON CONFLICT DO NOTHING;
+
+  INSERT INTO churn_save_offers (user_id, kind, discount_pct, discount_duration_months, sent_by, sent_at, expires_at, polar_discount_code, reason)
+    VALUES (u, 'annual_3mo_25pct', 25, 3, a, now(), now()+interval '7 days', 'SECRET-COUPON-XYZ', 'retention');
+
+  SELECT metadata->'record' INTO rec FROM audit_log WHERE resource_type='churn_save_offers' ORDER BY created_at DESC LIMIT 1;
+  IF rec IS NULL THEN RAISE EXCEPTION 'TEST 2 FAILED: churn insert not audited'; END IF;
+  IF rec ? 'polar_discount_code' THEN
+    RAISE EXCEPTION 'TEST 2 FAILED: polar_discount_code leaked into audit_log: %', rec->>'polar_discount_code';
+  END IF;
+
+  RAISE NOTICE 'TEST 2 PASS: churn_save_offers polar_discount_code scrubbed from audit_log';
+END;$$;
+
+ROLLBACK; BEGIN;
+
+-- Test 3: profiles self-delete still FK-safe (096 behavior preserved by 097).
+DO $$
+DECLARE u uuid := gen_random_uuid(); logged record; n int;
+BEGIN
+  INSERT INTO auth.users (id, email) VALUES (u, 'selfdel097@test.local');
+  INSERT INTO profiles (id) VALUES (u) ON CONFLICT DO NOTHING;
+  PERFORM set_config('request.jwt.claim.sub', u::text, true);
+  PERFORM set_config('request.jwt.claims', json_build_object('sub',u::text,'role','authenticated')::text, true);
+  DELETE FROM public.profiles WHERE id = u;  -- must NOT raise 23503
+  PERFORM set_config('request.jwt.claim.sub', '', true);
+  SELECT count(*) INTO n FROM profiles WHERE id = u;
+  IF n <> 0 THEN RAISE EXCEPTION 'TEST 3 FAILED: profile not deleted'; END IF;
+  SELECT user_id, resource_id INTO logged FROM audit_log WHERE resource_type='profiles' AND resource_id=u ORDER BY created_at DESC LIMIT 1;
+  IF logged.user_id IS NOT NULL THEN RAISE EXCEPTION 'TEST 3 FAILED: self-delete audit user_id should be NULL'; END IF;
+  RAISE NOTICE 'TEST 3 PASS: profiles self-delete FK-safe + audited (user_id NULL)';
+END;$$;
+
+ROLLBACK;
+
+DO $$ BEGIN
+  RAISE NOTICE '================================================================';
+  RAISE NOTICE 'ALL TESTS PASSED — migration 097 audit_trigger_fn defensive blocks intact';
+  RAISE NOTICE '================================================================';
+END;$$;


### PR DESCRIPTION
First wave of fixes from the comprehensive adversarial bug-hunt (each finding verified by a skeptic agent before fixing). 14 bugs total.

## DB — critical (already applied to prod)
**Migration 097** restores the two defensive blocks that migration 096 (PR #331, this session) silently dropped when it rewrote `audit_trigger_fn` from scratch:
1. **bigserial-PK cast guard** — without it, the first write to `billing_credits` / `churn_save_offers` / `support_access_grants` raised `22P02` and **500'd every admin credit / churn-save / support-access op**.
2. **`churn_save_offers.polar_discount_code` scrub** — without it, every churn offer **leaked the Polar coupon code** into the owner-readable `audit_log` + GDPR export.

Preserves 096's profile-delete FK-safety. +regression test exercising a bigserial table + the scrub (096's test only covered profiles — why it regressed silently). **Verified on prod**: no 22P02, coupon scrubbed.

## Shared
- **context-sync** leaked absolute file paths cross-agent despite documented basename scrub → masked at source.
- **generateDeviceId** built a non-time-ordered UUID v7 → rewritten per RFC 9562 (+ordering test).

## Mobile
- **invite-accept** non-atomic (seat race + stranded user) → atomic `accept_team_invitation` RPC like web.
- error-status sessions invisible in both filters → `error` is terminal.
- `isPaid` / budget-limit now `normalizeTier()` (defensive power→growth).
- `useCosts` realtime leak on fast unmount → cancelled flag.
- **VoiceInput** never stopped the mic on unmount → cleanup effect.
- cold-start notification double-navigate → dedupe by id.
- CloudTaskSubmitSheet showed teammates' repo paths → `.eq('user_id')`.
- budget-alert rendered quota-%/credits as USD → format by type.
- auto-mark-onboarded fired on public deep-links → gated to auth route.

## Web
- subscription-confirmed email labeled Growth subscribers **"Power"** → "Growth".

## Test Plan
- [x] migration 097 applied + verified on prod (no 22P02, coupon scrubbed)
- [x] typecheck 7/7 · mobile 1695 · shared 1311 · web 3841 tests pass · mobile+shared lint clean
- [ ] CI green

Offline-sync cluster excluded (separate feature build). Full audit: `docs/planning/styrby-bughunt-2026-06-09.md` (local).

🤖 Shipped via /gh-ship