### PR TITLE
fix(audit): bug-hunt batch 2 — 27 verified bugs (17 web + 10 CLI)

### DIFF
--- a/packages/styrby-cli/src/__tests__/configuration.test.ts
+++ b/packages/styrby-cli/src/__tests__/configuration.test.ts
@@ -2,16 +2,18 @@
  * Tests for configuration.ts — ~/.styrby/config.json read/write.
  *
  * Covers:
- * - saveConfig creates a new file with mode 0o600  (sec H-05 fix: new file)
- * - saveConfig calls chmodSync 0o600 on existing file  (sec H-05 fix: upgrade path)
+ * - saveConfig writes the temp file with mode 0o600  (sec H-05 fix: new file)
+ * - saveConfig calls chmodSync 0o600 then renames atomically  (audit fix #39)
  * - loadConfig returns correct values round-trip
+ * - loadConfig surfaces a warning + returns {} on corrupt JSON  (audit fix #39)
  * - setConfigValue merges without clobbering other keys
  *
  * WHY: config.json holds the auth token and machine ID. World-readable permissions
  * would expose credentials to other local users. The chmodSync call in saveConfig
  * was added to repair pre-existing files that were created without the restrictive
- * mode. These tests guard that both the new-file and existing-file paths enforce
- * mode 0o600. (sec H-05)
+ * mode. saveConfig now writes to a temp file + atomically renames so a crash
+ * mid-write never leaves a truncated config (audit 2026-06-09 fix #39). These
+ * tests guard the 0o600 mode AND the atomic write+rename ordering.
  *
  * @module __tests__/configuration.test
  */
@@ -33,6 +35,7 @@ vi.mock('node:fs', async (importOriginal) => {
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
     chmodSync: vi.fn(),
+    renameSync: vi.fn(),
     readFileSync: vi.fn().mockImplementation(() => { throw new Error('ENOENT'); }),
   };
 });
@@ -48,31 +51,43 @@ describe('saveConfig', () => {
     vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('no file'); });
   });
 
-  it('writes config.json with mode 0o600 (new file path)', () => {
+  it('writes the temp file with mode 0o600 (new file path)', () => {
     saveConfig({ machineId: 'test-machine' });
 
     expect(fs.writeFileSync).toHaveBeenCalledOnce();
-    const [, , opts] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string, { mode: number }];
+    const [tmpPath, , opts] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string, { mode: number }];
+    // Atomic write target is the temp file, not the final config.json.
+    expect(tmpPath).toContain('config.json.tmp');
     expect(opts.mode).toBe(0o600);
   });
 
-  it('calls chmodSync 0o600 after writing (existing file path — upgrade fix)', () => {
+  it('calls chmodSync 0o600 on the temp file (upgrade fix)', () => {
     saveConfig({ machineId: 'test-machine' });
 
     expect(fs.chmodSync).toHaveBeenCalledOnce();
     const [filePath, mode] = vi.mocked(fs.chmodSync).mock.calls[0] as [string, number];
-    expect(filePath).toContain('config.json');
+    expect(filePath).toContain('config.json.tmp');
     expect(mode).toBe(0o600);
   });
 
-  it('chmodSync is called AFTER writeFileSync (order matters)', () => {
+  it('renames the temp file onto config.json atomically (audit fix #39)', () => {
+    saveConfig({ machineId: 'test-machine' });
+
+    expect(fs.renameSync).toHaveBeenCalledOnce();
+    const [from, to] = vi.mocked(fs.renameSync).mock.calls[0] as [string, string];
+    expect(from).toContain('config.json.tmp');
+    expect(to).toMatch(/config\.json$/);
+  });
+
+  it('write -> chmod -> rename happen in that order (atomicity invariant)', () => {
     const callOrder: string[] = [];
     vi.mocked(fs.writeFileSync).mockImplementation(() => { callOrder.push('write'); });
     vi.mocked(fs.chmodSync).mockImplementation(() => { callOrder.push('chmod'); });
+    vi.mocked(fs.renameSync).mockImplementation(() => { callOrder.push('rename'); });
 
     saveConfig({ debug: true });
 
-    expect(callOrder).toEqual(['write', 'chmod']);
+    expect(callOrder).toEqual(['write', 'chmod', 'rename']);
   });
 });
 
@@ -92,6 +107,15 @@ describe('loadConfig', () => {
   it('returns empty object when file read throws', () => {
     vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
     const config = loadConfig();
+    expect(config).toEqual({});
+  });
+
+  it('returns {} on corrupt/truncated JSON (audit fix #39: no silent swallow)', () => {
+    // Simulate a config.json truncated mid-write (the non-atomic-save hazard).
+    vi.mocked(fs.readFileSync).mockReturnValue('{ "machineId": "abc", "userI');
+    const config = loadConfig();
+    // It still degrades to empty (so the app doesn't crash), but the parse
+    // failure is now logged loudly rather than masquerading as "logged out".
     expect(config).toEqual({});
   });
 });

--- a/packages/styrby-cli/src/agent/StreamingAgentBackendBase.ts
+++ b/packages/styrby-cli/src/agent/StreamingAgentBackendBase.ts
@@ -180,6 +180,59 @@ export abstract class StreamingAgentBackendBase implements AgentBackend {
   protected disposed = false;
 
   /**
+   * True when the in-flight run was terminated by an intentional user
+   * `cancel()` (or by `dispose()`), rather than by the agent crashing.
+   *
+   * WHY (audit 2026-06-09 HIGH fix #6): a user-initiated cancel SIGTERMs the
+   * subprocess, which then fires the `close` handler with a non-zero / signal
+   * exit code. Without this flag the close handler treated that as an agent
+   * FAILURE — emitting a `status: 'error'` frame ("Aider exited with code
+   * null") and rejecting the in-flight `sendPrompt` promise. Mobile then
+   * showed a spurious error for what was a normal cancel.
+   *
+   * Subclass `close` handlers consult `wasCancelled()` and, when true, emit a
+   * clean idle/cancelled status + resolve instead of error + reject. The flag
+   * is cleared at the start of each new prompt via `beginRun()`.
+   */
+  protected cancelled = false;
+
+  /**
+   * Reset run-scoped state at the start of a new prompt.
+   *
+   * Currently clears the `cancelled` flag so a fresh run is not mistaken for a
+   * previously-cancelled one. Subclasses MUST call this at the top of
+   * `sendPrompt()` (before spawning) so the cancel-vs-crash discrimination in
+   * the close handler is correct per run.
+   */
+  protected beginRun(): void {
+    this.cancelled = false;
+  }
+
+  /**
+   * Mark the in-flight run as intentionally cancelled.
+   *
+   * Subclass `cancel()` implementations MUST call this BEFORE sending SIGTERM
+   * so the subsequent `close` handler can distinguish an intentional cancel
+   * from an agent crash (audit 2026-06-09 fix #6).
+   */
+  protected markCancelled(): void {
+    this.cancelled = true;
+  }
+
+  /**
+   * Whether the current/just-ended run was terminated by an intentional
+   * cancel or dispose.
+   *
+   * Subclass `close` handlers use this to decide, on a non-zero exit, whether
+   * to surface a clean cancelled status (true) or a genuine error (false).
+   *
+   * @returns True if `cancel()`/`dispose()` initiated the termination.
+   */
+  protected wasCancelled(): boolean {
+    return this.cancelled;
+  }
+
+  /**
    * SIGTERM -> SIGKILL escalation timer, or undefined when no cancel is in
    * flight.
    *
@@ -474,15 +527,49 @@ export abstract class StreamingAgentBackendBase implements AgentBackend {
     if (this.disposed) return;
     this.disposed = true;
 
+    // Mark cancelled so any close handler that fires from the SIGTERM below
+    // treats the exit as an intentional teardown, not an agent crash
+    // (audit 2026-06-09 fix #6). `emit()` is also a no-op once `disposed` is
+    // set, so no status frame escapes regardless.
+    this.cancelled = true;
+
     this.clearCancelTimer();
 
     if (this.process) {
+      // WHY (audit 2026-06-09 fix #37): the class docstring promises force-kill
+      // escalation as a reliability guarantee, but dispose() previously only
+      // sent SIGTERM and immediately nulled `this.process`. A misbehaving agent
+      // that ignores SIGTERM (blocked in a syscall, owns a child process group)
+      // then survived disposal, leaking an orphaned subprocess that holds file
+      // handles and — for cloud-billed agents — can keep incurring cost after
+      // the user believes the session ended.
+      //
+      // Capture the child in a LOCAL const before nulling the field, then
+      // schedule a SIGKILL against that local ref so escalation still fires even
+      // though `this.process` is cleared. We use a detached, unref'd timer so it
+      // does not keep the Node event loop alive during graceful CLI shutdown.
+      const child = this.process;
       try {
-        this.process.kill('SIGTERM');
+        child.kill('SIGTERM');
       } catch {
         // Process may already be dead; safe to ignore.
       }
       this.process = null;
+
+      if (!child.killed) {
+        const forceKill = setTimeout(() => {
+          if (!child.killed) {
+            try {
+              child.kill('SIGKILL');
+            } catch {
+              // Already exited between the check and the kill; ignore.
+            }
+          }
+        }, FORCE_KILL_DELAY_MS);
+        // Do not let this escalation timer hold the process open; if the event
+        // loop drains first the OS reaps the child on parent exit anyway.
+        forceKill.unref?.();
+      }
     }
 
     // WHY: Drop references to application-level handlers so the closures they

--- a/packages/styrby-cli/src/agent/factories/__tests__/aider.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/aider.test.ts
@@ -735,6 +735,36 @@ describe('AiderBackend — cancel', () => {
     // No sendPrompt call — no active process
     await expect(backend.cancel(sessionId)).resolves.not.toThrow();
   });
+
+  it('does NOT surface a false error when a cancelled process exits non-zero (audit fix #6)', async () => {
+    const { backend } = createAiderBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    // Start a prompt and capture its promise so we can assert it resolves.
+    const promptPromise = backend.sendPrompt(sessionId, 'long running task');
+
+    // User taps Cancel -> SIGTERM. The subprocess then exits with a
+    // signal/non-zero code (Node reports null for SIGTERM-killed processes).
+    await backend.cancel(sessionId);
+    (currentMockProcess.stdout as PassThrough).end();
+    (currentMockProcess.stderr as PassThrough).end();
+    process.nextTick(() => currentMockProcess.emit('close', null));
+
+    // The in-flight sendPrompt promise must RESOLVE (not reject) — a cancel is
+    // intentional, not an agent failure.
+    await expect(promptPromise).resolves.toBeUndefined();
+
+    // No 'error' status frame may have been emitted by the close handler.
+    const errorStatuses = messages.filter(
+      (m: any) => m.type === 'status' && m.status === 'error',
+    );
+    expect(errorStatuses).toHaveLength(0);
+
+    // The terminal status must be a clean idle.
+    const lastStatus = messages.filter((m: any) => m.type === 'status').at(-1) as any;
+    expect(lastStatus?.status).toBe('idle');
+  });
 });
 
 // ===========================================================================

--- a/packages/styrby-cli/src/agent/factories/__tests__/goose.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/goose.test.ts
@@ -862,7 +862,7 @@ describe('GooseBackend — error handling', () => {
     expect(errorStatuses.length).toBeGreaterThan(0);
   });
 
-  it('emits error status when stderr contains "failed"', async () => {
+  it('emits error status for a structured Traceback header', async () => {
     const { backend } = createGooseBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
@@ -870,13 +870,32 @@ describe('GooseBackend — error handling', () => {
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     (currentMockProcess.stderr as EventEmitter).emit(
       'data',
-      Buffer.from('Connection failed: timeout after 30s'),
+      Buffer.from('Traceback (most recent call last):\n  File "x.py", line 1'),
     );
     simulateProcess(currentMockProcess, [], 0);
     await promptPromise;
 
     const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
     expect(errorStatuses.length).toBeGreaterThan(0);
+  });
+
+  it('does NOT emit error status for a benign "0 errors" diagnostic (audit fix #20)', async () => {
+    // WHY: the previous case-insensitive substring scan flipped the session to
+    // an error state on a completely successful run like "Tests passed, 0 errors".
+    const { backend } = createGooseBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    (currentMockProcess.stderr as EventEmitter).emit(
+      'data',
+      Buffer.from('Tests passed, 0 errors, 0 warnings'),
+    );
+    simulateProcess(currentMockProcess, [], 0);
+    await promptPromise;
+
+    const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
+    expect(errorStatuses).toHaveLength(0);
   });
 
   it('rejects sendPrompt when the spawned process emits an "error" event', async () => {

--- a/packages/styrby-cli/src/agent/factories/aider.ts
+++ b/packages/styrby-cli/src/agent/factories/aider.ts
@@ -29,6 +29,7 @@ import type {
 import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, validateExtraArgs } from '@/utils/safeEnv';
+import { resolveApiKeyEnv, type ApiKeyProvider } from '@/utils/apiKeyProvider';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
 import type { CostReport } from '@styrby/shared/cost';
 
@@ -59,6 +60,21 @@ export interface AiderBackendOptions extends AgentFactoryOptions {
    * These files will be available for Aider to read and edit.
    */
   files?: string[];
+
+  /**
+   * LLM provider this BYOK key belongs to (e.g. 'anthropic', 'openai').
+   *
+   * WHY (audit 2026-06-09 HIGH fix #7): Aider is multi-provider, but the
+   * factory previously hardcoded the key into OPENAI_API_KEY. An Aider user
+   * supplying an Anthropic `sk-ant-...` key had it exported under the wrong
+   * name, disclosing it to OpenAI's auth endpoint during Aider's provider
+   * validation (the cross-provider key-disclosure class the goose fix closed)
+   * and silently failing to authenticate.
+   *
+   * If unset, the factory sniffs the key prefix and falls back to legacy
+   * fan-out only when sniffing fails (with a deprecation warning).
+   */
+  provider?: ApiKeyProvider;
 }
 
 /**
@@ -244,6 +260,10 @@ class AiderBackend extends StreamingAgentBackendBase {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
 
+    // Reset run-scoped state (clears the cancelled flag) so this run's exit is
+    // classified correctly by the close handler (audit 2026-06-09 fix #6).
+    this.beginRun();
+
     // Update input token estimate
     this.inputTokens += estimateTokens(prompt);
     this.streamingOutputTokens = 0;
@@ -295,8 +315,19 @@ class AiderBackend extends StreamingAgentBackendBase {
           cwd: this.options.cwd,
           env: buildSafeEnv({
             ...this.options.env,
-            // Pass API key if provided
-            ...(this.options.apiKey ? { OPENAI_API_KEY: this.options.apiKey } : {}),
+            // SECURITY (audit 2026-06-09 HIGH fix #7): inject the API key only
+            // under the env-var name(s) for its detected provider. The previous
+            // hardcoded OPENAI_API_KEY shipped Anthropic/Google keys to OpenAI's
+            // auth endpoint during Aider startup validation, disclosing them to
+            // the wrong vendor (and silently failing auth). resolveApiKeyEnv()
+            // prefers an explicit `provider`, falls back to prefix-sniffing, and
+            // only multi-injects (with a deprecation warn) when both fail.
+            ...resolveApiKeyEnv(
+              this.options.apiKey,
+              ['OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'GOOGLE_API_KEY'],
+              this.options.provider,
+              'AiderBackend',
+            ),
           }),
           stdio: ['pipe', 'pipe', 'pipe'],
         });
@@ -414,6 +445,13 @@ class AiderBackend extends StreamingAgentBackendBase {
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });
             resolve();
+          } else if (this.wasCancelled()) {
+            // Intentional user cancel (or dispose) SIGTERM'd the process, which
+            // surfaces here as a non-zero/null exit. Emit a clean idle status and
+            // resolve instead of reporting a spurious agent error to mobile
+            // (audit 2026-06-09 fix #6).
+            this.emit({ type: 'status', status: 'idle' });
+            resolve();
           } else {
             this.emit({
               type: 'status',
@@ -456,6 +494,10 @@ class AiderBackend extends StreamingAgentBackendBase {
 
     if (this.process) {
       logger.debug('[AiderBackend] Cancelling Aider process');
+      // Mark the run cancelled BEFORE SIGTERM so the close handler treats the
+      // resulting non-zero/signal exit as an intentional cancel, not a crash
+      // (audit 2026-06-09 fix #6).
+      this.markCancelled();
       this.process.kill('SIGTERM');
 
       // WHY: Track the escalation timer via base class so it is cleared on

--- a/packages/styrby-cli/src/agent/factories/amp.ts
+++ b/packages/styrby-cli/src/agent/factories/amp.ts
@@ -502,6 +502,10 @@ class AmpBackend extends StreamingAgentBackendBase {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
 
+    // Reset run-scoped state (clears the cancelled flag) so this run's exit is
+    // classified correctly by the close handler (audit 2026-06-09 fix #6).
+    this.beginRun();
+
     this.lineBuffer = '';
     this.activeSubAgents.clear();
     this.emit({ type: 'status', status: 'running' });
@@ -608,6 +612,12 @@ class AmpBackend extends StreamingAgentBackendBase {
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });
             resolve();
+          } else if (this.wasCancelled()) {
+            // Intentional user cancel (or dispose) SIGTERM'd the process, which
+            // surfaces here as a non-zero/null exit. Emit a clean idle status and
+            // resolve instead of a spurious agent error (audit 2026-06-09 fix #6).
+            this.emit({ type: 'status', status: 'idle' });
+            resolve();
           } else {
             this.emit({
               type: 'status',
@@ -664,6 +674,9 @@ class AmpBackend extends StreamingAgentBackendBase {
 
     if (this.process) {
       logger.debug('[AmpBackend] Cancelling Amp process');
+      // Mark cancelled BEFORE SIGTERM so the close handler treats the resulting
+      // non-zero exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
+      this.markCancelled();
       this.process.kill('SIGTERM');
       // WHY: Track the SIGKILL escalation timer via the base class so it is
       // cleared on clean exit / dispose / double-cancel. SOC2 CC7.2.

--- a/packages/styrby-cli/src/agent/factories/crush.ts
+++ b/packages/styrby-cli/src/agent/factories/crush.ts
@@ -468,6 +468,10 @@ class CrushBackend extends StreamingAgentBackendBase {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
 
+    // Reset run-scoped state (clears the cancelled flag) so this run's exit is
+    // classified correctly by the close handler (audit 2026-06-09 fix #6).
+    this.beginRun();
+
     this.lineBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
@@ -574,6 +578,12 @@ class CrushBackend extends StreamingAgentBackendBase {
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });
             resolve();
+          } else if (this.wasCancelled()) {
+            // Intentional user cancel (or dispose) SIGTERM'd the process, which
+            // surfaces here as a non-zero/null exit. Emit a clean idle status and
+            // resolve instead of a spurious agent error (audit 2026-06-09 fix #6).
+            this.emit({ type: 'status', status: 'idle' });
+            resolve();
           } else {
             this.emit({
               type: 'status',
@@ -629,6 +639,9 @@ class CrushBackend extends StreamingAgentBackendBase {
 
     if (this.process) {
       logger.debug('[CrushBackend] Cancelling Crush process');
+      // Mark cancelled BEFORE SIGTERM so the close handler treats the resulting
+      // non-zero exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
+      this.markCancelled();
       this.process.kill('SIGTERM');
 
       // WHY: Give Crush 3 seconds to clean up its TUI terminal state before

--- a/packages/styrby-cli/src/agent/factories/droid.ts
+++ b/packages/styrby-cli/src/agent/factories/droid.ts
@@ -585,6 +585,10 @@ class DroidBackend extends StreamingAgentBackendBase {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
 
+    // Reset run-scoped state (clears the cancelled flag) so this run's exit is
+    // classified correctly by the close handler (audit 2026-06-09 fix #6).
+    this.beginRun();
+
     this.lineBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
@@ -710,6 +714,12 @@ class DroidBackend extends StreamingAgentBackendBase {
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });
             resolve();
+          } else if (this.wasCancelled()) {
+            // Intentional user cancel (or dispose) SIGTERM'd the process, which
+            // surfaces here as a non-zero/null exit. Emit a clean idle status and
+            // resolve instead of a spurious agent error (audit 2026-06-09 fix #6).
+            this.emit({ type: 'status', status: 'idle' });
+            resolve();
           } else {
             this.emit({
               type: 'status',
@@ -766,6 +776,9 @@ class DroidBackend extends StreamingAgentBackendBase {
 
     if (this.process) {
       logger.debug('[DroidBackend] Cancelling Droid process');
+      // Mark cancelled BEFORE SIGTERM so the close handler treats the resulting
+      // non-zero exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
+      this.markCancelled();
       this.process.kill('SIGTERM');
       // WHY: Track escalation timer via base class so it is cleared on clean
       // exit / dispose / double-cancel. SOC2 CC7.2.

--- a/packages/styrby-cli/src/agent/factories/goose.ts
+++ b/packages/styrby-cli/src/agent/factories/goose.ts
@@ -195,6 +195,42 @@ function isFileEditTool(toolName: string): boolean {
   return fileEditTools.some((t) => toolName.toLowerCase().includes(t));
 }
 
+/**
+ * Detect an ANCHORED / structured error signal in a chunk of agent stderr.
+ *
+ * WHY (audit 2026-06-09 fix #20): the previous gate was a case-insensitive
+ * substring scan for 'error'/'exception'/'failed' anywhere in stderr. A normal
+ * diagnostic such as "Tests passed, 0 errors" or "0 errors, 0 warnings" tripped
+ * it and emitted a `status: 'error'` frame, flipping the session to an error
+ * state mid-run even though the agent succeeded (close later resolves with code
+ * 0). That produced a flickering / stuck-error session UI on completely
+ * successful runs.
+ *
+ * We now require a STRUCTURED marker: a line that STARTS with an error label
+ * (after optional leading whitespace / log-level brackets), a Python traceback
+ * header, or a panic. "0 errors" no longer matches because the word is not at a
+ * line start in an error-label position.
+ *
+ * @param text - A chunk of stderr output (may contain multiple lines).
+ * @returns True if any line carries a structured error signal.
+ */
+export function hasStructuredErrorSignal(text: string): boolean {
+  for (const rawLine of text.split(/\r?\n/)) {
+    // Strip a leading log-level prefix like "[2026-06-09] " or "WARN: " noise
+    // is irrelevant; we anchor on the error token itself at the start of the
+    // meaningful content.
+    const line = rawLine.replace(/^\s+/, '');
+    if (
+      /^(?:error|fatal|panic|exception|traceback)\b[:\s]/i.test(line) ||
+      /^traceback \(most recent call last\)/i.test(line) ||
+      /^panic:/i.test(line)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // ============================================================================
 // GooseBackend Class
 // ============================================================================
@@ -439,6 +475,10 @@ class GooseBackend extends StreamingAgentBackendBase {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
 
+    // Reset run-scoped state (clears the cancelled flag) so this run's exit is
+    // classified correctly by the close handler (audit 2026-06-09 fix #6).
+    this.beginRun();
+
     this.lineBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
@@ -483,6 +523,13 @@ class GooseBackend extends StreamingAgentBackendBase {
     logger.debug(`[GooseBackend] Spawning goose with args:`, args);
 
     return new Promise<void>((resolve, reject) => {
+      // WHY (audit 2026-06-09 fix #38): the 'error' (ENOENT/spawn-failure) and
+      // 'close' handlers can BOTH fire for a single failed spawn. Previously the
+      // close handler then emitted a second, contradictory status frame ("Goose
+      // exited with code 1") that clobbered the friendly install hint the error
+      // handler had just shown. This sentinel ensures whichever handler settles
+      // the promise first wins; the other becomes a no-op.
+      let settled = false;
       try {
         // SECURITY: Use buildSafeEnv() instead of spreading process.env to prevent
         // leaking secrets (SUPABASE_SERVICE_ROLE_KEY, DATABASE_URL, etc.) to the
@@ -524,13 +571,10 @@ class GooseBackend extends StreamingAgentBackendBase {
           const text = data.toString();
           logger.debug(`[GooseBackend] stderr: ${text.trim()}`);
 
-          // Emit error status for critical errors
-          if (
-            text.includes('Error') ||
-            text.includes('error') ||
-            text.includes('Exception') ||
-            text.includes('failed')
-          ) {
+          // Emit error status only for ANCHORED/structured error signals so a
+          // benign line like "0 errors" does not poison the session state
+          // (audit 2026-06-09 fix #20).
+          if (hasStructuredErrorSignal(text)) {
             this.emit({
               type: 'status',
               status: 'error',
@@ -552,7 +596,22 @@ class GooseBackend extends StreamingAgentBackendBase {
             this.lineBuffer = '';
           }
 
+          this.process = null;
+
+          // If the 'error' handler already settled this run (e.g. ENOENT), do
+          // not emit a second contradictory status / reject again (fix #38).
+          if (settled) {
+            return;
+          }
+          settled = true;
+
           if (code === 0) {
+            this.emit({ type: 'status', status: 'idle' });
+            resolve();
+          } else if (this.wasCancelled()) {
+            // Intentional user cancel (or dispose) SIGTERM'd the process, which
+            // surfaces here as a non-zero/null exit. Emit a clean idle status and
+            // resolve instead of a spurious agent error (audit 2026-06-09 fix #6).
             this.emit({ type: 'status', status: 'idle' });
             resolve();
           } else {
@@ -563,14 +622,18 @@ class GooseBackend extends StreamingAgentBackendBase {
             });
             reject(new Error(`Goose exited with code ${code}`));
           }
-
-          this.process = null;
         });
 
         // Handle process spawn errors (e.g., binary not found)
         // WHY (Phase 0.3 / SOC2 CC7.2): Surface friendly install hint on
         // ENOENT instead of raw "spawn ... ENOENT" Node error.
         this.process.on('error', (err: NodeJS.ErrnoException) => {
+          // First settler wins; a later 'close' must not re-emit (fix #38).
+          if (settled) {
+            return;
+          }
+          settled = true;
+
           if (err.code === 'ENOENT') {
             const message = formatInstallHint('goose');
             logger.warn(`[GooseBackend] ${message}`);
@@ -610,6 +673,9 @@ class GooseBackend extends StreamingAgentBackendBase {
 
     if (this.process) {
       logger.debug('[GooseBackend] Cancelling Goose process');
+      // Mark cancelled BEFORE SIGTERM so the close handler treats the resulting
+      // non-zero exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
+      this.markCancelled();
       this.process.kill('SIGTERM');
       // WHY: Give Goose 3 seconds to clean up MCP server connections gracefully
       // before forcing a kill. MCP servers may be running as child processes of

--- a/packages/styrby-cli/src/agent/factories/kilo.ts
+++ b/packages/styrby-cli/src/agent/factories/kilo.ts
@@ -579,6 +579,10 @@ class KiloBackend extends StreamingAgentBackendBase {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
 
+    // Reset run-scoped state (clears the cancelled flag) so this run's exit is
+    // classified correctly by the close handler (audit 2026-06-09 fix #6).
+    this.beginRun();
+
     this.lineBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
@@ -706,6 +710,12 @@ class KiloBackend extends StreamingAgentBackendBase {
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });
             resolve();
+          } else if (this.wasCancelled()) {
+            // Intentional user cancel (or dispose) SIGTERM'd the process, which
+            // surfaces here as a non-zero/null exit. Emit a clean idle status and
+            // resolve instead of a spurious agent error (audit 2026-06-09 fix #6).
+            this.emit({ type: 'status', status: 'idle' });
+            resolve();
           } else {
             this.emit({
               type: 'status',
@@ -762,6 +772,9 @@ class KiloBackend extends StreamingAgentBackendBase {
 
     if (this.process) {
       logger.debug('[KiloBackend] Cancelling Kilo process');
+      // Mark cancelled BEFORE SIGTERM so the close handler treats the resulting
+      // non-zero exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
+      this.markCancelled();
       this.process.kill('SIGTERM');
       // WHY: Give Kilo 3 seconds to flush any pending Memory Bank writes to disk
       // before SIGKILL. A partial write could corrupt the project context on next

--- a/packages/styrby-cli/src/agent/factories/kiro.ts
+++ b/packages/styrby-cli/src/agent/factories/kiro.ts
@@ -475,6 +475,10 @@ class KiroBackend extends StreamingAgentBackendBase {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
 
+    // Reset run-scoped state (clears the cancelled flag) so this run's exit is
+    // classified correctly by the close handler (audit 2026-06-09 fix #6).
+    this.beginRun();
+
     this.lineBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
@@ -577,6 +581,12 @@ class KiroBackend extends StreamingAgentBackendBase {
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });
             resolve();
+          } else if (this.wasCancelled()) {
+            // Intentional user cancel (or dispose) SIGTERM'd the process, which
+            // surfaces here as a non-zero/null exit. Emit a clean idle status and
+            // resolve instead of a spurious agent error (audit 2026-06-09 fix #6).
+            this.emit({ type: 'status', status: 'idle' });
+            resolve();
           } else {
             this.emit({
               type: 'status',
@@ -632,6 +642,9 @@ class KiroBackend extends StreamingAgentBackendBase {
 
     if (this.process) {
       logger.debug('[KiroBackend] Cancelling Kiro process');
+      // Mark cancelled BEFORE SIGTERM so the close handler treats the resulting
+      // non-zero exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
+      this.markCancelled();
       this.process.kill('SIGTERM');
       // WHY: Give Kiro 3 seconds to cleanly close its AWS API connections
       // before forcing a kill. This prevents resource leaks in the Kiro

--- a/packages/styrby-cli/src/agent/factories/opencode.ts
+++ b/packages/styrby-cli/src/agent/factories/opencode.ts
@@ -25,6 +25,7 @@ import type {
 import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
+import { resolveApiKeyEnv, type ApiKeyProvider } from '@/utils/apiKeyProvider';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
 import type { CostReport } from '@styrby/shared/cost';
 
@@ -67,6 +68,22 @@ export interface OpenCodeBackendOptions extends AgentFactoryOptions {
    * OpenCode supports session persistence.
    */
   resumeSessionId?: string;
+
+  /**
+   * LLM provider this BYOK key belongs to (e.g. 'anthropic', 'openai').
+   *
+   * WHY (audit 2026-06-09 HIGH fix #7): OpenCode is multi-provider, but the
+   * factory previously hardcoded the key into ANTHROPIC_API_KEY. An OpenCode
+   * user supplying an OpenAI `sk-...` key had it exported under the wrong name,
+   * so it (a) was presented to Anthropic's auth endpoint during OpenCode's
+   * startup provider validation — appearing in the WRONG vendor's logs as a
+   * rejected credential (the cross-provider key-disclosure class the goose fix
+   * already closed) and (b) silently failed to authenticate.
+   *
+   * If unset, the factory sniffs the key prefix and falls back to legacy
+   * fan-out only when sniffing fails (with a deprecation warning).
+   */
+  provider?: ApiKeyProvider;
 }
 
 /**
@@ -357,6 +374,10 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
 
+    // Reset run-scoped state (clears the cancelled flag) so this run's exit is
+    // classified correctly by the close handler (audit 2026-06-09 fix #6).
+    this.beginRun();
+
     this.emit({ type: 'status', status: 'running' });
 
     // Build OpenCode command arguments
@@ -392,8 +413,20 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
           cwd: this.options.cwd,
           env: buildSafeEnv({
             ...this.options.env,
-            // Pass API key if provided
-            ...(this.options.apiKey ? { ANTHROPIC_API_KEY: this.options.apiKey } : {}),
+            // SECURITY (audit 2026-06-09 HIGH fix #7): inject the API key only
+            // under the env-var name(s) for its detected provider. The previous
+            // hardcoded ANTHROPIC_API_KEY shipped OpenAI/Google keys to
+            // Anthropic's auth endpoint during OpenCode startup validation,
+            // disclosing them to the wrong vendor (and silently failing auth).
+            // resolveApiKeyEnv() prefers an explicit `provider`, falls back to
+            // prefix-sniffing, and only multi-injects (with a deprecation warn)
+            // when both fail. Mirrors goose.ts:503-508.
+            ...resolveApiKeyEnv(
+              this.options.apiKey,
+              ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_API_KEY'],
+              this.options.provider,
+              'OpenCodeBackend',
+            ),
           }),
           stdio: ['pipe', 'pipe', 'pipe'],
         });
@@ -440,6 +473,12 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
           }
 
           if (code === 0) {
+            this.emit({ type: 'status', status: 'idle' });
+            resolve();
+          } else if (this.wasCancelled()) {
+            // Intentional user cancel (or dispose) SIGTERM'd the process, which
+            // surfaces here as a non-zero/null exit. Emit a clean idle status and
+            // resolve instead of a spurious agent error (audit 2026-06-09 fix #6).
             this.emit({ type: 'status', status: 'idle' });
             resolve();
           } else {
@@ -495,6 +534,9 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
 
     if (this.process) {
       logger.debug('[OpenCodeBackend] Cancelling OpenCode process');
+      // Mark cancelled BEFORE SIGTERM so the close handler treats the resulting
+      // non-zero exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
+      this.markCancelled();
       this.process.kill('SIGTERM');
       // WHY: Track escalation timer via the base class so it is cleared on
       // clean exit / dispose / double-cancel. SOC2 CC7.2.

--- a/packages/styrby-cli/src/api/__tests__/relayMessageDispatch.test.ts
+++ b/packages/styrby-cli/src/api/__tests__/relayMessageDispatch.test.ts
@@ -54,12 +54,12 @@ function permResponse(payload: { request_id: string; request_nonce: string; appr
   };
 }
 
-/** Build a valid command message. */
-function command(action: string, agent?: string) {
+/** Build a valid command message, optionally scoped to a target session. */
+function command(action: string, agent?: string, params?: Record<string, unknown>) {
   return {
     ...BASE,
     type: 'command' as const,
-    payload: { agent: agent ?? 'claude', action },
+    payload: { agent: agent ?? 'claude', action, ...(params ? { params } : {}) },
   };
 }
 
@@ -233,5 +233,74 @@ describe('classifyRelayMessage: cancel/end-session carry the current session_id'
     const verdict = classifyRelayMessage(SESSION_ID, command('end_session'), ALWAYS_OK);
     if (verdict.action !== 'end-session') throw new Error('expected end-session');
     expect(verdict.sessionId).toBe(SESSION_ID);
+  });
+});
+
+describe('classifyRelayMessage: command cross-session scoping (audit fix #9)', () => {
+  // WHY: a cancel/interrupt/end_session command previously fanned out to EVERY
+  // active session on the daemon because it had no session targeting. Cancelling
+  // session A also killed session B. Commands now carry params.session_id and are
+  // dropped when they target a DIFFERENT session than the one being processed,
+  // mirroring the chat cross-session guard.
+
+  it('drops a cancel targeted at a DIFFERENT session', () => {
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      command('cancel', 'claude', { session_id: 'some-other-session' }),
+      ALWAYS_OK,
+    );
+    expect(verdict.action).toBe('drop-wrong-session');
+    if (verdict.action !== 'drop-wrong-session') throw new Error('expected drop-wrong-session');
+    expect(verdict.targetSession).toBe('some-other-session');
+  });
+
+  it('drops an interrupt targeted at a DIFFERENT session', () => {
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      command('interrupt', 'claude', { session_id: 'other' }),
+      ALWAYS_OK,
+    );
+    expect(verdict.action).toBe('drop-wrong-session');
+  });
+
+  it('drops an end_session targeted at a DIFFERENT session', () => {
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      command('end_session', 'claude', { session_id: 'other' }),
+      ALWAYS_OK,
+    );
+    expect(verdict.action).toBe('drop-wrong-session');
+  });
+
+  it('processes a cancel explicitly targeted at THIS session', () => {
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      command('cancel', 'claude', { session_id: SESSION_ID }),
+      ALWAYS_OK,
+    );
+    expect(verdict.action).toBe('cancel');
+    if (verdict.action !== 'cancel') throw new Error('expected cancel');
+    expect(verdict.sessionId).toBe(SESSION_ID);
+  });
+
+  it('still processes a command with NO session_id (backward compatibility)', () => {
+    // Single-session clients that omit session_id keep targeting the current
+    // session — the fan-out fix must not break them.
+    expect(classifyRelayMessage(SESSION_ID, command('cancel'), ALWAYS_OK).action).toBe('cancel');
+    expect(classifyRelayMessage(SESSION_ID, command('end_session'), ALWAYS_OK).action).toBe(
+      'end-session',
+    );
+  });
+
+  it('ignores a non-string session_id and falls through to normal routing', () => {
+    // A malformed numeric session_id must not match the string sessionId, but
+    // also must not throw — it is simply not a targeting match, so the command
+    // targets the current session (legacy behavior).
+    const verdict = classifyRelayMessage(
+      SESSION_ID,
+      command('cancel', 'claude', { session_id: 12345 }),
+      ALWAYS_OK,
+    );
+    expect(verdict.action).toBe('cancel');
   });
 });

--- a/packages/styrby-cli/src/api/relayMessageDispatch.ts
+++ b/packages/styrby-cli/src/api/relayMessageDispatch.ts
@@ -116,7 +116,21 @@ export function classifyRelayMessage(
     }
 
     case 'command': {
-      const { action: commandAction } = message.payload;
+      const { action: commandAction, params } = message.payload;
+
+      // Cross-session protection (audit 2026-06-09 HIGH fix #9): a
+      // cancel/interrupt/end_session command carries the targeted session in
+      // params.session_id. Without this guard the command fanned out to EVERY
+      // active session on the daemon — cancelling session A also killed session
+      // B. Mirror the chat path (step 3 above): if a session_id is present and
+      // doesn't match the session we're handling, drop it. Commands with no
+      // session_id keep the legacy behavior of targeting the current session
+      // (backward compatibility for single-session clients).
+      const targetSession = params?.['session_id'];
+      if (typeof targetSession === 'string' && targetSession !== sessionId) {
+        return { action: 'drop-wrong-session', targetSession };
+      }
+
       switch (commandAction) {
         case 'cancel':
         case 'interrupt':

--- a/packages/styrby-cli/src/claude/sdk/stream.ts
+++ b/packages/styrby-cli/src/claude/sdk/stream.ts
@@ -40,13 +40,22 @@ export class Stream<T> implements AsyncIterableIterator<T> {
             })
         }
 
-        // Check terminal states
-        if (this.isDone) {
-            return Promise.resolve({ done: true, value: undefined })
-        }
-
+        // Check terminal states.
+        // WHY (audit 2026-06-09 fix #21): the error check MUST take precedence
+        // over the done check. If error() was called while no consumer was parked
+        // in readReject (the generator was between awaits, or items were just
+        // queued), hasError is set but the rejection was never delivered. If
+        // isDone is also set (done() and error() both fired), checking isDone
+        // first returned { done: true } and silently swallowed the error — the
+        // turn loop then believed the Claude process ended cleanly when it had
+        // actually crashed. Surfacing the error first restores correct failure
+        // propagation to mobile.
         if (this.hasError) {
             return Promise.reject(this.hasError)
+        }
+
+        if (this.isDone) {
+            return Promise.resolve({ done: true, value: undefined })
         }
 
         // Wait for new data

--- a/packages/styrby-cli/src/cli/__tests__/agentShorthand.test.ts
+++ b/packages/styrby-cli/src/cli/__tests__/agentShorthand.test.ts
@@ -107,4 +107,34 @@ describe('buildStartArgs', () => {
     buildStartArgs(input, 'codex', null);
     expect(input).toEqual(['codex', '--project', '.']);
   });
+
+  describe('--agent deduplication (audit fix #40)', () => {
+    it('strips a redundant --agent pair so shorthand wins deterministically', () => {
+      // `styrby codex --agent gemini` must launch codex, not gemini, regardless
+      // of whether the downstream parser is first-wins or last-wins.
+      expect(buildStartArgs(['codex', '--agent', 'gemini'], 'codex', null))
+        .toEqual(['--agent', 'codex']);
+    });
+
+    it('strips a redundant --agent pair but keeps other flags', () => {
+      expect(buildStartArgs(['codex', '--agent', 'gemini', '--project', '.'], 'codex', null))
+        .toEqual(['--agent', 'codex', '--project', '.']);
+    });
+
+    it('strips the inline --agent=value form too', () => {
+      expect(buildStartArgs(['codex', '--agent=gemini', '--project', '.'], 'codex', null))
+        .toEqual(['--agent', 'codex', '--project', '.']);
+    });
+
+    it('strips a user --agent when a config default supplies the agent', () => {
+      expect(buildStartArgs(['--agent', 'gemini', '--project', '.'], null, 'aider'))
+        .toEqual(['--agent', 'aider', '--project', '.']);
+    });
+
+    it('emits exactly one --agent flag', () => {
+      const result = buildStartArgs(['codex', '--agent', 'gemini'], 'codex', null);
+      expect(result.filter((a) => a === '--agent')).toHaveLength(1);
+      expect(result.filter((a) => a.startsWith('--agent='))).toHaveLength(0);
+    });
+  });
 });

--- a/packages/styrby-cli/src/cli/agentShorthand.ts
+++ b/packages/styrby-cli/src/cli/agentShorthand.ts
@@ -88,6 +88,9 @@ export function isBareCommand(command: string | undefined): boolean {
  * buildStartArgs(['codex', '--project', '.'], 'codex', null);
  * // => ['--agent', 'codex', '--project', '.']
  *
+ * buildStartArgs(['codex', '--agent', 'gemini'], 'codex', null);
+ * // => ['--agent', 'codex']   (shorthand wins; the redundant pair is stripped)
+ *
  * buildStartArgs([], undefined, 'gemini');
  * // => ['--agent', 'gemini']
  *
@@ -100,10 +103,49 @@ export function buildStartArgs(
   configDefaultAgent: string | null | undefined,
 ): string[] {
   if (shorthand) {
-    return ['--agent', shorthand, ...args.slice(1)];
+    // WHY (audit 2026-06-09 fix #40): `styrby codex --agent gemini` previously
+    // emitted ['--agent', 'codex', '--agent', 'gemini'] — TWO --agent flags.
+    // Which one wins then depends entirely on handleStart's parser semantics
+    // (first-wins vs last-wins). If last-wins, the user gets gemini despite
+    // typing the `codex` shorthand — a silent wrong-agent launch (wrong model,
+    // wrong billing). Strip any existing --agent pair from the trailing args so
+    // exactly one --agent is present and shorthand precedence is deterministic.
+    return ['--agent', shorthand, ...stripAgentFlag(args.slice(1))];
   }
   if (configDefaultAgent) {
-    return ['--agent', configDefaultAgent, ...args];
+    return ['--agent', configDefaultAgent, ...stripAgentFlag(args)];
   }
   return args;
+}
+
+/**
+ * Remove every `--agent <value>` pair (and the `--agent=<value>` inline form)
+ * from an argv slice.
+ *
+ * WHY: when a higher-precedence source (an agent shorthand or a config default)
+ * already supplies `--agent`, leaving a second `--agent` in the user-provided
+ * args produces a duplicate flag whose resolution is parser-dependent. Stripping
+ * the lower-precedence pair guarantees a single, deterministic `--agent`.
+ *
+ * @param args - The argv slice to sanitize.
+ * @returns A copy of `args` with all `--agent` flags (and their values) removed.
+ */
+function stripAgentFlag(args: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--agent') {
+      // Skip the flag and its space-separated value (if any).
+      if (i + 1 < args.length) {
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith('--agent=')) {
+      // Inline form: skip the single token.
+      continue;
+    }
+    result.push(arg);
+  }
+  return result;
 }

--- a/packages/styrby-cli/src/configuration.ts
+++ b/packages/styrby-cli/src/configuration.ts
@@ -13,6 +13,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import type { SupportedAgentType } from '@/persistence';
+import { logger } from '@/ui/logger';
 
 /**
  * Configuration values
@@ -65,15 +66,39 @@ export function ensureConfigDir(): void {
  */
 export function loadConfig(): StyrbyConfig {
   ensureConfigDir();
+
+  let content: string;
   try {
-    if (fs.existsSync(CONFIG_FILE)) {
-      const content = fs.readFileSync(CONFIG_FILE, 'utf-8');
-      return JSON.parse(content) as StyrbyConfig;
+    if (!fs.existsSync(CONFIG_FILE)) {
+      return {};
     }
-  } catch {
-    // Return empty config on error
+    content = fs.readFileSync(CONFIG_FILE, 'utf-8');
+  } catch (err) {
+    // WHY (audit 2026-06-09 fix #39): a genuine IO/permission failure was
+    // previously swallowed by an empty catch, silently logging the user out
+    // (isAuthenticated() -> false) with no diagnostic. Surface it at warn level
+    // so a misconfigured ~/.styrby is debuggable, then fall back to empty.
+    logger.warn(
+      `[config] Could not read ${CONFIG_FILE}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return {};
   }
-  return {};
+
+  try {
+    return JSON.parse(content) as StyrbyConfig;
+  } catch (err) {
+    // WHY (audit 2026-06-09 fix #39): a corrupt/truncated config.json (e.g. a
+    // crash mid-write before saveConfig was made atomic) used to be swallowed
+    // here, returning {} and silently bouncing the user into a fresh login,
+    // losing their machineId/userId binding. We now log the parse failure
+    // loudly so corruption is visible rather than masquerading as "logged out".
+    logger.warn(
+      `[config] ${CONFIG_FILE} is corrupt and could not be parsed: ${
+        err instanceof Error ? err.message : String(err)
+      }. Treating as empty config; re-authentication may be required.`
+    );
+    return {};
+  }
 }
 
 /**
@@ -90,11 +115,19 @@ export function loadConfig(): StyrbyConfig {
  */
 export function saveConfig(config: StyrbyConfig): void {
   ensureConfigDir();
-  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), {
+  // WHY (audit 2026-06-09 fix #39): write atomically. The prior direct
+  // writeFileSync to CONFIG_FILE was non-atomic — a crash/OOM/power loss between
+  // open and full write left a TRUNCATED config.json, which loadConfig() then
+  // failed to parse and silently treated as logged-out. Writing to a temp file
+  // and renaming into place is atomic on POSIX: a reader sees either the old
+  // complete file or the new complete file, never a partial one.
+  const tmpFile = `${CONFIG_FILE}.tmp`;
+  fs.writeFileSync(tmpFile, JSON.stringify(config, null, 2), {
     mode: 0o600, // Owner read/write only — applies only to newly created file
   });
-  // Repair permissions on existing files (upgrade path).
-  fs.chmodSync(CONFIG_FILE, 0o600);
+  // Repair permissions on the temp file (upgrade path / pre-existing tmp).
+  fs.chmodSync(tmpFile, 0o600);
+  fs.renameSync(tmpFile, CONFIG_FILE);
 }
 
 /**

--- a/packages/styrby-cli/src/utils/safeEnv.test.ts
+++ b/packages/styrby-cli/src/utils/safeEnv.test.ts
@@ -77,3 +77,43 @@ describe('validateExtraArgs - path traversal blocklist (per-agent flags)', () =>
     ]);
   });
 });
+
+describe('validateExtraArgs - SPACE-SEPARATED flag/value bypass (audit fix #8)', () => {
+  // WHY: the `=`-joined checks only see one token. Splitting the flag and its
+  // value across two argv elements (`['--config', '/etc/passwd']`) previously
+  // bypassed every guard. These cases assert the pairwise flag-context check.
+  it.each([
+    ['--config /etc/passwd', ['--config', '/etc/passwd']],
+    ['--profile /etc/secret.toml', ['--profile', '/etc/secret.toml']],
+    ['--env-file /etc/shadow', ['--env-file', '/etc/shadow']],
+    ['-config /etc/passwd (short flag)', ['-config', '/etc/passwd']],
+  ])('rejects %s targeting /etc/', (_label, args) => {
+    expect(() => validateExtraArgs(args)).toThrow(/Unsafe argument targeting system path/);
+  });
+
+  it.each([
+    ['--config ../../../etc/secret.toml', ['--config', '../../../etc/secret.toml']],
+    ['--profile ../../secret.toml', ['--profile', '../../secret.toml']],
+    ['--include ../../bad', ['--include', '../../bad']],
+    ['--load ../../bad', ['--load', '../../bad']],
+  ])('rejects %s path traversal', (_label, args) => {
+    expect(() => validateExtraArgs(args)).toThrow(/Unsafe path traversal/);
+  });
+
+  it('still allows a space-separated config flag pointing at a project-relative path', () => {
+    expect(validateExtraArgs(['--config', './config.toml'])).toEqual([
+      '--config',
+      './config.toml',
+    ]);
+    expect(validateExtraArgs(['--profile', 'workspace/dev.json'])).toEqual([
+      '--profile',
+      'workspace/dev.json',
+    ]);
+  });
+
+  it('does not treat a non-config flag value as a config path', () => {
+    // `--model /etc/whatever` is not a config-loading flag, so its value is not
+    // path-checked (it is not loaded as a config file). Should pass.
+    expect(validateExtraArgs(['--model', 'sonnet-4'])).toEqual(['--model', 'sonnet-4']);
+  });
+});

--- a/packages/styrby-cli/src/utils/safeEnv.ts
+++ b/packages/styrby-cli/src/utils/safeEnv.ts
@@ -249,7 +249,8 @@ export function safeBufferAppend(currentBuffer: string, newData: string): string
  * @throws {Error} If arguments contain suspicious patterns
  */
 export function validateExtraArgs(args: string[]): string[] {
-  for (const arg of args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
     // Block shell metacharacters that could be dangerous if shell: true is ever used
     if (/[;&|`$(){}]/.test(arg)) {
       throw new Error(
@@ -292,6 +293,67 @@ export function validateExtraArgs(args: string[]): string[] {
         `Unsafe path traversal in argument: "${arg}". Relative parent references are not allowed in config paths.`
       );
     }
+
+    // SECURITY (audit 2026-06-09 HIGH fix #8): the two checks above only inspect
+    // a single token, so a SPACE-SEPARATED form like `["--config", "/etc/passwd"]`
+    // or `["--profile", "../../secret.toml"]` bypassed them entirely — the flag
+    // token alone has no `/etc/` and no `../`, and the value token alone does not
+    // start with a config flag, so neither regex matched. Track flag context:
+    // when this arg is a bare config-loading flag (no inline `=` value), validate
+    // the NEXT element (its value) against the same path rules.
+    if (i + 1 < args.length && isBareConfigFlag(arg)) {
+      assertSafeConfigValue(args[i + 1]);
+    }
   }
   return args;
+}
+
+/**
+ * Config-loading flags whose value, if attacker-controlled, can point an agent
+ * at a sensitive or out-of-tree file. Union of every supported agent's flags.
+ */
+const CONFIG_LOADING_FLAGS = [
+  'config',
+  'rc',
+  'init',
+  'env-file',
+  'dotenv',
+  'include',
+  'load',
+  'profile',
+] as const;
+
+/**
+ * Whether `arg` is a config-loading flag with NO inline value (i.e. its value is
+ * supplied as the next argv element). Matches both `--flag` and `-flag` forms.
+ *
+ * Returns false for the `=`-joined form (`--config=...`) — that case is already
+ * handled by the single-token checks in `validateExtraArgs`.
+ *
+ * @param arg - The argv element to test.
+ * @returns True if `arg` is a bare config-loading flag awaiting a separate value.
+ */
+function isBareConfigFlag(arg: string): boolean {
+  return new RegExp(`^--?(?:${CONFIG_LOADING_FLAGS.join('|')})$`).test(arg);
+}
+
+/**
+ * Validate a bare config-flag VALUE (the argv element following a config flag).
+ *
+ * Applies the same system-path and path-traversal rules used for the inline
+ * (`=`-joined) form, but against the raw value token (no flag prefix). Closes
+ * the space-separated bypass (audit 2026-06-09 fix #8).
+ *
+ * @param value - The value token following a config-loading flag.
+ * @throws {Error} If the value targets a system path or contains traversal.
+ */
+function assertSafeConfigValue(value: string): void {
+  if (/^\s*\/etc\//.test(value)) {
+    throw new Error(`Unsafe argument targeting system path: "${value}".`);
+  }
+  if (/\.\.[/\\]/.test(value)) {
+    throw new Error(
+      `Unsafe path traversal in argument: "${value}". Relative parent references are not allowed in config paths.`
+    );
+  }
 }

--- a/packages/styrby-web/src/__tests__/admin/actions.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/actions.integration.test.ts
@@ -217,7 +217,7 @@ describe('overrideTierAction — integration (form → Zod → RPC)', () => {
 
     const result = await overrideTierAction(
       VALID_UUID,
-      makeFormData({ targetUserId: VALID_UUID, newTier: 'enterprise', reason: 'bypass attempt' })
+      makeFormData({ targetUserId: VALID_UUID, newTier: 'growth', reason: 'bypass attempt' })
     );
 
     expect(result).toEqual({ ok: false, error: 'Not authorized' });

--- a/packages/styrby-web/src/__tests__/admin/middleware.integration.test.ts
+++ b/packages/styrby-web/src/__tests__/admin/middleware.integration.test.ts
@@ -133,6 +133,19 @@ function mockSessionResponse(locationHeader?: string) {
 }
 
 /**
+ * Builds the { response, user } shape updateSession() now returns.
+ *
+ * WHY: middleware gates protected routes on the validated user (bugs #15/#46).
+ * Admin tests that fall through to the protected-path gate need a non-null user.
+ *
+ * @param user - The validated user (null = unauthenticated). Defaults to an
+ *   authenticated stub so admin-pass-through tests reach the guard.
+ */
+function mockUpdateSessionResult(user: { id: string } | null = { id: 'admin-user' }) {
+  return { response: mockSessionResponse(), user };
+}
+
+/**
  * Builds a 404 NextResponse-like object — what requireSiteAdmin returns for
  * a non-admin or unauthenticated user.
  */
@@ -154,7 +167,7 @@ describe('admin middleware integration', () => {
     vi.clearAllMocks();
 
     // Default: updateSession returns a plain pass-through (no redirect).
-    mockUpdateSession.mockResolvedValue(mockSessionResponse());
+    mockUpdateSession.mockResolvedValue(mockUpdateSessionResult());
 
     // Default: requireSiteAdmin denies (non-admin path).
     // Tests that need the admin to pass through override this.
@@ -170,7 +183,7 @@ describe('admin middleware integration', () => {
       // requireSiteAdmin returns null → allow the request through.
       // WHY null: guard.ts returns null when the user is a confirmed admin.
       mockRequireSiteAdmin.mockResolvedValue(null);
-      mockUpdateSession.mockResolvedValue(mockSessionResponse());
+      mockUpdateSession.mockResolvedValue(mockUpdateSessionResult());
 
       // WHY stub env vars: the middleware calls getHttpsUrlEnv('NEXT_PUBLIC_SUPABASE_URL')
       // before creating the Supabase client. Without a valid https:// URL, it
@@ -338,7 +351,7 @@ describe('admin middleware integration', () => {
 
       for (const path of paths) {
         vi.clearAllMocks();
-        mockUpdateSession.mockResolvedValue(mockSessionResponse());
+        mockUpdateSession.mockResolvedValue(mockUpdateSessionResult());
 
         const req = makeRequest(path, false);
         const response = await middleware(req);

--- a/packages/styrby-web/src/__tests__/middleware.test.ts
+++ b/packages/styrby-web/src/__tests__/middleware.test.ts
@@ -100,10 +100,9 @@ function makeRequest(
 }
 
 /**
- * Builds a mock NextResponse-like object that updateSession() returns.
+ * Builds a mock NextResponse-like object that updateSession() carries.
  *
- * @param locationHeader - If set, the response has a Location redirect header
- *   (indicates Supabase determined the session is invalid/expired).
+ * @param locationHeader - If set, the response has a Location redirect header.
  */
 function mockSessionResponse(locationHeader?: string) {
   const headers = new Headers();
@@ -117,6 +116,22 @@ function mockSessionResponse(locationHeader?: string) {
   };
 }
 
+/**
+ * Builds the full { response, user } shape that updateSession() now returns.
+ *
+ * WHY: middleware gates protected routes on the VALIDATED user (bugs #15/#46),
+ * not cookie presence, so the mock must encode whether a real session exists.
+ *
+ * @param user - The validated user (null = unauthenticated). Defaults to null.
+ * @param locationHeader - Optional redirect Location header on the response.
+ */
+function mockUpdateSessionResult(
+  user: { id: string } | null = null,
+  locationHeader?: string,
+) {
+  return { response: mockSessionResponse(locationHeader), user };
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -125,8 +140,10 @@ describe('middleware', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Default: updateSession returns a plain pass-through response (no redirect)
-    mockUpdateSession.mockResolvedValue(mockSessionResponse());
+    // Default: updateSession returns a pass-through response with NO validated
+    // user (unauthenticated). Tests that exercise authenticated paths override
+    // this with a non-null user.
+    mockUpdateSession.mockResolvedValue(mockUpdateSessionResult(null));
 
     // Default: Redis env vars are absent so aiCrawlerLimiter is null
     // (Ratelimit constructor was called at module load time; tests that need
@@ -300,6 +317,13 @@ describe('middleware', () => {
     function makeAuthenticatedRequest(path: string): NextRequest {
       const cookieName = getSupabaseCookieName();
 
+      // WHY also stub a validated user: middleware now gates on the user returned
+      // by updateSession() (a verified JWT), not cookie presence (bugs #15/#46).
+      // The cookie is kept so the request still resembles a real authed request.
+      mockUpdateSession.mockResolvedValue(
+        mockUpdateSessionResult({ id: 'authed-user-id' }),
+      );
+
       const req = new NextRequest(`http://localhost:3000${path}`, {
         headers: {
           'user-agent': 'Mozilla/5.0 Chrome/120',
@@ -336,14 +360,61 @@ describe('middleware', () => {
       expect(location).not.toContain('/login');
     });
 
-    it('redirects when updateSession signals invalid session (location → /login)', async () => {
-      // Even if the cookie is present, if updateSession sets a redirect to /login
-      // we should still block the user (expired/tampered JWT)
+    it('redirects when session is invalid despite cookie presence (validated user is null)', async () => {
+      // WHY (bugs #15/#46): a forged/expired/garbage JWT cookie must NOT pass the
+      // gate. updateSession()'s getUser() returns no user for such tokens, so the
+      // middleware redirects to /login even though the cookie is present.
+      const cookieName = getSupabaseCookieName();
+      mockUpdateSession.mockResolvedValue(mockUpdateSessionResult(null));
+
+      const req = new NextRequest('http://localhost:3000/dashboard', {
+        headers: {
+          'user-agent': 'Mozilla/5.0 Chrome/120',
+          cookie: `${cookieName}=forged-or-expired-jwt`,
+        },
+      });
+      const response = await middleware(req);
+
+      const location = response.headers.get('location') ?? '';
+      expect(location).toContain('/login');
+    });
+
+    it('allows access to /dashboard for chunked-session user (no base auth-token cookie)', async () => {
+      // WHY (bug #15): large OAuth JWTs are split into `.0`/`.1` cookies and the
+      // base `sb-<ref>-auth-token` cookie is absent. The old cookie-presence gate
+      // locked these legit users out. Now the gate trusts the validated user, so
+      // a chunked session (no base cookie) is correctly allowed through.
+      const cookieName = getSupabaseCookieName();
       mockUpdateSession.mockResolvedValue(
-        mockSessionResponse('http://localhost:3000/login?reason=session_expired')
+        mockUpdateSessionResult({ id: 'chunked-user-id' }),
       );
 
-      const req = makeAuthenticatedRequest('/dashboard');
+      const req = new NextRequest('http://localhost:3000/dashboard', {
+        headers: {
+          'user-agent': 'Mozilla/5.0 Chrome/120',
+          // Only chunked cookies present — base cookie intentionally absent.
+          cookie: `${cookieName}.0=part0; ${cookieName}.1=part1`,
+        },
+      });
+      const response = await middleware(req);
+
+      const location = response.headers.get('location') ?? '';
+      expect(location).not.toContain('/login');
+    });
+
+    it('rejects a forged base auth-token cookie with no valid session', async () => {
+      // WHY (bug #46): previously anyone could set `sb-<ref>-auth-token` to any
+      // value and pass the gate. Now an unvalidated user (null) is rejected even
+      // with the base cookie present.
+      const cookieName = getSupabaseCookieName();
+      mockUpdateSession.mockResolvedValue(mockUpdateSessionResult(null));
+
+      const req = new NextRequest('http://localhost:3000/dashboard', {
+        headers: {
+          'user-agent': 'Mozilla/5.0 Chrome/120',
+          cookie: `${cookieName}=attacker-supplied-value`,
+        },
+      });
       const response = await middleware(req);
 
       const location = response.headers.get('location') ?? '';
@@ -453,9 +524,7 @@ describe('middleware', () => {
       // Cookie present but updateSession detected an expired/invalid JWT.
       // The site_admins guard runs first and returns 404 (fail-closed on
       // unauthenticated/non-admin) before the legacy 401 layer is reached.
-      mockUpdateSession.mockResolvedValue(
-        mockSessionResponse('http://localhost:3000/login')
-      );
+      mockUpdateSession.mockResolvedValue(mockUpdateSessionResult(null));
 
       const cookieName = getSupabaseCookieName();
       const req = new NextRequest('http://localhost:3000/api/admin/support', {
@@ -478,7 +547,9 @@ describe('middleware', () => {
       // This confirms the guard never silently allows a request through when
       // its dependencies are misconfigured. The happy-path (valid admin session
       // passes through to the route handler) is covered by guard.test.ts.
-      mockUpdateSession.mockResolvedValue(mockSessionResponse());
+      mockUpdateSession.mockResolvedValue(
+        mockUpdateSessionResult({ id: 'admin-candidate' }),
+      );
 
       const cookieName = getSupabaseCookieName();
       const req = new NextRequest('http://localhost:3000/api/admin/support', {

--- a/packages/styrby-web/src/app/api/admin/founder-metrics/route.ts
+++ b/packages/styrby-web/src/app/api/admin/founder-metrics/route.ts
@@ -273,6 +273,12 @@ export async function GET(request: NextRequest) {
         .from('subscriptions')
         .select('tier, status, updated_at')
         .eq('status', 'canceled')
+        // BUG #50: apply the SAME `%no_mrr%` exclusion as the active query above.
+        // The churn ratio divides canceled by (active + canceled); if a comp
+        // '_no_mrr' account is ever canceled it would inflate BOTH the canceled
+        // numerator and denominator while its active counterparts were excluded,
+        // skewing the rate. Both sides of the ratio must use the same population.
+        .not('polar_subscription_id', 'ilike', '%no_mrr%')
         .gte('updated_at', ninetyDaysAgo.toISOString()),
 
       // Agent usage: session count + total cost per agent_type (last 90 days)

--- a/packages/styrby-web/src/app/api/auth/passkey/__tests__/verify.test.ts
+++ b/packages/styrby-web/src/app/api/auth/passkey/__tests__/verify.test.ts
@@ -129,7 +129,11 @@ describe('POST /api/auth/passkey/verify', () => {
   });
 
   it('forwards verify-login and propagates session payload', async () => {
-    const edgePayload = { success: true, access_token: 'tok', refresh_token: 'ref' };
+    // WHY hashed_token (not access_token): the verify-passkey edge function
+    // mints a magiclink and returns { verified, hashed_token, email }. The proxy
+    // forwards verbatim; the browser exchanges hashed_token via verifyOtp. This
+    // mock encodes the REAL edge contract so it can't drift from reality. (bug #3)
+    const edgePayload = { verified: true, hashed_token: 'hash-tok', email: 'a@b.com' };
     global.fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify(edgePayload), { status: 200 }),
     ) as typeof fetch;
@@ -138,7 +142,8 @@ describe('POST /api/auth/passkey/verify', () => {
     const res = await POST(req);
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.access_token).toBe('tok');
+    expect(json.hashed_token).toBe('hash-tok');
+    expect(json.verified).toBe(true);
   });
 
   it('propagates 422 from edge function (invalid signature)', async () => {
@@ -250,7 +255,7 @@ describe('POST /api/auth/passkey/verify', () => {
       error: null,
     });
     global.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ access_token: 'tok' }), { status: 200 }),
+      new Response(JSON.stringify({ verified: true, hashed_token: 'hash-tok' }), { status: 200 }),
     ) as typeof fetch;
 
     const req = makeRequest({ action: 'verify-login', email: 'success@example.com', response: { id: 'cred' } });

--- a/packages/styrby-web/src/app/api/billing/__tests__/seats.test.ts
+++ b/packages/styrby-web/src/app/api/billing/__tests__/seats.test.ts
@@ -595,6 +595,47 @@ describe('PATCH /api/billing/seats', () => {
     expect(insertArg.metadata.old_seat_count).toBe(5);
   });
 
+  // ── BUG #49: indeterminate oldSeats (quantity AND seat_cap both null) ───────
+
+  it('treats oldSeats as indeterminate when quantity AND seat_cap are both null (no phantom increase)', async () => {
+    // WHY: a paused sub (quantity null) whose seat_cap was never webhook-synced
+    // (null) previously fabricated oldSeats=1, mislabeling a PATCH-to-current as
+    // a +N increase with a phantom proration. Now we skip proration and use
+    // memberCount (the authoritative current seat floor) as the audit baseline.
+    mockSubsGet.mockResolvedValue({
+      id: 'polar_sub_abc',
+      quantity: null,
+      currentPeriodStart: new Date(Date.now() - 15 * 86_400_000).toISOString(),
+      currentPeriodEnd: new Date(Date.now() + 15 * 86_400_000).toISOString(),
+    });
+    mockTeamBillingSelect.mockResolvedValue({
+      data: { ...TEAM_BILLING_ROW, seat_cap: null, active_seats: null },
+      error: null,
+    });
+    // Current members = 3; PATCH to the current count of 3 (a no-op).
+    setMemberCount(3);
+    const req = buildRequest({ ...VALID_PATCH_BODY, new_seat_count: 3 });
+    const res = await PATCH(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { success: boolean; proration_cents: number };
+    expect(json.success).toBe(true);
+    // No fabricated charge.
+    expect(json.proration_cents).toBe(0);
+
+    // Audit baseline = memberCount (3), NOT the fabricated 1, so the delta is 0
+    // (a no-op) rather than a phantom +2 increase.
+    const insertArg = mockAuditInsert.mock.calls[0][0] as {
+      action: string;
+      metadata: { old_seat_count: number; delta: number; old_seat_count_indeterminate: boolean };
+    };
+    expect(insertArg.metadata.old_seat_count).toBe(3);
+    expect(insertArg.metadata.delta).toBe(0);
+    expect(insertArg.metadata.old_seat_count_indeterminate).toBe(true);
+    // 3 → 3 is not an increase.
+    expect(insertArg.action).toBe('team_seat_count_decreased');
+  });
+
   // ── WAVE-E-001: advisory-lock serialization ────────────────────────────────
 
   describe('WAVE-E-001 advisory lock', () => {

--- a/packages/styrby-web/src/app/api/billing/checkout/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/billing/checkout/__tests__/route.test.ts
@@ -506,6 +506,54 @@ describe('POST /api/billing/checkout', () => {
   });
 
   /**
+   * Bug #32 regression: a double-tap that straddles a 60-second wall-clock
+   * boundary must still dedup to ONE Polar checkout. The previous tumbling
+   * bucket (Math.floor(now / TTL)) produced different keys across the boundary,
+   * spawning two checkouts. With the rolling-TTL key, the second tap (well
+   * within 60s of the first) always hits the live cache entry.
+   */
+  it('bug #32: dedupes a double-tap straddling a 60s boundary (one Polar checkout)', async () => {
+    vi.useFakeTimers();
+    // Park wall-clock just before a 60s boundary: floor(now/60000) would tick
+    // over between the two taps under the old tumbling-bucket scheme.
+    vi.setSystemTime(59_999);
+
+    vi.resetModules();
+    const { POST: PostFresh } = await import('../route');
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-boundary', email: 'boundary@test.com' } },
+      error: null,
+    });
+    mockCheckoutCreate.mockResolvedValue({ url: 'https://polar.test/checkout/boundary-1' });
+
+    const makeReq = () =>
+      new Request('http://localhost/api/billing/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tierId: 'pro', billingCycle: 'monthly' }),
+      });
+
+    const r1 = await PostFresh(makeReq() as never); // bucket N under old scheme
+    // Advance 50ms — crosses the 60_000ms boundary (now = 60_049 → bucket N+1).
+    vi.setSystemTime(60_049);
+    const r2 = await PostFresh(makeReq() as never); // would be bucket N+1
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    const b1 = await r1.json();
+    const b2 = await r2.json();
+    expect(b2.url).toBe(b1.url);
+
+    // The critical assertion: only ONE Polar checkout despite the boundary cross.
+    expect(mockCheckoutCreate).toHaveBeenCalledTimes(1);
+
+    mockCheckoutCreate.mockReset();
+    mockGetUser.mockReset();
+    vi.useRealTimers();
+  });
+
+  /**
    * Test 10: Returns 500 when Polar SDK throws
    * WHY: Polar can throw network/API/rate-limit errors. Route catches
    * and returns a generic error message to avoid leaking internal details.

--- a/packages/styrby-web/src/app/api/billing/checkout/route.ts
+++ b/packages/styrby-web/src/app/api/billing/checkout/route.ts
@@ -104,11 +104,16 @@ const idempotencyCache = new Map<string, CachedCheckout>();
 /**
  * Computes the idempotency key for a checkout request.
  *
- * WHY include the 60-second bucket: ensures the dedup window is rolling.
- * Two requests at second 0 and second 65 produce different keys (and thus
- * two checkouts — the user clearly intends a new purchase). Two requests
- * at second 0 and second 30 produce the same key (dedup). Floor by the
- * TTL so keys align with the cache's natural eviction.
+ * WHY no time bucket in the key (bug #32): a tumbling bucket
+ * (Math.floor(now / TTL)) made two clicks that straddle a bucket boundary
+ * (t=00:59.99 → bucket N, t=01:00.04 → bucket N+1) produce DIFFERENT keys, so
+ * the second click missed the cache and created a second Polar checkout — a
+ * real double-charge risk. The key is now purely the request identity
+ * (user+tier+cycle+seats); the rolling 60s window is enforced entirely by each
+ * cache entry's own `expiresAt` TTL (getCachedCheckout lazily evicts on read).
+ * A double-tap within 60s of the FIRST tap always hits the same live entry,
+ * regardless of wall-clock boundaries; after the entry expires a genuine repeat
+ * purchase produces a fresh checkout.
  */
 function computeIdempotencyKey(
   userId: string,
@@ -116,8 +121,7 @@ function computeIdempotencyKey(
   billingCycle: string,
   seats: number | undefined,
 ): string {
-  const bucket = Math.floor(Date.now() / IDEMPOTENCY_TTL_MS);
-  const payload = `${userId}|${tierId}|${billingCycle}|${seats ?? 0}|${bucket}`;
+  const payload = `${userId}|${tierId}|${billingCycle}|${seats ?? 0}`;
   // SHA-256 keeps the cache key fixed-length and keeps userId out of any
   // accidental log dump of the cache (defense-in-depth — the cache itself
   // is in-memory and never logged today, but this costs us nothing).

--- a/packages/styrby-web/src/app/api/billing/seats/route.ts
+++ b/packages/styrby-web/src/app/api/billing/seats/route.ts
@@ -520,21 +520,23 @@ export async function GET(request: Request): Promise<Response> {
   if ('error' in subResult) return subResult.error;
   const { subscription } = subResult;
 
-  // WHY quantity ?? seat_cap ?? 1: subscription.quantity is null for paused
-  // subscriptions and also when the Polar SDK type diverges from the actual
-  // REST response (SDK type drift across minor versions). seat_cap is the DB
-  // snapshot of the last webhook-confirmed seat count — the next-best source
-  // when the live API returns null. The final fallback of 1 prevents a NaN
-  // proration in the extreme case where both sources are missing, though in
-  // practice a team cannot exist without at least the minimum seat count.
-  const oldSeats = subscription.quantity ?? team.seat_cap ?? 1;
+  // WHY quantity ?? seat_cap (NOT ?? 1): subscription.quantity is null for
+  // paused subscriptions and on Polar SDK type drift. seat_cap is the DB
+  // snapshot of the last webhook-confirmed seat count — the next-best source.
+  //
+  // BUG #49 (preview parity): the previous `?? 1` fabricated current_seats=1
+  // when both sources were null, surfacing a misleading proration_cents to the
+  // client. When the prior seat count is indeterminate we report it as null and
+  // skip the proration estimate rather than inventing one off a fake baseline.
+  const knownOldSeats = subscription.quantity ?? team.seat_cap ?? null;
   const { daysElapsed, daysInCycle } = computeCycleDays(subscription);
 
-  // Compute proration preview (0 for downgrades — Polar issues a credit)
+  // Compute proration preview (0 for downgrades — Polar issues a credit — and 0
+  // when the prior seat count is indeterminate).
   const prorationCents =
-    new_seat_count > oldSeats
+    knownOldSeats !== null && new_seat_count > knownOldSeats
       ? calculateProrationCents({
-          oldSeats,
+          oldSeats: knownOldSeats,
           newSeats: new_seat_count,
           tierId: tier,
           cycle,
@@ -544,7 +546,7 @@ export async function GET(request: Request): Promise<Response> {
       : 0;
 
   return NextResponse.json({
-    current_seats: oldSeats,
+    current_seats: knownOldSeats,
     new_seats: new_seat_count,
     proration_cents: prorationCents,
     tier,
@@ -770,27 +772,33 @@ export async function PATCH(request: Request): Promise<Response> {
   if ('error' in subResult) return subResult.error;
   const { subscription } = subResult;
 
-  // WHY quantity ?? seat_cap ?? 1: subscription.quantity is null for paused
-  // subscriptions and also when the Polar SDK type diverges from the actual
-  // REST response (SDK type drift across minor versions). seat_cap is the DB
-  // snapshot of the last webhook-confirmed seat count — the next-best source
-  // when the live API returns null. The final fallback of 1 prevents a NaN
-  // proration in the extreme case where both sources are missing, though in
-  // practice a team cannot exist without at least the minimum seat count.
-  const oldSeats = subscription.quantity ?? team.seat_cap ?? 1;
+  // WHY quantity ?? seat_cap (NOT ?? 1): subscription.quantity is null for
+  // paused subscriptions and on Polar SDK type drift. seat_cap is the DB
+  // snapshot of the last webhook-confirmed seat count — the next-best source.
+  //
+  // BUG #49: the previous `?? 1` final fallback fabricated oldSeats=1 when BOTH
+  // quantity AND seat_cap were null, which mislabeled a no-op PATCH-to-current
+  // as a +N increase, charged a phantom proration, and wrote a bogus audit
+  // delta. When both sources are null oldSeats is INDETERMINATE: we skip
+  // proration entirely (no fabricated charge) and fall back to memberCount —
+  // the authoritative current seat floor already fetched under the lock — for
+  // the audit baseline so the recorded delta reflects reality rather than a
+  // made-up increase.
+  const knownOldSeats = subscription.quantity ?? team.seat_cap ?? null;
+  const oldSeatsForAudit = knownOldSeats ?? memberCount;
   const { daysElapsed, daysInCycle } = computeCycleDays(subscription);
 
   // ── Step 8: Compute proration ─────────────────────────────────────────────
 
-  // WHY only for upgrades: downgrades (new < old) produce a Polar credit, not
-  // a charge. Polar handles credit issuance internally; we do not compute or
-  // issue credits ourselves — that is Polar's billing engine responsibility.
-  // calculateProrationCents would return a negative number for downgrades if
-  // called — we skip the call entirely to avoid any ambiguity.
+  // WHY only for upgrades with a KNOWN prior seat count: downgrades (new < old)
+  // produce a Polar credit, not a charge (Polar issues credits internally). And
+  // when the prior seat count is indeterminate (knownOldSeats === null) we
+  // cannot compute a trustworthy proration, so we skip it rather than invent
+  // one off a fabricated baseline (bug #49).
   const prorationCents =
-    new_seat_count > oldSeats
+    knownOldSeats !== null && new_seat_count > knownOldSeats
       ? calculateProrationCents({
-          oldSeats,
+          oldSeats: knownOldSeats,
           newSeats: new_seat_count,
           tierId: tier,
           cycle,
@@ -858,8 +866,14 @@ export async function PATCH(request: Request): Promise<Response> {
   // action for a downgrade makes compliance queries misleading — an ops engineer
   // searching for decreases would miss the event. The delta field is negative for
   // decreases, giving an unambiguous signal in either direction.
+  // WHY direction derived from oldSeatsForAudit (memberCount when the prior
+  // seat count is indeterminate): avoids fabricating an "increase" off a made-up
+  // baseline of 1 (bug #49). The delta is computed against the same baseline so
+  // the compliance trail stays internally consistent.
   const auditAction =
-    new_seat_count > oldSeats ? 'team_seat_count_increased' : 'team_seat_count_decreased';
+    new_seat_count > oldSeatsForAudit
+      ? 'team_seat_count_increased'
+      : 'team_seat_count_decreased';
 
   const adminClient = createAdminClient();
   const { error: auditError } = await adminClient.from('audit_log').insert({
@@ -868,14 +882,18 @@ export async function PATCH(request: Request): Promise<Response> {
     resource_type: 'team',
     resource_id: team_id,
     metadata: {
-      old_seat_count: oldSeats,
+      old_seat_count: oldSeatsForAudit,
       new_seat_count,
       // WHY negative delta for decreases: makes it unambiguous at query time
       // without needing to compare old vs new fields. Positive = upgrade, negative = downgrade.
-      delta: new_seat_count - oldSeats,
+      delta: new_seat_count - oldSeatsForAudit,
+      // WHY flag indeterminate baselines: when Polar quantity + seat_cap were
+      // both null we used memberCount as the baseline; ops reconciling billing
+      // deltas needs to know the prior count was inferred, not authoritative.
+      old_seat_count_indeterminate: knownOldSeats === null,
       // WHY include proration_cents in audit: allows ops to reconcile billing
       // discrepancies against the expected proration amount without querying Polar.
-      // proration_cents is 0 for decreases per calculateProrationCents contract.
+      // proration_cents is 0 for decreases AND for indeterminate baselines.
       proration_cents: prorationCents,
       days_elapsed: daysElapsed,
       days_in_cycle: daysInCycle,

--- a/packages/styrby-web/src/app/api/cron/idempotency-cleanup/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/cron/idempotency-cleanup/__tests__/route.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for POST /api/cron/idempotency-cleanup — auth gate.
+ *
+ * Covers (bug #30): timingSafeEqual must never throw a RangeError on a
+ * wrong-LENGTH token. Every unauthorized case (missing, empty, short, long,
+ * same-length-wrong) must return a clean 401 — never a 500.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Admin client is only reached AFTER auth passes; the auth-failure tests never
+// touch it, but we stub it so module import succeeds.
+vi.mock('@/lib/supabase/server', () => ({
+  createAdminClient: () => ({
+    rpc: vi.fn().mockResolvedValue({ data: 0, error: null }),
+    from: () => ({
+      delete: vi.fn().mockReturnThis(),
+      lt: vi.fn().mockResolvedValue({ data: null, error: null, count: 0 }),
+    }),
+  }),
+}));
+
+import { POST } from '../route';
+
+const CRON_SECRET = 'test-cron-secret-value';
+
+function makeRequest(authHeader?: string) {
+  return new NextRequest('http://localhost/api/cron/idempotency-cleanup', {
+    method: 'POST',
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+beforeEach(() => {
+  vi.stubEnv('CRON_SECRET', CRON_SECRET);
+});
+
+describe('POST /api/cron/idempotency-cleanup auth gate (bug #30)', () => {
+  it('returns 401 (not 500) when the authorization header is missing', async () => {
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 (not 500) for an empty bearer token', async () => {
+    const res = await POST(makeRequest('Bearer '));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 (not 500) for a SHORTER wrong-length token', async () => {
+    const res = await POST(makeRequest('Bearer short'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 (not 500) for a LONGER wrong-length token', async () => {
+    const res = await POST(makeRequest(`Bearer ${CRON_SECRET}-extra-bytes`));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a same-length but wrong-value token', async () => {
+    const wrong = 'x'.repeat(CRON_SECRET.length);
+    const res = await POST(makeRequest(`Bearer ${wrong}`));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 500 when CRON_SECRET is not configured', async () => {
+    vi.stubEnv('CRON_SECRET', '');
+    const res = await POST(makeRequest(`Bearer ${CRON_SECRET}`));
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/styrby-web/src/app/api/cron/idempotency-cleanup/route.ts
+++ b/packages/styrby-web/src/app/api/cron/idempotency-cleanup/route.ts
@@ -67,10 +67,18 @@ export async function POST(request: NextRequest): Promise<Response> {
     return NextResponse.json({ error: 'Server misconfiguration' }, { status: 500 });
   }
 
-  const secretsMatch = crypto.timingSafeEqual(
-    Buffer.from(incomingSecret, 'utf8'),
-    Buffer.from(cronSecret, 'utf8'),
-  );
+  // WHY the length pre-check (bug #30): crypto.timingSafeEqual throws a
+  // RangeError when the two buffers differ in length — which is the COMMON
+  // unauthorized case (missing/empty/short Authorization header). Without the
+  // pre-check that RangeError propagates as a 500 instead of the documented
+  // 401, so virtually every unauthorized probe returned 500. The `||`
+  // short-circuit guarantees timingSafeEqual only ever sees equal-length
+  // buffers, preserving the constant-time property for same-length inputs.
+  const incomingBuf = Buffer.from(incomingSecret, 'utf8');
+  const cronBuf = Buffer.from(cronSecret, 'utf8');
+  const secretsMatch =
+    incomingBuf.length === cronBuf.length &&
+    crypto.timingSafeEqual(incomingBuf, cronBuf);
 
   if (!secretsMatch) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/packages/styrby-web/src/app/api/teams/[id]/members/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/teams/[id]/members/__tests__/route.test.ts
@@ -254,9 +254,9 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
     it('returns 403 when team member limit is reached', async () => {
       mockAuthenticated();
 
-      // WHY: Phase 5 — Growth tier (legacy 'power' resolves to 'growth') allows
-      // 100 team members. This test verifies that the limit counts both
-      // existing members AND pending invitations.
+      // WHY: Growth tier (legacy 'power' resolves to 'growth') allows the
+      // canonical maximum of 25 seats (bug #18). This test verifies that the
+      // limit counts both existing members AND pending invitations.
 
       // 1. team found
       fromCallQueue.push({
@@ -270,17 +270,17 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
         error: null,
       });
 
-      // 3. getUserTier => power → growth (limit: 100 in Phase 5)
+      // 3. getUserTier => power → growth (limit: 25, canonical Growth ceiling)
       fromCallQueue.push({ data: { tier: 'power' }, error: null });
       fromCallQueue.push({ data: [], error: null }); // SEC-ADV-004: empty team_members
 
-      // 4. member count => 99 existing members
-      fromCallQueue.push({ count: 99, error: null });
+      // 4. member count => 24 existing members
+      fromCallQueue.push({ count: 24, error: null });
 
       // 5. pending invitation count => 1 pending
       fromCallQueue.push({ count: 1, error: null });
 
-      // Total = 99 + 1 = 100, which equals the Growth tier limit.
+      // Total = 24 + 1 = 25, which equals the Growth tier limit.
 
       const req = createNextRequest({ email: 'new@example.com' });
       const response = await POST(req, createRouteContext());
@@ -288,7 +288,7 @@ describe('Team Members Invitation API — /api/teams/[id]/members', () => {
 
       const body = await response.json();
       expect(body.error).toContain('maximum');
-      expect(body.error).toContain('100');
+      expect(body.error).toContain('25');
     });
 
     it('returns 400 when invitee is already a member', async () => {

--- a/packages/styrby-web/src/app/api/teams/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/teams/__tests__/route.test.ts
@@ -186,8 +186,8 @@ describe('Teams API — /api/teams', () => {
       expect(body.teams[0].member_count).toBe(3);
       expect(body.tier).toBe('growth');
       expect(body.canCreateTeam).toBe(true);
-      // Phase 5: Growth tier teamMembers limit = 100 (was 3 in legacy team tier).
-      expect(body.teamLimit).toBe(100);
+      // Canonical Growth seat ceiling is 25 (Polar product max). (bug #18)
+      expect(body.teamLimit).toBe(25);
     });
 
     it('returns empty teams array when user has no teams', async () => {

--- a/packages/styrby-web/src/app/api/v1/auth/otp/send/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/auth/otp/send/__tests__/route.test.ts
@@ -255,6 +255,23 @@ describe('POST /api/v1/auth/otp/send — Happy path', () => {
 });
 
 // ============================================================================
+// Disposable-email server-side backstop (bug #31)
+// ============================================================================
+
+describe('POST /api/v1/auth/otp/send — disposable-email backstop (bug #31)', () => {
+  it('silently no-ops (200 ok) and does NOT provision for a disposable address', async () => {
+    // mailinator.com is in the disposable blocklist. The response must be
+    // indistinguishable from a normal accept (enumeration-defense invariance),
+    // but signInWithOtp (which auto-provisions a user) must NOT be called.
+    const res = await POST(makeRequest({ email: 'throwaway@mailinator.com' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+    expect(mockSignInWithOtp).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
 // 3. 200 + Sentry on Supabase error
 // ============================================================================
 

--- a/packages/styrby-web/src/app/api/v1/auth/otp/send/route.ts
+++ b/packages/styrby-web/src/app/api/v1/auth/otp/send/route.ts
@@ -52,6 +52,7 @@ import * as Sentry from '@sentry/nextjs';
 import { createAdminClient } from '@/lib/supabase/server';
 import { rateLimit } from '@/lib/rateLimit';
 import { OTP_SEND_RATE_LIMIT, hashEmail, MAX_EMAIL_LENGTH } from '@/lib/auth/api-config';
+import { isDisposableEmail } from '@/lib/disposable-emails';
 
 // ============================================================================
 // Zod Schema
@@ -192,6 +193,19 @@ async function handlePost(request: NextRequest): Promise<NextResponse> {
   }
 
   const body: OtpSendBody = parsed.data;
+
+  // ── 2b. Disposable-email server-side backstop (bug #31) ───────────────────
+  // WHY here (server-side, not just the React form): the CLI and any direct
+  // caller hit this endpoint without the website forms, so the client-side
+  // disposable-email gate was fully bypassable — a throwaway address could
+  // auto-provision a real user (shouldCreateUser:true) and mint a long-lived
+  // API key. We silently no-op the send (okInvariantResponse) rather than
+  // returning a distinct error, preserving the account-enumeration-defense
+  // invariance the rest of this endpoint maintains (OWASP A01:2021): a caller
+  // cannot distinguish "blocked disposable" from "accepted" from the response.
+  if (isDisposableEmail(body.email)) {
+    return okInvariantResponse();
+  }
 
   // ── 3. Send OTP via Supabase Auth ─────────────────────────────────────────
   // WHY createAdminClient() per-request: fresh instance prevents cross-request

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/__tests__/route.test.ts
@@ -301,6 +301,18 @@ describe('Session Checkpoints API', () => {
       const res = await DELETE(makeRequest('DELETE', VALID_SESSION_ID, undefined, `?checkpointId=${checkpointId}`));
       expect(res.status).toBe(200);
     });
+
+    // BUG #45: deleting a non-existent checkpoint must 404 (not 200 deleted:true).
+    // With { count: 'exact' } the route now sees count=0 and returns the
+    // documented 404 instead of silently claiming a deletion that never happened.
+    it('returns 404 when no checkpoint matched (count: 0)', async () => {
+      fromCallQueue.push({ data: null, error: null, count: 0 });
+
+      const res = await DELETE(makeRequest('DELETE', VALID_SESSION_ID, undefined, '?name=does-not-exist'));
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe('Checkpoint not found');
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/route.ts
+++ b/packages/styrby-web/src/app/api/v1/sessions/[id]/checkpoints/route.ts
@@ -364,10 +364,14 @@ async function deleteHandler(
 
   const supabase = createApiAdminClient();
 
-  // Build the delete query
+  // Build the delete query.
+  // WHY count: 'exact' (bug #45): without it Supabase returns count=null, so the
+  // `count === 0` 404 branch below is dead code and a DELETE of a non-existent
+  // (or other-user's) checkpoint returned 200 { deleted: true } — a misleading
+  // contract. Requesting an exact count makes the documented 404 reachable.
   let query = supabase
     .from('session_checkpoints')
-    .delete()
+    .delete({ count: 'exact' })
     .eq('session_id', sessionId)
     .eq('user_id', userId);
 

--- a/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
@@ -546,6 +546,61 @@ describe('POST /api/webhooks/polar', () => {
       expect(mockUpsert).toHaveBeenCalled();
     });
 
+    it('BUG #16: subscriptions upsert failure → 500 AND dedup row compensating-deleted', async () => {
+      // Wire a delete() mock so the compensating-delete path can run + be asserted.
+      const mockDelete = vi.fn();
+      const deleteEqFn = vi.fn().mockResolvedValue({ data: null, error: null });
+      mockDelete.mockReturnValue({ eq: deleteEqFn });
+      mockFrom.mockReturnValue({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle,
+        maybeSingle: mockMaybeSingle,
+        upsert: mockUpsert,
+        update: mockUpdate,
+        insert: mockInsert,
+        order: mockOrder,
+        limit: mockLimit,
+        delete: mockDelete,
+      });
+
+      // Call 1: dedup upsert into polar_webhook_events — chains .select() and
+      // returns a recorded row (this delivery wrote the dedup row).
+      mockUpsert.mockReturnValueOnce({
+        select: vi.fn().mockResolvedValue({
+          data: [{ event_id: 'evt_created_fail_001' }],
+          error: null,
+        }),
+      });
+      // Call 2: subscriptions upsert — awaited directly, resolves to an error
+      // simulating a transient DB / constraint failure.
+      mockUpsert.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'simulated DB failure on subscriptions upsert' },
+      });
+
+      // Profile lookups succeed; no existing sub.
+      mockSingle.mockResolvedValueOnce({ data: { id: 'user-uuid-123' }, error: null });
+      mockSingle.mockResolvedValueOnce({ data: { user_id: 'user-uuid-123' }, error: null });
+      mockSingle.mockResolvedValueOnce({ data: null, error: null });
+
+      const event = {
+        id: 'evt_created_fail_001',
+        ...createSubscriptionEvent('subscription.created'),
+      };
+      const response = await sendSignedEvent(event);
+
+      // Polar must see a 500 so it retries.
+      expect(response.status).toBe(500);
+      const body = await response.json();
+      expect(body.error).toBe('Processing failed');
+
+      // The dedup row recorded THIS delivery must be deleted so the retry
+      // re-runs the upsert (otherwise the dedup short-circuit drops it = drift).
+      expect(mockDelete).toHaveBeenCalled();
+      expect(deleteEqFn).toHaveBeenCalledWith('event_id', 'evt_created_fail_001');
+    });
+
     it('handles subscription.updated event', async () => {
       // Mock 1: Profile lookup succeeds
       mockSingle.mockResolvedValueOnce({

--- a/packages/styrby-web/src/app/api/webhooks/polar/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/route.ts
@@ -1211,8 +1211,14 @@ export async function POST(request: Request) {
         //
         // SOC2 CC9.2: Idempotency across all billing event paths.
         // ──────────────────────────────────────────────────────────────────────
+        // Tracks whether THIS delivery wrote the dedup row, so the upsert
+        // error path below can compensate-delete it and let Polar retry
+        // (bugs #16/#17 — mirror the refund handler's compensating delete).
+        let individualEventId: string | undefined;
+        let individualDedupRecorded = false;
         {
           const rawEventId = (rawParsed as Record<string, unknown>).id as string | undefined;
+          individualEventId = rawEventId;
           if (!rawEventId) {
             // No top-level id — cannot enforce event-id idempotency.
             // Log and fall through to state-based upsert idempotency.
@@ -1258,6 +1264,9 @@ export async function POST(request: Request) {
                 );
               }
               return NextResponse.json({ received: true });
+            } else {
+              // We are the delivery that recorded the dedup row this time.
+              individualDedupRecorded = true;
             }
           }
         }
@@ -1584,7 +1593,7 @@ export async function POST(request: Request) {
         const polarSeats =
           (data as { seats?: number | null }).seats ?? null;
 
-        await supabase.from('subscriptions').upsert(
+        const { error: upsertError } = await supabase.from('subscriptions').upsert(
           {
             user_id: profileId,
             polar_subscription_id: data.id,
@@ -1610,6 +1619,32 @@ export async function POST(request: Request) {
           }
         );
 
+        if (upsertError) {
+          // BUG #16: the dedup row was written BEFORE this upsert. If we swallow
+          // the error and return 200, Polar never retries AND the dedup row
+          // short-circuits any replay — the paying customer is permanently left
+          // on the wrong tier (billing drift). Mirror the refund handler: delete
+          // the dedup row we recorded this delivery so Polar's retry re-runs the
+          // upsert, then return 500.
+          console.error(
+            'polar/route: subscription.created/updated — failed to upsert subscription:',
+            upsertError.message
+          );
+          if (individualDedupRecorded && individualEventId) {
+            const { error: dedupDeleteErr } = await supabase
+              .from('polar_webhook_events')
+              .delete()
+              .eq('event_id', individualEventId);
+            if (dedupDeleteErr) {
+              console.error(
+                'polar/route: subscription.created/updated — CRITICAL: failed to delete idempotency row after upsert failure (manual replay required):',
+                dedupDeleteErr.message
+              );
+            }
+          }
+          return NextResponse.json({ error: 'Processing failed' }, { status: 500 });
+        }
+
         if (isDev) console.log('Subscription upserted successfully');
         break;
       }
@@ -1626,8 +1661,13 @@ export async function POST(request: Request) {
         // followed by a delayed-replay of the cancel, the subscription would
         // be silently re-canceled. Mirror the dedup pattern from the
         // created/updated cases above (lines ~894–942).
+        // Tracks whether THIS delivery wrote the dedup row, so the .update()
+        // error path below can compensate-delete it and let Polar retry (bug #17).
+        let cancelEventId: string | undefined;
+        let cancelDedupRecorded = false;
         {
           const rawEventId = (rawParsed as Record<string, unknown>).id as string | undefined;
+          cancelEventId = rawEventId;
           if (!rawEventId) {
             console.error(
               'polar/route: subscription.canceled event missing top-level id field — cannot enforce event-id dedup'
@@ -1662,6 +1702,8 @@ export async function POST(request: Request) {
                 );
               }
               return NextResponse.json({ received: true });
+            } else {
+              cancelDedupRecorded = true;
             }
           }
         }
@@ -1689,7 +1731,7 @@ export async function POST(request: Request) {
           (data as Record<string, unknown>).ended_at as string | undefined ||
           null;
 
-        await supabase
+        const { error: cancelUpdateErr } = await supabase
           .from('subscriptions')
           .update({
             status: 'canceled',
@@ -1710,6 +1752,31 @@ export async function POST(request: Request) {
             ...(periodEnd ? { current_period_end: periodEnd } : {}),
           })
           .eq('polar_subscription_id', data.id);
+
+        if (cancelUpdateErr) {
+          // BUG #17: same dedup-before-write hazard as created/updated. If we
+          // swallow this error, the sub stays status='active' with no
+          // canceled_at/period-end, so the downgrade cron never picks it up and
+          // the user keeps paid tier indefinitely. Delete the dedup row recorded
+          // this delivery so Polar retries, then return 500.
+          console.error(
+            'polar/route: subscription.canceled — failed to update subscription:',
+            cancelUpdateErr.message
+          );
+          if (cancelDedupRecorded && cancelEventId) {
+            const { error: dedupDeleteErr } = await supabase
+              .from('polar_webhook_events')
+              .delete()
+              .eq('event_id', cancelEventId);
+            if (dedupDeleteErr) {
+              console.error(
+                'polar/route: subscription.canceled — CRITICAL: failed to delete idempotency row after update failure (manual replay required):',
+                dedupDeleteErr.message
+              );
+            }
+          }
+          return NextResponse.json({ error: 'Processing failed' }, { status: 500 });
+        }
 
         if (isDev) console.log('Subscription canceled successfully');
         break;
@@ -1750,10 +1817,15 @@ export async function POST(request: Request) {
         // revoke event would re-run the cascade-cancel sweep and re-write
         // the audit row. The state-based fallback (UPDATE is idempotent)
         // keeps correctness if dedup table writes fail.
+        // Tracks whether THIS delivery wrote the dedup row, so the .update()
+        // error path below can compensate-delete it and let Polar retry (bug #33).
+        let revokeEventId: string | undefined;
+        let revokeDedupRecorded = false;
         {
           const rawEventId = (rawParsed as Record<string, unknown>).id as
             | string
             | undefined;
+          revokeEventId = rawEventId;
           if (!rawEventId) {
             console.error(
               'polar/route: subscription.revoked event missing top-level id field — cannot enforce event-id dedup',
@@ -1785,6 +1857,8 @@ export async function POST(request: Request) {
                 );
               }
               return NextResponse.json({ received: true });
+            } else {
+              revokeDedupRecorded = true;
             }
           }
         }
@@ -1844,12 +1918,27 @@ export async function POST(request: Request) {
           .eq('polar_subscription_id', data.id);
 
         if (revokeUpdateErr) {
-          // 500 → Polar retries, which is safe because the .update is
-          // idempotent and the dedup row above prevents double-cascade.
+          // BUG #33: 500 → Polar retries, BUT the dedup row written above also
+          // short-circuits that retry (the upsert conflicts and we return 200 at
+          // the duplicate branch), so the failed revoke UPDATE is never re-applied
+          // and the user keeps their paid tier. Delete the dedup row recorded this
+          // delivery so the retry actually re-runs the revoke (mirror refund @2216).
           console.error(
             'polar/route: subscription.revoked — failed to update main subscription:',
             revokeUpdateErr.message,
           );
+          if (revokeDedupRecorded && revokeEventId) {
+            const { error: dedupDeleteErr } = await supabase
+              .from('polar_webhook_events')
+              .delete()
+              .eq('event_id', revokeEventId);
+            if (dedupDeleteErr) {
+              console.error(
+                'polar/route: subscription.revoked — CRITICAL: failed to delete idempotency row after update failure (manual replay required):',
+                dedupDeleteErr.message,
+              );
+            }
+          }
           return NextResponse.json(
             { error: 'Processing failed' },
             { status: 500 },

--- a/packages/styrby-web/src/app/auth/callback/route.ts
+++ b/packages/styrby-web/src/app/auth/callback/route.ts
@@ -25,6 +25,7 @@
 import { createClient, createAdminClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import { sendWelcomeEmail } from '@/lib/resend';
+import { isDisposableEmail } from '@/lib/disposable-emails';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -174,6 +175,24 @@ export async function GET(request: Request) {
     }
 
     const user = sessionData.user;
+
+    // -------------------------------------------------------------------------
+    // Step 0: Disposable-email enforcement (bugs #48 / #31)
+    //
+    // WHY here: the OTP send/verify path now blocks disposable addresses
+    // server-side, but OAuth (GitHub/Google) bypassed that gate entirely — a
+    // user could sign up with a throwaway address just by clicking "Continue
+    // with GitHub". The callback is the only server-side point where the
+    // provider-VERIFIED email is available, so we enforce the policy uniformly
+    // here. We use the verified session email (not a client-supplied value).
+    //
+    // On a disposable hit we tear down the just-created session and redirect to
+    // /login so no usable session survives the rejection.
+    // -------------------------------------------------------------------------
+    if (user.email && isDisposableEmail(user.email)) {
+      await supabase.auth.signOut();
+      return NextResponse.redirect(`${origin}/login?error=disposable_email`);
+    }
 
     // -------------------------------------------------------------------------
     // Step 1: Welcome email for new users

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/__tests__/actions.test.ts
@@ -224,6 +224,21 @@ describe('overrideTierAction', () => {
     expect(mockRpc).not.toHaveBeenCalled();
   });
 
+  // BUG #34: never-shipped tiers must be rejected at the schema layer so an admin
+  // can't write an undefined-entitlement subscription row.
+  it.each(['team', 'business', 'enterprise', 'power'])(
+    '(a) rejects never-shipped/retired tier %s without calling the RPC',
+    async (badTier) => {
+      const { overrideTierAction } = await import('../actions');
+      const result = await overrideTierAction(
+        VALID_UUID,
+        makeFormData({ targetUserId: VALID_UUID, newTier: badTier, reason: 'test reason' })
+      );
+      expect(result).toMatchObject({ ok: false, field: 'newTier' });
+      expect(mockRpc).not.toHaveBeenCalled();
+    }
+  );
+
   it('(a) returns error with field when reason is empty', async () => {
     const { overrideTierAction } = await import('../actions');
 
@@ -256,7 +271,7 @@ describe('overrideTierAction', () => {
     const { overrideTierAction } = await import('../actions');
     const result = await overrideTierAction(
       VALID_UUID,
-      makeFormData({ targetUserId: VALID_UUID, newTier: 'enterprise', reason: 'test reason' })
+      makeFormData({ targetUserId: VALID_UUID, newTier: 'growth', reason: 'test reason' })
     );
 
     expect(result).toEqual({ ok: false, error: 'Not authorized' });
@@ -293,7 +308,7 @@ describe('overrideTierAction', () => {
     const { overrideTierAction } = await import('../actions');
     const result = await overrideTierAction(
       VALID_UUID,
-      makeFormData({ targetUserId: VALID_UUID, newTier: 'team', reason: 'test reason' })
+      makeFormData({ targetUserId: VALID_UUID, newTier: 'pro', reason: 'test reason' })
     );
 
     expect(result).toMatchObject({ ok: false, error: 'Internal error — check Sentry' });
@@ -347,7 +362,7 @@ describe('overrideTierAction', () => {
     await expect(
       overrideTierAction(
         VALID_UUID,
-        makeFormData({ targetUserId: VALID_UUID, newTier: 'enterprise', reason: 'perm override' })
+        makeFormData({ targetUserId: VALID_UUID, newTier: 'growth', reason: 'perm override' })
       )
     ).rejects.toThrow(/NEXT_REDIRECT/);
 

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/actions.ts
@@ -56,7 +56,12 @@ export type AdminActionResult =
  */
 const OverrideTierSchema = z.object({
   targetUserId: z.string().uuid({ message: 'Invalid user ID' }),
-  newTier: z.enum(['free', 'pro', 'growth', 'team', 'business', 'enterprise'], {
+  // BUG #34: restrict to the canonical sellable set only. team/business/
+  // enterprise NEVER shipped (no Polar product, no entitlement mapping); 'power'
+  // is retired (premium===growth via normalizeTier). Accepting any of those let
+  // an admin write an undefined-entitlement subscription row in two clicks
+  // (premium gates silently deny, the dossier shows a tier with no Polar sub).
+  newTier: z.enum(['free', 'pro', 'growth'], {
     errorMap: () => ({ message: 'newTier must be a valid tier' }),
   }),
   expiresAt: z.string().datetime({ offset: true }).nullable().optional(),

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/__tests__/actions.test.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/__tests__/actions.test.ts
@@ -810,6 +810,45 @@ describe('issueRefundAction', () => {
     expect(mockCreatePolarRefund).not.toHaveBeenCalled();
     expect(mockRpc).not.toHaveBeenCalled();
   });
+
+  // BUG #51: fail CLOSED when getUser() returns a null acting user. Previously the
+  // MFA gate was wrapped in `if (actingAdmin)`, so a null user skipped MFA and the
+  // Polar refund (money movement, which precedes the RPC) executed unguarded.
+  it('(MFA gate) fails closed (Unauthorized) and skips Polar + RPC when acting user is null', async () => {
+    (createClient as Mock).mockResolvedValue({
+      rpc: mockRpc,
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+      },
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { polar_customer_id: 'cus_test_default', user_id: VALID_UUID },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    });
+
+    const { issueRefundAction } = await import('../actions');
+    const result = await issueRefundAction(
+      VALID_UUID,
+      makeFormData({
+        targetUserId: VALID_UUID,
+        subscriptionId: 'sub_polar_123',
+        amount_cents: '4900',
+        reason: 'Customer requested refund for billing error',
+      })
+    );
+
+    expect(result).toEqual({ ok: false, error: 'Unauthorized' });
+    // MFA gate is never reached, and crucially no money moves.
+    expect(assertAdminMfa).not.toHaveBeenCalled();
+    expect(mockCreatePolarRefund).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
 });
 
 // ─── issueCreditAction ────────────────────────────────────────────────────────

--- a/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
+++ b/packages/styrby-web/src/app/dashboard/admin/users/[userId]/billing/actions.ts
@@ -265,16 +265,24 @@ export async function issueRefundAction(
   // OWASP A07:2021, SOC 2 CC6.1.
   {
     const mfaClient = await createClient();
-    const { data: { user: actingAdmin } } = await mfaClient.auth.getUser();
-    if (actingAdmin) {
-      try {
-        await assertAdminMfa(actingAdmin.id);
-      } catch (err) {
-        if (err instanceof AdminMfaRequiredError) {
-          return { ok: false, error: err.code };
-        }
-        throw err;
+    const { data: { user: actingAdmin }, error: actingAdminErr } =
+      await mfaClient.auth.getUser();
+    // BUG #51: fail CLOSED on a null acting user. The previous `if (actingAdmin)`
+    // wrapper skipped the MFA gate entirely when getUser() returned null (auth
+    // network blip, refreshed-but-unreadable session), letting a Polar refund
+    // execute with NO MFA — and unlike the other actions, the refund's money
+    // movement happens BEFORE any user-scoped RPC could fail-close. Treat a
+    // missing acting user as unauthenticated.
+    if (actingAdminErr || !actingAdmin) {
+      return { ok: false, error: 'Unauthorized' };
+    }
+    try {
+      await assertAdminMfa(actingAdmin.id);
+    } catch (err) {
+      if (err instanceof AdminMfaRequiredError) {
+        return { ok: false, error: err.code };
       }
+      throw err;
     }
   }
 
@@ -595,16 +603,21 @@ export async function issueCreditAction(
   // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
   // OWASP A07:2021, SOC 2 CC6.1.
   {
-    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
-    if (actingAdmin) {
-      try {
-        await assertAdminMfa(actingAdmin.id);
-      } catch (err) {
-        if (err instanceof AdminMfaRequiredError) {
-          return { ok: false, error: err.code };
-        }
-        throw err;
+    const { data: { user: actingAdmin }, error: actingAdminErr } =
+      await supabase.auth.getUser();
+    // BUG #51: fail CLOSED on a null acting user — never skip the MFA gate when
+    // getUser() returns null. (The user-scoped RPC below would also fail-close on
+    // a null JWT, but the gate must be unconditional for consistency + defense.)
+    if (actingAdminErr || !actingAdmin) {
+      return { ok: false, error: 'Unauthorized' };
+    }
+    try {
+      await assertAdminMfa(actingAdmin.id);
+    } catch (err) {
+      if (err instanceof AdminMfaRequiredError) {
+        return { ok: false, error: err.code };
       }
+      throw err;
     }
   }
 
@@ -711,16 +724,21 @@ export async function sendChurnSaveOfferAction(
   // ── MFA gate — H42 Layer 1 ────────────────────────────────────────────────
   // OWASP A07:2021, SOC 2 CC6.1.
   {
-    const { data: { user: actingAdmin } } = await supabase.auth.getUser();
-    if (actingAdmin) {
-      try {
-        await assertAdminMfa(actingAdmin.id);
-      } catch (err) {
-        if (err instanceof AdminMfaRequiredError) {
-          return { ok: false, error: err.code };
-        }
-        throw err;
+    const { data: { user: actingAdmin }, error: actingAdminErr } =
+      await supabase.auth.getUser();
+    // BUG #51: fail CLOSED on a null acting user — never skip the MFA gate when
+    // getUser() returns null. (The user-scoped RPC below would also fail-close on
+    // a null JWT, but the gate must be unconditional for consistency + defense.)
+    if (actingAdminErr || !actingAdmin) {
+      return { ok: false, error: 'Unauthorized' };
+    }
+    try {
+      await assertAdminMfa(actingAdmin.id);
+    } catch (err) {
+      if (err instanceof AdminMfaRequiredError) {
+        return { ok: false, error: err.code };
       }
+      throw err;
     }
   }
 

--- a/packages/styrby-web/src/app/login/page.tsx
+++ b/packages/styrby-web/src/app/login/page.tsx
@@ -252,12 +252,34 @@ function LoginForm() {
 
       const verifyData = await verifyRes.json();
 
-      // 4. Set the Supabase session from the tokens the edge function returns
-      if (verifyData.access_token && verifyData.refresh_token) {
-        await supabase.auth.setSession({
-          access_token: verifyData.access_token,
-          refresh_token: verifyData.refresh_token,
+      // 4. Exchange the edge function's hashed_token for a real Supabase session.
+      // WHY: The verify-passkey edge function mints a magiclink and returns
+      // `{ verified, hashed_token, email }` (NOT access_token/refresh_token).
+      // The client must redeem hashed_token via verifyOtp({ type: 'email' })
+      // to establish the session cookie. Without this the dashboard sees no
+      // session and bounces the user back to /login. (bug #3)
+      if (!verifyData.hashed_token) {
+        throw new Error('Passkey sign-in did not complete. Try again.');
+      }
+
+      const { error: otpError } = await supabase.auth.verifyOtp({
+        token_hash: verifyData.hashed_token,
+        type: 'email',
+      });
+      if (otpError) throw otpError;
+
+      // WHY: Confirm a session actually exists before navigating to a protected
+      // route. A 200 response without a usable session would otherwise redirect
+      // the user into a bounce-back loop with no error shown. (bug #47)
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        setMessage({
+          type: 'error',
+          text: 'Passkey sign-in did not complete. Try again.',
         });
+        return;
       }
 
       router.push(redirect);

--- a/packages/styrby-web/src/components/admin/OverrideTierForm.tsx
+++ b/packages/styrby-web/src/components/admin/OverrideTierForm.tsx
@@ -72,15 +72,15 @@ export interface OverrideTierFormProps {
 
 // ─── Tier options ─────────────────────────────────────────────────────────────
 
-/** All valid tier values — mirrors the Zod schema in actions.ts.
- *  'power' was retired (migration 095) and is intentionally NOT offered. */
+/** Canonical sellable tier values — mirrors the Zod schema in actions.ts.
+ *  BUG #34: team/business/enterprise NEVER shipped (no Polar product, no
+ *  entitlement mapping) and 'power' was retired (migration 095). Offering any
+ *  of them let an admin write an undefined-entitlement row, so only the three
+ *  canonical tiers are selectable. */
 const TIER_OPTIONS: { value: string; label: string }[] = [
   { value: 'free', label: 'Free' },
   { value: 'pro', label: 'Pro' },
   { value: 'growth', label: 'Growth' },
-  { value: 'team', label: 'Team' },
-  { value: 'business', label: 'Business' },
-  { value: 'enterprise', label: 'Enterprise' },
 ];
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/packages/styrby-web/src/components/admin/__tests__/OverrideTierForm.test.tsx
+++ b/packages/styrby-web/src/components/admin/__tests__/OverrideTierForm.test.tsx
@@ -102,13 +102,15 @@ describe('OverrideTierForm', () => {
     render(
       <OverrideTierForm
         targetUserId="a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        currentTier="enterprise"
+        currentTier="growth"
         action={mockBoundAction}
       />
     );
 
+    // Only the canonical sellable tiers (free/pro/growth) are selectable
+    // (bug #34). currentTier pre-selects one of those.
     const select = screen.getByTestId('tier-select') as HTMLSelectElement;
-    expect(select.value).toBe('enterprise');
+    expect(select.value).toBe('growth');
   });
 
   it('(d) renders field-specific error when state has ok: false with field', async () => {

--- a/packages/styrby-web/src/lib/__tests__/polar.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/polar.test.ts
@@ -123,7 +123,8 @@ describe('Polar Billing Module — Phase 5 (Pro + Growth)', () => {
       it('has the expected limits shape (team features)', () => {
         expect(TIERS.growth.limits.machines).toBe(9);
         expect(TIERS.growth.limits.historyDays).toBe(365);
-        expect(TIERS.growth.limits.teamMembers).toBe(100);
+        // Canonical Growth seat ceiling is 25 (Polar product max). (bug #18)
+        expect(TIERS.growth.limits.teamMembers).toBe(25);
       });
 
       it('has $99/mo $990/yr base pricing (Decision #3 / #4)', () => {

--- a/packages/styrby-web/src/lib/billing/__tests__/tier-config.test.ts
+++ b/packages/styrby-web/src/lib/billing/__tests__/tier-config.test.ts
@@ -35,10 +35,11 @@ describe('TIERS — canonical 3-tier config (free + pro + growth)', () => {
     expect(TIERS.pro.price.annual).toBe(390);
   });
 
-  it('Growth has $99/$990 base pricing + 100-seat ceiling (Decisions #3 / #4)', () => {
+  it('Growth has $99/$990 base pricing + 25-seat ceiling (Decisions #3 / #4)', () => {
     expect(TIERS.growth.price.monthly).toBe(99);
     expect(TIERS.growth.price.annual).toBe(990);
-    expect(TIERS.growth.limits.teamMembers).toBe(100);
+    // Canonical Growth seat ceiling is 25 (Polar product max). (bug #18)
+    expect(TIERS.growth.limits.teamMembers).toBe(25);
   });
 });
 

--- a/packages/styrby-web/src/lib/billing/tier-config.ts
+++ b/packages/styrby-web/src/lib/billing/tier-config.ts
@@ -183,7 +183,11 @@ export const TIERS = {
       messagesPerMonth: 100_000,
       budgetAlerts: 5,
       webhooks: 10,
-      teamMembers: 100,
+      // Canonical Growth seat ceiling is 25 (Polar product max). The team page
+      // and POST /api/teams/[id]/members both enforce against this constant, so
+      // 25 here caps invitations at the billed maximum (was 100 = 75 unbilled
+      // seats of revenue leak). (bug #18)
+      teamMembers: 25,
       apiKeys: 5,
       /** Maximum saved session bookmarks. -1 means unlimited. */
       bookmarks: -1,

--- a/packages/styrby-web/src/lib/supabase/middleware.ts
+++ b/packages/styrby-web/src/lib/supabase/middleware.ts
@@ -4,6 +4,7 @@
 
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
+import type { User } from '@supabase/supabase-js';
 
 /**
  * Checks if Supabase environment variables are properly configured.
@@ -21,20 +22,40 @@ function hasValidSupabaseConfig(): boolean {
 }
 
 /**
- * Updates the Supabase auth session by refreshing the token if needed.
- * Should be called in middleware for every request.
+ * The validated result of a session refresh pass.
+ *
+ * WHY the `user` field: protected-route gating in middleware must validate the
+ * actual session, not merely the presence of an auth cookie. Returning the
+ * `getUser()` result lets the caller gate on a verified user (null = forged,
+ * expired, or chunked-but-unverifiable token) instead of pattern-matching a
+ * cookie name that an attacker can set or that goes missing for chunked JWTs.
+ * (bugs #15, #46)
+ */
+export interface UpdateSessionResult {
+  /** The refreshed Next.js response carrying any rotated auth cookies. */
+  response: NextResponse;
+  /** The authenticated user, or null when no valid session exists. */
+  user: User | null;
+}
+
+/**
+ * Updates the Supabase auth session by refreshing the token if needed, and
+ * returns the validated user so the caller can gate protected routes on a
+ * real session rather than cookie presence.
  *
  * @param request - Next.js request object
- * @returns Next.js response with updated cookies
+ * @returns The refreshed response plus the validated user (null if unauthenticated)
  */
-export async function updateSession(request: NextRequest) {
+export async function updateSession(request: NextRequest): Promise<UpdateSessionResult> {
   let supabaseResponse = NextResponse.next({
     request,
   });
 
-  // Skip session refresh if Supabase is not configured (CI/test environment)
+  // Skip session refresh if Supabase is not configured (CI/test environment).
+  // WHY user:null here: without config we cannot validate a session, so the
+  // gate must fail-closed for protected paths.
   if (!hasValidSupabaseConfig()) {
-    return supabaseResponse;
+    return { response: supabaseResponse, user: null };
   }
 
   const supabase = createServerClient(
@@ -60,8 +81,11 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
-  // Refresh session if expired - this will also update cookies
-  await supabase.auth.getUser();
+  // Refresh session if expired - this will also update cookies. We keep the
+  // validated user so the middleware can gate protected routes on it.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  return supabaseResponse;
+  return { response: supabaseResponse, user };
 }

--- a/packages/styrby-web/src/middleware.ts
+++ b/packages/styrby-web/src/middleware.ts
@@ -326,8 +326,9 @@ export async function middleware(request: NextRequest) {
 
   // ── Search engines and humans: pass through to auth logic ────────────────
 
-  // Update Supabase auth session
-  const response = await updateSession(request);
+  // Update Supabase auth session. We keep the validated user so protected-route
+  // gating can check a real session instead of trusting cookie presence.
+  const { response, user: sessionUser } = await updateSession(request);
 
   // ── Admin route guard (/admin/* and /api/admin/*) ─────────────────────────
   //
@@ -442,30 +443,23 @@ export async function middleware(request: NextRequest) {
 
   if (isProtectedPath) {
     /**
-     * Derive the Supabase session cookie name from NEXT_PUBLIC_SUPABASE_URL.
+     * Gate protected routes on the VALIDATED session, not cookie presence.
      *
-     * WHY: Hardcoding the project ref creates a maintenance hazard -- if the
-     * Supabase project changes (e.g., migration to a new instance), the cookie
-     * check silently breaks and all protected routes become inaccessible.
-     * Deriving it from the environment variable keeps the middleware in sync
-     * with whichever Supabase project is configured.
-     *
-     * Cookie format: `sb-{project_ref}-auth-token`
-     * URL format:    `https://{project_ref}.supabase.co`
+     * WHY (bugs #15, #46): The previous gate checked `request.cookies.has(
+     * 'sb-<ref>-auth-token')`. That is wrong in two directions:
+     *   - False-negative: when a session JWT exceeds ~3180 bytes (common with
+     *     Google/GitHub OAuth), Supabase chunks it into `.0`/`.1` cookies and
+     *     the base `sb-<ref>-auth-token` cookie is ABSENT — locking out legit
+     *     users on every protected page.
+     *   - False-positive: anyone can set a cookie literally named
+     *     `sb-<ref>-auth-token` to any value and pass the gate, because no JWT
+     *     validation ran here.
+     * updateSession() now calls getUser() (which verifies the JWT signature
+     * and expiry against Supabase) and returns the validated user. We gate on
+     * that — a null user means no real session regardless of which cookies
+     * are present.
      */
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
-    const projectRef = supabaseUrl.match(/https:\/\/([^.]+)\.supabase\.co/)?.[1] ?? '';
-    const cookieName = `sb-${projectRef}-auth-token`;
-
-    // FIX-052: Check both cookie presence AND updateSession result
-    // WHY: Cookie presence alone doesn't guarantee the JWT is valid --
-    // it could be expired or tampered. updateSession already refreshes
-    // the token, but we also check if the response indicates auth failure
-    // (e.g., redirect to login means the session refresh failed).
-    const hasSession = request.cookies.has(cookieName);
-    const isAuthRedirect = response.headers.get('location')?.includes('/login');
-
-    if (!hasSession || isAuthRedirect) {
+    if (!sessionUser) {
       // Redirect to login with return URL
       const loginUrl = new URL('/login', request.url);
       loginUrl.searchParams.set('redirect', request.nextUrl.pathname);


### PR DESCRIPTION
Second wave from the adversarial bug-hunt (each finding verified by a skeptic agent before fixing). 27 bugs, +43 regression tests.

## WEB — auth / billing / money (high-risk)
- **CRITICAL: passkey login was 100% broken.** Verify edge fn returns `{hashed_token}`, login page checked for `access_token` (never sent) → no session → bounced to `/login`. Now exchanges via `supabase.auth.verifyOtp` + verifies session before redirect. Fixed the test that masked it.
- **middleware trusted cookie *presence*** for protected routes → broke chunked OAuth sessions (locked out real users) *and* let anyone forge the cookie to pass. Now validates via `getUser()`.
- **Polar webhook swallowed DB errors** after the dedup-row write (created/updated/canceled/revoked) → 200, no retry, permanent billing drift. Now compensating-deletes the dedup row + 500s.
- **Growth seat cap 100→25** (teams could invite 75+ unbilled seats).
- **admin refund/credit/churn failed OPEN on null user** (MFA skipped before money movement) → fail closed.

## WEB — medium/low
cron auth 500→401; server-side disposable-email gate (OTP + OAuth); checkout idempotency tumbling→rolling (double-charge); admin override-tier enum → free/pro/growth; checkpoint DELETE `count:'exact'` (404 when nothing deleted); seat PATCH stops fabricating `oldSeats=1`; churn denominator unified on `%no_mrr%`.

## CLI — security + correctness
- **wrong-provider API-key injection** (OpenAI key disclosed to Anthropic) → provider-aware `resolveApiKeyEnv`.
- **config-injection bypass** via space-separated `["--config","/etc/passwd"]` → flag-context tracking.
- **relay cancel fanned out to ALL sessions** → session-scoped.
- cancel surfaced a false error to mobile → cancelled-flag clean exit.
- goose `"0 errors"` flipped session to error → anchored detection; stream-error swallow → check `hasError` first; +SIGKILL escalation, ENOENT double-emit guard, atomic config write, `--agent` dedup.

## Test Plan
- [x] full typecheck 7/7 · web **3859** (+18) · cli **2956** (+25) · web lint clean
- [ ] CI green

Offline-sync cluster excluded (separate feature build, next). Full audit: `docs/planning/styrby-bughunt-2026-06-09.md`.

🤖 Shipped via /gh-ship