### PR TITLE
feat(cli): managed-spawn for claude + codex; fix agent registration + relay dispatch

### DIFF
--- a/packages/styrby-cli/src/agent/__tests__/factory-matrix.test.ts
+++ b/packages/styrby-cli/src/agent/__tests__/factory-matrix.test.ts
@@ -1,9 +1,10 @@
 /**
- * Conformance test for the 9 streaming agent factories.
+ * Conformance test for the 10 streaming agent factories.
  *
  * WHY this file exists (Track C3, in-session task #68):
- *   The CLI supports 11 agents (claude + codex via launcher pattern, plus 9
- *   "streaming" agents via the StreamingAgentBackendBase pattern). Each
+ *   The CLI supports 11 agents: 10 "streaming" agents via the
+ *   StreamingAgentBackendBase pattern (claude joined in PR2 as a managed
+ *   binary-spawn over stream-json) + codex via the launcher/MCP pattern. Each
  *   streaming agent registers itself with the global `agentRegistry` via a
  *   `registerXAgent()` function. The recurring bug class this catches:
  *     "we added agent #12 and forgot to wire it into the registry / index."
@@ -17,15 +18,17 @@
  *   - DOES NOT spawn any actual agent processes (those are integration tests)
  *
  * Excluded:
- *   - claude + codex use the launcher pattern (not streaming base class), so
- *     they don't register via this mechanism. Their conformance is verified
- *     by their own dedicated tests + the e2e smoke tests.
+ *   - codex uses the launcher/MCP pattern (implements AgentBackend directly,
+ *     not via the streaming base class), so it doesn't register via this
+ *     mechanism. Its conformance is verified by its own dedicated test
+ *     (codex.test.ts) + the e2e smoke tests.
  *
  * @module agent/__tests__/factory-matrix
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
+  registerClaudeAgent,
   registerGeminiAgent,
   registerAiderAgent,
   registerOpenCodeAgent,
@@ -47,6 +50,7 @@ import type { AgentBackend, AgentId } from '@/agent/core/AgentBackend';
  * Order matters only for output readability; the registry is unordered.
  */
 const EXPECTED_STREAMING_AGENTS: AgentId[] = [
+  'claude',
   'gemini',
   'aider',
   'opencode',
@@ -63,6 +67,7 @@ const EXPECTED_STREAMING_AGENTS: AgentId[] = [
  * register-then-verify in a single loop.
  */
 const REGISTRATIONS: Record<string, () => void> = {
+  claude: registerClaudeAgent,
   gemini: registerGeminiAgent,
   aider: registerAiderAgent,
   opencode: registerOpenCodeAgent,
@@ -88,16 +93,16 @@ const REQUIRED_BACKEND_METHODS = [
   'onMessage',
 ] as const;
 
-describe('Agent factory conformance matrix (9 streaming agents)', () => {
+describe('Agent factory conformance matrix (10 streaming agents)', () => {
   beforeAll(() => {
-    // Register all 9. Idempotent — register() just re-overwrites the entry.
+    // Register all 10. Idempotent — register() just re-overwrites the entry.
     for (const fn of Object.values(REGISTRATIONS)) {
       fn();
     }
   });
 
   describe('registry contents', () => {
-    it('contains all 9 expected streaming agent IDs', () => {
+    it('contains all 10 expected streaming agent IDs', () => {
       const registered = agentRegistry.list();
       for (const expected of EXPECTED_STREAMING_AGENTS) {
         expect(registered).toContain(expected);
@@ -174,12 +179,15 @@ describe('Agent factory conformance matrix (9 streaming agents)', () => {
       // factories/ doesn't, the streaming-list and canonical-list will fall
       // out of sync. We assert via cardinality + the known exclusions.
       //
-      // Canonical 11 = streaming 9 + launcher 2 (claude + codex)
-      // 9 + 2 = 11 ✓
-      expect(EXPECTED_STREAMING_AGENTS.length).toBe(9);
+      // Canonical 11 = streaming 10 (incl. claude) + launcher 1 (codex)
+      // 10 + 1 = 11 ✓
+      // claude moved to the streaming set in PR2 (managed binary-spawn via
+      // stream-json, StreamingAgentBackendBase). codex stays launcher-pattern
+      // (implements AgentBackend directly over the MCP transport).
+      expect(EXPECTED_STREAMING_AGENTS.length).toBe(10);
 
-      // Sanity check: claude + codex should NOT be in the streaming list
-      expect(EXPECTED_STREAMING_AGENTS).not.toContain('claude' as AgentId);
+      // claude IS streaming now; codex is the sole launcher-pattern agent.
+      expect(EXPECTED_STREAMING_AGENTS).toContain('claude' as AgentId);
       expect(EXPECTED_STREAMING_AGENTS).not.toContain('codex' as AgentId);
     });
   });

--- a/packages/styrby-cli/src/agent/__tests__/initializeAgents.test.ts
+++ b/packages/styrby-cli/src/agent/__tests__/initializeAgents.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression test for initializeAgents().
+ *
+ * WHY this exists (2026-06-10, found by live verification): the previous
+ * implementation registered agents via bare `require('./factories/...')` inside
+ * try/catch. This package is ESM ("type": "module"), where `require` is
+ * undefined — so under the real CLI runtime EVERY require() threw and was
+ * silently swallowed, leaving the registry empty ("Registered agents: none
+ * registered"). No managed agent worked at runtime. The unit suites missed it
+ * because they call `registerXAgent()` directly, never `initializeAgents()`.
+ *
+ * This test calls the REAL initializeAgents() (no mocks) so the dynamic-import
+ * registration path is exercised end-to-end: if it regresses to a broken import
+ * mechanism, the registry comes back empty and this fails.
+ *
+ * @module agent/__tests__/initializeAgents
+ */
+
+import { describe, it, expect } from 'vitest';
+import { initializeAgents } from '../index';
+import { agentRegistry } from '../core';
+import type { AgentId } from '../core/AgentBackend';
+
+/** The canonical 11 agents that must all register. */
+const ALL_AGENTS: AgentId[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'opencode',
+  'aider',
+  'goose',
+  'amp',
+  'crush',
+  'kilo',
+  'kiro',
+  'droid',
+];
+
+describe('initializeAgents (real registration, no mocks)', () => {
+  it('registers all 11 agents via the dynamic-import path', async () => {
+    await initializeAgents();
+    const registered = agentRegistry.list();
+    for (const id of ALL_AGENTS) {
+      expect(registered, `agent "${id}" should be registered`).toContain(id);
+    }
+  });
+
+  it('every registered agent can be constructed into a backend', async () => {
+    await initializeAgents();
+    for (const id of ALL_AGENTS) {
+      const backend = agentRegistry.create(id, { cwd: '/tmp' });
+      expect(backend, `agent "${id}" should construct`).toBeDefined();
+      expect(typeof backend.startSession).toBe('function');
+      expect(typeof backend.sendPrompt).toBe('function');
+    }
+  });
+
+  it('is idempotent — a second call does not throw', async () => {
+    await initializeAgents();
+    await expect(initializeAgents()).resolves.toBeUndefined();
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/claude-backend.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/claude-backend.test.ts
@@ -1,0 +1,241 @@
+/**
+ * ClaudeBackend — managed binary-spawn (stream-json) test suite.
+ *
+ * Separate from claude.test.ts (which covers the pure cost helpers and mocks
+ * node:fs) so the spawn mock here can't interfere with that file's fs mock.
+ *
+ * Tests cover:
+ *  - createClaudeBackend factory shape + metadata
+ *  - registerClaudeAgent registry integration
+ *  - spawn arg construction (-p, stream-json, --verbose, --permission-mode,
+ *    --model, --allowedTools, --resume from a captured session_id)
+ *  - stream-json line -> AgentMessage mapping (assistant text/tool_use, fs-edit,
+ *    user tool_result, cost-report from usage)
+ *  - lifecycle: clean exit -> idle+resolve, non-zero -> error+reject,
+ *    cancel -> SIGTERM+idle, disposed guard
+ *
+ * The `claude` binary is mocked at node:child_process.spawn. stdout uses a real
+ * PassThrough because the backend reads it via the base class's readline-based
+ * streamLines().
+ *
+ * @module factories/__tests__/claude-backend.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+class FakeChild extends EventEmitter {
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  stdin = new PassThrough();
+  killed = false;
+  kill = vi.fn((_sig?: string) => { this.killed = true; return true; });
+}
+
+// WHY inline the vi.fn inside the factory (not reference an outer const): vi.mock
+// is hoisted above top-level consts, so referencing an outer `spawnMock` at
+// factory-execution time hits the temporal dead zone. The factory body only runs
+// when spawn() is actually called (in a test), by which point FakeChild/lastChild
+// are initialized. We grab the spy below via vi.mocked(spawn).
+let lastChild: FakeChild;
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => {
+    lastChild = new FakeChild();
+    return lastChild;
+  }),
+}));
+vi.mock('@/ui/logger', () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import { spawn } from 'node:child_process';
+import { createClaudeBackend, registerClaudeAgent } from '../claude';
+import { agentRegistry } from '../../core';
+import type { AgentMessage } from '../../core/AgentBackend';
+
+const spawnMock = vi.mocked(spawn);
+
+function makeBackend(opts: Record<string, unknown> = {}) {
+  const { backend } = createClaudeBackend({ cwd: '/tmp/project', ...opts } as any);
+  const messages: AgentMessage[] = [];
+  backend.onMessage((m) => messages.push(m));
+  return { backend, messages };
+}
+
+/** Drive a pending sendPrompt: feed JSONL stdout lines, end stream, close proc. */
+async function drive(run: Promise<unknown>, lines: Array<Record<string, unknown>>, code: number | null = 0): Promise<void> {
+  await new Promise((r) => setImmediate(r)); // let spawn + listeners attach
+  for (const line of lines) lastChild.stdout.write(JSON.stringify(line) + '\n');
+  lastChild.stdout.end();
+  await new Promise((r) => setImmediate(r)); // let readline flush 'line' events
+  lastChild.emit('close', code);
+  await run;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createClaudeBackend', () => {
+  it('returns backend, resolved model, and metadata', () => {
+    const r = createClaudeBackend({ cwd: '/tmp/p', model: 'claude-sonnet-4-6' });
+    expect(r.backend).toBeDefined();
+    expect(r.model).toBe('claude-sonnet-4-6');
+    expect(r.metadata).toEqual({ modelSource: 'explicit', supportsStreaming: true, supportsTools: true });
+  });
+
+  it('metadata.modelSource is "default" without a model', () => {
+    expect(createClaudeBackend({ cwd: '/tmp/p' }).metadata.modelSource).toBe('default');
+  });
+});
+
+describe('registerClaudeAgent', () => {
+  it('registers "claude" as a working backend', () => {
+    registerClaudeAgent();
+    expect(agentRegistry.has('claude')).toBe(true);
+    expect(agentRegistry.create('claude', { cwd: '/tmp/p' })).toBeDefined();
+  });
+});
+
+describe('startSession (no prompt)', () => {
+  it('returns a sessionId, emits idle, and does NOT spawn', async () => {
+    const { backend, messages } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    expect(sessionId).toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/i);
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(messages.some((m) => m.type === 'status' && m.status === 'idle')).toBe(true);
+  });
+});
+
+describe('spawn arg construction', () => {
+  it('uses stream-json + verbose + acceptEdits by default', async () => {
+    const { backend } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    await drive(backend.sendPrompt(sessionId, 'hello'), [{ type: 'result' }]);
+
+    const [command, args] = spawnMock.mock.calls[0];
+    expect(command).toBe('claude');
+    expect(args).toEqual(
+      expect.arrayContaining(['-p', 'hello', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'acceptEdits']),
+    );
+  });
+
+  it('includes --model and --allowedTools when provided', async () => {
+    const { backend } = makeBackend({ model: 'claude-opus-4-8', allowedTools: ['Read', 'Bash(git *)'] });
+    const { sessionId } = await backend.startSession();
+    await drive(backend.sendPrompt(sessionId, 'go'), [{ type: 'result' }]);
+
+    const [, args] = spawnMock.mock.calls[0];
+    expect(args).toEqual(expect.arrayContaining(['--model', 'claude-opus-4-8', '--allowedTools', 'Read,Bash(git *)']));
+  });
+
+  it('resumes the captured claude session_id on the next prompt', async () => {
+    const { backend } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    await drive(backend.sendPrompt(sessionId, 'first'), [
+      { type: 'system', subtype: 'init', session_id: 'claude-abc' },
+      { type: 'result' },
+    ]);
+    await drive(backend.sendPrompt(sessionId, 'second'), [{ type: 'result' }]);
+
+    const [, args2] = spawnMock.mock.calls[1];
+    expect(args2).toEqual(expect.arrayContaining(['--resume', 'claude-abc']));
+  });
+});
+
+describe('stream-json -> AgentMessage mapping', () => {
+  it('assistant text -> model-output; usage -> cost-report', async () => {
+    const { backend, messages } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    await drive(backend.sendPrompt(sessionId, 'hi'), [
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'Hello!' }], usage: { input_tokens: 12, output_tokens: 7 } } },
+      { type: 'result' },
+    ]);
+    expect(messages).toContainEqual({ type: 'model-output', fullText: 'Hello!' });
+    expect(messages.some((m) => m.type === 'cost-report')).toBe(true);
+  });
+
+  it('assistant tool_use -> tool-call (+ fs-edit for Edit/Write)', async () => {
+    const { backend, messages } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    await drive(backend.sendPrompt(sessionId, 'edit'), [
+      { type: 'assistant', message: { content: [
+        { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } },
+        { type: 'tool_use', id: 't2', name: 'Edit', input: { file_path: '/p/a.ts' } },
+      ] } },
+      { type: 'result' },
+    ]);
+    expect(messages).toContainEqual(expect.objectContaining({ type: 'tool-call', toolName: 'Bash', callId: 't1' }));
+    expect(messages).toContainEqual(expect.objectContaining({ type: 'tool-call', toolName: 'Edit', callId: 't2' }));
+    expect(messages).toContainEqual(expect.objectContaining({ type: 'fs-edit', path: '/p/a.ts' }));
+  });
+
+  it('user tool_result -> tool-result', async () => {
+    const { backend, messages } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    await drive(backend.sendPrompt(sessionId, 'x'), [
+      { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'output' }] } },
+      { type: 'result' },
+    ]);
+    expect(messages).toContainEqual(expect.objectContaining({ type: 'tool-result', callId: 't1', result: 'output' }));
+  });
+
+  it('non-JSON stdout lines are ignored (no model-output, no throw)', async () => {
+    const { backend, messages } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    const run = backend.sendPrompt(sessionId, 'x');
+    await new Promise((r) => setImmediate(r));
+    lastChild.stdout.write('not json at all\n');
+    lastChild.stdout.end();
+    await new Promise((r) => setImmediate(r));
+    lastChild.emit('close', 0);
+    await run;
+    expect(messages.some((m) => m.type === 'model-output')).toBe(false);
+  });
+});
+
+describe('lifecycle', () => {
+  it('clean exit (code 0) emits idle and resolves', async () => {
+    const { backend, messages } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    await drive(backend.sendPrompt(sessionId, 'x'), [{ type: 'result' }], 0);
+    expect(messages.some((m) => m.type === 'status' && m.status === 'idle')).toBe(true);
+  });
+
+  it('non-zero exit rejects with an error status', async () => {
+    const { backend, messages } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    const run = backend.sendPrompt(sessionId, 'x');
+    await new Promise((r) => setImmediate(r));
+    lastChild.stdout.end();
+    await new Promise((r) => setImmediate(r));
+    lastChild.emit('close', 2);
+    await expect(run).rejects.toThrow(/code 2/);
+    expect(messages.some((m) => m.type === 'status' && m.status === 'error')).toBe(true);
+  });
+
+  it('cancel sends SIGTERM, emits idle, and the run resolves (intentional cancel)', async () => {
+    const { backend, messages } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    const run = backend.sendPrompt(sessionId, 'x');
+    await new Promise((r) => setImmediate(r));
+    await backend.cancel(sessionId);
+    expect(lastChild.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(messages.some((m) => m.type === 'status' && m.status === 'idle')).toBe(true);
+    lastChild.emit('close', null); // cancelled exit
+    await expect(run).resolves.toBeUndefined();
+  });
+
+  it('sendPrompt after dispose throws', async () => {
+    const { backend } = makeBackend();
+    await backend.dispose();
+    await expect(backend.sendPrompt('s', 'p')).rejects.toThrow(/disposed/);
+  });
+
+  it('sendPrompt with a mismatched sessionId throws', async () => {
+    const { backend } = makeBackend();
+    await backend.startSession();
+    await expect(backend.sendPrompt('wrong-id', 'p')).rejects.toThrow(/Invalid session ID/);
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/codex.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/codex.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Codex Backend — test suite
+ *
+ * Tests cover:
+ *  - createCodexBackend factory (return shape + metadata)
+ *  - registerCodexAgent (registry integration)
+ *  - Session lifecycle: startSession (config + status), sendPrompt, cancel, dispose
+ *  - Codex event -> AgentMessage mapping for every handled msg.type
+ *  - Permission bridge: handleToolCall -> permission-request -> respondToPermission
+ *  - Event emission: onMessage/offMessage, handler-exception isolation
+ *
+ * The MCP transport (CodexMcpClient) is mocked at the module boundary so these
+ * tests exercise the ADAPTER (event mapping + permission bridging), not the
+ * subprocess. That mirrors the project rule: mock the third-party client at the
+ * boundary, test our logic.
+ *
+ * @module factories/__tests__/codex.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock CodexMcpClient at the module boundary. vi.hoisted exposes a shared fake
+// client (with vi.fn spies) and captures the handler + permission bridge that
+// CodexBackend registers in its constructor.
+// ---------------------------------------------------------------------------
+const { fakeClient, captured } = vi.hoisted(() => {
+  const captured: {
+    handler: ((e: unknown) => void) | null;
+    bridge:
+      | { handleToolCall: (id: string, name: string, input: unknown) => Promise<{ decision: string }> }
+      | null;
+  } = { handler: null, bridge: null };
+
+  const fakeClient = {
+    setHandler: vi.fn((h: (e: unknown) => void) => { captured.handler = h; }),
+    setPermissionHandler: vi.fn((b: any) => { captured.bridge = b; }),
+    connect: vi.fn(async () => {}),
+    startSession: vi.fn(async () => ({ content: [] })),
+    continueSession: vi.fn(async () => ({ content: [] })),
+    getSessionId: vi.fn(() => 'codex-session-123'),
+    storeSessionForResume: vi.fn(() => 'codex-session-123'),
+    forceCloseSession: vi.fn(async () => {}),
+  };
+
+  return { fakeClient, captured };
+});
+
+vi.mock('@/codex/codexMcpClient', () => ({
+  CodexMcpClient: vi.fn(() => fakeClient),
+}));
+
+vi.mock('@/ui/logger', () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// Import SUT after mocks are registered.
+import { createCodexBackend, registerCodexAgent } from '../codex';
+import { agentRegistry } from '../../core';
+import type { AgentMessage } from '../../core/AgentBackend';
+
+function makeBackend(opts: Partial<{ cwd: string; model: string }> = {}) {
+  const { backend } = createCodexBackend({ cwd: opts.cwd ?? '/tmp/project', model: opts.model });
+  const messages: AgentMessage[] = [];
+  backend.onMessage((m) => messages.push(m));
+  return { backend, messages };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  captured.handler = null;
+  captured.bridge = null;
+});
+
+// ---------------------------------------------------------------------------
+describe('createCodexBackend', () => {
+  it('returns a backend, the resolved model, and capability metadata', () => {
+    const result = createCodexBackend({ cwd: '/tmp/p', model: 'gpt-5-codex' });
+    expect(result.backend).toBeDefined();
+    expect(result.model).toBe('gpt-5-codex');
+    expect(result.metadata).toEqual({
+      modelSource: 'explicit',
+      supportsStreaming: true,
+      supportsTools: true,
+    });
+  });
+
+  it('reports modelSource "default" when no model is given', () => {
+    expect(createCodexBackend({ cwd: '/tmp/p' }).metadata.modelSource).toBe('default');
+  });
+
+  it('registers the constructor-time event handler and permission bridge', () => {
+    makeBackend();
+    expect(fakeClient.setHandler).toHaveBeenCalledTimes(1);
+    expect(fakeClient.setPermissionHandler).toHaveBeenCalledTimes(1);
+    expect(captured.handler).toBeTypeOf('function');
+    expect(captured.bridge).toBeTruthy();
+  });
+});
+
+describe('registerCodexAgent', () => {
+  it('registers "codex" in the global registry', () => {
+    registerCodexAgent();
+    expect(agentRegistry.has('codex')).toBe(true);
+    const backend = agentRegistry.create('codex', { cwd: '/tmp/p' });
+    expect(backend).toBeDefined();
+  });
+});
+
+describe('session lifecycle', () => {
+  it('startSession connects, sends config, and returns the codex session id', async () => {
+    const { backend, messages } = makeBackend({ model: 'gpt-5-codex' });
+    const result = await backend.startSession('hello');
+
+    expect(result.sessionId).toBe('codex-session-123');
+    expect(fakeClient.startSession).toHaveBeenCalledTimes(1);
+    const config = fakeClient.startSession.mock.calls[0][0];
+    expect(config).toMatchObject({
+      prompt: 'hello',
+      cwd: '/tmp/project',
+      sandbox: 'workspace-write',
+      'approval-policy': 'on-request',
+      model: 'gpt-5-codex',
+    });
+    // status transitions: starting -> running
+    expect(messages.map((m) => m.type === 'status' && m.status)).toContain('starting');
+    expect(messages.map((m) => m.type === 'status' && m.status)).toContain('running');
+  });
+
+  it('falls back to a local UUID when codex reports no session id', async () => {
+    fakeClient.getSessionId.mockReturnValueOnce(null);
+    const { backend } = makeBackend();
+    const result = await backend.startSession();
+    expect(result.sessionId).toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/i);
+  });
+
+  it('sendPrompt forwards to continueSession', async () => {
+    const { backend } = makeBackend();
+    await backend.startSession('init');
+    await backend.sendPrompt('codex-session-123', 'do the thing');
+    expect(fakeClient.continueSession).toHaveBeenCalledWith('do the thing', expect.anything());
+  });
+
+  it('cancel aborts and keeps the session resumable', async () => {
+    const { backend, messages } = makeBackend();
+    await backend.startSession('init');
+    await backend.cancel('codex-session-123');
+    expect(fakeClient.storeSessionForResume).toHaveBeenCalled();
+    expect(messages.some((m) => m.type === 'status' && m.detail === 'cancelled')).toBe(true);
+  });
+
+  it('dispose force-closes the client and emits stopped', async () => {
+    const { backend, messages } = makeBackend();
+    await backend.startSession('init');
+    await backend.dispose();
+    expect(fakeClient.forceCloseSession).toHaveBeenCalledTimes(1);
+    expect(messages.some((m) => m.type === 'status' && m.status === 'stopped')).toBe(true);
+  });
+
+  it('sendPrompt after dispose throws', async () => {
+    const { backend } = makeBackend();
+    await backend.dispose();
+    await expect(backend.sendPrompt('s', 'p')).rejects.toThrow(/disposed/);
+  });
+});
+
+describe('codex event -> AgentMessage mapping', () => {
+  function emit(event: Record<string, unknown>): AgentMessage[] {
+    const { messages } = makeBackend();
+    captured.handler!(event);
+    return messages;
+  }
+
+  it('agent_message -> model-output fullText', () => {
+    const out = emit({ type: 'agent_message', message: 'hi there' });
+    expect(out).toContainEqual({ type: 'model-output', fullText: 'hi there' });
+  });
+
+  it('agent_message_delta -> model-output textDelta', () => {
+    const out = emit({ type: 'agent_message_delta', delta: 'chunk' });
+    expect(out).toContainEqual({ type: 'model-output', textDelta: 'chunk' });
+  });
+
+  it('agent_reasoning -> reasoning event (not model-output)', () => {
+    const out = emit({ type: 'agent_reasoning', text: 'thinking' });
+    expect(out).toContainEqual({ type: 'event', name: 'reasoning', payload: { text: 'thinking' } });
+    expect(out.some((m) => m.type === 'model-output')).toBe(false);
+  });
+
+  it('exec_command_begin -> tool-call shell with command + callId', () => {
+    const out = emit({ type: 'exec_command_begin', call_id: 'c1', command: ['ls', '-la'] });
+    const tc = out.find((m) => m.type === 'tool-call');
+    expect(tc).toMatchObject({ type: 'tool-call', toolName: 'shell', callId: 'c1' });
+    expect((tc as any).args.command).toEqual(['ls', '-la']);
+  });
+
+  it('exec_approval_request -> exec-approval-request with call_id', () => {
+    const out = emit({ type: 'exec_approval_request', call_id: 'c2', command: ['rm', '-rf'] });
+    expect(out).toContainEqual(expect.objectContaining({ type: 'exec-approval-request', call_id: 'c2' }));
+  });
+
+  it('exec_command_end -> tool-result with callId', () => {
+    const out = emit({ type: 'exec_command_end', call_id: 'c1', output: 'done', error: '' });
+    expect(out).toContainEqual(expect.objectContaining({ type: 'tool-result', toolName: 'shell', callId: 'c1' }));
+  });
+
+  it('patch_apply_begin / patch_apply_end map to patch variants', () => {
+    const begin = emit({ type: 'patch_apply_begin', call_id: 'p1', auto_approved: true, changes: { 'a.ts': {} } });
+    expect(begin).toContainEqual(expect.objectContaining({ type: 'patch-apply-begin', call_id: 'p1', auto_approved: true }));
+
+    const end = emit({ type: 'patch_apply_end', call_id: 'p1', stdout: 'ok', stderr: '', success: true });
+    expect(end).toContainEqual(expect.objectContaining({ type: 'patch-apply-end', call_id: 'p1', success: true }));
+  });
+
+  it('turn_diff with unified_diff -> fs-edit', () => {
+    const out = emit({ type: 'turn_diff', unified_diff: '--- a\n+++ b\n' });
+    expect(out).toContainEqual(expect.objectContaining({ type: 'fs-edit', diff: '--- a\n+++ b\n' }));
+  });
+
+  it('token_count -> token-count', () => {
+    const out = emit({ type: 'token_count', input_tokens: 10, output_tokens: 5 });
+    expect(out).toContainEqual(expect.objectContaining({ type: 'token-count', input_tokens: 10, output_tokens: 5 }));
+  });
+
+  it('task_started / task_complete / turn_aborted -> status', () => {
+    expect(emit({ type: 'task_started' })).toContainEqual({ type: 'status', status: 'running' });
+    expect(emit({ type: 'task_complete' })).toContainEqual({ type: 'status', status: 'idle' });
+    expect(emit({ type: 'turn_aborted' })).toContainEqual({ type: 'status', status: 'idle', detail: 'turn_aborted' });
+  });
+
+  it('unknown event type -> generic event (not dropped)', () => {
+    const out = emit({ type: 'some_future_event', foo: 1 });
+    expect(out).toContainEqual(expect.objectContaining({ type: 'event', name: 'some_future_event' }));
+  });
+
+  it('non-object event is ignored', () => {
+    const { messages } = makeBackend();
+    captured.handler!('not an object');
+    captured.handler!(null);
+    expect(messages).toHaveLength(0);
+  });
+});
+
+describe('permission bridge', () => {
+  it('handleToolCall emits a permission-request and respondToPermission resolves it (approved)', async () => {
+    const { backend, messages } = makeBackend();
+    const decisionPromise = captured.bridge!.handleToolCall('call-1', 'CodexBash', { command: ['ls'] });
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'permission-request', id: 'call-1', payload: { command: ['ls'] } }),
+    );
+
+    await backend.respondToPermission!('call-1', true);
+    await expect(decisionPromise).resolves.toEqual({ decision: 'approved' });
+    expect(messages).toContainEqual({ type: 'permission-response', id: 'call-1', approved: true });
+  });
+
+  it('respondToPermission(false) resolves denied', async () => {
+    const { backend } = makeBackend();
+    const decisionPromise = captured.bridge!.handleToolCall('call-2', 'CodexBash', {});
+    await backend.respondToPermission!('call-2', false);
+    await expect(decisionPromise).resolves.toEqual({ decision: 'denied' });
+  });
+
+  it('dispose denies any outstanding approval so its promise never hangs', async () => {
+    const { backend } = makeBackend();
+    const decisionPromise = captured.bridge!.handleToolCall('call-3', 'CodexBash', {});
+    await backend.dispose();
+    await expect(decisionPromise).resolves.toEqual({ decision: 'denied' });
+  });
+
+  it('respondToPermission for an unknown id is a no-op (does not throw)', async () => {
+    const { backend } = makeBackend();
+    await expect(backend.respondToPermission!('nope', true)).resolves.toBeUndefined();
+  });
+});
+
+describe('event emission', () => {
+  it('offMessage stops delivery', () => {
+    const { backend } = makeBackend();
+    const seen: AgentMessage[] = [];
+    const handler = (m: AgentMessage) => seen.push(m);
+    backend.onMessage(handler);
+    captured.handler!({ type: 'task_started' });
+    backend.offMessage!(handler);
+    captured.handler!({ type: 'task_complete' });
+    // handler saw the first but not the second
+    expect(seen.filter((m) => m.type === 'status' && m.status === 'running')).toHaveLength(1);
+    expect(seen.some((m) => m.type === 'status' && m.status === 'idle')).toBe(false);
+  });
+
+  it('a throwing handler does not stop delivery to others', () => {
+    const { backend, messages } = makeBackend();
+    backend.onMessage(() => { throw new Error('boom'); });
+    expect(() => captured.handler!({ type: 'task_started' })).not.toThrow();
+    expect(messages).toContainEqual({ type: 'status', status: 'running' });
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/claude.ts
+++ b/packages/styrby-cli/src/agent/factories/claude.ts
@@ -28,8 +28,17 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { randomUUID } from 'node:crypto';
 import { logger } from '@/ui/logger';
 import type { CostReport, BillingModel } from '@styrby/shared/cost';
+import type {
+  SessionId,
+  StartSessionResult,
+  AgentFactoryOptions,
+  AgentFactoryMetadata,
+} from '../core';
+import { agentRegistry } from '../core';
+import { StreamingAgentBackendBase } from '../StreamingAgentBackendBase';
 
 // ============================================================================
 // Auth Mode Detection
@@ -187,4 +196,344 @@ export function parseClaudeJsonlLine(
   };
 
   return report;
+}
+
+// ============================================================================
+// Claude Backend (managed binary-spawn, stream-json)
+// ============================================================================
+
+/**
+ * Permission mode passed to the `claude` CLI for a managed session.
+ *
+ * WHY default 'acceptEdits': a remote-controlled session runs unattended, so it
+ * must not block on interactive prompts; 'acceptEdits' lets Claude apply file
+ * edits while the sandbox/allowlist still governs riskier actions. Override via
+ * options for a stricter ('plan') or looser ('bypassPermissions') posture.
+ */
+export type ClaudePermissionMode =
+  | 'acceptEdits'
+  | 'auto'
+  | 'plan'
+  | 'default'
+  | 'bypassPermissions';
+
+/**
+ * Options for creating a Claude backend.
+ */
+export interface ClaudeBackendOptions extends AgentFactoryOptions {
+  /** Model alias/id for the session (e.g. 'claude-sonnet-4-6'). */
+  model?: string;
+  /** Permission mode for the headless session (default 'acceptEdits'). */
+  permissionMode?: ClaudePermissionMode;
+  /** Claude session id to resume (preserves conversation context across prompts). */
+  resumeSessionId?: string;
+  /** Tool allowlist (e.g. ['Bash(git *)', 'Read']). */
+  allowedTools?: string[];
+  /** Extra `claude` CLI args (validated for shell-safety by the base class). */
+  extraArgs?: string[];
+}
+
+/**
+ * Result of creating a Claude backend.
+ */
+export interface ClaudeBackendResult {
+  /** The backend instance, ready to start a session. */
+  backend: ClaudeBackend;
+  /** The resolved model (undefined = Claude's configured default). */
+  model: string | undefined;
+  /** Capability / source metadata. */
+  metadata: AgentFactoryMetadata;
+}
+
+/**
+ * A single Claude Code stream-json line.
+ *
+ * Claude emits newline-delimited JSON in `--output-format stream-json` mode: a
+ * `system`/init line (carries the resumable `session_id`), one or more
+ * `assistant`/`user` lines (message content + tool use/results), and a final
+ * `result` line. Typed loosely because only a subset of fields is consumed.
+ */
+interface ClaudeStreamMessage {
+  type: 'system' | 'assistant' | 'user' | 'result' | string;
+  subtype?: string;
+  session_id?: string;
+  message?: {
+    role?: string;
+    content?: Array<{
+      type: string;
+      text?: string;
+      name?: string;
+      input?: Record<string, unknown>;
+      id?: string;
+      tool_use_id?: string;
+      content?: unknown;
+    }>;
+  };
+}
+
+/** Claude tool names that mutate files (for fs-edit surfacing). */
+const CLAUDE_EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+
+/**
+ * Claude Code backend — clean-room managed spawn of the `claude` binary.
+ *
+ * WHY this reimplements the spawn technique instead of wrapping Happy's
+ * `src/claude/` loop: that loop (`runClaude`/`loop`/`session`) imports
+ * `ApiClient`/`AgentState` symbols deleted in the Supabase relay refactor, so it
+ * is stale, broken, and quarantined from typechecking. Reusing it would drag
+ * ~6.8k LOC of dead code into the build (a large seam). Instead we spawn the
+ * `claude` binary in headless stream-json mode and parse its JSONL — the same
+ * line-based pattern {@link StreamingAgentBackendBase} already powers for
+ * opencode/aider.
+ *
+ * WHY binary-spawn (not the official Agent SDK): spawning the user's installed
+ * `claude` runs against their `~/.claude/auth.json`, preserving Max/Pro
+ * SUBSCRIPTION billing (costUsd=0). The Agent SDK expects API-key auth and a
+ * separate credit pool, which would be a cost regression for subscription users.
+ */
+export class ClaudeBackend extends StreamingAgentBackendBase {
+  protected readonly logTag = 'ClaudeBackend';
+
+  /** Claude's own session id, captured from the init line; used for --resume. */
+  private claudeSessionId: string | null;
+  private readonly billingModel: BillingModel;
+
+  constructor(private readonly options: ClaudeBackendOptions) {
+    super();
+    // Detect subscription vs api-key once so every cost-report is classified
+    // correctly (subscription => costUsd 0).
+    this.billingModel = detectClaudeBillingModel();
+    this.claudeSessionId = options.resumeSessionId ?? null;
+  }
+
+  /**
+   * Start a Claude session, optionally with an initial prompt.
+   *
+   * @param initialPrompt - First prompt; when omitted the backend idles until
+   *   the first {@link sendPrompt}.
+   * @returns The local session id (a UUID; Claude's own id is tracked internally
+   *   for --resume continuity).
+   */
+  async startSession(initialPrompt?: string): Promise<StartSessionResult> {
+    if (this.disposed) throw new Error('ClaudeBackend has been disposed');
+    this.sessionId = randomUUID();
+    this.emit({ type: 'status', status: 'starting' });
+
+    if (initialPrompt) {
+      this.emit({ type: 'status', status: 'running' });
+      await this.sendPrompt(this.sessionId, initialPrompt);
+    } else {
+      this.emit({ type: 'status', status: 'idle' });
+    }
+    return { sessionId: this.sessionId };
+  }
+
+  /**
+   * Send a prompt to the Claude session.
+   *
+   * Spawns `claude -p <prompt> --output-format stream-json --verbose`, resuming
+   * the prior Claude conversation (via `--resume`) so context carries across
+   * prompts. Resolves when the process exits cleanly (or was cancelled).
+   *
+   * @param sessionId - Must match the active session id.
+   * @param prompt - The user's prompt text.
+   */
+  async sendPrompt(sessionId: SessionId, prompt: string): Promise<void> {
+    if (this.disposed) throw new Error('ClaudeBackend has been disposed');
+    if (sessionId !== this.sessionId) throw new Error(`Invalid session ID: ${sessionId}`);
+
+    // Reset run-scoped state (clears the cancelled flag) so this run's exit is
+    // classified correctly by the close handler.
+    this.beginRun();
+    this.emit({ type: 'status', status: 'running' });
+
+    const args: string[] = [
+      '-p',
+      prompt,
+      '--output-format',
+      'stream-json',
+      // --verbose is required for stream-json to emit the full event stream in
+      // print mode (otherwise only the final result is printed).
+      '--verbose',
+      '--permission-mode',
+      this.options.permissionMode ?? 'acceptEdits',
+    ];
+    if (this.options.model) args.push('--model', this.options.model);
+    if (this.claudeSessionId) args.push('--resume', this.claudeSessionId);
+    if (this.options.allowedTools?.length) {
+      args.push('--allowedTools', this.options.allowedTools.join(','));
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const child = this.spawnAgent({
+        command: 'claude',
+        args,
+        cwd: this.options.cwd,
+        extraEnv: this.options.env,
+        userExtraArgs: this.options.extraArgs,
+        // The prompt is passed via `-p`, not stdin. Ignore stdin so claude
+        // doesn't wait ~3s for input that never comes ("no stdin data received
+        // in 3s") before each turn. stdout/stderr stay piped for streamLines().
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      if (child.stdout) {
+        this.streamLines(child.stdout, (line) => this.handleLine(line));
+      }
+      if (child.stderr) {
+        child.stderr.on('data', (data: Buffer) => {
+          logger.debug(`[ClaudeBackend] stderr: ${data.toString().trim()}`);
+        });
+      }
+
+      child.on('close', (code) => {
+        logger.debug(`[ClaudeBackend] Process exited with code: ${code}`);
+        this.process = null;
+        this.clearCancelTimer();
+        if (code === 0 || this.wasCancelled()) {
+          this.emit({ type: 'status', status: 'idle' });
+          resolve();
+        } else {
+          const detail = `Claude exited with code ${code}`;
+          this.emit({ type: 'status', status: 'error', detail });
+          reject(new Error(detail));
+        }
+      });
+
+      // ENOENT -> friendly install hint; other spawn errors forwarded.
+      this.attachInstallHintErrorHandler(child, 'claude', reject);
+    });
+  }
+
+  /**
+   * Cancel the in-flight prompt (SIGTERM, then SIGKILL escalation via the base).
+   *
+   * @param sessionId - Must match the active session id.
+   */
+  async cancel(sessionId: SessionId): Promise<void> {
+    if (sessionId !== this.sessionId) throw new Error(`Invalid session ID: ${sessionId}`);
+    if (this.process) {
+      // Mark cancelled BEFORE SIGTERM so the close handler treats the resulting
+      // non-zero exit as an intentional cancel, not a crash.
+      this.markCancelled();
+      this.process.kill('SIGTERM');
+      this.scheduleForceKill();
+    }
+    this.emit({ type: 'status', status: 'idle' });
+  }
+
+  /**
+   * Parse one stream-json line: emit a cost-report if it carries usage, then map
+   * its content to {@link AgentMessage}s.
+   */
+  private handleLine(line: string): void {
+    if (!line.trim()) return;
+
+    // Cost extraction (assistant lines with a usage block) reuses the shared
+    // parser so subscription billing stays correct.
+    const report = parseClaudeJsonlLine(line, this.sessionId ?? '', this.billingModel);
+    if (report) this.emit({ type: 'cost-report', report });
+
+    let msg: ClaudeStreamMessage;
+    try {
+      msg = JSON.parse(line) as ClaudeStreamMessage;
+    } catch {
+      logger.debug('[ClaudeBackend] Non-JSON stdout line ignored');
+      return;
+    }
+
+    // Capture Claude's session id from any line that carries it so follow-up
+    // prompts can --resume the same conversation.
+    if (typeof msg.session_id === 'string') this.claudeSessionId = msg.session_id;
+
+    switch (msg.type) {
+      case 'assistant':
+        for (const block of msg.message?.content ?? []) {
+          if (block.type === 'text' && block.text) {
+            this.emit({ type: 'model-output', fullText: block.text });
+          } else if (block.type === 'tool_use' && block.id) {
+            this.emit({
+              type: 'tool-call',
+              toolName: block.name ?? 'unknown',
+              args: block.input ?? {},
+              callId: block.id,
+            });
+            // Surface file mutations so the mobile UI can show a diff affordance.
+            if (block.name && CLAUDE_EDIT_TOOLS.has(block.name)) {
+              const input = block.input ?? {};
+              const filePath = (input.file_path as string) ?? (input.path as string);
+              if (filePath) {
+                this.emit({ type: 'fs-edit', description: `${block.name}: ${filePath}`, path: filePath });
+              }
+            }
+          }
+        }
+        return;
+      case 'user':
+        // Claude echoes tool results back as a user message.
+        for (const block of msg.message?.content ?? []) {
+          if (block.type === 'tool_result' && block.tool_use_id) {
+            this.emit({
+              type: 'tool-result',
+              toolName: 'tool',
+              result: block.content,
+              callId: block.tool_use_id,
+            });
+          }
+        }
+        return;
+      case 'result':
+        // Final line; the close handler emits idle. Nothing extra to map here.
+        return;
+      default:
+        // system/init and any future line types: no content to surface.
+        return;
+    }
+  }
+
+  // respondToPermission, waitForResponseComplete, onMessage/offMessage and
+  // dispose are inherited from StreamingAgentBackendBase. The session runs with
+  // a fixed --permission-mode, so the base emit-only permission default is
+  // correct (interactive per-tool mobile approval is a follow-up).
+}
+
+/**
+ * Create a Claude backend.
+ *
+ * @param options - Configuration options (cwd is required).
+ * @returns The backend plus resolved model + capability metadata.
+ *
+ * @example
+ * ```ts
+ * const { backend } = createClaudeBackend({ cwd: '/path/to/project' });
+ * const { sessionId } = await backend.startSession('Explain this repo');
+ * ```
+ */
+export function createClaudeBackend(options: ClaudeBackendOptions): ClaudeBackendResult {
+  logger.debug('[ClaudeBackend] Creating backend', {
+    cwd: options.cwd,
+    model: options.model,
+    permissionMode: options.permissionMode ?? 'acceptEdits',
+  });
+
+  return {
+    backend: new ClaudeBackend(options),
+    model: options.model,
+    metadata: {
+      modelSource: options.model ? 'explicit' : 'default',
+      supportsStreaming: true,
+      supportsTools: true,
+    },
+  };
+}
+
+/**
+ * Register the Claude backend with the global agent registry.
+ *
+ * Called from `initializeAgents()` so `styrby start --agent claude` resolves to
+ * a managed, relay-bridged session instead of the old informational MCP stub.
+ */
+export function registerClaudeAgent(): void {
+  agentRegistry.register('claude', (opts) => createClaudeBackend(opts).backend);
+  logger.debug('[ClaudeBackend] Registered with agent registry');
 }

--- a/packages/styrby-cli/src/agent/factories/codex.ts
+++ b/packages/styrby-cli/src/agent/factories/codex.ts
@@ -1,0 +1,402 @@
+/**
+ * Codex Backend - OpenAI Codex CLI agent adapter
+ *
+ * Bridges the OpenAI Codex CLI to Styrby's universal {@link AgentBackend}
+ * interface so `styrby start --agent codex` behaves identically to every other
+ * managed agent (gemini, opencode, aider, ...): Styrby spawns Codex, streams its
+ * output to the relay, and forwards mobile input back to it.
+ *
+ * WHY this wraps {@link CodexMcpClient} instead of extending
+ * {@link StreamingAgentBackendBase}: Codex does NOT emit line-based stdout like
+ * opencode/aider — it speaks MCP (JSON-RPC over stdio) via `codex mcp-server`.
+ * `CodexMcpClient` already encapsulates that transport (version-aware subcommand
+ * selection, `buildSafeEnv` so only OPENAI_API_KEY reaches the subprocess, full
+ * session lifecycle). This backend is therefore a thin, seam-free ADAPTER: it
+ * maps Codex's `codex/event` notifications onto our {@link AgentMessage} union
+ * and translates Codex's elicitation-based tool approvals into our
+ * `permission-request` / `respondToPermission` contract, which
+ * {@link ApiSessionManager} relays to the mobile app exactly like other agents.
+ *
+ * The Codex event vocabulary handled here mirrors the standalone `runCodex.ts`
+ * runner (the same `msg.type` values + field names), so behaviour is consistent
+ * across both entry points.
+ *
+ * @module factories/codex
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  AgentBackend,
+  SessionId,
+  StartSessionResult,
+  AgentFactoryOptions,
+  AgentFactoryMetadata,
+} from '../core';
+import type { AgentMessage, AgentMessageHandler } from '../core/AgentBackend';
+import { agentRegistry } from '../core';
+import { CodexMcpClient } from '@/codex/codexMcpClient';
+import type { CodexSessionConfig } from '@/codex/types';
+import type { CodexPermissionResult } from '@/codex/permissionBridge';
+import { logger } from '@/ui/logger';
+
+/**
+ * Options for creating a Codex backend.
+ */
+export interface CodexBackendOptions extends AgentFactoryOptions {
+  /**
+   * Model override (e.g. 'gpt-5-codex'). Defaults to Codex's configured model.
+   */
+  model?: string;
+
+  /**
+   * Filesystem sandbox Codex runs commands under.
+   *
+   * WHY default 'workspace-write': matches the safe-but-useful default the
+   * `runCodex` permission mapping uses for normal mode — Codex may edit files
+   * in the project but not touch the wider system. Override to 'read-only' for
+   * a non-mutating session or 'danger-full-access' for unrestricted access.
+   */
+  sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+
+  /**
+   * When Codex asks before running a command.
+   *
+   * WHY default 'on-request': Codex decides which commands need approval and
+   * surfaces those as elicitation requests, which this backend turns into
+   * `permission-request` AgentMessages the user approves from mobile. 'never'
+   * auto-runs everything (relies on the sandbox for safety); 'untrusted' asks
+   * for every non-trusted command.
+   */
+  approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
+
+  /** Extra base instructions prepended to the system prompt. */
+  baseInstructions?: string;
+
+  /** Whether to expose Codex's plan tool. */
+  includePlanTool?: boolean;
+
+  /** Named Codex profile from the user's config. */
+  profile?: string;
+}
+
+/**
+ * Result of creating a Codex backend.
+ */
+export interface CodexBackendResult {
+  /** The backend instance, ready to start a session. */
+  backend: AgentBackend;
+  /** The resolved model (undefined = Codex default). */
+  model: string | undefined;
+  /** Capability / source metadata. */
+  metadata: AgentFactoryMetadata;
+}
+
+/**
+ * A pending tool-approval awaiting the user's decision.
+ *
+ * WHY: Codex requests command approval synchronously via an MCP elicitation
+ * that `CodexMcpClient` awaits. We park that promise's resolver here, emit a
+ * `permission-request` AgentMessage, and resolve it when `respondToPermission`
+ * is later called with the relayed mobile decision.
+ */
+interface PendingApproval {
+  resolve: (result: CodexPermissionResult) => void;
+}
+
+/**
+ * Codex backend implementation.
+ *
+ * Implements {@link AgentBackend} directly (rather than via
+ * {@link StreamingAgentBackendBase}) because the MCP transport is owned by
+ * {@link CodexMcpClient}, not by a line-streamed subprocess.
+ */
+class CodexBackend implements AgentBackend {
+  private readonly client = new CodexMcpClient();
+  private readonly listeners: AgentMessageHandler[] = [];
+  private readonly pendingApprovals = new Map<string, PendingApproval>();
+  private sessionId: SessionId | null = null;
+  private abortController: AbortController | null = null;
+  private disposed = false;
+
+  constructor(private readonly options: CodexBackendOptions) {
+    // Bridge Codex's elicitation-based approvals into our permission contract.
+    // CodexMcpClient calls handleToolCall(callId, toolName, input) and awaits a
+    // PermissionResult; we surface the request as a `permission-request`
+    // AgentMessage and defer resolution to respondToPermission().
+    this.client.setPermissionHandler({
+      handleToolCall: (toolCallId, toolName, input) =>
+        new Promise<CodexPermissionResult>((resolve) => {
+          this.pendingApprovals.set(toolCallId, { resolve });
+          this.emit({
+            type: 'permission-request',
+            id: toolCallId,
+            reason: `Codex wants to run: ${toolName}`,
+            payload: input,
+          });
+        }),
+    });
+
+    // Map every Codex MCP event onto an AgentMessage.
+    this.client.setHandler((raw) => this.handleCodexEvent(raw));
+  }
+
+  /**
+   * Start a Codex session, optionally with an initial prompt.
+   *
+   * @param initialPrompt - First prompt for the session (Codex requires a
+   *   prompt to create a conversation; we send a no-op space if none is given
+   *   so the session id is established before the first real prompt).
+   * @returns The session id (Codex's own id once known, else a local UUID).
+   */
+  async startSession(initialPrompt?: string): Promise<StartSessionResult> {
+    this.abortController = new AbortController();
+    this.emit({ type: 'status', status: 'starting' });
+
+    const config: CodexSessionConfig = {
+      prompt: initialPrompt ?? '',
+      cwd: this.options.cwd,
+      sandbox: this.options.sandbox ?? 'workspace-write',
+      'approval-policy': this.options.approvalPolicy ?? 'on-request',
+      ...(this.options.model ? { model: this.options.model } : {}),
+      ...(this.options.profile ? { profile: this.options.profile } : {}),
+      ...(this.options.baseInstructions
+        ? { 'base-instructions': this.options.baseInstructions }
+        : {}),
+      ...(this.options.includePlanTool ? { 'include-plan-tool': true } : {}),
+    };
+
+    await this.client.startSession(config, { signal: this.abortController.signal });
+
+    // Codex's session id is discovered from the response/events; fall back to a
+    // local UUID so the caller always has a stable handle for this session.
+    this.sessionId = this.client.getSessionId() ?? randomUUID();
+    this.emit({ type: 'status', status: 'running' });
+    return { sessionId: this.sessionId };
+  }
+
+  /**
+   * Send a follow-up prompt to the active Codex session.
+   *
+   * @param _sessionId - Accepted for interface parity; Codex tracks the active
+   *   conversation internally via {@link CodexMcpClient}.
+   * @param prompt - The user's prompt text.
+   */
+  async sendPrompt(_sessionId: SessionId, prompt: string): Promise<void> {
+    if (this.disposed) throw new Error('CodexBackend is disposed');
+    this.abortController = new AbortController();
+    await this.client.continueSession(prompt, { signal: this.abortController.signal });
+  }
+
+  /**
+   * Cancel the in-flight Codex turn while keeping the session resumable.
+   *
+   * @param _sessionId - Accepted for interface parity.
+   */
+  async cancel(_sessionId: SessionId): Promise<void> {
+    this.abortController?.abort();
+    this.client.storeSessionForResume();
+    this.emit({ type: 'status', status: 'idle', detail: 'cancelled' });
+  }
+
+  /**
+   * Respond to a pending tool-approval request.
+   *
+   * @param requestId - The Codex call id from the `permission-request` message.
+   * @param approved - Whether the user approved the command.
+   */
+  async respondToPermission(requestId: string, approved: boolean): Promise<void> {
+    const pending = this.pendingApprovals.get(requestId);
+    if (!pending) {
+      logger.debug('[CodexBackend] respondToPermission: no pending request', { requestId });
+      return;
+    }
+    this.pendingApprovals.delete(requestId);
+    pending.resolve({ decision: approved ? 'approved' : 'denied' });
+    this.emit({ type: 'permission-response', id: requestId, approved });
+  }
+
+  /**
+   * Register a handler for agent messages.
+   *
+   * @param handler - Called for each {@link AgentMessage} the backend emits.
+   */
+  onMessage(handler: AgentMessageHandler): void {
+    this.listeners.push(handler);
+  }
+
+  /**
+   * Remove a previously registered message handler.
+   *
+   * @param handler - The handler to remove.
+   */
+  offMessage(handler: AgentMessageHandler): void {
+    const i = this.listeners.indexOf(handler);
+    if (i !== -1) this.listeners.splice(i, 1);
+  }
+
+  /**
+   * Tear down the Codex subprocess and reject any unresolved approvals.
+   */
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.abortController?.abort();
+    // Deny any outstanding approvals so awaited promises never hang.
+    for (const [, pending] of this.pendingApprovals) {
+      pending.resolve({ decision: 'denied' });
+    }
+    this.pendingApprovals.clear();
+    await this.client.forceCloseSession();
+    this.emit({ type: 'status', status: 'stopped' });
+    this.listeners.length = 0;
+  }
+
+  /**
+   * Emit an {@link AgentMessage} to every registered listener.
+   *
+   * A throwing listener must not stop delivery to the others, so each call is
+   * isolated.
+   */
+  private emit(msg: AgentMessage): void {
+    for (const listener of [...this.listeners]) {
+      try {
+        listener(msg);
+      } catch (error) {
+        logger.debug('[CodexBackend] message handler threw', { error });
+      }
+    }
+  }
+
+  /**
+   * Translate one Codex `codex/event` payload into an {@link AgentMessage}.
+   *
+   * Field names mirror `runCodex.ts` so the two entry points stay consistent.
+   */
+  private handleCodexEvent(raw: unknown): void {
+    if (!raw || typeof raw !== 'object') return;
+    const msg = raw as Record<string, any>;
+
+    switch (msg.type) {
+      case 'agent_message':
+        this.emit({ type: 'model-output', fullText: String(msg.message ?? '') });
+        return;
+      case 'agent_message_delta':
+        this.emit({ type: 'model-output', textDelta: String(msg.delta ?? '') });
+        return;
+      case 'agent_reasoning_delta':
+        this.emit({ type: 'event', name: 'reasoning-delta', payload: { delta: msg.delta } });
+        return;
+      case 'agent_reasoning':
+        this.emit({ type: 'event', name: 'reasoning', payload: { text: msg.text } });
+        return;
+      case 'exec_command_begin': {
+        const { call_id, type: _t, ...rest } = msg;
+        this.emit({
+          type: 'tool-call',
+          toolName: 'shell',
+          args: { command: msg.command, ...rest },
+          callId: String(call_id),
+        });
+        return;
+      }
+      case 'exec_approval_request': {
+        // Strip codex's own `type` from the rest-spread so it can't clobber our
+        // AgentMessage discriminant.
+        const { call_id, type: _t, ...rest } = msg;
+        this.emit({ type: 'exec-approval-request', call_id: String(call_id), ...rest });
+        return;
+      }
+      case 'exec_command_end': {
+        const { call_id, type: _t, ...output } = msg;
+        this.emit({
+          type: 'tool-result',
+          toolName: 'shell',
+          result: output,
+          callId: String(call_id),
+        });
+        return;
+      }
+      case 'patch_apply_begin':
+        this.emit({
+          type: 'patch-apply-begin',
+          call_id: String(msg.call_id),
+          auto_approved: Boolean(msg.auto_approved),
+          changes: (msg.changes ?? {}) as Record<string, unknown>,
+        });
+        return;
+      case 'patch_apply_end':
+        this.emit({
+          type: 'patch-apply-end',
+          call_id: String(msg.call_id),
+          stdout: msg.stdout,
+          stderr: msg.stderr,
+          success: Boolean(msg.success),
+        });
+        return;
+      case 'turn_diff':
+        if (msg.unified_diff) {
+          this.emit({ type: 'fs-edit', description: 'Codex applied changes', diff: msg.unified_diff });
+        }
+        return;
+      case 'token_count':
+        // Spread first, then pin our discriminant so codex's `type:'token_count'`
+        // cannot overwrite it.
+        this.emit({ ...msg, type: 'token-count' });
+        return;
+      case 'task_started':
+        this.emit({ type: 'status', status: 'running' });
+        return;
+      case 'task_complete':
+        this.emit({ type: 'status', status: 'idle' });
+        return;
+      case 'turn_aborted':
+        this.emit({ type: 'status', status: 'idle', detail: 'turn_aborted' });
+        return;
+      default:
+        // Unknown event types are forwarded as generic events rather than
+        // dropped, so new Codex event kinds remain visible without a code change.
+        this.emit({ type: 'event', name: String(msg.type ?? 'codex-event'), payload: msg });
+    }
+  }
+}
+
+/**
+ * Create a Codex backend.
+ *
+ * @param options - Configuration options (cwd is required).
+ * @returns The backend plus resolved model + capability metadata.
+ *
+ * @example
+ * ```ts
+ * const { backend } = createCodexBackend({ cwd: '/path/to/project' });
+ * const { sessionId } = await backend.startSession('Fix the failing test');
+ * ```
+ */
+export function createCodexBackend(options: CodexBackendOptions): CodexBackendResult {
+  logger.debug('[CodexBackend] Creating backend', {
+    cwd: options.cwd,
+    model: options.model,
+    sandbox: options.sandbox ?? 'workspace-write',
+  });
+
+  return {
+    backend: new CodexBackend(options),
+    model: options.model,
+    metadata: {
+      modelSource: options.model ? 'explicit' : 'default',
+      supportsStreaming: true,
+      supportsTools: true,
+    },
+  };
+}
+
+/**
+ * Register the Codex backend with the global agent registry.
+ *
+ * Called from `initializeAgents()` so `styrby start --agent codex` resolves to
+ * a real, managed backend.
+ */
+export function registerCodexAgent(): void {
+  agentRegistry.register('codex', (opts) => createCodexBackend(opts).backend);
+  logger.debug('[CodexBackend] Registered with agent registry');
+}

--- a/packages/styrby-cli/src/agent/factories/index.ts
+++ b/packages/styrby-cli/src/agent/factories/index.ts
@@ -79,6 +79,19 @@ export {
   type DroidBackendResult,
 } from './droid';
 
-// Future factories:
-// export { createCodexBackend, registerCodexAgent, type CodexBackendOptions } from './codex';
-// export { createClaudeBackend, registerClaudeAgent, type ClaudeBackendOptions } from './claude';
+// Codex factory (OpenAI, MCP transport via `codex mcp-server`)
+export {
+  createCodexBackend,
+  registerCodexAgent,
+  type CodexBackendOptions,
+  type CodexBackendResult,
+} from './codex';
+
+// Claude factory (managed binary-spawn, stream-json — preserves subscription billing)
+export {
+  createClaudeBackend,
+  registerClaudeAgent,
+  type ClaudeBackendOptions,
+  type ClaudeBackendResult,
+  type ClaudePermissionMode,
+} from './claude';

--- a/packages/styrby-cli/src/agent/index.ts
+++ b/packages/styrby-cli/src/agent/index.ts
@@ -48,80 +48,29 @@ export * from './factories';
  * - Kiro (AWS, per-prompt credit billing)
  * - Droid (BYOK, multi-backend via LiteLLM)
  */
-export function initializeAgents(): void {
-  // Import and register agents from factories
-  // Each factory is optional - if it doesn't exist, we skip registration
+export async function initializeAgents(): Promise<void> {
+  // WHY async dynamic import (not require()): this package is ESM
+  // ("type": "module"), where bare `require()` is undefined. Under tsx every
+  // require() in the previous implementation threw and was silently swallowed
+  // by a per-factory try/catch, so NO agent registered at runtime — the CLI
+  // reported "Registered agents: none registered" and every `styrby start
+  // --agent <x>` failed. `await import('./factories')` loads the factory barrel
+  // lazily HERE (only on `start`, not on every CLI command — preserving the
+  // original startup-perf intent) and works under both tsx and the esbuild
+  // bundle. No try/catch: a factory that fails to load should fail loudly, not
+  // leave the registry silently empty.
+  const factories = await import('./factories');
 
-  // Gemini - Google AI
-  try {
-    const { registerGeminiAgent } = require('./factories/gemini');
-    registerGeminiAgent();
-  } catch {
-    // Gemini factory not available
-  }
-
-  // OpenCode - Terminal-based AI coding assistant with JSON output support
-  try {
-    const { registerOpenCodeAgent } = require('./factories/opencode');
-    registerOpenCodeAgent();
-  } catch {
-    // OpenCode factory not available
-  }
-
-  // Aider - AI pair programming tool
-  try {
-    const { registerAiderAgent } = require('./factories/aider');
-    registerAiderAgent();
-  } catch {
-    // Aider factory not available
-  }
-
-  // Goose - Block/Square AI coding agent (Apache 2.0, MCP protocol)
-  try {
-    const { registerGooseAgent } = require('./factories/goose');
-    registerGooseAgent();
-  } catch {
-    // Goose factory not available
-  }
-
-  // Amp - Sourcegraph AI coding agent (deep mode with sub-agents)
-  try {
-    const { registerAmpAgent } = require('./factories/amp');
-    registerAmpAgent();
-  } catch {
-    // Amp factory not available
-  }
-
-  // Crush - Charmbracelet AI coding agent (ACP-compatible, charm TUI)
-  try {
-    const { registerCrushAgent } = require('./factories/crush');
-    registerCrushAgent();
-  } catch {
-    // Crush factory not available
-  }
-
-  // Kilo - Community AI coding agent (500+ models, Memory Bank)
-  try {
-    const { registerKiloAgent } = require('./factories/kilo');
-    registerKiloAgent();
-  } catch {
-    // Kilo factory not available
-  }
-
-  // Kiro - AWS AI coding agent (per-prompt credit billing)
-  try {
-    const { registerKiroAgent } = require('./factories/kiro');
-    registerKiroAgent();
-  } catch {
-    // Kiro factory not available
-  }
-
-  // Droid - BYOK AI coding agent (multi-backend via LiteLLM)
-  try {
-    const { registerDroidAgent } = require('./factories/droid');
-    registerDroidAgent();
-  } catch {
-    // Droid factory not available
-  }
+  factories.registerClaudeAgent();   // Anthropic — managed binary-spawn (stream-json), subscription billing
+  factories.registerCodexAgent();    // OpenAI — MCP transport via `codex mcp-server`
+  factories.registerGeminiAgent();   // Google AI
+  factories.registerOpenCodeAgent(); // terminal-based, JSON output
+  factories.registerAiderAgent();    // AI pair programming
+  factories.registerGooseAgent();    // Block/Square (Apache 2.0, MCP)
+  factories.registerAmpAgent();      // Sourcegraph (deep mode)
+  factories.registerCrushAgent();    // Charmbracelet (ACP)
+  factories.registerKiloAgent();     // Community (500+ models)
+  factories.registerKiroAgent();     // AWS (per-prompt credits)
+  factories.registerDroidAgent();    // BYOK (multi-backend)
 }
 

--- a/packages/styrby-cli/src/agent/multiAgentOrchestrator.ts
+++ b/packages/styrby-cli/src/agent/multiAgentOrchestrator.ts
@@ -291,7 +291,7 @@ export class MultiAgentOrchestrator {
 
     // ── 3. Spawn agents ───────────────────────────────────────────────────────
     const { initializeAgents, agentRegistry } = await import('@/agent/index');
-    initializeAgents();
+    await initializeAgents();
 
     const spawnedAgents: SpawnedAgent[] = [];
 

--- a/packages/styrby-cli/src/api/__tests__/apiSession-session-id.test.ts
+++ b/packages/styrby-cli/src/api/__tests__/apiSession-session-id.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression test: ApiSessionManager addresses the backend by ITS OWN session id.
+ *
+ * WHY this exists (2026-06-10, found by live verification): the manager mints a
+ * canonical session id (written to Supabase + addressed by mobile), but a
+ * backend mints a DIFFERENT id in startSession() and validates against it in
+ * sendPrompt()/cancel(). The relay dispatcher previously forwarded the manager
+ * id to agent.sendPrompt(), so every chat failed with "Invalid session ID:
+ * <managerId>" and no prompt ever reached the agent. The fix threads the
+ * backend's real id (startResult.sessionId) onto the agent calls.
+ *
+ * This test drives a managed session with a fake agent whose startSession()
+ * returns a distinct id, fires a relay chat through the captured handler, and
+ * asserts sendPrompt was called with the BACKEND id — not the manager id.
+ *
+ * @module api/__tests__/apiSession-session-id
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/ui/logger', () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import { ApiSessionManager } from '../apiSession';
+import type { RelayMessage } from 'styrby-shared';
+
+const BACKEND_ID = 'backend-mint-0000-0000-000000000000';
+
+function makeSupabaseOk() {
+  const ok = { error: null };
+  const chain = {
+    insert: vi.fn(async () => ok),
+    update: vi.fn(() => ({ eq: vi.fn(async () => ok) })),
+  };
+  return { from: vi.fn(() => chain) } as any;
+}
+
+function makeFakeAgent() {
+  return {
+    // The backend mints its OWN id, deliberately != the manager's.
+    startSession: vi.fn(async () => ({ sessionId: BACKEND_ID })),
+    sendPrompt: vi.fn(async () => {}),
+    cancel: vi.fn(async () => {}),
+    onMessage: vi.fn(),
+    offMessage: vi.fn(),
+    dispose: vi.fn(async () => {}),
+  } as any;
+}
+
+function makeFakeApi() {
+  const state: { relayHandler?: (m: RelayMessage) => void } = {};
+  const api = {
+    onRelayMessage: vi.fn((h: (m: RelayMessage) => void) => { state.relayHandler = h; }),
+    offRelayMessage: vi.fn(),
+    sendSessionState: vi.fn(async () => {}),
+    endSession: vi.fn(async () => {}),
+    verifyAndConsumePermissionNonce: vi.fn(() => false),
+  } as any;
+  return { api, state };
+}
+
+function chatMessage(content: string): RelayMessage {
+  // No session_id in the payload => the dispatcher forwards to the active
+  // session (it only drops on a PRESENT-but-mismatched session_id).
+  return {
+    id: 'msg-1',
+    timestamp: new Date().toISOString(),
+    sender_device_id: 'dev-1',
+    sender_type: 'web',
+    type: 'chat',
+    payload: { content, agent: 'claude' },
+  } as unknown as RelayMessage;
+}
+
+describe('ApiSessionManager session-id threading', () => {
+  it('forwards relay chat to agent.sendPrompt using the BACKEND session id', async () => {
+    const supabase = makeSupabaseOk();
+    const agent = makeFakeAgent();
+    const { api, state } = makeFakeApi();
+
+    const mgr = new ApiSessionManager();
+    const active = await mgr.startManagedSession({
+      supabase,
+      api,
+      agent,
+      agentType: 'claude',
+      userId: 'user-1',
+      machineId: 'machine-1',
+      projectPath: '/tmp/project',
+    });
+
+    // The manager's canonical id (returned to mobile) is NOT the backend id.
+    expect(active.sessionId).not.toBe(BACKEND_ID);
+    expect(state.relayHandler).toBeTypeOf('function');
+
+    // Fire a chat through the captured relay handler.
+    state.relayHandler!(chatMessage('do the thing'));
+    // Let the async dispatch settle.
+    await new Promise((r) => setImmediate(r));
+
+    // The fix: sendPrompt must receive the BACKEND id, not the manager id.
+    expect(agent.sendPrompt).toHaveBeenCalledWith(BACKEND_ID, 'do the thing');
+    expect(agent.sendPrompt).not.toHaveBeenCalledWith(active.sessionId, 'do the thing');
+
+    await active.stop();
+  });
+});

--- a/packages/styrby-cli/src/api/apiSession.ts
+++ b/packages/styrby-cli/src/api/apiSession.ts
@@ -167,15 +167,25 @@ export class ApiSessionManager {
     };
     agent.onMessage(agentMessageHandler);
 
+    // WHY: the manager owns the canonical session id (`sessionId`, written to
+    // Supabase + addressed by mobile), but a backend mints its OWN id in
+    // startSession() and validates against it in sendPrompt()/cancel(). We track
+    // the backend's id and pass it on the agent calls so relay input reaches the
+    // backend's session (the relay handler runs after startSession, so the
+    // closure reads the updated value). Without this, every chat/cancel failed
+    // with "Invalid session ID" — the manager id never matched the backend id.
+    let backendSessionId: string = sessionId;
+
     // 3. Set up relay -> agent bridge (mobile input goes to agent)
     const relayMessageHandler = (message: RelayMessage) => {
-      this.handleRelayMessage(sessionId, message, agent, agentType, api);
+      this.handleRelayMessage(sessionId, message, agent, agentType, api, backendSessionId);
     };
     api.onRelayMessage(relayMessageHandler);
 
     // 4. Start the agent process
     logger.debug('Starting agent session', { sessionId, agentType, projectPath });
     const startResult = await agent.startSession();
+    backendSessionId = startResult.sessionId;
     logger.debug('Agent session started', { sessionId, agentSessionId: startResult.sessionId });
 
     // Update status to running
@@ -406,18 +416,22 @@ export class ApiSessionManager {
    * - command:end_session -> triggers session stop
    * - command:interrupt -> agent.cancel() (same as cancel for now)
    *
-   * @param sessionId - Session the message targets
+   * @param sessionId - Canonical (manager) session id the message targets; used
+   *   for session-matching + relay responses.
    * @param message - The relay message from mobile
    * @param agent - Agent backend to forward input to
    * @param agentType - Agent type for logging
    * @param api - StyrbyApi for sending responses back
+   * @param backendSessionId - The backend's OWN session id (from startSession);
+   *   used on agent.sendPrompt()/cancel() since backends validate their own id.
    */
   private handleRelayMessage(
     sessionId: string,
     message: RelayMessage,
     agent: AgentBackend,
     agentType: SharedAgentType,
-    api: StyrbyApi
+    api: StyrbyApi,
+    backendSessionId: string
   ): void {
     // SECURITY: classification (schema validation + nonce verify + routing)
     // is delegated to the pure `classifyRelayMessage` helper. See
@@ -468,7 +482,7 @@ export class ApiSessionManager {
           sessionId: verdict.sessionId,
           contentLength: verdict.content.length,
         });
-        agent.sendPrompt(verdict.sessionId, verdict.content).catch((error) => {
+        agent.sendPrompt(backendSessionId, verdict.content).catch((error) => {
           logger.error('Failed to send prompt to agent', { error });
           // Also surface the error to mobile via session-state. Wrapped in
           // safeRelaySend so a relay-down condition doesn't mask the
@@ -503,7 +517,7 @@ export class ApiSessionManager {
         return;
 
       case 'cancel':
-        agent.cancel(verdict.sessionId).catch((error) => {
+        agent.cancel(backendSessionId).catch((error) => {
           logger.debug('Error cancelling agent', { error });
         });
         return;

--- a/packages/styrby-cli/src/cli/handlers/start.ts
+++ b/packages/styrby-cli/src/cli/handlers/start.ts
@@ -133,40 +133,15 @@ export async function handleStart(args: string[]): Promise<void> {
   // factories have heavy imports (@agentclientprotocol/sdk, transport handlers)
   // that would slow down CLI startup for every command, not just 'start'.
   const { initializeAgents, agentRegistry } = await import('@/agent/index');
-  initializeAgents();
+  await initializeAgents();
 
-  // ── Special case: claude integrates via Claude Code's own MCP server,
-  //                 not via a programmatic agent factory.
-  //
-  // WHY: Anthropic's `claude` CLI ships its own MCP client. When the user
-  // runs `claude` in a project directory, Claude Code auto-connects to
-  // any MCP servers configured at the user/project level — which includes
-  // Styrby's MCP server. The mobile app sees the session through that
-  // path, not through an agentRegistry entry that styrby-cli would spawn
-  // and manage.
-  //
-  // Pre-this-fix the registry check below would print
-  //   "Agent 'claude' is not available. Registered agents: gemini, ..."
-  // which is technically true (no factory) but actively misleading —
-  // Claude Code IS the recommended agent. Detecting it here and printing
-  // the correct guidance instead lets users run `claude` directly with
-  // confidence.
-  if (agentType === 'claude') {
-    console.log(chalk.yellow('\nClaude Code uses Anthropic\'s own MCP integration — it does not'));
-    console.log(chalk.yellow('require a Styrby-managed backend.'));
-    console.log('');
-    console.log(`Run ${chalk.cyan('claude')} in your project directory:`);
-    console.log(chalk.gray(`  cd ${projectPath}`));
-    console.log(chalk.gray('  claude'));
-    console.log('');
-    console.log('Claude Code will auto-connect to Styrby via MCP. The mobile app');
-    console.log(`will see the session at the Styrby home tab. Look for ${chalk.cyan('/remote-control')}`);
-    console.log('in the Claude Code prompt to confirm the bridge is active.');
-    console.log('');
-    console.log(`For other agents (Codex, Gemini, Aider, etc.) use ${chalk.cyan('styrby start --agent <name>')}.\n`);
-    await apiClient.disconnect();
-    process.exit(0);
-  }
+  // WHY: claude is now a first-class managed backend (factories/claude.ts) that
+  // spawns the `claude` binary in headless stream-json mode, bridging it to the
+  // relay exactly like every other agent — uniform UX, and it preserves the
+  // user's Max/Pro subscription billing (binary-spawn against ~/.claude/auth.json
+  // rather than the API-key-billed Agent SDK). The old informational MCP stub
+  // (connect-then-disconnect) was removed so `--agent claude` takes the managed
+  // path below. The optional native-MCP path still exists for advanced users.
 
   // Validate the requested agent is available
   const validAgentId = agentType as import('@/agent/core/AgentBackend').AgentId;

--- a/packages/styrby-cli/src/codex/codexMcpClient.ts
+++ b/packages/styrby-cli/src/codex/codexMcpClient.ts
@@ -8,7 +8,7 @@ import { logger } from '@/ui/logger';
 import type { CodexSessionConfig, CodexToolResponse } from './types';
 import { z } from 'zod';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { CodexPermissionHandler } from './utils/permissionHandler';
+import type { CodexPermissionBridge } from './permissionBridge';
 import { execSync } from 'child_process';
 import { buildSafeEnv } from '@/utils/safeEnv';
 
@@ -55,7 +55,7 @@ export class CodexMcpClient {
     private sessionId: string | null = null;
     private conversationId: string | null = null;
     private handler: ((event: unknown) => void) | null = null;
-    private permissionHandler: CodexPermissionHandler | null = null;
+    private permissionHandler: CodexPermissionBridge | null = null;
 
     constructor() {
         this.client = new Client(
@@ -87,7 +87,7 @@ export class CodexMcpClient {
     /**
      * Set the permission handler for tool approval
      */
-    setPermissionHandler(handler: CodexPermissionHandler): void {
+    setPermissionHandler(handler: CodexPermissionBridge): void {
         this.permissionHandler = handler;
     }
 

--- a/packages/styrby-cli/src/codex/permissionBridge.ts
+++ b/packages/styrby-cli/src/codex/permissionBridge.ts
@@ -1,0 +1,42 @@
+/**
+ * Codex permission bridge types.
+ *
+ * WHY this is a standalone, dependency-free module: {@link CodexMcpClient} and
+ * the {@link AgentBackend}-based `CodexBackend` both need the tool-approval
+ * contract, but the legacy `CodexPermissionHandler` (in `utils/permissionHandler`)
+ * is bound to the pre-Supabase `ApiSessionClient` and is currently quarantined
+ * from typechecking. Defining the contract here keeps the live codex path
+ * decoupled from that stale plumbing — no seam, no broken import dragged into
+ * the typechecked agent layer. The legacy handler still satisfies this
+ * interface structurally, so the old `runCodex` path is unaffected.
+ *
+ * @module codex/permissionBridge
+ */
+
+/** Decision returned for a Codex tool-approval request. */
+export type CodexPermissionDecision =
+  | 'approved'
+  | 'approved_for_session'
+  | 'denied'
+  | 'abort';
+
+/** Result of resolving a Codex tool-approval request. */
+export interface CodexPermissionResult {
+  decision: CodexPermissionDecision;
+  reason?: string;
+}
+
+/**
+ * Anything that can resolve a Codex tool-approval request.
+ *
+ * `CodexMcpClient` calls `handleToolCall` when Codex elicits approval for a
+ * command; the implementer returns the user's decision (possibly after a relay
+ * round-trip to the mobile app).
+ */
+export interface CodexPermissionBridge {
+  handleToolCall(
+    toolCallId: string,
+    toolName: string,
+    input: unknown,
+  ): Promise<CodexPermissionResult>;
+}


### PR DESCRIPTION
## Summary
Makes all 11 agents uniformly **managed** when launched via `styrby start`, and fixes two **critical pre-existing runtime bugs** that live verification surfaced (the managed-agent path never actually worked at runtime before this).

- **claude** → clean-room managed spawn of the `claude` binary in headless `--output-format stream-json` mode (on `StreamingAgentBackendBase`). Preserves Max/Pro **subscription billing** (spawns the user's binary, not the API-key-billed Agent SDK). The old connect-then-disconnect MCP stub is removed so `--agent claude` takes the managed path.
- **codex** → wraps the existing `codexMcpClient` over the `codex mcp-server` MCP transport via a clean `permissionBridge`. Also fixes the paper-cut where codex was advertised in `VALID_AGENTS` but its factory was commented out.

## Critical fixes (found by live verification, not unit tests)
1. **`initializeAgents()` registered nothing at runtime.** It used bare `require()` in an ESM (`type:module`) package → every call threw and was swallowed by try/catch → `"Registered agents: none registered"` → every `styrby start --agent <x>` failed. Rewrote to `async` + `await import('./factories')` (lazy, loud-on-failure); awaited the two callers.
2. **Manager↔backend session-id mismatch.** The manager mints its own session id but backends mint a different one and validate it in `sendPrompt`/`cancel`; the dispatcher forwarded the manager id → `"Invalid session ID"` → no prompt reached any agent. `ApiSessionManager` now threads the backend's real `startResult.sessionId` onto the agent calls (manager id still used for matching + relay responses).

Plus: claude spawns with stdin ignored (prompt via `-p`) to drop a 3s per-turn stdin wait.

## Changes
- `agent/factories/claude.ts` (+ClaudeBackend), `agent/factories/codex.ts` (new), `codex/permissionBridge.ts` (new)
- `agent/index.ts` (async dynamic-import registration), `agent/factories/index.ts`, `cli/handlers/start.ts` (stub removed)
- `api/apiSession.ts` (session-id threading), `codex/codexMcpClient.ts` (clean bridge), `multiAgentOrchestrator.ts` (await)
- +48 tests; `factory-matrix.test.ts` updated (claude → streaming set)

## Test Plan
- [x] typecheck + build green
- [x] Full CLI suite: **3007 passed / 3 skipped (142 files)**
- [x] Live-verified end-to-end: controller → relay → CLI dispatcher → ClaudeBackend → real `claude` binary → stream-json → relay `agent_response` → clean exit
- [ ] codex live-verify deferred (needs `OPENAI_API_KEY`) — ships unit-verified
- [ ] CI passes

## Follow-ups (tracked, not in this PR)
- Delete the now-unused quarantined stale Happy code (`runClaude`/`loop`/`session`)
- `detectClaudeBillingModel` is stale (checks `~/.claude/auth.json` which modern claude no longer writes) → mislabels subscription as api-key
- Interactive per-tool mobile approval for claude (currently fixed `--permission-mode`)

🤖 Shipped via /gh-ship