### PR TITLE
feat(web): real-time send path — dashboard can drive an agent live

### DIFF
--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/chat-input.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/chat-input.test.tsx
@@ -15,17 +15,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const h = vi.hoisted(() => ({
-  sendChat: vi.fn(async () => {}),
-  connected: true,
-  encryptForSession: vi.fn(async () => ({ content_encrypted: 'CT', encryption_nonce: 'NONCE' })),
-}));
+const h = vi.hoisted(() => {
+  type Enc = { content_encrypted: string; encryption_nonce: string } | null;
+  return {
+    sendChat: vi.fn(async (_content: string, _agent: string, _sessionId?: string): Promise<void> => {}),
+    connected: true,
+    encryptForSession: vi.fn(
+      async (_content: string, _machineId: string): Promise<Enc> => ({
+        content_encrypted: 'CT',
+        encryption_nonce: 'NONCE',
+      }),
+    ),
+  };
+});
 
 vi.mock('@/hooks/useRelaySend', () => ({
   useRelaySend: () => ({ sendChat: h.sendChat, connected: h.connected }),
 }));
 vi.mock('@/lib/encryption', () => ({
-  encryptForSession: (...args: unknown[]) => h.encryptForSession(...args),
+  encryptForSession: (content: string, machineId: string) => h.encryptForSession(content, machineId),
 }));
 
 import { ChatInput } from '../chat-input';

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/chat-input.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/chat-input.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for the web ChatInput send path.
+ *
+ * Covers the two-channel send (web-send PR-A):
+ *  - LIVE: broadcasts plaintext to the relay via sendChat(content, agent, sessionId)
+ *  - HISTORY: encrypts (encryptForSession) + POSTs to /api/relay/send-message
+ *  - persist is best-effort: skipped when no machineId or no CLI key (null)
+ *  - send is gated on relay connection (button disabled + "Connecting…" hint)
+ *  - sendChat failure surfaces an error and does not clear the input
+ *
+ * @module sessions/[id]/__tests__/chat-input
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const h = vi.hoisted(() => ({
+  sendChat: vi.fn(async () => {}),
+  connected: true,
+  encryptForSession: vi.fn(async () => ({ content_encrypted: 'CT', encryption_nonce: 'NONCE' })),
+}));
+
+vi.mock('@/hooks/useRelaySend', () => ({
+  useRelaySend: () => ({ sendChat: h.sendChat, connected: h.connected }),
+}));
+vi.mock('@/lib/encryption', () => ({
+  encryptForSession: (...args: unknown[]) => h.encryptForSession(...args),
+}));
+
+import { ChatInput } from '../chat-input';
+
+const BASE_PROPS = { sessionId: 'sess-1', userId: 'user-1', agent: 'claude' as const, machineId: 'machine-1' };
+
+beforeEach(() => {
+  h.connected = true;
+  h.sendChat.mockClear().mockResolvedValue(undefined);
+  h.encryptForSession.mockClear().mockResolvedValue({ content_encrypted: 'CT', encryption_nonce: 'NONCE' });
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+async function typeAndSend(text: string) {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText('Message input'), text);
+  await user.click(screen.getByLabelText('Send message'));
+}
+
+describe('ChatInput send path', () => {
+  it('broadcasts plaintext over the relay AND persists encrypted', async () => {
+    render(<ChatInput {...BASE_PROPS} />);
+    await typeAndSend('do the thing');
+
+    await waitFor(() => expect(h.sendChat).toHaveBeenCalledWith('do the thing', 'claude', 'sess-1'));
+    expect(h.encryptForSession).toHaveBeenCalledWith('do the thing', 'machine-1');
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith('/api/relay/send-message', expect.objectContaining({ method: 'POST' }));
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toEqual({ sessionId: 'sess-1', content_encrypted: 'CT', encryption_nonce: 'NONCE' });
+
+    // Input cleared on success.
+    await waitFor(() => expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe(''));
+  });
+
+  it('skips persistence (no fetch) when the CLI key is unavailable, but still broadcasts', async () => {
+    h.encryptForSession.mockResolvedValue(null);
+    render(<ChatInput {...BASE_PROPS} />);
+    await typeAndSend('hi');
+
+    await waitFor(() => expect(h.sendChat).toHaveBeenCalledTimes(1));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('skips encryption + persistence entirely when machineId is null', async () => {
+    render(<ChatInput {...BASE_PROPS} machineId={null} />);
+    await typeAndSend('hi');
+
+    await waitFor(() => expect(h.sendChat).toHaveBeenCalledTimes(1));
+    expect(h.encryptForSession).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('disables send + shows a connecting hint when the relay is not connected', () => {
+    h.connected = false;
+    render(<ChatInput {...BASE_PROPS} />);
+
+    expect(screen.getByLabelText('Send message')).toBeDisabled();
+    expect(screen.getByText(/Connecting to relay/i)).toBeInTheDocument();
+  });
+
+  it('surfaces an error and keeps the input when the broadcast fails', async () => {
+    h.sendChat.mockRejectedValue(new Error('Relay is not connected'));
+    render(<ChatInput {...BASE_PROPS} />);
+    await typeAndSend('keep me');
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/Relay is not connected/i));
+    expect((screen.getByLabelText('Message input') as HTMLTextAreaElement).value).toBe('keep me');
+  });
+});

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-input.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-input.tsx
@@ -8,6 +8,9 @@
  */
 
 import { useState, useRef, KeyboardEvent } from 'react';
+import type { AgentType } from '@styrby/shared';
+import { useRelaySend } from '@/hooks/useRelaySend';
+import { encryptForSession } from '@/lib/encryption';
 
 /* ──────────────────────────── Types ──────────────────────────── */
 
@@ -17,6 +20,16 @@ import { useState, useRef, KeyboardEvent } from 'react';
 interface ChatInputProps {
   /** Session ID for sending messages */
   sessionId: string;
+  /** Authenticated user id — relay channel is `relay:{userId}`. */
+  userId: string;
+  /** The session's agent type (carried in the relay chat payload). */
+  agent: AgentType;
+  /**
+   * The session's CLI machine id. Used to encrypt the message for at-rest
+   * persistence in `session_messages`. Null when the session has no machine
+   * (the live broadcast still works; persistence is skipped).
+   */
+  machineId: string | null;
 }
 
 /* ──────────────────────────── Icons ──────────────────────────── */
@@ -69,36 +82,53 @@ function LoaderIcon({ className }: { className?: string }) {
  *
  * @param props - ChatInput configuration
  */
-export function ChatInput({ sessionId }: ChatInputProps) {
+export function ChatInput({ sessionId, userId, agent, machineId }: ChatInputProps) {
   const [message, setMessage] = useState('');
   const [isSending, setIsSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { sendChat, connected } = useRelaySend(userId);
 
   /**
    * Sends the current message to the session.
+   *
+   * Two channels (see the web-send plan):
+   *  1. LIVE control — broadcast plaintext over the relay so the CLI/agent
+   *     receives it now (`sendChat`). This is the path that drives the agent.
+   *  2. HISTORY — encrypt for at-rest E2E and persist to `session_messages`
+   *     so the message renders in the thread (ChatThread reads that table via
+   *     realtime). Best-effort: if the CLI key isn't available we skip it
+   *     rather than fail the send — the agent already got the message.
+   *
    * Clears the input and refocuses on success.
    */
   const sendMessage = async () => {
     const trimmedMessage = message.trim();
-    if (!trimmedMessage || isSending) return;
+    if (!trimmedMessage || isSending || !connected) return;
 
     setIsSending(true);
     setError(null);
 
     try {
-      const response = await fetch('/api/relay/send-message', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          sessionId,
-          content: trimmedMessage,
-        }),
-      });
+      // 1. Live control path (required) — reaches the agent.
+      await sendChat(trimmedMessage, agent, sessionId);
 
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to send message');
+      // 2. Persist for history (best-effort, E2E at-rest).
+      if (machineId) {
+        const enc = await encryptForSession(trimmedMessage, machineId);
+        if (enc) {
+          const response = await fetch('/api/relay/send-message', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sessionId, ...enc }),
+          });
+          if (!response.ok) {
+            // History persistence failed, but the agent already received the
+            // message via the broadcast. Log, don't block the send.
+            const data = await response.json().catch(() => ({}));
+            console.error('Failed to persist message to history:', data.error);
+          }
+        }
       }
 
       setMessage('');
@@ -175,7 +205,7 @@ export function ChatInput({ sessionId }: ChatInputProps) {
         {/* Send button */}
         <button
           onClick={sendMessage}
-          disabled={!message.trim() || isSending}
+          disabled={!message.trim() || isSending || !connected}
           className="flex-shrink-0 rounded-lg bg-orange-600 p-3 text-white hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-zinc-900"
           aria-label={isSending ? 'Sending message...' : 'Send message'}
         >
@@ -187,11 +217,17 @@ export function ChatInput({ sessionId }: ChatInputProps) {
         </button>
       </div>
 
-      {/* Keyboard shortcut hint */}
-      <p className="mt-2 text-xs text-zinc-400">
-        Press <kbd className="px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400">Enter</kbd> to send,{' '}
-        <kbd className="px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400">Shift + Enter</kbd> for new line
-      </p>
+      {/* Keyboard shortcut hint / relay status */}
+      {connected ? (
+        <p className="mt-2 text-xs text-zinc-400">
+          Press <kbd className="px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400">Enter</kbd> to send,{' '}
+          <kbd className="px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400">Shift + Enter</kbd> for new line
+        </p>
+      ) : (
+        <p className="mt-2 text-xs text-amber-400/80" role="status">
+          Connecting to relay…
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/session-view.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/session-view.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useCallback } from 'react';
+import type { AgentType } from '@styrby/shared';
 import { ChatThread } from './chat-thread';
 import { ChatInput } from './chat-input';
 import { SummaryTab } from './summary-tab';
@@ -259,7 +260,14 @@ export function SessionView({
           />
 
           {/* Input (only shown for active sessions) */}
-          {isSessionActive && <ChatInput sessionId={session.id} />}
+          {isSessionActive && (
+            <ChatInput
+              sessionId={session.id}
+              userId={userId}
+              agent={session.agent_type as AgentType}
+              machineId={session.machine_id}
+            />
+          )}
 
           {/* Ended session footer with summary */}
           {!isSessionActive && (

--- a/packages/styrby-web/src/hooks/useRelaySend.ts
+++ b/packages/styrby-web/src/hooks/useRelaySend.ts
@@ -1,0 +1,116 @@
+'use client';
+
+/**
+ * useRelaySend
+ *
+ * Connects the web dashboard to the user's Supabase Realtime relay channel
+ * (`relay:{userId}`) as a `web` device and exposes `sendChat` for pushing a
+ * chat message to the CLI/agent live.
+ *
+ * WHY a client-side RelayClient (not a server route): this mirrors the mobile
+ * app exactly (both use the shared `styrby-shared/relay` `RelayClient`), reuses
+ * the tested transport, and lets the CLI see the web device's presence. The CLI
+ * dispatcher reads `payload.content` as PLAINTEXT, so the relay payload is
+ * intentionally unencrypted here — E2E encryption applies only to the persisted
+ * `session_messages` history (see `encryptForSession`), not the transient relay
+ * control message.
+ *
+ * Inbound (agent responses) is NOT handled here: `ChatThread` already subscribes
+ * to `session_messages` via Supabase postgres_changes, and the CLI persists the
+ * agent's output there. This hook is outbound-only.
+ *
+ * @module hooks/useRelaySend
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createRelayClient, type RelayClient } from '@styrby/shared/relay';
+import type { AgentType } from '@styrby/shared';
+import { createClient } from '@/lib/supabase/client';
+
+/** localStorage key holding the web device's machine id (set by registerWebDevice). */
+const WEB_MACHINE_ID_KEY = 'styrby_web_machine_id';
+
+/**
+ * Return value of {@link useRelaySend}.
+ */
+export interface UseRelaySendReturn {
+  /**
+   * Broadcast a chat message to the CLI/agent over the relay (plaintext).
+   *
+   * @param content - The user's message (plaintext — the CLI reads it directly).
+   * @param agent - The session's agent type.
+   * @param sessionId - The session id (the CLI drops chats for other sessions).
+   * @throws If the relay client is not connected yet.
+   */
+  sendChat: (content: string, agent: AgentType, sessionId?: string) => Promise<void>;
+  /** Whether the relay channel is currently connected. */
+  connected: boolean;
+}
+
+/**
+ * Connect to the relay as a web device and expose `sendChat`.
+ *
+ * The client connects on mount (once `userId` is known) and disconnects on
+ * unmount. A stable per-device id is reused from localStorage when present
+ * (the registered web machine id) so the CLI sees a consistent web presence.
+ *
+ * @param userId - The authenticated user's id (relay channel is `relay:{userId}`).
+ * @returns `{ sendChat, connected }`.
+ */
+export function useRelaySend(userId: string): UseRelaySendReturn {
+  const clientRef = useRef<RelayClient | null>(null);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    // Reuse the registered web machine id when available so the CLI sees a
+    // stable web presence; otherwise a per-tab ephemeral id is fine for sending.
+    const deviceId =
+      (typeof localStorage !== 'undefined' && localStorage.getItem(WEB_MACHINE_ID_KEY)) ||
+      `web_${crypto.randomUUID()}`;
+
+    // No channelSuffix — matches the CLI, which connects to `relay:{userId}`.
+    const client = createRelayClient({
+      supabase: createClient(),
+      userId,
+      deviceId,
+      deviceType: 'web',
+      deviceName: 'Web Dashboard',
+      platform: 'web',
+    });
+    clientRef.current = client;
+
+    let cancelled = false;
+    client
+      .connect()
+      .then(() => {
+        if (!cancelled) setConnected(true);
+      })
+      .catch((err: unknown) => {
+        if (process.env.NODE_ENV === 'development') {
+          console.error('[useRelaySend] relay connect failed:', err);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      setConnected(false);
+      clientRef.current = null;
+      void client.disconnect().catch(() => {
+        /* best-effort teardown */
+      });
+    };
+  }, [userId]);
+
+  const sendChat = useCallback(
+    async (content: string, agent: AgentType, sessionId?: string): Promise<void> => {
+      const client = clientRef.current;
+      if (!client) throw new Error('Relay is not connected');
+      await client.sendChat(content, agent, sessionId);
+    },
+    []
+  );
+
+  return { sendChat, connected };
+}

--- a/packages/styrby-web/src/lib/__tests__/encryption.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/encryption.test.ts
@@ -415,3 +415,69 @@ describe('tryDecryptMessage()', () => {
     expect(chain.single).toHaveBeenCalledOnce();
   });
 });
+
+describe('encryptForSession()', () => {
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    mockLocalStorage.getItem.mockClear();
+    vi.clearAllMocks();
+    mockCreateClient.mockReturnValue({ from: mockSupabaseFrom });
+  });
+
+  /** Seed the web device's keypair into localStorage and mock the CLI key lookup. */
+  async function setup(cliPublicKeyBase64: string | null, webKeypair: { publicKey: Uint8Array; secretKey: Uint8Array }) {
+    const { encodeBase64 } = await import('@styrby/shared/encryption');
+    const storedKeypair = JSON.stringify({
+      publicKey: await encodeBase64(webKeypair.publicKey),
+      secretKey: await encodeBase64(webKeypair.secretKey),
+    });
+    mockLocalStorage.getItem.mockImplementation((key: string) =>
+      key === 'styrby_web_encryption_keypair' ? storedKeypair : null
+    );
+    mockSupabaseFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: cliPublicKeyBase64 ? { public_key: cliPublicKeyBase64 } : null,
+        error: null,
+      }),
+    });
+  }
+
+  it('returns null when the CLI machine has no registered public key', async () => {
+    const webKeypair = await generateKeyPair();
+    await setup(null, webKeypair);
+
+    const { encryptForSession } = await freshEncryption();
+    const result = await encryptForSession('hello', 'machine-without-key');
+
+    expect(result).toBeNull();
+  });
+
+  it('produces content_encrypted + encryption_nonce that the CLI can decrypt', async () => {
+    // web = sender, CLI = recipient. The CLI opens with (webPublicKey, cliSecret).
+    const webKeypair = await generateKeyPair();
+    const cliKeypair = await generateKeyPair();
+    const { encodeBase64, decryptFromStorage } = await import('@styrby/shared/encryption');
+    await setup(await encodeBase64(cliKeypair.publicKey), webKeypair);
+
+    const { encryptForSession } = await freshEncryption();
+    const plaintext = 'Fix the failing test in main.ts';
+    const enc = await encryptForSession(plaintext, 'cli-machine-id');
+
+    expect(enc).not.toBeNull();
+    expect(typeof enc!.content_encrypted).toBe('string');
+    expect(enc!.content_encrypted.length).toBeGreaterThan(0);
+    expect(typeof enc!.encryption_nonce).toBe('string');
+    expect(enc!.encryption_nonce.length).toBeGreaterThan(0);
+
+    // The CLI decrypts with the web sender's public key + its own secret.
+    const decrypted = await decryptFromStorage(
+      enc!.content_encrypted,
+      enc!.encryption_nonce,
+      webKeypair.publicKey,
+      cliKeypair.secretKey
+    );
+    expect(decrypted).toBe(plaintext);
+  });
+});

--- a/packages/styrby-web/src/lib/encryption.ts
+++ b/packages/styrby-web/src/lib/encryption.ts
@@ -310,3 +310,68 @@ export async function tryDecryptMessage(
     return { content: null, wasEncrypted: true };
   }
 }
+
+// ============================================================================
+// Encryption (outbound — for persisting the user's own messages)
+// ============================================================================
+
+/**
+ * Encrypted payload produced by {@link encryptForSession}, shaped to the
+ * `session_messages` columns the `/api/relay/send-message` route requires.
+ */
+export interface EncryptedForSession {
+  /** NaCl box ciphertext (base64) → `session_messages.content_encrypted`. */
+  content_encrypted: string;
+  /** NaCl box nonce (base64) → `session_messages.encryption_nonce`. */
+  encryption_nonce: string;
+}
+
+/**
+ * Encrypt a message for at-rest E2E storage in `session_messages`.
+ *
+ * Mirrors the mobile `encryptMessage()` service: NaCl box of the plaintext
+ * to the CLI machine's public key using this web device's secret key.
+ *
+ * WHY persistence only (NOT the relay payload): the live control path
+ * broadcasts PLAINTEXT on `relay:{userId}` because the CLI dispatcher reads
+ * `payload.content` directly and never decrypts. crypto_box here protects the
+ * stored history at rest, which is the only place E2E applies. (Mobile also
+ * encrypts the relay payload, but the CLI ignores `encrypted_content` — a
+ * separate mobile bug; web deliberately does NOT replicate it.)
+ *
+ * @param content - Plaintext message to encrypt.
+ * @param machineId - The session's CLI machine id (recipient of the box).
+ * @returns The `{ content_encrypted, encryption_nonce }` pair, or `null` when
+ *   the CLI's public key isn't available yet (caller persists best-effort:
+ *   skip persistence, the live broadcast still delivers the message).
+ * @throws Never for the missing-key case (returns null); only propagates an
+ *   unexpected crypto fault from the libsodium layer.
+ *
+ * @example
+ * const enc = await encryptForSession('Fix the test', session.machine_id);
+ * if (enc) await fetch('/api/relay/send-message', {
+ *   method: 'POST',
+ *   body: JSON.stringify({ sessionId, ...enc }),
+ * });
+ */
+export async function encryptForSession(
+  content: string,
+  machineId: string
+): Promise<EncryptedForSession | null> {
+  const senderPublicKey = await getSenderPublicKey(machineId);
+  if (!senderPublicKey) {
+    // No CLI public key registered yet — cannot encrypt. Caller skips
+    // persistence; the plaintext relay broadcast still reaches the agent.
+    return null;
+  }
+
+  const keypair = await getOrCreateWebKeyPair();
+  const { encryptForStorage } = await loadCrypto();
+  const { encrypted, nonce } = await encryptForStorage(
+    content,
+    senderPublicKey,
+    keypair.secretKey
+  );
+
+  return { content_encrypted: encrypted, encryption_nonce: nonce };
+}


### PR DESCRIPTION
## Summary
Wires the **outbound send path** for the web dashboard. Before this, the dashboard had **no path to the relay** — `ChatInput` POSTed plaintext to a persistence route that requires encrypted content, and nothing broadcast to `relay:{userId}`, so a dashboard message never reached the agent. (Unblocked by #339, which made the CLI relay path actually work at runtime.)

Approach **A** (client-side `RelayClient`, mobile-parity) per product decision.

## How it works (three channels, cleanly separated)
- **Outbound / live control:** `ChatInput` → `useRelaySend().sendChat(content, agent, sessionId)` broadcasts **plaintext** on `relay:{userId}` via the shared `styrby-shared/relay` client → CLI dispatcher → agent. Plaintext because the CLI dispatcher reads `payload.content` directly and never decrypts.
- **History:** `encryptForSession(content, machineId)` (NaCl box to the CLI's pubkey) → POST `/api/relay/send-message` with `content_encrypted`+`encryption_nonce`. Best-effort (skipped if the CLI key isn't registered — the agent already got the live message).
- **Inbound:** unchanged — `ChatThread` already subscribes to `session_messages` via Supabase realtime; the CLI persists agent output there.

## Changes
- `web/lib/encryption.ts` (+`encryptForSession`)
- `hooks/useRelaySend.ts` (new — client RelayClient, deviceType `web`, no channelSuffix → matches CLI)
- `chat-input.tsx` (broadcast + persist + connection gating), `session-view.tsx` (thread `userId`/`agent`/`machineId`)
- +7 tests

## Test Plan
- [x] typecheck + web build green
- [x] encryptForSession: CLI-decryptable round-trip + null-on-no-key
- [x] ChatInput: broadcast+persist, skip-persist paths, connection gating, error path
- [x] Outbound verified by composition (ChatInput→sendChat unit + shared RelayClient broadcast + #339 live relay→agent proof)
- [ ] Browser live-verify (dashboard → agent → dashboard) — residual step
- [ ] CI passes

## Bug found (separate, high-pri follow-up — NOT this PR)
Mobile's `useChatSend` encrypts the **relay payload** (`encrypted_content`, `content:''`) when paired, but the CLI dispatcher reads only plaintext `payload.content` → forwards an **empty string** to the agent. Mobile→agent chat is likely broken when a machine is paired. Web deliberately does not replicate this. Tracked in the backlog + plan doc.

🤖 Shipped via /gh-ship