### PR TITLE
feat(web): complete offline command sync — queue, deliver, fix latent bugs

### DIFF
--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/chat-input.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/__tests__/chat-input.test.tsx
@@ -26,6 +26,7 @@ const h = vi.hoisted(() => {
         encryption_nonce: 'NONCE',
       }),
     ),
+    saveCommand: vi.fn(async (_input: unknown): Promise<unknown> => ({})),
   };
 });
 
@@ -34,6 +35,9 @@ vi.mock('@/hooks/useRelaySend', () => ({
 }));
 vi.mock('@/lib/encryption', () => ({
   encryptForSession: (content: string, machineId: string) => h.encryptForSession(content, machineId),
+}));
+vi.mock('@/lib/offline-storage', () => ({
+  saveCommand: (input: unknown) => h.saveCommand(input),
 }));
 
 import { ChatInput } from '../chat-input';
@@ -44,6 +48,7 @@ beforeEach(() => {
   h.connected = true;
   h.sendChat.mockClear().mockResolvedValue(undefined);
   h.encryptForSession.mockClear().mockResolvedValue({ content_encrypted: 'CT', encryption_nonce: 'NONCE' });
+  h.saveCommand.mockClear().mockResolvedValue({});
   global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }) as unknown as typeof fetch;
 });
 afterEach(() => cleanup());
@@ -89,12 +94,39 @@ describe('ChatInput send path', () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it('disables send + shows a connecting hint when the relay is not connected', () => {
+  it('queues offline (saveCommand) instead of broadcasting when disconnected', async () => {
     h.connected = false;
     render(<ChatInput {...BASE_PROPS} />);
 
-    expect(screen.getByLabelText('Send message')).toBeDisabled();
-    expect(screen.getByText(/Connecting to relay/i)).toBeInTheDocument();
+    // Offline hint shown. Sending while offline is allowed (queueing) — proven
+    // by saveCommand being invoked below (a disabled button wouldn't fire it).
+    expect(screen.getByText(/Offline — messages are queued/i)).toBeInTheDocument();
+
+    await typeAndSend('offline message');
+
+    await waitFor(() =>
+      expect(h.saveCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command_type: 'chat',
+          payload: { content: 'offline message', agent: 'claude', session_id: 'sess-1' },
+          machine_id: 'machine-1',
+          session_id: 'sess-1',
+        }),
+      ),
+    );
+    expect(h.sendChat).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+    // The confirmation notice (distinct from the standing offline hint).
+    expect(screen.getByText(/message queued\. It will send/i)).toBeInTheDocument();
+  });
+
+  it('errors when queueing offline with no paired machine', async () => {
+    h.connected = false;
+    render(<ChatInput {...BASE_PROPS} machineId={null} />);
+    await typeAndSend('offline message');
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/no paired machine/i));
+    expect(h.saveCommand).not.toHaveBeenCalled();
   });
 
   it('surfaces an error and keeps the input when the broadcast fails', async () => {

--- a/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-input.tsx
+++ b/packages/styrby-web/src/app/dashboard/sessions/[id]/chat-input.tsx
@@ -11,6 +11,7 @@ import { useState, useRef, KeyboardEvent } from 'react';
 import type { AgentType } from '@styrby/shared';
 import { useRelaySend } from '@/hooks/useRelaySend';
 import { encryptForSession } from '@/lib/encryption';
+import { saveCommand } from '@/lib/offline-storage';
 
 /* ──────────────────────────── Types ──────────────────────────── */
 
@@ -86,6 +87,7 @@ export function ChatInput({ sessionId, userId, agent, machineId }: ChatInputProp
   const [message, setMessage] = useState('');
   const [isSending, setIsSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { sendChat, connected } = useRelaySend(userId);
 
@@ -104,31 +106,50 @@ export function ChatInput({ sessionId, userId, agent, machineId }: ChatInputProp
    */
   const sendMessage = async () => {
     const trimmedMessage = message.trim();
-    if (!trimmedMessage || isSending || !connected) return;
+    if (!trimmedMessage || isSending) return;
 
     setIsSending(true);
     setError(null);
+    setNotice(null);
 
     try {
-      // 1. Live control path (required) — reaches the agent.
-      await sendChat(trimmedMessage, agent, sessionId);
+      if (connected) {
+        // ── ONLINE ──────────────────────────────────────────────────────
+        // 1. Live control path (required) — reaches the agent now.
+        await sendChat(trimmedMessage, agent, sessionId);
 
-      // 2. Persist for history (best-effort, E2E at-rest).
-      if (machineId) {
-        const enc = await encryptForSession(trimmedMessage, machineId);
-        if (enc) {
-          const response = await fetch('/api/relay/send-message', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ sessionId, ...enc }),
-          });
-          if (!response.ok) {
-            // History persistence failed, but the agent already received the
-            // message via the broadcast. Log, don't block the send.
-            const data = await response.json().catch(() => ({}));
-            console.error('Failed to persist message to history:', data.error);
+        // 2. Persist for history (best-effort, E2E at-rest).
+        if (machineId) {
+          const enc = await encryptForSession(trimmedMessage, machineId);
+          if (enc) {
+            const response = await fetch('/api/relay/send-message', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ sessionId, ...enc }),
+            });
+            if (!response.ok) {
+              // History persistence failed, but the agent already received the
+              // message via the broadcast. Log, don't block the send.
+              const data = await response.json().catch(() => ({}));
+              console.error('Failed to persist message to history:', data.error);
+            }
           }
         }
+      } else {
+        // ── OFFLINE ─────────────────────────────────────────────────────
+        // Queue locally; offline-sync delivers it over the relay + records it
+        // in offline_command_queue on reconnect. Requires a machine id (the
+        // queue's machine_id FK is NOT NULL).
+        if (!machineId) {
+          throw new Error('Cannot queue while offline: this session has no paired machine.');
+        }
+        await saveCommand({
+          command_type: 'chat',
+          payload: { content: trimmedMessage, agent, session_id: sessionId },
+          machine_id: machineId,
+          session_id: sessionId,
+        });
+        setNotice('Offline — message queued. It will send when you reconnect.');
       }
 
       setMessage('');
@@ -205,7 +226,7 @@ export function ChatInput({ sessionId, userId, agent, machineId }: ChatInputProp
         {/* Send button */}
         <button
           onClick={sendMessage}
-          disabled={!message.trim() || isSending || !connected}
+          disabled={!message.trim() || isSending}
           className="flex-shrink-0 rounded-lg bg-orange-600 p-3 text-white hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-zinc-900"
           aria-label={isSending ? 'Sending message...' : 'Send message'}
         >
@@ -217,6 +238,13 @@ export function ChatInput({ sessionId, userId, agent, machineId }: ChatInputProp
         </button>
       </div>
 
+      {/* Queued-offline confirmation */}
+      {notice && (
+        <p className="mt-2 text-xs text-emerald-400/90" role="status">
+          {notice}
+        </p>
+      )}
+
       {/* Keyboard shortcut hint / relay status */}
       {connected ? (
         <p className="mt-2 text-xs text-zinc-400">
@@ -225,7 +253,7 @@ export function ChatInput({ sessionId, userId, agent, machineId }: ChatInputProp
         </p>
       ) : (
         <p className="mt-2 text-xs text-amber-400/80" role="status">
-          Connecting to relay…
+          Offline — messages are queued and sent when you reconnect.
         </p>
       )}
     </div>

--- a/packages/styrby-web/src/lib/__tests__/offline-sync.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/offline-sync.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the web offline-sync service.
+ *
+ * Guards the latent bugs the bug-hunt found (2026-06-09) + the delivery loop
+ * added 2026-06-10:
+ *  - machine_id uses the command's REAL machine (was userId → FK violation)
+ *  - session_id is carried through
+ *  - queue_order = Date.parse(created_at) ms-epoch (BIGINT, migration 098)
+ *  - upsert on `id` with ignoreDuplicates (idempotent re-sync)
+ *  - chat commands are DELIVERED over the relay on reconnect; non-chat aren't
+ *  - delivery is best-effort: relay unavailable → commands still persisted
+ *
+ * @module lib/__tests__/offline-sync
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// openDeliveryRelay reads localStorage for a stable web device id. This test
+// env lacks a functional localStorage, so provide a minimal stub (the relay
+// delivery path would otherwise fail-soft to "no delivery").
+const mockLocalStorage = (() => {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string): string | null => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+  };
+})();
+Object.defineProperty(globalThis, 'localStorage', { value: mockLocalStorage, writable: true });
+
+const h = vi.hoisted(() => ({
+  upsert: vi.fn(async (_row: unknown, _opts: unknown) => ({ error: null as { message: string } | null })),
+  getUser: vi.fn(
+    async (): Promise<{ data: { user: { id: string } | null }; error: unknown }> => ({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    }),
+  ),
+  connect: vi.fn(async () => {}),
+  sendChat: vi.fn(async (_c: string, _a: string, _s?: string) => {}),
+  disconnect: vi.fn(async () => {}),
+  relayThrows: false,
+  pending: [] as Array<Record<string, unknown>>,
+  markSynced: vi.fn(async (_id: string) => {}),
+  clearSynced: vi.fn(async () => 0),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    from: () => ({ upsert: h.upsert }),
+    auth: { getUser: h.getUser },
+  }),
+}));
+vi.mock('@styrby/shared/relay', () => ({
+  createRelayClient: () => {
+    if (h.relayThrows) throw new Error('relay unavailable');
+    return { connect: h.connect, sendChat: h.sendChat, disconnect: h.disconnect };
+  },
+}));
+vi.mock('../offline-storage', () => ({
+  getPendingCommands: async () => h.pending,
+  markSynced: (id: string) => h.markSynced(id),
+  clearSynced: () => h.clearSynced(),
+}));
+
+import { syncPendingCommands } from '../offline-sync';
+
+const CREATED_AT = '2026-06-10T00:00:00.000Z';
+
+function chatCommand(over: Record<string, unknown> = {}) {
+  return {
+    id: 'c1',
+    command_type: 'chat',
+    payload: JSON.stringify({ content: 'hi there', agent: 'claude' }),
+    machine_id: 'machine-xyz',
+    session_id: 'sess-1',
+    created_at: CREATED_AT,
+    synced: false,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.relayThrows = false;
+  h.pending = [];
+  h.upsert.mockResolvedValue({ error: null });
+  h.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+  h.clearSynced.mockResolvedValue(0);
+});
+
+describe('syncPendingCommands', () => {
+  it('upserts with the REAL machine_id (not userId), session_id, id-dedup, and ms queue_order', async () => {
+    h.pending = [chatCommand()];
+
+    const count = await syncPendingCommands();
+
+    expect(count).toBe(1);
+    expect(h.upsert).toHaveBeenCalledTimes(1);
+    const [row, opts] = h.upsert.mock.calls[0];
+    expect(row).toMatchObject({
+      id: 'c1',
+      user_id: 'user-1',
+      machine_id: 'machine-xyz', // the FK fix — NOT 'user-1'
+      session_id: 'sess-1',
+      queue_order: Date.parse(CREATED_AT), // 1.7e12 — only valid as BIGINT
+      status: 'pending',
+    });
+    expect((row as { machine_id: string }).machine_id).not.toBe('user-1');
+    expect(opts).toEqual({ onConflict: 'id', ignoreDuplicates: true });
+    expect(h.markSynced).toHaveBeenCalledWith('c1');
+    expect(h.clearSynced).toHaveBeenCalled();
+  });
+
+  it('delivers chat commands over the relay (connect → sendChat → disconnect)', async () => {
+    h.pending = [chatCommand()];
+
+    await syncPendingCommands();
+
+    expect(h.connect).toHaveBeenCalled();
+    expect(h.sendChat).toHaveBeenCalledWith('hi there', 'claude', 'sess-1');
+    expect(h.disconnect).toHaveBeenCalled();
+  });
+
+  it('does NOT deliver non-chat commands over the relay (but still persists them)', async () => {
+    h.pending = [chatCommand({ id: 'c2', command_type: 'cancel', payload: JSON.stringify({ session_id: 'sess-1' }) })];
+
+    const count = await syncPendingCommands();
+
+    expect(count).toBe(1);
+    expect(h.upsert).toHaveBeenCalledTimes(1);
+    expect(h.sendChat).not.toHaveBeenCalled();
+  });
+
+  it('still persists commands when the delivery relay is unavailable (best-effort)', async () => {
+    h.relayThrows = true;
+    h.pending = [chatCommand()];
+
+    const count = await syncPendingCommands();
+
+    expect(count).toBe(1);
+    expect(h.upsert).toHaveBeenCalledTimes(1);
+    expect(h.sendChat).not.toHaveBeenCalled();
+    expect(h.markSynced).toHaveBeenCalledWith('c1');
+  });
+
+  it('returns 0 and does nothing when there are no pending commands', async () => {
+    h.pending = [];
+    const count = await syncPendingCommands();
+    expect(count).toBe(0);
+    expect(h.upsert).not.toHaveBeenCalled();
+  });
+
+  it('defers (returns 0) when there is no authenticated user', async () => {
+    h.pending = [chatCommand()];
+    h.getUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const count = await syncPendingCommands();
+
+    expect(count).toBe(0);
+    expect(h.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/packages/styrby-web/src/lib/offline-storage.ts
+++ b/packages/styrby-web/src/lib/offline-storage.ts
@@ -27,12 +27,20 @@ import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
 export interface StoredCommand {
   /** Auto-incrementing local key (used as IndexedDB primary key) */
   localId?: number;
-  /** Unique command ID (UUID) */
+  /** Unique command ID (UUID) — also used as the server queue PK for dedup */
   id: string;
   /** The type of command (e.g., 'chat', 'permission_response', 'cancel') */
   command_type: string;
   /** JSON-serialized command payload */
   payload: string;
+  /**
+   * The CLI machine this command targets. REQUIRED: `offline_command_queue`
+   * has `machine_id UUID NOT NULL REFERENCES machines(id)`, so this must be a
+   * real machine id (NOT the user id — that was the FK-violation bug).
+   */
+  machine_id: string;
+  /** The session this command belongs to, or null for session-less commands. */
+  session_id: string | null;
   /** ISO 8601 timestamp when the command was created */
   created_at: string;
   /** Whether this command has been synced to Supabase */
@@ -50,6 +58,10 @@ export interface SaveCommandInput {
   command_type: string;
   /** The command payload (will be JSON-stringified) */
   payload: Record<string, unknown>;
+  /** Target CLI machine id (required — FK to machines on the server queue). */
+  machine_id: string;
+  /** Owning session id, or null. */
+  session_id?: string | null;
   /** Optional custom timestamp; defaults to now */
   created_at?: string;
 }
@@ -143,6 +155,8 @@ async function getDb(): Promise<IDBPDatabase<OfflineStorageDB>> {
  * await saveCommand({
  *   command_type: 'chat',
  *   payload: { content: 'Hello', agent: 'claude' },
+ *   machine_id: session.machine_id,
+ *   session_id: session.id,
  * });
  */
 export async function saveCommand(command: SaveCommandInput): Promise<StoredCommand> {
@@ -152,6 +166,8 @@ export async function saveCommand(command: SaveCommandInput): Promise<StoredComm
     id: command.id ?? crypto.randomUUID(),
     command_type: command.command_type,
     payload: JSON.stringify(command.payload),
+    machine_id: command.machine_id,
+    session_id: command.session_id ?? null,
     created_at: command.created_at ?? new Date().toISOString(),
     synced: false,
   };

--- a/packages/styrby-web/src/lib/offline-sync.ts
+++ b/packages/styrby-web/src/lib/offline-sync.ts
@@ -14,6 +14,8 @@
  * browsers.
  */
 
+import { createRelayClient, type RelayClient } from '@styrby/shared/relay';
+import type { AgentType } from '@styrby/shared';
 import { createClient } from '@/lib/supabase/client';
 import {
   getPendingCommands,
@@ -21,6 +23,9 @@ import {
   clearSynced,
   type StoredCommand,
 } from './offline-storage';
+
+/** localStorage key holding the web device's machine id (shared with useRelaySend). */
+const WEB_MACHINE_ID_KEY = 'styrby_web_machine_id';
 
 // ============================================================================
 // State
@@ -73,17 +78,30 @@ export async function syncPendingCommands(): Promise<number> {
       return 0;
     }
 
-    for (const command of pending) {
-      try {
-        await syncSingleCommand(command, user.id, supabase);
-        await markSynced(command.id);
-        syncedCount++;
-      } catch (error) {
-        // WHY: We log and continue rather than throwing. A single failed
-        // insert (e.g., duplicate key, schema mismatch) should not prevent
-        // the rest of the queue from syncing.
-        console.error(`[OfflineSync] Failed to sync command ${command.id}:`, error);
+    // Open a transient relay connection to DELIVER queued chats now that we're
+    // back online. Best-effort: if the relay can't connect, commands are still
+    // persisted to the audit queue below (delivery just doesn't happen this
+    // pass). The CLI session may also have ended — then the broadcast reaches
+    // no listener, which is acceptable (the command is still recorded).
+    const relay = await openDeliveryRelay(supabase, user.id);
+
+    try {
+      for (const command of pending) {
+        try {
+          // 1. Persist to the server queue (audit + cross-device record).
+          await syncSingleCommand(command, user.id, supabase);
+          // 2. Deliver chats to the agent over the relay (best-effort).
+          await deliverCommand(relay, command);
+          await markSynced(command.id);
+          syncedCount++;
+        } catch (error) {
+          // WHY: We log and continue rather than throwing. A single failed
+          // upsert (e.g., schema mismatch) should not block the rest of the queue.
+          console.error(`[OfflineSync] Failed to sync command ${command.id}:`, error);
+        }
       }
+    } finally {
+      if (relay) await relay.disconnect().catch(() => { /* best-effort teardown */ });
     }
 
     // Clean up synced records from local storage
@@ -100,19 +118,27 @@ export async function syncPendingCommands(): Promise<number> {
 }
 
 /**
- * Inserts a single command into the Supabase `offline_command_queue` table.
+ * Upserts a single command into the Supabase `offline_command_queue` table.
  *
- * WHY the command is inserted with minimal encryption fields: The Supabase
- * schema requires `command_encrypted` and `encryption_nonce`. In a full
- * implementation these would use the machine key's TweetNaCl encryption.
- * For now we store the JSON payload as the "encrypted" value with a
- * placeholder nonce, since end-to-end encryption is handled at the relay
- * layer and these commands are already authenticated via RLS.
+ * Fixes the latent bugs the bug-hunt found (2026-06-09):
+ *  - machine_id is the command's REAL target machine (was `userId` → FK
+ *    violation against machines(id), so every sync failed).
+ *  - session_id is carried through (was omitted).
+ *  - queue_order = Date.parse(created_at) ms-epoch is now safe (migration 098
+ *    widened the column INTEGER → BIGINT; INT4 overflowed before).
+ *  - `upsert` on the `id` PK with ignoreDuplicates makes re-sync idempotent
+ *    (a markSynced failure or a double online event won't error or duplicate).
+ *
+ * WHY command_encrypted holds the JSON payload with a placeholder nonce: this
+ * row is the audit/cross-device record (RLS-protected, GDPR-exported); live
+ * E2E delivery happens over the relay (see the delivery step in
+ * syncPendingCommands). At-rest encryption of the queued command itself is a
+ * tracked follow-up.
  *
  * @param command - The locally stored command to sync
  * @param userId - The authenticated user's ID for the user_id column
  * @param supabase - The Supabase client instance
- * @throws Error if the Supabase insert fails
+ * @throws Error if the Supabase upsert fails
  */
 async function syncSingleCommand(
   command: StoredCommand,
@@ -121,22 +147,85 @@ async function syncSingleCommand(
 ): Promise<void> {
   const { error } = await supabase
     .from('offline_command_queue')
-    .insert({
-      user_id: userId,
-      // WHY machine_id uses a placeholder: The actual machine_id should come
-      // from the paired CLI instance. In a future iteration, the pairing
-      // service will provide this. For now we use the user_id as a fallback
-      // to satisfy the NOT NULL constraint.
-      machine_id: userId,
-      command_encrypted: command.payload,
-      encryption_nonce: 'pending',
-      queue_order: Date.parse(command.created_at),
-      status: 'pending',
-      created_at: command.created_at,
-    });
+    .upsert(
+      {
+        id: command.id,
+        user_id: userId,
+        machine_id: command.machine_id,
+        session_id: command.session_id,
+        command_encrypted: command.payload,
+        encryption_nonce: 'pending',
+        queue_order: Date.parse(command.created_at),
+        status: 'pending',
+        created_at: command.created_at,
+      },
+      { onConflict: 'id', ignoreDuplicates: true }
+    );
 
   if (error) {
-    throw new Error(`Supabase insert failed: ${error.message}`);
+    throw new Error(`Supabase upsert failed: ${error.message}`);
+  }
+}
+
+/**
+ * Open a transient relay connection used to deliver queued commands on
+ * reconnect. Returns null when the relay can't be created/connected — delivery
+ * is best-effort, so the caller still persists commands to the audit queue.
+ *
+ * @param supabase - Authenticated Supabase client.
+ * @param userId - The user's id (relay channel is `relay:{userId}`).
+ * @returns A connected RelayClient, or null if connection failed.
+ */
+async function openDeliveryRelay(
+  supabase: ReturnType<typeof createClient>,
+  userId: string
+): Promise<RelayClient | null> {
+  try {
+    const deviceId =
+      (typeof localStorage !== 'undefined' && localStorage.getItem(WEB_MACHINE_ID_KEY)) ||
+      `web_${crypto.randomUUID()}`;
+    const relay = createRelayClient({
+      supabase,
+      userId,
+      deviceId,
+      deviceType: 'web',
+      deviceName: 'Web Dashboard (offline-sync)',
+      platform: 'web',
+    });
+    await relay.connect();
+    return relay;
+  } catch (error) {
+    console.error(
+      '[OfflineSync] Delivery relay unavailable; commands persisted but not delivered this pass:',
+      error
+    );
+    return null;
+  }
+}
+
+/**
+ * Deliver a queued command to the agent over the relay (chat commands only).
+ *
+ * No-op when the relay is unavailable or the command isn't a deliverable chat.
+ * Never throws — delivery is best-effort and must not fail the sync (the command
+ * is already persisted to the audit queue by the caller).
+ *
+ * @param relay - The delivery relay (or null when unavailable).
+ * @param command - The queued command to deliver.
+ */
+async function deliverCommand(relay: RelayClient | null, command: StoredCommand): Promise<void> {
+  if (!relay || command.command_type !== 'chat') return;
+  try {
+    const payload = JSON.parse(command.payload) as { content?: string; agent?: string };
+    if (payload.content) {
+      await relay.sendChat(
+        payload.content,
+        (payload.agent as AgentType) ?? 'claude',
+        command.session_id ?? undefined
+      );
+    }
+  } catch (error) {
+    console.error(`[OfflineSync] Failed to deliver command ${command.id} over relay:`, error);
   }
 }
 

--- a/supabase/migrations/098_offline_queue_order_bigint.sql
+++ b/supabase/migrations/098_offline_queue_order_bigint.sql
@@ -1,0 +1,23 @@
+-- Migration 098: widen offline_command_queue.queue_order INTEGER -> BIGINT.
+--
+-- BUG (latent, found by the bug-hunt 2026-06-09; fixed as part of the web
+-- offline-sync loop 2026-06-10):
+--   The web offline-sync client sets queue_order = Date.parse(created_at), an
+--   epoch-milliseconds value (~1.7e12 today). The column was INTEGER (INT4,
+--   max 2,147,483,647 ≈ 2.1e9), so every offline-queue insert would overflow
+--   with "integer out of range" (SQLSTATE 22003) and abort. Combined with the
+--   FK bug (machine_id was set to user_id) the sync path never succeeded — it
+--   was unreachable only because no producer fed it. Now that a producer +
+--   delivery exist, queue_order must hold an ms-epoch (or any monotonic 64-bit)
+--   value, so BIGINT is required.
+--
+-- queue_order stays NOT NULL with no default (the client supplies a monotonic
+-- ordering value per command). BIGINT is a non-lossy widening of INTEGER, so
+-- existing rows are preserved; the supporting index
+-- idx_offline_queue_pending (user_id, machine_id, queue_order) rebuilds
+-- automatically on the column rewrite.
+--
+-- Governing: data-integrity (no silent insert failure on a NOT NULL queue).
+
+ALTER TABLE public.offline_command_queue
+  ALTER COLUMN queue_order TYPE BIGINT;


### PR DESCRIPTION
## Summary
Closes the **offline loop** for the web dashboard and fixes three latent bugs the bug-hunt found. A message typed while offline is now queued locally, then on reconnect **delivered to the agent over the relay** *and* recorded in `offline_command_queue`. Before this, the sync path always failed (FK violation) and had no producer feeding it.

## Latent bug fixes
- **FK violation:** `machine_id` now uses the command's real target machine (was `userId` → violated `machines(id)` FK, so every sync errored).
- **INT4 overflow:** `queue_order = Date.parse(created_at)` (~1.7e12) overflowed `INTEGER`. **Migration 098** widens `offline_command_queue.queue_order` → `BIGINT` (applied + verified on prod: `data_type = bigint`).
- **No dedup:** `upsert` on the `id` PK with `ignoreDuplicates` → idempotent re-sync.
- **Missing fields:** `session_id` carried through; `StoredCommand`/`SaveCommandInput`/`saveCommand` gain `machine_id`/`session_id`.

## The loop (producer → sync → deliver)
- **Producer:** `ChatInput` enqueues a chat via `saveCommand` when the relay is offline (instead of being blocked), with an "offline — queued" notice + standing hint.
- **Delivery:** `syncPendingCommands` opens a transient relay on reconnect and broadcasts each queued chat to the agent. Best-effort — if the relay is down or the CLI session ended, the command is still persisted to the audit queue.
- **Inbound** unchanged (ChatThread + Supabase realtime).

## Changes
- `supabase/migrations/098_offline_queue_order_bigint.sql` (new, applied to prod)
- `lib/offline-storage.ts`, `lib/offline-sync.ts` (correct upsert + delivery helpers)
- `sessions/[id]/chat-input.tsx` (offline producer + UI)
- +8 tests (`offline-sync.test.ts` ×6, ChatInput offline ×2)

## Test Plan
- [x] Migration applied + verified on prod (`queue_order = bigint`)
- [x] typecheck (script, incl. tests) + web build green
- [x] offline-sync: real machine_id, dedup upsert, ms queue_order, delivery, non-chat-not-delivered, relay-unavailable, no-pending, no-auth
- [x] ChatInput: offline-queue + no-machine error
- [ ] CI passes

## Follow-ups (tracked)
- At-rest encryption of the queued command payload (currently stored as the JSON payload in `command_encrypted` with a placeholder nonce — RLS-protected; parallels `encryptForSession`)
- Mobile offline-sync parity (same fixes apply to `styrby-mobile`)

🤖 Shipped via /gh-ship