### PR TITLE
fix(mobile): send plaintext relay chat — encrypted payload forwarded empty to agent

### DIFF
--- a/packages/styrby-mobile/src/components/chat/hooks/__tests__/useChatSend.test.ts
+++ b/packages/styrby-mobile/src/components/chat/hooks/__tests__/useChatSend.test.ts
@@ -248,10 +248,10 @@ describe('useChatSend', () => {
   });
 
   // --------------------------------------------------------------------------
-  // E2E encryption path
+  // Relay payload is PLAINTEXT (regression for the 2026-06-10 fix)
   // --------------------------------------------------------------------------
 
-  it('encrypts the relay payload when pairingInfo is present', async () => {
+  it('sends PLAINTEXT content in the relay payload even when paired (no encryption)', async () => {
     const deps = buildDeps({
       pairingInfo: { machineId: 'machine-1', userId: 'u1', deviceName: 'MBP', pairedAt: '' },
     });
@@ -261,35 +261,20 @@ describe('useChatSend', () => {
       await result.current();
     });
 
-    expect(encryptMessage).toHaveBeenCalledWith('hello world', 'machine-1');
+    // WHY: the CLI dispatcher reads `payload.content` directly and never
+    // decrypts `encrypted_content`. The old code encrypted the payload and set
+    // `content: ''` when paired, so the CLI forwarded an EMPTY string to the
+    // agent. The relay payload must stay plaintext (E2E lives in saveMessageToDb).
+    expect(encryptMessage).not.toHaveBeenCalled();
     expect(deps.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        payload: expect.objectContaining({
-          encrypted_content: 'enc-base64',
-          nonce: 'nonce-base64',
-          content: '', // cleared when encrypted
-        }),
-      }),
-    );
-  });
-
-  it('falls back to plaintext when encryption throws', async () => {
-    (encryptMessage as jest.Mock).mockRejectedValueOnce(new Error('encrypt fail'));
-    const deps = buildDeps({
-      pairingInfo: { machineId: 'machine-1', userId: 'u1', deviceName: 'MBP', pairedAt: '' },
-    });
-    const { result } = renderHook(() => useChatSend(deps));
-
-    await act(async () => {
-      await result.current();
-    });
-
-    // Should still call sendMessage with plaintext content
-    expect(deps.sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
+        type: 'chat',
         payload: expect.objectContaining({ content: 'hello world' }),
       }),
     );
+    const payload = (deps.sendMessage as jest.Mock).mock.calls[0][0].payload;
+    expect(payload.content).toBe('hello world');
+    expect(payload.encrypted_content).toBeUndefined();
   });
 
   // --------------------------------------------------------------------------

--- a/packages/styrby-mobile/src/components/chat/hooks/useChatSend.ts
+++ b/packages/styrby-mobile/src/components/chat/hooks/useChatSend.ts
@@ -16,8 +16,6 @@ import type { AgentType } from 'styrby-shared';
 import type { ChatMessageData } from '../../ChatMessage';
 import type { AgentState } from '../../TypingIndicator';
 import type { PairingInfo, UseRelayReturn } from '../../../hooks/useRelay';
-import { encryptMessage } from '../../../services/encryption';
-import { chatLogger as logger } from '../agent-config';
 import { createSession, saveMessageToDb } from '../chat-session';
 
 /**
@@ -110,43 +108,21 @@ export function useChatSend(deps: UseChatSendDeps): () => Promise<void> {
     }
 
     try {
-      // WHY: When a paired machine is available, encrypt the relay payload
-      // so the message content is protected in transit via Supabase Realtime.
-      // The CLI will decrypt using its secret key + mobile's public key.
-      // If encryption fails, fall back to plaintext relay (CLI handles both).
-      let relayPayload: {
-        content: string;
-        agent: AgentType;
-        session_id?: string;
-        encrypted_content?: string;
-        nonce?: string;
-      } = {
-        content,
-        agent: selectedAgent ?? 'claude',
-        session_id: currentSessionId ?? undefined,
-      };
-
-      if (machineId) {
-        try {
-          const encrypted = await encryptMessage(content, machineId);
-          relayPayload = {
-            ...relayPayload,
-            encrypted_content: encrypted.encrypted,
-            nonce: encrypted.nonce,
-            // WHY: Set content to empty to signal encryption to the CLI.
-            // The CLI checks for encrypted_content first.
-            content: '',
-          };
-        } catch (encryptError) {
-          // WHY: Relay-encryption failure is non-fatal. Send plaintext so
-          // the message reaches the CLI. Common during initial pairing.
-          logger.error('Relay encryption failed, sending plaintext:', encryptError);
-        }
-      }
-
+      // WHY a PLAINTEXT relay payload (fixed 2026-06-10): the CLI dispatcher
+      // (`relayMessageDispatch` chat case) reads ONLY `payload.content` and
+      // never decrypts `encrypted_content`. The previous code encrypted the
+      // relay payload and set `content: ''` when a machine was paired — so the
+      // CLI forwarded an EMPTY string to the agent in the normal (paired) case,
+      // breaking mobile→agent chat. E2E encryption is applied to the persisted
+      // history via `saveMessageToDb` (above); the transient relay control
+      // message is plaintext over TLS, matching the web client.
       await sendMessage({
         type: 'chat',
-        payload: relayPayload,
+        payload: {
+          content,
+          agent: selectedAgent ?? 'claude',
+          session_id: currentSessionId ?? undefined,
+        },
       });
     } catch {
       const errorId = `error_${Date.now()}`;


### PR DESCRIPTION
## Summary
**Bug (potential live):** mobile `useChatSend` encrypted the *relay* payload (`encrypted_content` + `nonce`) and set `content: ''` whenever a machine was paired — "to signal encryption to the CLI." But the CLI dispatcher (`relayMessageDispatch` chat case) reads **only `payload.content`** and never decrypts. So in the normal paired case, the agent received an **empty string**. Mobile→agent chat was broken whenever a machine was paired.

**Fix:** always send plaintext `{ content, agent, session_id }` in the relay payload, matching the web client. E2E encryption still applies to the persisted **history** via `saveMessageToDb` (unchanged); the transient relay control message is plaintext over TLS.

Found 2026-06-10 while building the web send path (#340/#341); the CLI-reads-plaintext behavior was verified live in #339.

## Changes
- `useChatSend.ts`: removed the encrypt-relay-payload block; send plaintext. Dropped now-unused `encryptMessage` + `logger` imports.
- `useChatSend.test.ts`: the encrypt/blank-content assertions become a regression guard (relay payload stays plaintext; `encryptMessage` NOT called; `content` is the plaintext, not `''`).

## Test Plan
- [x] typecheck + mobile lint clean
- [x] useChatSend.test.ts — 14/14 (incl. new plaintext-relay guard)
- [ ] CI passes

🤖 Shipped via /gh-ship