### PR TITLE
feat(mobile): offline command sync parity — fix latent bugs + queue/deliver loop

### DIFF
--- a/packages/styrby-mobile/src/components/chat/hooks/__tests__/useChatSend.test.ts
+++ b/packages/styrby-mobile/src/components/chat/hooks/__tests__/useChatSend.test.ts
@@ -44,6 +44,16 @@ jest.mock('../../agent-config', () => ({
   chatLogger: { error: jest.fn(), log: jest.fn(), warn: jest.fn() },
 }));
 
+/** Capture offline-storage saveCommand calls for the offline-enqueue path. */
+const mockSaveCommand = jest.fn<Promise<unknown>, unknown[]>(async () => ({}));
+
+// WHY @/ alias: the source imports '../../../services/offline-storage' (relative
+// from hooks/), but jest.mock resolves paths relative to THIS test file, which
+// sits one level deeper (__tests__/). @/ maps to src/ — same absolute target.
+jest.mock('@/services/offline-storage', () => ({
+  saveCommand: (...args: unknown[]) => mockSaveCommand(...args),
+}));
+
 // ============================================================================
 // Imports
 // ============================================================================
@@ -117,8 +127,14 @@ describe('useChatSend', () => {
     expect(deps.sendMessage).not.toHaveBeenCalled();
   });
 
-  it('does nothing when not connected', async () => {
-    const deps = buildDeps({ isConnected: false });
+  it('does NOT broadcast over the relay when offline (queues instead)', async () => {
+    // WHY: offline sends no longer early-return — they enqueue locally via
+    // saveCommand and are delivered on reconnect by offline-sync. The relay
+    // broadcast (sendMessage) must NOT be called while offline.
+    const deps = buildDeps({
+      isConnected: false,
+      pairingInfo: { machineId: 'machine-1', userId: 'u1', deviceName: 'MBP', pairedAt: '' },
+    });
     const { result } = renderHook(() => useChatSend(deps));
 
     await act(async () => {
@@ -126,6 +142,55 @@ describe('useChatSend', () => {
     });
 
     expect(deps.sendMessage).not.toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // Offline enqueue (parity with web ChatInput offline branch)
+  // --------------------------------------------------------------------------
+
+  it('enqueues the chat via saveCommand when offline with a paired machine', async () => {
+    const deps = buildDeps({
+      isConnected: false,
+      sessionId: 'existing-session',
+      pairingInfo: { machineId: 'machine-1', userId: 'u1', deviceName: 'MBP', pairedAt: '' },
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(mockSaveCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command_type: 'chat',
+        payload: expect.objectContaining({
+          content: 'hello world',
+          agent: 'claude',
+          session_id: 'existing-session',
+        }),
+        machine_id: 'machine-1',
+        session_id: 'existing-session',
+      }),
+    );
+    // Optimistic append still happens so the user sees their message.
+    expect(deps.setMessages).toHaveBeenCalledWith(expect.any(Function));
+    expect(deps.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('appends an error and does NOT enqueue when offline with no paired machine', async () => {
+    const deps = buildDeps({ isConnected: false, pairingInfo: null });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(mockSaveCommand).not.toHaveBeenCalled();
+    // The catch block appends an error message (optimistic + error = 2 calls).
+    const calls = (deps.setMessages as jest.Mock).mock.calls;
+    const errorUpdater = calls[calls.length - 1][0];
+    const errorMessages = errorUpdater([]);
+    expect(errorMessages[0].role).toBe('error');
   });
 
   // --------------------------------------------------------------------------

--- a/packages/styrby-mobile/src/components/chat/hooks/useChatSend.ts
+++ b/packages/styrby-mobile/src/components/chat/hooks/useChatSend.ts
@@ -17,6 +17,7 @@ import type { ChatMessageData } from '../../ChatMessage';
 import type { AgentState } from '../../TypingIndicator';
 import type { PairingInfo, UseRelayReturn } from '../../../hooks/useRelay';
 import { createSession, saveMessageToDb } from '../chat-session';
+import { saveCommand } from '../../../services/offline-storage';
 
 /**
  * Dependencies for {@link useChatSend}.
@@ -67,7 +68,7 @@ export function useChatSend(deps: UseChatSendDeps): () => Promise<void> {
   } = deps;
 
   return useCallback(async () => {
-    if (!inputText.trim() || !isConnected) return;
+    if (!inputText.trim()) return;
 
     const content = inputText.trim();
     // WHY: crypto.randomUUID() is available in Hermes (React Native) and
@@ -108,22 +109,44 @@ export function useChatSend(deps: UseChatSendDeps): () => Promise<void> {
     }
 
     try {
-      // WHY a PLAINTEXT relay payload (fixed 2026-06-10): the CLI dispatcher
-      // (`relayMessageDispatch` chat case) reads ONLY `payload.content` and
-      // never decrypts `encrypted_content`. The previous code encrypted the
-      // relay payload and set `content: ''` when a machine was paired — so the
-      // CLI forwarded an EMPTY string to the agent in the normal (paired) case,
-      // breaking mobile→agent chat. E2E encryption is applied to the persisted
-      // history via `saveMessageToDb` (above); the transient relay control
-      // message is plaintext over TLS, matching the web client.
-      await sendMessage({
-        type: 'chat',
-        payload: {
-          content,
-          agent: selectedAgent ?? 'claude',
-          session_id: currentSessionId ?? undefined,
-        },
-      });
+      if (isConnected) {
+        // ── ONLINE ────────────────────────────────────────────────────────
+        // WHY a PLAINTEXT relay payload (fixed 2026-06-10): the CLI dispatcher
+        // (`relayMessageDispatch` chat case) reads ONLY `payload.content` and
+        // never decrypts `encrypted_content`. The previous code encrypted the
+        // relay payload and set `content: ''` when a machine was paired — so the
+        // CLI forwarded an EMPTY string to the agent in the normal (paired) case,
+        // breaking mobile→agent chat. E2E encryption is applied to the persisted
+        // history via `saveMessageToDb` (above); the transient relay control
+        // message is plaintext over TLS, matching the web client.
+        await sendMessage({
+          type: 'chat',
+          payload: {
+            content,
+            agent: selectedAgent ?? 'claude',
+            session_id: currentSessionId ?? undefined,
+          },
+        });
+      } else if (machineId) {
+        // ── OFFLINE ───────────────────────────────────────────────────────
+        // Queue locally; offline-sync delivers it over the relay + records it
+        // in offline_command_queue on reconnect. Requires a machine id (the
+        // queue's machine_id FK is NOT NULL). Mirrors web ChatInput's offline
+        // branch — the optimistic UI append above already showed the message.
+        await saveCommand({
+          command_type: 'chat',
+          payload: {
+            content,
+            agent: selectedAgent ?? 'claude',
+            session_id: currentSessionId ?? undefined,
+          },
+          machine_id: machineId,
+          session_id: currentSessionId ?? null,
+        });
+      } else {
+        // Offline with no paired machine: cannot queue (FK is NOT NULL).
+        throw new Error('Cannot queue while offline: this session has no paired machine.');
+      }
     } catch {
       const errorId = `error_${Date.now()}`;
       const errorContent = 'Failed to send message. Please try again.';

--- a/packages/styrby-mobile/src/services/__tests__/offline-storage.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/offline-storage.test.ts
@@ -33,8 +33,10 @@ const mockRunAsync = jest.fn(async (sql: string, params: unknown[] = []) => {
       id: params[0],
       command_type: params[1],
       payload: params[2],
-      created_at: params[3],
-      synced: params[4],
+      machine_id: params[3],
+      session_id: params[4],
+      created_at: params[5],
+      synced: params[6],
     });
     return { changes: 1 };
   }
@@ -65,6 +67,21 @@ const mockRunAsync = jest.fn(async (sql: string, params: unknown[] = []) => {
 
 const mockGetAllAsync = jest.fn(async (sql: string) => {
   sqlCalls.push({ sql, params: [] });
+
+  // initDatabase() runs `PRAGMA table_info(offline_storage)` to decide whether
+  // to ALTER in the machine_id/session_id columns. Report them as already
+  // present so the fresh-install path is exercised (CREATE TABLE includes them).
+  if (sql.includes('PRAGMA table_info')) {
+    return [
+      { name: 'id' },
+      { name: 'command_type' },
+      { name: 'payload' },
+      { name: 'machine_id' },
+      { name: 'session_id' },
+      { name: 'created_at' },
+      { name: 'synced' },
+    ];
+  }
 
   if (sql.includes('WHERE synced = 0')) {
     const results: Record<string, unknown>[] = [];
@@ -137,7 +154,7 @@ describe('Offline Storage Service', () => {
 
   describe('database initialization', () => {
     it('creates the database and storage table on first operation', async () => {
-      await saveCommand({ command_type: 'chat', payload: { content: 'init' } });
+      await saveCommand({ command_type: 'chat', payload: { content: 'init' }, machine_id: 'machine-1' });
 
       expect(SQLite.openDatabaseAsync).toHaveBeenCalledWith('styrby_offline_storage.db');
       expect(mockExecAsync).toHaveBeenCalledWith(
@@ -150,7 +167,7 @@ describe('Offline Storage Service', () => {
       // Subsequent calls skip initDatabase() entirely.
       mockExecAsync.mockClear();
 
-      await saveCommand({ command_type: 'chat', payload: { content: 'no-reinit' } });
+      await saveCommand({ command_type: 'chat', payload: { content: 'no-reinit' }, machine_id: 'machine-1' });
 
       // execAsync should NOT be called again since db is already initialized
       expect(mockExecAsync).not.toHaveBeenCalled();
@@ -166,6 +183,8 @@ describe('Offline Storage Service', () => {
       const input: SaveCommandInput = {
         command_type: 'chat',
         payload: { content: 'hello', agent: 'claude' },
+        machine_id: 'machine-1',
+        session_id: 'sess-1',
       };
 
       const result = await saveCommand(input);
@@ -173,6 +192,8 @@ describe('Offline Storage Service', () => {
       expect(result.id).toBeDefined();
       expect(result.command_type).toBe('chat');
       expect(result.payload).toBe(JSON.stringify({ content: 'hello', agent: 'claude' }));
+      expect(result.machine_id).toBe('machine-1');
+      expect(result.session_id).toBe('sess-1');
       expect(result.created_at).toBeDefined();
       expect(result.synced).toBe(false);
     });
@@ -182,6 +203,7 @@ describe('Offline Storage Service', () => {
         id: 'custom-id-123',
         command_type: 'cancel',
         payload: { action: 'cancel' },
+        machine_id: 'machine-1',
       };
 
       const result = await saveCommand(input);
@@ -195,6 +217,7 @@ describe('Offline Storage Service', () => {
         command_type: 'chat',
         payload: { content: 'with-timestamp' },
         created_at: customTimestamp,
+        machine_id: 'machine-1',
       };
 
       const result = await saveCommand(input);
@@ -212,6 +235,7 @@ describe('Offline Storage Service', () => {
       const result = await saveCommand({
         command_type: 'chat',
         payload: complexPayload,
+        machine_id: 'machine-1',
       });
 
       expect(result.payload).toBe(JSON.stringify(complexPayload));
@@ -221,44 +245,71 @@ describe('Offline Storage Service', () => {
       await saveCommand({
         command_type: 'chat',
         payload: { content: 'sync-check' },
+        machine_id: 'machine-1',
       });
 
       const insertCall = mockRunAsync.mock.calls.find(
         (call) => typeof call[0] === 'string' && call[0].includes('INSERT')
       );
       expect(insertCall).toBeDefined();
-      // synced is the 5th param (index 4)
-      expect((insertCall![1] as unknown[])[4]).toBe(0);
+      // Columns: id, command_type, payload, machine_id, session_id, created_at, synced.
+      // synced is the 7th param (index 6).
+      expect((insertCall![1] as unknown[])[6]).toBe(0);
     });
 
     it('inserts into the correct table with correct column order', async () => {
       await saveCommand({
         command_type: 'permission_response',
         payload: { request_id: 'req_1', approved: true },
+        machine_id: 'machine-xyz',
+        session_id: 'sess-9',
       });
 
       expect(mockRunAsync).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO offline_storage'),
-        expect.arrayContaining([
+        [
           expect.any(String), // id
           'permission_response', // command_type
           expect.any(String), // payload (JSON)
+          'machine-xyz', // machine_id
+          'sess-9', // session_id
           expect.any(String), // created_at
           0, // synced
-        ])
+        ]
       );
+    });
+
+    it('persists machine_id and session_id, defaulting session_id to null', async () => {
+      const result = await saveCommand({
+        command_type: 'chat',
+        payload: { content: 'no-session' },
+        machine_id: 'machine-abc',
+      });
+
+      expect(result.machine_id).toBe('machine-abc');
+      expect(result.session_id).toBeNull();
+
+      const insertCall = mockRunAsync.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('INSERT')
+      );
+      // machine_id is index 3, session_id is index 4 (null when omitted).
+      expect((insertCall![1] as unknown[])[3]).toBe('machine-abc');
+      expect((insertCall![1] as unknown[])[4]).toBeNull();
     });
 
     it('returns a proper StoredCommand object', async () => {
       const result = await saveCommand({
         command_type: 'chat',
         payload: { content: 'typed' },
+        machine_id: 'machine-1',
       });
 
       // Verify all StoredCommand properties exist
       expect(result).toHaveProperty('id');
       expect(result).toHaveProperty('command_type');
       expect(result).toHaveProperty('payload');
+      expect(result).toHaveProperty('machine_id');
+      expect(result).toHaveProperty('session_id');
       expect(result).toHaveProperty('created_at');
       expect(result).toHaveProperty('synced');
     });
@@ -267,6 +318,7 @@ describe('Offline Storage Service', () => {
       const result = await saveCommand({
         command_type: 'ping',
         payload: {},
+        machine_id: 'machine-1',
       });
 
       expect(result.payload).toBe('{}');
@@ -486,6 +538,8 @@ describe('Offline Storage Service', () => {
         id: 'round_trip',
         command_type: 'chat',
         payload: { content: 'round-trip test', nested: { key: 'value' } },
+        machine_id: 'machine-rt',
+        session_id: 'sess-rt',
         created_at: '2026-03-15T10:30:00.000Z',
       };
 
@@ -497,6 +551,8 @@ describe('Offline Storage Service', () => {
       expect(pending[0].id).toBe('round_trip');
       expect(pending[0].command_type).toBe('chat');
       expect(pending[0].payload).toBe(JSON.stringify(input.payload));
+      expect(pending[0].machine_id).toBe('machine-rt');
+      expect(pending[0].session_id).toBe('sess-rt');
       expect(pending[0].created_at).toBe('2026-03-15T10:30:00.000Z');
       expect(pending[0].synced).toBe(false);
     });
@@ -527,8 +583,8 @@ describe('Offline Storage Service', () => {
 
     it('handles multiple save-sync-clear cycles', async () => {
       // Save
-      await saveCommand({ id: 'cycle_1', command_type: 'chat', payload: { n: 1 } });
-      await saveCommand({ id: 'cycle_2', command_type: 'chat', payload: { n: 2 } });
+      await saveCommand({ id: 'cycle_1', command_type: 'chat', payload: { n: 1 }, machine_id: 'machine-1' });
+      await saveCommand({ id: 'cycle_2', command_type: 'chat', payload: { n: 2 }, machine_id: 'machine-1' });
 
       // Sync first one
       await markSynced('cycle_1');
@@ -556,6 +612,7 @@ describe('Offline Storage Service', () => {
       const result = await saveCommand({
         command_type: 'chat',
         payload: { content: 'Hello "world" & <test> \'quotes\'' },
+        machine_id: 'machine-1',
       });
 
       expect(result.payload).toBe(
@@ -568,6 +625,7 @@ describe('Offline Storage Service', () => {
       const result = await saveCommand({
         command_type: 'chat',
         payload: { content: longContent },
+        machine_id: 'machine-1',
       });
 
       const parsed = JSON.parse(result.payload);
@@ -580,6 +638,7 @@ describe('Offline Storage Service', () => {
           id: `concurrent_${i}`,
           command_type: 'chat',
           payload: { index: i },
+          machine_id: 'machine-1',
         })
       );
 
@@ -599,7 +658,7 @@ describe('Offline Storage Service', () => {
       mockRunAsync.mockRejectedValueOnce(new Error('SQLITE_FULL'));
 
       await expect(
-        saveCommand({ command_type: 'chat', payload: { content: 'fail-write' } })
+        saveCommand({ command_type: 'chat', payload: { content: 'fail-write' }, machine_id: 'machine-1' })
       ).rejects.toThrow('SQLITE_FULL');
     });
   });

--- a/packages/styrby-mobile/src/services/__tests__/offline-sync.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/offline-sync.test.ts
@@ -1,15 +1,18 @@
 /**
- * Offline Sync Service Test Suite
+ * Offline Sync Service Test Suite (Mobile)
  *
- * Tests the connectivity-aware sync service that pushes locally stored
- * commands to the Supabase offline_command_queue table, covering:
- * - syncPendingCommands() with authenticated/unauthenticated users
- * - Single command insertion to Supabase
- * - Partial failure handling (one command fails, others succeed)
- * - Concurrent sync prevention (isSyncing guard)
- * - Connectivity listener lifecycle (start, stop, duplicate prevention)
- * - Network state transitions (offline->online triggers sync)
- * - Cleanup of synced records after successful sync
+ * Mirrors the web offline-sync test (lib/__tests__/offline-sync.test.ts) and
+ * guards the offline-sync parity fixes:
+ *  - machine_id uses the command's REAL machine (was userId → FK violation)
+ *  - session_id is carried through
+ *  - queue_order = Date.parse(created_at) ms-epoch (BIGINT, migration 098)
+ *  - upsert on `id` with ignoreDuplicates (idempotent re-sync)
+ *  - chat commands are DELIVERED over the relay on reconnect; non-chat aren't
+ *  - delivery is best-effort: relay unavailable → commands still persisted
+ *
+ * Plus the mobile-specific connectivity-listener lifecycle (NetInfo).
+ *
+ * @module services/__tests__/offline-sync
  */
 
 // ============================================================================
@@ -36,20 +39,45 @@ jest.mock('../offline-storage', () => ({
 }));
 
 // ============================================================================
+// Mock styrby-shared (relay delivery)
+// ============================================================================
+
+let mockRelayThrows = false;
+const mockConnect = jest.fn<Promise<void>, unknown[]>(async () => {});
+const mockSendChat = jest.fn<Promise<void>, unknown[]>(async () => {});
+const mockDisconnect = jest.fn<Promise<void>, unknown[]>(async () => {});
+
+jest.mock('styrby-shared', () => ({
+  createRelayClient: () => {
+    if (mockRelayThrows) throw new Error('relay unavailable');
+    return { connect: mockConnect, sendChat: mockSendChat, disconnect: mockDisconnect };
+  },
+}));
+
+// ============================================================================
+// Mock expo-secure-store (device id lookup for delivery relay)
+// ============================================================================
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(async () => 'mobile_test-device'),
+  setItemAsync: jest.fn(async () => {}),
+}));
+
+// ============================================================================
 // Mock Supabase
 // ============================================================================
 
-let mockInsertError: { message: string } | null = null;
+let mockUpsertError: { message: string } | null = null;
 let mockAuthUser: { id: string } | null = { id: 'test-user-id' };
 let mockAuthError: { message: string } | null = null;
 
 jest.mock('../../lib/supabase', () => {
   const createChain = () => {
-    const chain: Record<string, jest.Mock | ((resolve: (v: unknown) => void) => Promise<unknown>)> = {
-      insert: jest.fn().mockReturnThis(),
+    const chain: Record<string, unknown> = {
+      upsert: jest.fn().mockReturnThis(),
     };
     chain.then = (resolve: (v: unknown) => void) =>
-      Promise.resolve({ error: mockInsertError }).then(resolve);
+      Promise.resolve({ error: mockUpsertError }).then(resolve);
     return chain;
   };
 
@@ -82,10 +110,6 @@ import { supabase } from '../../lib/supabase';
 // Import module under test AFTER mocks
 // ============================================================================
 
-// WHY isolateModules: The sync service has module-level state (isSyncing,
-// unsubscribeNetInfo). We need fresh imports for tests that check these.
-// For most tests we use the direct import and reset state manually.
-
 import {
   syncPendingCommands,
   startConnectivityListener,
@@ -96,17 +120,31 @@ import {
 // Test Helpers
 // ============================================================================
 
+const CREATED_AT = '2026-06-10T00:00:00.000Z';
+
 /**
- * Creates a mock StoredCommand for testing.
+ * Creates a mock StoredCommand for testing. Defaults to a deliverable chat
+ * command targeting a REAL machine id (not the user id).
  */
 function createStoredCommand(overrides: Partial<StoredCommand> = {}): StoredCommand {
   return {
     id: overrides.id ?? `cmd_${crypto.randomUUID()}`,
     command_type: overrides.command_type ?? 'chat',
-    payload: overrides.payload ?? '{"content":"test"}',
-    created_at: overrides.created_at ?? new Date().toISOString(),
+    payload: overrides.payload ?? JSON.stringify({ content: 'hi there', agent: 'claude' }),
+    machine_id: overrides.machine_id ?? 'machine-xyz',
+    // WHY a property-presence check (not ??): an explicit `session_id: null`
+    // override must survive — `null ?? 'sess-1'` would wrongly coerce to 'sess-1'.
+    session_id: 'session_id' in overrides ? (overrides.session_id as string | null) : 'sess-1',
+    created_at: overrides.created_at ?? CREATED_AT,
     synced: overrides.synced ?? false,
   };
+}
+
+/** Returns the upsert mock fn from the most recent supabase.from() call. */
+function lastUpsert(): jest.Mock {
+  const fromMock = supabase.from as jest.Mock;
+  const chain = fromMock.mock.results[fromMock.mock.results.length - 1].value;
+  return chain.upsert as jest.Mock;
 }
 
 // ============================================================================
@@ -118,23 +156,27 @@ describe('Offline Sync Service', () => {
     jest.clearAllMocks();
 
     // Reset mutable mock state
-    mockInsertError = null;
+    mockUpsertError = null;
     mockAuthUser = { id: 'test-user-id' };
     mockAuthError = null;
+    mockRelayThrows = false;
     mockGetPendingCommands.mockReset();
     mockGetPendingCommands.mockResolvedValue([]);
     mockMarkSynced.mockReset();
     mockMarkSynced.mockResolvedValue(undefined);
     mockClearSynced.mockReset();
     mockClearSynced.mockResolvedValue(0);
+    mockConnect.mockResolvedValue(undefined);
+    mockSendChat.mockResolvedValue(undefined);
+    mockDisconnect.mockResolvedValue(undefined);
 
     // Restore supabase.from to use the factory mock (may have been overridden)
     (supabase.from as jest.Mock).mockImplementation(() => {
       const chain: Record<string, unknown> = {
-        insert: jest.fn().mockReturnThis(),
+        upsert: jest.fn().mockReturnThis(),
       };
       chain.then = (resolve: (v: unknown) => void) =>
-        Promise.resolve({ error: mockInsertError }).then(resolve);
+        Promise.resolve({ error: mockUpsertError }).then(resolve);
       return chain;
     });
     (supabase.auth.getUser as jest.Mock).mockImplementation(async () => ({
@@ -147,61 +189,138 @@ describe('Offline Sync Service', () => {
   });
 
   // ==========================================================================
-  // syncPendingCommands()
+  // syncPendingCommands() — upsert shape (mirrors web)
   // ==========================================================================
 
-  describe('syncPendingCommands()', () => {
-    it('returns 0 when no pending commands exist', async () => {
-      mockGetPendingCommands.mockResolvedValue([]);
+  describe('syncPendingCommands() — upsert', () => {
+    it('upserts with the REAL machine_id (not userId), session_id, id-dedup, and ms queue_order', async () => {
+      mockGetPendingCommands.mockResolvedValue([createStoredCommand({ id: 'c1' })]);
 
-      const result = await syncPendingCommands();
+      const count = await syncPendingCommands();
 
-      expect(result).toBe(0);
-      expect(mockGetPendingCommands).toHaveBeenCalled();
+      expect(count).toBe(1);
+      expect(supabase.from).toHaveBeenCalledWith('offline_command_queue');
+      const upsert = lastUpsert();
+      expect(upsert).toHaveBeenCalledTimes(1);
+      const [row, opts] = upsert.mock.calls[0];
+      expect(row).toMatchObject({
+        id: 'c1',
+        user_id: 'test-user-id',
+        machine_id: 'machine-xyz', // the FK fix — NOT 'test-user-id'
+        session_id: 'sess-1',
+        command_encrypted: JSON.stringify({ content: 'hi there', agent: 'claude' }),
+        encryption_nonce: 'pending',
+        queue_order: Date.parse(CREATED_AT), // 1.7e12 — only valid as BIGINT
+        status: 'pending',
+        created_at: CREATED_AT,
+      });
+      expect((row as { machine_id: string }).machine_id).not.toBe('test-user-id');
+      expect(opts).toEqual({ onConflict: 'id', ignoreDuplicates: true });
+      expect(mockMarkSynced).toHaveBeenCalledWith('c1');
+      expect(mockClearSynced).toHaveBeenCalled();
     });
 
-    it('returns 0 when no authenticated user', async () => {
+    it('carries a null session_id through to the upsert', async () => {
+      mockGetPendingCommands.mockResolvedValue([
+        createStoredCommand({ id: 'c-null', session_id: null }),
+      ]);
+
+      await syncPendingCommands();
+
+      const [row] = lastUpsert().mock.calls[0];
+      expect((row as { session_id: string | null }).session_id).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // syncPendingCommands() — relay delivery (mirrors web)
+  // ==========================================================================
+
+  describe('syncPendingCommands() — delivery', () => {
+    it('delivers chat commands over the relay (connect → sendChat → disconnect)', async () => {
+      mockGetPendingCommands.mockResolvedValue([createStoredCommand()]);
+
+      await syncPendingCommands();
+
+      expect(mockConnect).toHaveBeenCalled();
+      expect(mockSendChat).toHaveBeenCalledWith('hi there', 'claude', 'sess-1');
+      expect(mockDisconnect).toHaveBeenCalled();
+    });
+
+    it('does NOT deliver non-chat commands over the relay (but still persists them)', async () => {
+      mockGetPendingCommands.mockResolvedValue([
+        createStoredCommand({
+          id: 'c2',
+          command_type: 'cancel',
+          payload: JSON.stringify({ session_id: 'sess-1' }),
+        }),
+      ]);
+
+      const count = await syncPendingCommands();
+
+      expect(count).toBe(1);
+      expect(lastUpsert()).toHaveBeenCalledTimes(1);
+      expect(mockSendChat).not.toHaveBeenCalled();
+    });
+
+    it('still persists commands when the delivery relay is unavailable (best-effort)', async () => {
+      mockRelayThrows = true;
+      mockGetPendingCommands.mockResolvedValue([createStoredCommand({ id: 'c1' })]);
+
+      const count = await syncPendingCommands();
+
+      expect(count).toBe(1);
+      expect(lastUpsert()).toHaveBeenCalledTimes(1);
+      expect(mockSendChat).not.toHaveBeenCalled();
+      expect(mockMarkSynced).toHaveBeenCalledWith('c1');
+    });
+  });
+
+  // ==========================================================================
+  // syncPendingCommands() — auth + empty (mirrors web)
+  // ==========================================================================
+
+  describe('syncPendingCommands() — guards', () => {
+    it('returns 0 and does nothing when there are no pending commands', async () => {
+      mockGetPendingCommands.mockResolvedValue([]);
+
+      const count = await syncPendingCommands();
+
+      expect(count).toBe(0);
+      expect(supabase.from).not.toHaveBeenCalled();
+    });
+
+    it('defers (returns 0) when there is no authenticated user', async () => {
       mockAuthUser = null;
       mockGetPendingCommands.mockResolvedValue([createStoredCommand()]);
 
-      const result = await syncPendingCommands();
+      const count = await syncPendingCommands();
 
-      expect(result).toBe(0);
-      expect(supabase.auth.getUser).toHaveBeenCalled();
+      expect(count).toBe(0);
+      expect(supabase.from).not.toHaveBeenCalled();
     });
 
     it('returns 0 when auth returns an error', async () => {
       mockAuthError = { message: 'Auth session expired' };
       mockGetPendingCommands.mockResolvedValue([createStoredCommand()]);
 
-      const result = await syncPendingCommands();
+      const count = await syncPendingCommands();
 
-      expect(result).toBe(0);
+      expect(count).toBe(0);
     });
+  });
 
-    it('syncs a single pending command to Supabase', async () => {
-      const command = createStoredCommand({
-        id: 'cmd_single',
-        command_type: 'chat',
-        payload: '{"content":"hello"}',
-        created_at: '2026-03-15T10:00:00.000Z',
-      });
-      mockGetPendingCommands.mockResolvedValue([command]);
+  // ==========================================================================
+  // syncPendingCommands() — multi-command + partial failure
+  // ==========================================================================
 
-      const result = await syncPendingCommands();
-
-      expect(result).toBe(1);
-      expect(supabase.from).toHaveBeenCalledWith('offline_command_queue');
-      expect(mockMarkSynced).toHaveBeenCalledWith('cmd_single');
-    });
-
+  describe('syncPendingCommands() — batch behavior', () => {
     it('syncs multiple pending commands', async () => {
-      const commands = [
+      mockGetPendingCommands.mockResolvedValue([
         createStoredCommand({ id: 'cmd_1' }),
         createStoredCommand({ id: 'cmd_2' }),
         createStoredCommand({ id: 'cmd_3' }),
-      ];
-      mockGetPendingCommands.mockResolvedValue(commands);
+      ]);
 
       const result = await syncPendingCommands();
 
@@ -212,132 +331,79 @@ describe('Offline Sync Service', () => {
       expect(mockMarkSynced).toHaveBeenCalledWith('cmd_3');
     });
 
-    it('calls clearSynced after successful sync', async () => {
-      mockGetPendingCommands.mockResolvedValue([createStoredCommand()]);
-
-      await syncPendingCommands();
-
-      expect(mockClearSynced).toHaveBeenCalled();
-    });
-
-    it('does not call clearSynced when no commands were synced', async () => {
-      mockGetPendingCommands.mockResolvedValue([]);
-
-      await syncPendingCommands();
-
-      expect(mockClearSynced).not.toHaveBeenCalled();
-    });
-
-    it('inserts with correct Supabase schema fields', async () => {
-      const command = createStoredCommand({
-        id: 'cmd_schema',
-        payload: '{"action":"test"}',
-        created_at: '2026-03-15T12:00:00.000Z',
-      });
-      mockGetPendingCommands.mockResolvedValue([command]);
-
-      await syncPendingCommands();
-
-      // Verify from() was called with the correct table
-      expect(supabase.from).toHaveBeenCalledWith('offline_command_queue');
-
-      // Verify insert was called (via the chain mock)
-      const fromMock = supabase.from as jest.Mock;
-      const chain = fromMock.mock.results[0].value;
-      expect(chain.insert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          user_id: 'test-user-id',
-          machine_id: 'test-user-id',
-          command_encrypted: '{"action":"test"}',
-          encryption_nonce: 'pending',
-          status: 'pending',
-          created_at: '2026-03-15T12:00:00.000Z',
-        })
-      );
-    });
-
-    it('uses Date.parse for queue_order field', async () => {
-      const timestamp = '2026-03-15T12:00:00.000Z';
-      const command = createStoredCommand({ created_at: timestamp });
-      mockGetPendingCommands.mockResolvedValue([command]);
-
-      await syncPendingCommands();
-
-      const fromMock = supabase.from as jest.Mock;
-      const chain = fromMock.mock.results[0].value;
-      expect(chain.insert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          queue_order: Date.parse(timestamp),
-        })
-      );
-    });
-
-    it('continues syncing remaining commands when one fails', async () => {
-      const commands = [
+    it('continues syncing remaining commands when one upsert fails', async () => {
+      mockGetPendingCommands.mockResolvedValue([
         createStoredCommand({ id: 'cmd_ok_1' }),
         createStoredCommand({ id: 'cmd_fail' }),
         createStoredCommand({ id: 'cmd_ok_2' }),
-      ];
-      mockGetPendingCommands.mockResolvedValue(commands);
+      ]);
 
-      // Make the second insert fail
+      // Make the second upsert fail
       let callCount = 0;
       (supabase.from as jest.Mock).mockImplementation(() => {
         callCount++;
         const chain: Record<string, unknown> = {
-          insert: jest.fn().mockReturnThis(),
+          upsert: jest.fn().mockReturnThis(),
         };
-        if (callCount === 2) {
-          chain.then = (resolve: (v: unknown) => void) =>
-            Promise.resolve({ error: { message: 'Duplicate key' } }).then(resolve);
-        } else {
-          chain.then = (resolve: (v: unknown) => void) =>
-            Promise.resolve({ error: null }).then(resolve);
-        }
+        const error = callCount === 2 ? { message: 'Duplicate key' } : null;
+        chain.then = (resolve: (v: unknown) => void) =>
+          Promise.resolve({ error }).then(resolve);
         return chain;
       });
 
       const result = await syncPendingCommands();
 
-      // 2 succeeded, 1 failed
       expect(result).toBe(2);
       expect(mockMarkSynced).toHaveBeenCalledWith('cmd_ok_1');
       expect(mockMarkSynced).not.toHaveBeenCalledWith('cmd_fail');
       expect(mockMarkSynced).toHaveBeenCalledWith('cmd_ok_2');
     });
 
-    it('handles Supabase insert error by throwing inside syncSingleCommand', async () => {
-      mockInsertError = { message: 'Table not found' };
-      mockGetPendingCommands.mockResolvedValue([createStoredCommand({ id: 'cmd_err' })]);
+    it('does not call clearSynced when every command fails to upsert', async () => {
+      mockGetPendingCommands.mockResolvedValue([
+        createStoredCommand({ id: 'f1' }),
+        createStoredCommand({ id: 'f2' }),
+      ]);
+      mockUpsertError = { message: 'Constraint violation' };
 
       const result = await syncPendingCommands();
 
-      // Should not crash, just skip the failed command
       expect(result).toBe(0);
       expect(mockMarkSynced).not.toHaveBeenCalled();
+      expect(mockClearSynced).not.toHaveBeenCalled();
     });
 
+    it('disconnects the relay even when upserts fail', async () => {
+      mockGetPendingCommands.mockResolvedValue([createStoredCommand({ id: 'f1' })]);
+      mockUpsertError = { message: 'boom' };
+
+      await syncPendingCommands();
+
+      expect(mockDisconnect).toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // syncPendingCommands() — concurrency + error resilience
+  // ==========================================================================
+
+  describe('syncPendingCommands() — resilience', () => {
     it('prevents concurrent sync calls (isSyncing guard)', async () => {
-      // WHY: The module-level isSyncing flag prevents double-syncing.
-      // We test this by making getPendingCommands slow enough to trigger overlap.
       let resolveFirst: (() => void) | null = null;
       const slowPending = new Promise<StoredCommand[]>((resolve) => {
         resolveFirst = () => resolve([createStoredCommand({ id: 'slow' })]);
       });
 
-      mockGetPendingCommands.mockReturnValueOnce(slowPending as unknown as ReturnType<typeof mockGetPendingCommands>);
+      mockGetPendingCommands.mockReturnValueOnce(
+        slowPending as unknown as ReturnType<typeof mockGetPendingCommands>
+      );
 
-      // Start first sync (will block on getPendingCommands)
       const sync1 = syncPendingCommands();
-
-      // Start second sync immediately — should be skipped
       const sync2 = syncPendingCommands();
 
-      // Second call should return 0 immediately because isSyncing is true
       const result2 = await sync2;
       expect(result2).toBe(0);
 
-      // Now resolve the first sync
       resolveFirst!();
       const result1 = await sync1;
       expect(result1).toBe(1);
@@ -349,12 +415,9 @@ describe('Offline Sync Service', () => {
       const result = await syncPendingCommands();
       expect(result).toBe(0);
 
-      // Should be able to sync again (isSyncing was reset)
       mockGetPendingCommands.mockResolvedValue([]);
       const result2 = await syncPendingCommands();
       expect(result2).toBe(0);
-      // If isSyncing was still true, the second call would return 0
-      // without calling getPendingCommands. Verify it was called.
       expect(mockGetPendingCommands).toHaveBeenCalledTimes(2);
     });
   });
@@ -381,7 +444,6 @@ describe('Offline Sync Service', () => {
 
       startConnectivityListener();
 
-      // Wait for the async initial sync to complete
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(mockGetPendingCommands).toHaveBeenCalled();
@@ -391,7 +453,6 @@ describe('Offline Sync Service', () => {
       startConnectivityListener();
       startConnectivityListener();
 
-      // addEventListener should only have been called once (no duplicate listener)
       expect(NetInfo.addEventListener).toHaveBeenCalledTimes(1);
     });
 
@@ -400,21 +461,14 @@ describe('Offline Sync Service', () => {
 
       startConnectivityListener();
 
-      // Get the callback registered with NetInfo
       const addListenerMock = NetInfo.addEventListener as jest.Mock;
       const callback = addListenerMock.mock.calls[0][0];
 
-      // Simulate offline state
       callback({ isConnected: false, isInternetReachable: false });
-
-      // Wait for any async operations
       await new Promise<void>((resolve) => setImmediate(resolve));
       jest.clearAllMocks();
 
-      // Simulate coming back online
       callback({ isConnected: true, isInternetReachable: true });
-
-      // Wait for sync to be triggered
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(mockGetPendingCommands).toHaveBeenCalled();
@@ -423,40 +477,30 @@ describe('Offline Sync Service', () => {
     it('does not sync when remaining online (no transition)', async () => {
       mockGetPendingCommands.mockResolvedValue([]);
 
-      // Capture the callback before starting
       const addListenerMock = NetInfo.addEventListener as jest.Mock;
       startConnectivityListener();
       const callback = addListenerMock.mock.calls[0][0];
 
-      // Wait for initial sync
       await new Promise<void>((resolve) => setImmediate(resolve));
       jest.clearAllMocks();
 
-      // Simulate staying online
       callback({ isConnected: true, isInternetReachable: true });
-
-      // Wait for any async ops
       await new Promise<void>((resolve) => setImmediate(resolve));
 
-      // No sync should have been triggered (wasConnected was true)
       expect(mockGetPendingCommands).not.toHaveBeenCalled();
     });
 
     it('does not sync when going offline', async () => {
       mockGetPendingCommands.mockResolvedValue([]);
 
-      // Capture the callback before starting
       const addListenerMock = NetInfo.addEventListener as jest.Mock;
       startConnectivityListener();
       const callback = addListenerMock.mock.calls[0][0];
 
-      // Wait for initial sync
       await new Promise<void>((resolve) => setImmediate(resolve));
       jest.clearAllMocks();
 
-      // Go offline
       callback({ isConnected: false, isInternetReachable: false });
-
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(mockGetPendingCommands).not.toHaveBeenCalled();
@@ -469,18 +513,13 @@ describe('Offline Sync Service', () => {
       startConnectivityListener();
       const callback = addListenerMock.mock.calls[0][0];
 
-      // Go offline first
       callback({ isConnected: false, isInternetReachable: false });
-
       await new Promise<void>((resolve) => setImmediate(resolve));
       jest.clearAllMocks();
 
-      // Come back with isInternetReachable = null (common on Android)
       callback({ isConnected: true, isInternetReachable: null });
-
       await new Promise<void>((resolve) => setImmediate(resolve));
 
-      // Should have triggered sync because isInternetReachable !== false
       expect(mockGetPendingCommands).toHaveBeenCalled();
     });
   });
@@ -513,8 +552,6 @@ describe('Offline Sync Service', () => {
 
       startConnectivityListener();
       stopConnectivityListener();
-
-      // Should be able to start a new listener
       startConnectivityListener();
 
       expect(NetInfo.addEventListener).toHaveBeenCalledTimes(2);
@@ -528,151 +565,6 @@ describe('Offline Sync Service', () => {
       unsub();
 
       expect(mockUnsub).toHaveBeenCalled();
-    });
-  });
-
-  // ==========================================================================
-  // Logger (dev-only)
-  // ==========================================================================
-
-  describe('logger behavior', () => {
-    it('logs sync activity in __DEV__ mode', async () => {
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-      mockGetPendingCommands.mockResolvedValue([]);
-
-      await syncPendingCommands();
-
-      // In __DEV__ mode, should log "No pending commands to sync"
-      expect(consoleSpy).toHaveBeenCalledWith(
-        '[OfflineSync]',
-        'No pending commands to sync'
-      );
-
-      consoleSpy.mockRestore();
-    });
-
-    it('logs warning when no authenticated user', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      mockAuthUser = null;
-      mockGetPendingCommands.mockResolvedValue([createStoredCommand()]);
-
-      await syncPendingCommands();
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[OfflineSync]',
-        'No authenticated user, deferring sync'
-      );
-
-      warnSpy.mockRestore();
-    });
-
-    it('logs error when sync fails', async () => {
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      mockGetPendingCommands.mockRejectedValueOnce(new Error('SQLite error'));
-
-      await syncPendingCommands();
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        '[OfflineSync]',
-        'Sync failed:',
-        expect.any(Error)
-      );
-
-      errorSpy.mockRestore();
-    });
-  });
-
-  // ==========================================================================
-  // Edge Cases
-  // ==========================================================================
-
-  describe('edge cases', () => {
-    it('handles empty pending array gracefully', async () => {
-      mockGetPendingCommands.mockResolvedValue([]);
-
-      const result = await syncPendingCommands();
-
-      expect(result).toBe(0);
-      expect(supabase.from).not.toHaveBeenCalled();
-      expect(mockClearSynced).not.toHaveBeenCalled();
-    });
-
-    it('handles all commands failing without crashing', async () => {
-      const commands = [
-        createStoredCommand({ id: 'fail_1' }),
-        createStoredCommand({ id: 'fail_2' }),
-      ];
-      mockGetPendingCommands.mockResolvedValue(commands);
-      mockInsertError = { message: 'All fail' };
-
-      const result = await syncPendingCommands();
-
-      expect(result).toBe(0);
-      expect(mockMarkSynced).not.toHaveBeenCalled();
-      expect(mockClearSynced).not.toHaveBeenCalled();
-    });
-
-    it('uses user_id as machine_id fallback for the insert', async () => {
-      const command = createStoredCommand();
-      mockGetPendingCommands.mockResolvedValue([command]);
-
-      await syncPendingCommands();
-
-      const fromMock = supabase.from as jest.Mock;
-      const chain = fromMock.mock.results[0].value;
-      expect(chain.insert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          machine_id: 'test-user-id',
-        })
-      );
-    });
-  });
-
-  // ==========================================================================
-  // GAP-FILL: additional uncovered branches
-  // ==========================================================================
-
-  describe('syncPendingCommands() — clearSynced not called when all inserts fail', () => {
-    it('does not call clearSynced when every command fails to insert', async () => {
-      mockGetPendingCommands.mockResolvedValueOnce([
-        createStoredCommand({ id: 'gap_f1' }),
-        createStoredCommand({ id: 'gap_f2' }),
-      ]);
-
-      // All Supabase inserts return an error
-      (supabase.from as jest.Mock).mockImplementation(() => {
-        const chain: Record<string, unknown> = {
-          insert: jest.fn().mockReturnThis(),
-        };
-        chain.then = (resolve: (v: unknown) => void) =>
-          Promise.resolve({ error: { message: 'Constraint violation' } }).then(resolve);
-        return chain;
-      });
-
-      const result = await syncPendingCommands();
-
-      expect(result).toBe(0);
-      expect(mockClearSynced).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('syncPendingCommands() — null user with null error defers sync', () => {
-    it('returns 0 when auth.getUser returns null user and null error', async () => {
-      // WHY: If the session is missing but no error is returned (e.g. anonymous
-      // or expired session), we should still defer sync rather than crash.
-      mockGetPendingCommands.mockResolvedValueOnce([
-        createStoredCommand({ id: 'gap_nouser' }),
-      ]);
-
-      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
-        data: { user: null },
-        error: null,
-      });
-
-      const result = await syncPendingCommands();
-
-      expect(result).toBe(0);
-      expect(supabase.from).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/styrby-mobile/src/services/offline-storage.ts
+++ b/packages/styrby-mobile/src/services/offline-storage.ts
@@ -25,12 +25,20 @@ import * as SQLite from 'expo-sqlite';
  * Mirrors the columns in the `offline_command_queue` table.
  */
 export interface StoredCommand {
-  /** Unique command ID (UUID) */
+  /** Unique command ID (UUID) — also used as the server queue PK for dedup */
   id: string;
   /** The type of command (e.g., 'chat', 'permission_response', 'cancel') */
   command_type: string;
   /** JSON-serialized command payload */
   payload: string;
+  /**
+   * The CLI machine this command targets. REQUIRED: `offline_command_queue`
+   * has `machine_id UUID NOT NULL REFERENCES machines(id)`, so this must be a
+   * real machine id (NOT the user id — that was the FK-violation bug).
+   */
+  machine_id: string;
+  /** The session this command belongs to, or null for session-less commands. */
+  session_id: string | null;
   /** ISO 8601 timestamp when the command was created */
   created_at: string;
   /** Whether this command has been synced to Supabase */
@@ -48,6 +56,10 @@ export interface SaveCommandInput {
   command_type: string;
   /** The command payload (will be JSON-stringified) */
   payload: Record<string, unknown>;
+  /** Target CLI machine id (required — FK to machines on the server queue). */
+  machine_id: string;
+  /** Owning session id, or null. */
+  session_id?: string | null;
   /** Optional custom timestamp; defaults to now */
   created_at?: string;
 }
@@ -75,11 +87,14 @@ async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
 
   db = await SQLite.openDatabaseAsync(DB_NAME);
 
+  // Fresh installs get machine_id + session_id from the CREATE TABLE below.
   await db.execAsync(`
     CREATE TABLE IF NOT EXISTS offline_storage (
       id TEXT PRIMARY KEY,
       command_type TEXT NOT NULL,
       payload TEXT NOT NULL,
+      machine_id TEXT,
+      session_id TEXT,
       created_at TEXT NOT NULL,
       synced INTEGER NOT NULL DEFAULT 0
     );
@@ -92,7 +107,37 @@ async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
       ON offline_storage(created_at ASC);
   `);
 
+  // WHY idempotent ALTER: tables created before the offline-sync parity work
+  // (web PR-B mirror) lack the machine_id/session_id columns. SQLite's
+  // `ALTER TABLE ... ADD COLUMN` is not `IF NOT EXISTS`-aware and THROWS
+  // ("duplicate column name") if the column already exists, so we inspect the
+  // current schema via PRAGMA table_info and only add the missing columns.
+  // CREATE TABLE IF NOT EXISTS alone does not migrate an existing table.
+  await migrateAddColumns(db);
+
   return db;
+}
+
+/**
+ * Adds the `machine_id` / `session_id` columns to a pre-existing
+ * `offline_storage` table that was created before the offline-sync parity
+ * migration. Idempotent: inspects the live schema first and skips columns that
+ * already exist (fresh installs already have both via CREATE TABLE).
+ *
+ * @param database - The open SQLite database to migrate.
+ */
+async function migrateAddColumns(database: SQLite.SQLiteDatabase): Promise<void> {
+  const columns = await database.getAllAsync<{ name: string }>(
+    `PRAGMA table_info(offline_storage)`
+  );
+  const existing = new Set(columns.map((c) => c.name));
+
+  if (!existing.has('machine_id')) {
+    await database.execAsync(`ALTER TABLE offline_storage ADD COLUMN machine_id TEXT`);
+  }
+  if (!existing.has('session_id')) {
+    await database.execAsync(`ALTER TABLE offline_storage ADD COLUMN session_id TEXT`);
+  }
 }
 
 // ============================================================================
@@ -109,6 +154,8 @@ async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
  * await saveCommand({
  *   command_type: 'chat',
  *   payload: { content: 'Hello', agent: 'claude' },
+ *   machine_id: pairingInfo.machineId,
+ *   session_id: sessionId,
  * });
  */
 export async function saveCommand(command: SaveCommandInput): Promise<StoredCommand> {
@@ -118,14 +165,24 @@ export async function saveCommand(command: SaveCommandInput): Promise<StoredComm
     id: command.id ?? crypto.randomUUID(),
     command_type: command.command_type,
     payload: JSON.stringify(command.payload),
+    machine_id: command.machine_id,
+    session_id: command.session_id ?? null,
     created_at: command.created_at ?? new Date().toISOString(),
     synced: false,
   };
 
   await database.runAsync(
-    `INSERT INTO offline_storage (id, command_type, payload, created_at, synced)
-     VALUES (?, ?, ?, ?, ?)`,
-    [stored.id, stored.command_type, stored.payload, stored.created_at, 0]
+    `INSERT INTO offline_storage (id, command_type, payload, machine_id, session_id, created_at, synced)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      stored.id,
+      stored.command_type,
+      stored.payload,
+      stored.machine_id,
+      stored.session_id,
+      stored.created_at,
+      0,
+    ]
   );
 
   return stored;
@@ -208,6 +265,8 @@ function rowToStoredCommand(row: Record<string, unknown>): StoredCommand {
     id: row.id as string,
     command_type: row.command_type as string,
     payload: row.payload as string,
+    machine_id: row.machine_id as string,
+    session_id: (row.session_id as string | null) ?? null,
     created_at: row.created_at as string,
     synced: (row.synced as number) === 1,
   };

--- a/packages/styrby-mobile/src/services/offline-sync.ts
+++ b/packages/styrby-mobile/src/services/offline-sync.ts
@@ -14,6 +14,8 @@
  */
 
 import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
+import * as SecureStore from 'expo-secure-store';
+import { createRelayClient, type RelayClient, type AgentType } from 'styrby-shared';
 import { supabase } from '../lib/supabase';
 import {
   getPendingCommands,
@@ -21,6 +23,16 @@ import {
   clearSynced,
   type StoredCommand,
 } from './offline-storage';
+
+/**
+ * SecureStore key holding this device's stable relay identifier.
+ * WHY duplicated here (not imported from useRelay): `useRelay` does not export
+ * its STORAGE_KEYS map or getOrCreateDeviceId helper, and importing the hook
+ * module from a non-React service would pull React Native UI deps into the
+ * sync service. We read the same key directly so the offline-sync relay reuses
+ * the device id the live relay already persisted (no duplicate presence entry).
+ */
+const DEVICE_ID_KEY = 'styrby_device_id';
 
 // ============================================================================
 // Dev-Only Logger
@@ -89,17 +101,31 @@ export async function syncPendingCommands(): Promise<number> {
       return 0;
     }
 
-    for (const command of pending) {
-      try {
-        await syncSingleCommand(command, user.id);
-        await markSynced(command.id);
-        syncedCount++;
-      } catch (error) {
-        // WHY: We log and continue rather than throwing. A single failed
-        // insert (e.g., duplicate key, schema mismatch) should not prevent
-        // the rest of the queue from syncing.
-        logger.error(`Failed to sync command ${command.id}:`, error);
+    // Open a transient relay connection to DELIVER queued chats now that we're
+    // back online. Best-effort: if the relay can't connect, commands are still
+    // persisted to the audit queue below (delivery just doesn't happen this
+    // pass). The CLI session may also have ended — then the broadcast reaches
+    // no listener, which is acceptable (the command is still recorded).
+    const relay = await openDeliveryRelay(user.id);
+
+    try {
+      for (const command of pending) {
+        try {
+          // 1. Persist to the server queue (audit + cross-device record).
+          await syncSingleCommand(command, user.id);
+          // 2. Deliver chats to the agent over the relay (best-effort).
+          await deliverCommand(relay, command);
+          await markSynced(command.id);
+          syncedCount++;
+        } catch (error) {
+          // WHY: We log and continue rather than throwing. A single failed
+          // upsert (e.g., schema mismatch) should not prevent the rest of the
+          // queue from syncing.
+          logger.error(`Failed to sync command ${command.id}:`, error);
+        }
       }
+    } finally {
+      if (relay) await relay.disconnect().catch(() => { /* best-effort teardown */ });
     }
 
     // Clean up synced records from local storage
@@ -117,38 +143,113 @@ export async function syncPendingCommands(): Promise<number> {
 }
 
 /**
- * Inserts a single command into the Supabase `offline_command_queue` table.
+ * Upserts a single command into the Supabase `offline_command_queue` table.
  *
- * WHY the command is inserted with minimal encryption fields: The Supabase
- * schema requires `command_encrypted` and `encryption_nonce`. In a full
- * implementation these would use the machine key's TweetNaCl encryption.
- * For now we store the JSON payload as the "encrypted" value with a
- * placeholder nonce, since end-to-end encryption is handled at the relay
- * layer and these commands are already authenticated via RLS.
+ * Mirrors the web fix (2026-06-09 bug-hunt + 2026-06-10 delivery loop):
+ *  - machine_id is the command's REAL target machine (was `userId` → FK
+ *    violation against machines(id), so every sync failed).
+ *  - session_id is carried through (was omitted).
+ *  - queue_order = Date.parse(created_at) ms-epoch is now safe (migration 098
+ *    widened the column INTEGER → BIGINT; INT4 overflowed before).
+ *  - `upsert` on the `id` PK with ignoreDuplicates makes re-sync idempotent
+ *    (a markSynced failure or a double online event won't error or duplicate).
+ *
+ * WHY command_encrypted holds the JSON payload with a placeholder nonce: this
+ * row is the audit/cross-device record (RLS-protected, GDPR-exported); live
+ * E2E delivery happens over the relay (see deliverCommand). At-rest encryption
+ * of the queued command itself is a tracked follow-up.
  *
  * @param command - The locally stored command to sync
  * @param userId - The authenticated user's ID for the user_id column
- * @throws Error if the Supabase insert fails
+ * @throws Error if the Supabase upsert fails
  */
 async function syncSingleCommand(command: StoredCommand, userId: string): Promise<void> {
   const { error } = await supabase
     .from('offline_command_queue')
-    .insert({
-      user_id: userId,
-      // WHY machine_id uses a placeholder: The actual machine_id should come
-      // from the paired CLI instance. In a future iteration, the pairing
-      // service will provide this. For now we use the user_id as a fallback
-      // to satisfy the NOT NULL constraint.
-      machine_id: userId,
-      command_encrypted: command.payload,
-      encryption_nonce: 'pending',
-      queue_order: Date.parse(command.created_at),
-      status: 'pending',
-      created_at: command.created_at,
-    });
+    .upsert(
+      {
+        id: command.id,
+        user_id: userId,
+        machine_id: command.machine_id, // REAL machine, was userId = FK violation
+        session_id: command.session_id,
+        command_encrypted: command.payload,
+        encryption_nonce: 'pending',
+        queue_order: Date.parse(command.created_at), // BIGINT-safe via migration 098
+        status: 'pending',
+        created_at: command.created_at,
+      },
+      { onConflict: 'id', ignoreDuplicates: true }
+    );
 
   if (error) {
-    throw new Error(`Supabase insert failed: ${error.message}`);
+    throw new Error(`Supabase upsert failed: ${error.message}`);
+  }
+}
+
+/**
+ * Reads the device's stable relay identifier from SecureStore, falling back to
+ * a per-pass random id when none is persisted yet.
+ *
+ * @returns The device id (the live relay's `mobile_<uuid>` value when present).
+ */
+async function getDeviceId(): Promise<string> {
+  const stored = await SecureStore.getItemAsync(DEVICE_ID_KEY).catch(() => null);
+  return stored ?? `mobile_${crypto.randomUUID()}`;
+}
+
+/**
+ * Open a transient relay connection used to deliver queued commands on
+ * reconnect. Returns null when the relay can't be created/connected — delivery
+ * is best-effort, so the caller still persists commands to the audit queue.
+ *
+ * @param userId - The user's id (relay channel is `relay:{userId}`).
+ * @returns A connected RelayClient, or null if connection failed.
+ */
+async function openDeliveryRelay(userId: string): Promise<RelayClient | null> {
+  try {
+    const deviceId = await getDeviceId();
+    const relay = createRelayClient({
+      supabase,
+      userId,
+      deviceId,
+      deviceType: 'mobile',
+      deviceName: 'Mobile App (offline-sync)',
+      platform: 'mobile',
+    });
+    await relay.connect();
+    return relay;
+  } catch (error) {
+    logger.error(
+      'Delivery relay unavailable; commands persisted but not delivered this pass:',
+      error
+    );
+    return null;
+  }
+}
+
+/**
+ * Deliver a queued command to the agent over the relay (chat commands only).
+ *
+ * No-op when the relay is unavailable or the command isn't a deliverable chat.
+ * Never throws — delivery is best-effort and must not fail the sync (the command
+ * is already persisted to the audit queue by the caller).
+ *
+ * @param relay - The delivery relay (or null when unavailable).
+ * @param command - The queued command to deliver.
+ */
+async function deliverCommand(relay: RelayClient | null, command: StoredCommand): Promise<void> {
+  if (!relay || command.command_type !== 'chat') return;
+  try {
+    const payload = JSON.parse(command.payload) as { content?: string; agent?: string };
+    if (payload.content) {
+      await relay.sendChat(
+        payload.content,
+        (payload.agent as AgentType) ?? 'claude',
+        command.session_id ?? undefined
+      );
+    }
+  } catch (error) {
+    logger.error(`Failed to deliver command ${command.id} over relay:`, error);
   }
 }
 


### PR DESCRIPTION
## Summary
Mirrors web **PR-B (#341)** onto `styrby-mobile`. Mobile's offline-sync had the same latent bugs the bug-hunt found, and no producer fed the queue. Now: offline → queue locally (SQLite) → reconnect → deliver over relay + record in `offline_command_queue`.

## Latent bug fixes
- **FK violation:** `machine_id` uses the command's real target machine (was `userId`).
- **INT4 overflow:** `queue_order = Date.parse(created_at)` is BIGINT-safe (migration 098, already applied; shared with web).
- **Dedup:** `upsert` on `id` with `ignoreDuplicates`.
- **Missing fields:** `session_id` carried; `StoredCommand`/`SaveCommandInput`/`saveCommand` gain `machine_id`/`session_id`.

## The loop
- **offline-storage (SQLite):** new columns added to `CREATE TABLE` (fresh installs) + an idempotent `migrateAddColumns()` (`PRAGMA table_info` → `ALTER ADD COLUMN` only if missing — SQLite's ADD COLUMN isn't IF-NOT-EXISTS-aware).
- **Producer:** `useChatSend` enqueues a chat via `saveCommand` when offline (was an early-return); online path unchanged (plaintext relay, post-#342).
- **Delivery:** `syncPendingCommands` opens a transient relay (deviceType `mobile`, same `styrby_device_id` as the live relay) on reconnect and broadcasts each queued chat to the agent (best-effort) + records to the audit queue.

## Test Plan
- [x] typecheck + lint clean
- [x] Jest: offline-sync (real machine_id, dedup, ms queue_order, delivery, non-chat, relay-unavailable, no-pending, no-auth) + offline-storage (new columns) + useChatSend (offline-enqueue, no-machine error) — 75/75 targeted
- [x] Full mobile suite 1690 passed / 6 skipped (independently re-verified)
- [ ] CI passes

Implemented via a focused sub-agent, then diff-reviewed + gate re-verified by me.

🤖 Shipped via /gh-ship