### PR TITLE
feat(web,mobile): encrypt queued command payloads at rest

### DIFF
--- a/packages/styrby-mobile/src/services/__tests__/offline-sync.test.ts
+++ b/packages/styrby-mobile/src/services/__tests__/offline-sync.test.ts
@@ -39,6 +39,18 @@ jest.mock('../offline-storage', () => ({
 }));
 
 // ============================================================================
+// Mock the encryption service (at-rest payload encryption)
+// ============================================================================
+
+const mockEncryptMessage = jest.fn<Promise<{ encrypted: string; nonce: string }>, unknown[]>(
+  async () => ({ encrypted: 'CIPHERTEXT', nonce: 'NONCE' }),
+);
+
+jest.mock('../encryption', () => ({
+  encryptMessage: (...args: unknown[]) => mockEncryptMessage(...(args as [])),
+}));
+
+// ============================================================================
 // Mock styrby-shared (relay delivery)
 // ============================================================================
 
@@ -208,16 +220,31 @@ describe('Offline Sync Service', () => {
         user_id: 'test-user-id',
         machine_id: 'machine-xyz', // the FK fix — NOT 'test-user-id'
         session_id: 'sess-1',
-        command_encrypted: JSON.stringify({ content: 'hi there', agent: 'claude' }),
-        encryption_nonce: 'pending',
+        // payload encrypted at rest — NOT plaintext JSON, NOT a 'pending' nonce.
+        command_encrypted: 'CIPHERTEXT',
+        encryption_nonce: 'NONCE',
         queue_order: Date.parse(CREATED_AT), // 1.7e12 — only valid as BIGINT
         status: 'pending',
         created_at: CREATED_AT,
       });
+      expect(mockEncryptMessage).toHaveBeenCalledWith(expect.any(String), 'machine-xyz');
       expect((row as { machine_id: string }).machine_id).not.toBe('test-user-id');
       expect(opts).toEqual({ onConflict: 'id', ignoreDuplicates: true });
       expect(mockMarkSynced).toHaveBeenCalledWith('c1');
       expect(mockClearSynced).toHaveBeenCalled();
+    });
+
+    it('defers a command (no upsert, not marked synced) when encryption fails (CLI key unavailable)', async () => {
+      mockGetPendingCommands.mockResolvedValue([createStoredCommand({ id: 'c1' })]);
+      mockEncryptMessage.mockRejectedValueOnce(new Error('no key'));
+
+      const count = await syncPendingCommands();
+
+      expect(count).toBe(0);
+      // syncSingleCommand throws at encryptMessage before touching the DB, so
+      // the queue table is never reached — no plaintext (or anything) written.
+      expect(supabase.from).not.toHaveBeenCalled();
+      expect(mockMarkSynced).not.toHaveBeenCalled();
     });
 
     it('carries a null session_id through to the upsert', async () => {

--- a/packages/styrby-mobile/src/services/offline-sync.ts
+++ b/packages/styrby-mobile/src/services/offline-sync.ts
@@ -17,6 +17,7 @@ import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
 import * as SecureStore from 'expo-secure-store';
 import { createRelayClient, type RelayClient, type AgentType } from 'styrby-shared';
 import { supabase } from '../lib/supabase';
+import { encryptMessage } from './encryption';
 import {
   getPendingCommands,
   markSynced,
@@ -154,16 +155,20 @@ export async function syncPendingCommands(): Promise<number> {
  *  - `upsert` on the `id` PK with ignoreDuplicates makes re-sync idempotent
  *    (a markSynced failure or a double online event won't error or duplicate).
  *
- * WHY command_encrypted holds the JSON payload with a placeholder nonce: this
- * row is the audit/cross-device record (RLS-protected, GDPR-exported); live
- * E2E delivery happens over the relay (see deliverCommand). At-rest encryption
- * of the queued command itself is a tracked follow-up.
+ * Encrypts the command payload at rest (NaCl box to the target machine, same as
+ * session message E2E) so the DB holds ciphertext, not plaintext JSON — the row
+ * is owner-readable (RLS) + GDPR-exported. If the CLI's public key isn't
+ * available, encryptMessage throws and the per-command catch in
+ * syncPendingCommands leaves this command pending to retry next sync (no
+ * plaintext is ever written). Live delivery is separate (see deliverCommand).
  *
  * @param command - The locally stored command to sync
  * @param userId - The authenticated user's ID for the user_id column
- * @throws Error if the Supabase upsert fails
+ * @throws Error if encryption fails (CLI key unavailable) or the upsert fails
  */
 async function syncSingleCommand(command: StoredCommand, userId: string): Promise<void> {
+  const enc = await encryptMessage(command.payload, command.machine_id);
+
   const { error } = await supabase
     .from('offline_command_queue')
     .upsert(
@@ -172,8 +177,8 @@ async function syncSingleCommand(command: StoredCommand, userId: string): Promis
         user_id: userId,
         machine_id: command.machine_id, // REAL machine, was userId = FK violation
         session_id: command.session_id,
-        command_encrypted: command.payload,
-        encryption_nonce: 'pending',
+        command_encrypted: enc.encrypted,
+        encryption_nonce: enc.nonce,
         queue_order: Date.parse(command.created_at), // BIGINT-safe via migration 098
         status: 'pending',
         created_at: command.created_at,

--- a/packages/styrby-web/src/lib/__tests__/offline-sync.test.ts
+++ b/packages/styrby-web/src/lib/__tests__/offline-sync.test.ts
@@ -43,6 +43,15 @@ const h = vi.hoisted(() => ({
   pending: [] as Array<Record<string, unknown>>,
   markSynced: vi.fn(async (_id: string) => {}),
   clearSynced: vi.fn(async () => 0),
+  encryptForSession: vi.fn(
+    async (
+      _payload: string,
+      _machineId: string,
+    ): Promise<{ content_encrypted: string; encryption_nonce: string } | null> => ({
+      content_encrypted: 'CIPHERTEXT',
+      encryption_nonce: 'NONCE',
+    }),
+  ),
 }));
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -50,6 +59,9 @@ vi.mock('@/lib/supabase/client', () => ({
     from: () => ({ upsert: h.upsert }),
     auth: { getUser: h.getUser },
   }),
+}));
+vi.mock('../encryption', () => ({
+  encryptForSession: (payload: string, machineId: string) => h.encryptForSession(payload, machineId),
 }));
 vi.mock('@styrby/shared/relay', () => ({
   createRelayClient: () => {
@@ -87,6 +99,7 @@ beforeEach(() => {
   h.upsert.mockResolvedValue({ error: null });
   h.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
   h.clearSynced.mockResolvedValue(0);
+  h.encryptForSession.mockResolvedValue({ content_encrypted: 'CIPHERTEXT', encryption_nonce: 'NONCE' });
 });
 
 describe('syncPendingCommands', () => {
@@ -105,11 +118,26 @@ describe('syncPendingCommands', () => {
       session_id: 'sess-1',
       queue_order: Date.parse(CREATED_AT), // 1.7e12 — only valid as BIGINT
       status: 'pending',
+      // payload is encrypted at rest — NOT plaintext, NOT a 'pending' nonce.
+      command_encrypted: 'CIPHERTEXT',
+      encryption_nonce: 'NONCE',
     });
+    expect(h.encryptForSession).toHaveBeenCalledWith(expect.any(String), 'machine-xyz');
     expect((row as { machine_id: string }).machine_id).not.toBe('user-1');
     expect(opts).toEqual({ onConflict: 'id', ignoreDuplicates: true });
     expect(h.markSynced).toHaveBeenCalledWith('c1');
     expect(h.clearSynced).toHaveBeenCalled();
+  });
+
+  it('defers a command (no upsert, not marked synced) when the CLI key is unavailable', async () => {
+    h.encryptForSession.mockResolvedValue(null); // can't encrypt → never write plaintext
+    h.pending = [chatCommand()];
+
+    const count = await syncPendingCommands();
+
+    expect(count).toBe(0);
+    expect(h.upsert).not.toHaveBeenCalled();
+    expect(h.markSynced).not.toHaveBeenCalled();
   });
 
   it('delivers chat commands over the relay (connect → sendChat → disconnect)', async () => {

--- a/packages/styrby-web/src/lib/offline-sync.ts
+++ b/packages/styrby-web/src/lib/offline-sync.ts
@@ -17,6 +17,7 @@
 import { createRelayClient, type RelayClient } from '@styrby/shared/relay';
 import type { AgentType } from '@styrby/shared';
 import { createClient } from '@/lib/supabase/client';
+import { encryptForSession } from './encryption';
 import {
   getPendingCommands,
   markSynced,
@@ -145,6 +146,16 @@ async function syncSingleCommand(
   userId: string,
   supabase: ReturnType<typeof createClient>
 ): Promise<void> {
+  // Encrypt the command payload at rest (NaCl box to the target machine, same
+  // as session message E2E). The DB then holds ciphertext, not plaintext JSON —
+  // offline_command_queue is owner-readable (RLS) + GDPR-exported. If the CLI's
+  // public key isn't available yet we cannot encrypt: throw so this command
+  // stays pending and retries on the next sync (no plaintext is ever written).
+  const enc = await encryptForSession(command.payload, command.machine_id);
+  if (!enc) {
+    throw new Error(`No encryption key for machine ${command.machine_id}; deferring command ${command.id}`);
+  }
+
   const { error } = await supabase
     .from('offline_command_queue')
     .upsert(
@@ -153,8 +164,8 @@ async function syncSingleCommand(
         user_id: userId,
         machine_id: command.machine_id,
         session_id: command.session_id,
-        command_encrypted: command.payload,
-        encryption_nonce: 'pending',
+        command_encrypted: enc.content_encrypted,
+        encryption_nonce: enc.encryption_nonce,
         queue_order: Date.parse(command.created_at),
         status: 'pending',
         created_at: command.created_at,


### PR DESCRIPTION
## Summary
`offline_command_queue.command_encrypted` held the **plaintext JSON payload** with a placeholder `'pending'` nonce on both web and mobile. That table is owner-readable (RLS) + GDPR-exported, so the payload should be **ciphertext at rest**, like `session_messages`.

Both `syncSingleCommand` functions now NaCl-box the payload to the command's target machine before upsert (web: `encryptForSession`; mobile: `encryptMessage`) and write the real `content_encrypted` + `encryption_nonce`. If the CLI's public key isn't available, encryption fails and the per-command catch leaves the command **pending to retry next sync** — no plaintext is ever written. Live delivery (relay broadcast) is unaffected.

## Changes
- `styrby-web/src/lib/offline-sync.ts`, `styrby-mobile/src/services/offline-sync.ts` — encrypt before upsert
- +2 tests (web + mobile): upsert assertion now requires ciphertext + a real nonce (not plaintext / `'pending'`); + a defer-on-no-key test (no DB write, not marked synced)

## Test Plan
- [x] web typecheck + offline-sync 7/7 + web build
- [x] mobile typecheck + lint + offline-sync 27/27
- [ ] CI passes

## Follow-up
This is at-rest E2E parity with messages. Note: like `session_messages`, the queued payload is boxed to the CLI machine, so the GDPR export contains ciphertext (consistent with existing message handling).

🤖 Shipped via /gh-ship