### PR TITLE
fix(cli): detect claude billing from stream-json apiKeySource, not stale auth.json

### DIFF
--- a/packages/styrby-cli/src/agent/factories/__tests__/claude-backend.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/claude-backend.test.ts
@@ -239,3 +239,23 @@ describe('lifecycle', () => {
     await expect(backend.sendPrompt('wrong-id', 'p')).rejects.toThrow(/Invalid session ID/);
   });
 });
+
+describe('billing detection from stream-json apiKeySource', () => {
+  it('init apiKeySource:"none" → cost-report billed as subscription ($0)', async () => {
+    const { backend, messages } = makeBackend();
+    const { sessionId } = await backend.startSession();
+    await drive(backend.sendPrompt(sessionId, 'hi'), [
+      { type: 'system', subtype: 'init', session_id: 'claude-x', apiKeySource: 'none' },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }], usage: { input_tokens: 10, output_tokens: 5 } } },
+      { type: 'result' },
+    ]);
+
+    const cost = messages.find((m) => m.type === 'cost-report') as
+      | { type: 'cost-report'; report: { billingModel: string; costUsd: number } }
+      | undefined;
+    expect(cost).toBeDefined();
+    // Corrected from the api-key seed to subscription via the init line.
+    expect(cost!.report.billingModel).toBe('subscription');
+    expect(cost!.report.costUsd).toBe(0);
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/__tests__/claude.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/claude.test.ts
@@ -37,7 +37,7 @@ vi.mock('@/ui/logger', () => ({
 // ---------------------------------------------------------------------------
 
 import * as fs from 'node:fs';
-import { detectClaudeBillingModel, parseClaudeJsonlLine } from '../claude';
+import { detectClaudeBillingModel, parseClaudeJsonlLine, billingModelFromApiKeySource } from '../claude';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -374,5 +374,29 @@ describe('parseClaudeJsonlLine — subscription billing model', () => {
     const report = parseClaudeJsonlLine(line, SESSION_ID, 'subscription');
 
     expect(report!.source).toBe('agent-reported');
+  });
+});
+
+// ===========================================================================
+// billingModelFromApiKeySource — the authoritative (stream-json) signal
+// ===========================================================================
+
+/**
+ * Tests for billingModelFromApiKeySource — replaces the stale auth.json read.
+ */
+describe('billingModelFromApiKeySource', () => {
+  it('returns "subscription" when apiKeySource is "none" (no API key → subscription)', () => {
+    expect(billingModelFromApiKeySource('none')).toBe('subscription');
+  });
+
+  it.each(['user', 'project', 'org', 'apiKey', 'ANTHROPIC_API_KEY'])(
+    'returns "api-key" when apiKeySource is %s',
+    (source) => {
+      expect(billingModelFromApiKeySource(source)).toBe('api-key');
+    },
+  );
+
+  it('returns "api-key" when apiKeySource is undefined', () => {
+    expect(billingModelFromApiKeySource(undefined)).toBe('api-key');
   });
 });

--- a/packages/styrby-cli/src/agent/factories/claude.ts
+++ b/packages/styrby-cli/src/agent/factories/claude.ts
@@ -91,6 +91,25 @@ export function detectClaudeBillingModel(): BillingModel {
   }
 }
 
+/**
+ * Map the Claude Code stream-json `apiKeySource` to a billing model.
+ *
+ * This is the AUTHORITATIVE billing signal for a managed session, replacing the
+ * stale {@link detectClaudeBillingModel} heuristic: modern claude (2.1.x) no
+ * longer writes a `subscriptionType` to `~/.claude/auth.json` (auth moved to the
+ * keychain / `.credentials.json`), so the file-read mislabeled subscription
+ * users as `api-key`. The init line's `apiKeySource` reflects the actual session.
+ *
+ * @param apiKeySource - The `apiKeySource` field from the system/init line.
+ *   `'none'` means no API key is configured — the session runs on the user's
+ *   Claude subscription. Any other value (`'user'` / `'project'` / `'org'` /
+ *   `'apiKey'` / …) means an API key is in use.
+ * @returns `'subscription'` when `apiKeySource` is `'none'`, otherwise `'api-key'`.
+ */
+export function billingModelFromApiKeySource(apiKeySource: string | undefined): BillingModel {
+  return apiKeySource === 'none' ? 'subscription' : 'api-key';
+}
+
 // ============================================================================
 // JSONL Parser
 // ============================================================================
@@ -257,6 +276,8 @@ interface ClaudeStreamMessage {
   type: 'system' | 'assistant' | 'user' | 'result' | string;
   subtype?: string;
   session_id?: string;
+  /** Present on the system/init line: 'none' = subscription, else api-key. */
+  apiKeySource?: string;
   message?: {
     role?: string;
     content?: Array<{
@@ -296,7 +317,12 @@ export class ClaudeBackend extends StreamingAgentBackendBase {
 
   /** Claude's own session id, captured from the init line; used for --resume. */
   private claudeSessionId: string | null;
-  private readonly billingModel: BillingModel;
+  /**
+   * Billing model for cost reports. Seeded from the (stale) auth.json heuristic,
+   * then corrected to the authoritative value from the stream-json `apiKeySource`
+   * once the system/init line arrives (see handleLine).
+   */
+  private billingModel: BillingModel;
 
   constructor(private readonly options: ClaudeBackendOptions) {
     super();
@@ -445,6 +471,16 @@ export class ClaudeBackend extends StreamingAgentBackendBase {
     // Capture Claude's session id from any line that carries it so follow-up
     // prompts can --resume the same conversation.
     if (typeof msg.session_id === 'string') this.claudeSessionId = msg.session_id;
+
+    // Authoritative billing detection: the system/init line carries `apiKeySource`.
+    // 'none' means no API key — the session runs on the user's Claude subscription
+    // (costUsd 0). Any other value means an API key is in use (api-key billing).
+    // This corrects the constructor's detectClaudeBillingModel() seed, whose
+    // ~/.claude/auth.json heuristic is stale (modern claude stores auth elsewhere,
+    // so subscription users were mislabeled api-key).
+    if (typeof msg.apiKeySource === 'string') {
+      this.billingModel = billingModelFromApiKeySource(msg.apiKeySource);
+    }
 
     switch (msg.type) {
       case 'assistant':


### PR DESCRIPTION
## Summary
`detectClaudeBillingModel()` read `~/.claude/auth.json` for a `subscriptionType` field, but modern claude (2.1.x) no longer writes it (auth moved to keychain / `.credentials.json`). So **subscription users were mislabeled `api-key`** and their `cost_records` showed phantom non-zero costs instead of $0.

**Fix:** the Claude Code stream-json `system`/init line carries `apiKeySource` (`'none'` = no API key → running on the user's subscription; anything else = an API key is in use). `ClaudeBackend` now captures it in `handleLine` and corrects its `billingModel` to the authoritative per-session value. `detectClaudeBillingModel()` is kept only as the pre-stream seed. Added a `billingModelFromApiKeySource()` helper.

Verified live during #339 testing: a subscription session emits `apiKeySource:"none"` and is now correctly billed at `costUsd 0`.

## Changes
- `factories/claude.ts`: `ClaudeBackend.billingModel` now mutable; init-line `apiKeySource` capture; `billingModelFromApiKeySource()` helper
- +8 tests (helper truth table + a backend integration test)

## Test Plan
- [x] typecheck + build clean
- [x] claude + claude-backend suites 56/56
- [ ] CI passes

🤖 Shipped via /gh-ship