### PR TITLE
docs(mobile): document plaintext relay in useChatSend header

### DIFF
--- a/packages/styrby-mobile/src/components/chat/hooks/useChatSend.ts
+++ b/packages/styrby-mobile/src/components/chat/hooks/useChatSend.ts
@@ -2,8 +2,15 @@
  * useChatSend
  *
  * Builds the `handleSend` callback used by the chat input bar. Handles
- * session lazy-creation, optimistic message append, optional E2E encryption
- * of the relay payload, and Supabase persistence.
+ * session lazy-creation, optimistic message append, the relay send, and
+ * Supabase persistence.
+ *
+ * WHY the relay payload is PLAINTEXT (not E2E-encrypted): the CLI dispatcher
+ * reads `payload.content` directly and never decrypts an `encrypted_content`
+ * field. Encrypting the relay payload (as the pre-2026-06-10 code did, setting
+ * `content: ''` when paired) made the CLI forward an EMPTY string to the agent.
+ * E2E encryption lives on the persisted history instead, via `saveMessageToDb`;
+ * the transient relay control message is plaintext over TLS, matching web.
  *
  * WHY a dedicated hook: `handleSend` is ~90 LOC of branching logic. Pulling
  * it into a hook drops complexity from the orchestrator and gives us a


### PR DESCRIPTION
## Summary
- The mobile encrypted-relay bug (paired chat forwarding an EMPTY string to the agent) was **already fixed in PR #342** and is regression-tested (`useChatSend.test.ts` asserts plaintext `content` + `encrypted_content` undefined when paired; 16/16 green).
- This PR fixes the **last residual**: the `useChatSend.ts` file header still described the old buggy behavior ("optional E2E encryption of the relay payload") - the exact comment that would lead someone to reintroduce the bug.

## Why it matters
Per the project's comment-accuracy standard, a header that lies about behavior is a latent regression. Rewrote it to document WHY the relay payload is plaintext (the CLI dispatcher reads `payload.content` directly and never decrypts) and that E2E encryption lives on the persisted history via `saveMessageToDb`.

## Changes
- `packages/styrby-mobile/src/components/chat/hooks/useChatSend.ts` - header docstring only (no logic change)

## Verification (full relay-path audit done this session)
All mobile relay paths confirmed plaintext: `useChatSend` (online + offline queue), `use-review` (`code_review_response`), offline-sync `deliverCommand` (`relay.sendChat`), `useRelay.sendMessage` (pass-through). At-rest E2E unchanged (`saveMessageToDb`).

## Test Plan
- [x] Mobile typecheck clean
- [x] `useChatSend.test.ts` 16/16 (incl. paired-machine plaintext regression)
- [ ] CI passes

🤖 Shipped via /gh-ship