### PR TITLE
feat(cli): interactive per-tool mobile approval for claude

### DIFF
--- a/packages/styrby-cli/src/agent/factories/__tests__/claude-backend.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/claude-backend.test.ts
@@ -56,11 +56,31 @@ import type { AgentMessage } from '../../core/AgentBackend';
 
 const spawnMock = vi.mocked(spawn);
 
+// WHY interactivePermissions:false by default here: most of these tests assert
+// arg construction / stream mapping / lifecycle and should NOT spin up the real
+// in-process permission MCP server. The interactive default (true) is covered by
+// its own describe block + claudePermissionServer.test.ts.
 function makeBackend(opts: Record<string, unknown> = {}) {
-  const { backend } = createClaudeBackend({ cwd: '/tmp/project', ...opts } as any);
+  const { backend } = createClaudeBackend({ cwd: '/tmp/project', interactivePermissions: false, ...opts } as any);
   const messages: AgentMessage[] = [];
   backend.onMessage((m) => messages.push(m));
   return { backend, messages };
+}
+
+/**
+ * Build a backend with interactive per-tool approval ENABLED (the product
+ * default). `decide` is reachable via a typed cast for round-trip assertions
+ * without standing up the real claude<->MCP transport.
+ */
+function makeInteractive(opts: Record<string, unknown> = {}) {
+  const { backend } = createClaudeBackend({ cwd: '/tmp/project', ...opts } as any);
+  const messages: AgentMessage[] = [];
+  backend.onMessage((m) => messages.push(m));
+  const decide = (toolName: string, input: Record<string, unknown>, id: string | undefined) =>
+    (backend as unknown as {
+      decide: (t: string, i: Record<string, unknown>, id: string | undefined) => Promise<{ approved: boolean; message?: string }>;
+    }).decide(toolName, input, id);
+  return { backend, messages, decide };
 }
 
 /** Drive a pending sendPrompt: feed JSONL stdout lines, end stream, close proc. */
@@ -109,8 +129,8 @@ describe('startSession (no prompt)', () => {
 });
 
 describe('spawn arg construction', () => {
-  it('uses stream-json + verbose + acceptEdits by default', async () => {
-    const { backend } = makeBackend();
+  it('uses stream-json + verbose + acceptEdits when non-interactive', async () => {
+    const { backend } = makeBackend(); // interactivePermissions:false (see makeBackend)
     const { sessionId } = await backend.startSession();
     await drive(backend.sendPrompt(sessionId, 'hello'), [{ type: 'result' }]);
 
@@ -119,6 +139,9 @@ describe('spawn arg construction', () => {
     expect(args).toEqual(
       expect.arrayContaining(['-p', 'hello', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'acceptEdits']),
     );
+    // No interactive plumbing in non-interactive mode.
+    expect(args).not.toContain('--permission-prompt-tool');
+    expect(args).not.toContain('--mcp-config');
   });
 
   it('includes --model and --allowedTools when provided', async () => {
@@ -257,5 +280,88 @@ describe('billing detection from stream-json apiKeySource', () => {
     // Corrected from the api-key seed to subscription via the init line.
     expect(cost!.report.billingModel).toBe('subscription');
     expect(cost!.report.costUsd).toBe(0);
+  });
+});
+
+describe('interactive per-tool permissions', () => {
+  it('spawns with default mode + permission-prompt-tool + mcp-config (the product default)', async () => {
+    const { backend } = makeInteractive();
+    const { sessionId } = await backend.startSession();
+    await drive(backend.sendPrompt(sessionId, 'go'), [{ type: 'result' }]);
+
+    const [, args] = spawnMock.mock.calls[0];
+    expect(args).toEqual(
+      expect.arrayContaining([
+        '--permission-mode', 'default',
+        '--strict-mcp-config',
+        '--permission-prompt-tool', 'mcp__styrby__permission_prompt',
+      ]),
+    );
+    // --mcp-config points at a real temp file path.
+    const cfgIdx = args.indexOf('--mcp-config');
+    expect(cfgIdx).toBeGreaterThan(-1);
+    expect(typeof args[cfgIdx + 1]).toBe('string');
+    // --settings carries the permissions.ask list that forces gated tools to
+    // prompt (ask > allow) even under a permissive local config.
+    const setIdx = args.indexOf('--settings');
+    expect(setIdx).toBeGreaterThan(-1);
+    const settings = JSON.parse(args[setIdx + 1] as string);
+    expect(settings.permissions.ask).toEqual(
+      expect.arrayContaining(['Bash', 'Write', 'Edit']),
+    );
+    // It must NOT pass the fixed acceptEdits mode in interactive sessions.
+    expect(args).not.toContain('acceptEdits');
+    await backend.dispose();
+  });
+
+  it('decide() emits a permission-request and respondToPermission(true) approves', async () => {
+    const { backend, messages, decide } = makeInteractive();
+    const pending = decide('Bash', { command: 'ls' }, 'tool-1');
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'permission-request', id: 'tool-1', payload: { command: 'ls' } }),
+    );
+
+    await backend.respondToPermission('tool-1', true);
+    await expect(pending).resolves.toEqual({ approved: true });
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'permission-response', id: 'tool-1', approved: true }),
+    );
+    await backend.dispose();
+  });
+
+  it('respondToPermission(false) denies the parked tool-use', async () => {
+    const { backend, decide } = makeInteractive();
+    const pending = decide('Edit', { file_path: '/x.ts' }, 'tool-2');
+    await backend.respondToPermission('tool-2', false);
+    await expect(pending).resolves.toEqual({ approved: false });
+    await backend.dispose();
+  });
+
+  it('fails CLOSED (deny) when approval times out', async () => {
+    const { backend, messages, decide } = makeInteractive({ permissionTimeoutMs: 20 });
+    const pending = decide('Bash', { command: 'rm -rf /' }, 'tool-3');
+    await expect(pending).resolves.toEqual({ approved: false, message: 'Approval timed out' });
+    expect(messages).toContainEqual(
+      expect.objectContaining({ type: 'permission-response', id: 'tool-3', approved: false }),
+    );
+    await backend.dispose();
+  });
+
+  it('generates a correlation id when claude provides no tool_use id', async () => {
+    const { backend, messages, decide } = makeInteractive();
+    const pending = decide('Read', { file_path: '/y.ts' }, undefined);
+    const req = messages.find((m) => m.type === 'permission-request') as { id: string } | undefined;
+    expect(req?.id).toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/i);
+    await backend.respondToPermission(req!.id, true);
+    await expect(pending).resolves.toEqual({ approved: true });
+    await backend.dispose();
+  });
+
+  it('dispose() denies any still-parked approvals so claude can exit', async () => {
+    const { backend, decide } = makeInteractive();
+    const pending = decide('Bash', { command: 'sleep 999' }, 'tool-4');
+    await backend.dispose();
+    await expect(pending).resolves.toEqual(expect.objectContaining({ approved: false }));
   });
 });

--- a/packages/styrby-cli/src/agent/factories/__tests__/claudePermissionServer.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/claudePermissionServer.test.ts
@@ -1,0 +1,126 @@
+/**
+ * claudePermissionServer test suite.
+ *
+ * Drives a REAL MCP client (StreamableHTTP) against the in-process permission
+ * server to prove the end-to-end contract claude relies on:
+ *  - the server advertises exactly one tool (permission_prompt)
+ *  - calling it routes (tool_name, input, tool_use_id) to the injected decider
+ *  - an approve returns {behavior:'allow', updatedInput}
+ *  - a deny returns {behavior:'deny', message}
+ *  - a decider that throws fails CLOSED (deny) — never an implicit allow
+ *  - close() tears the HTTP server down
+ *
+ * The tool's text content is the JSON envelope claude's --permission-prompt-tool
+ * parses, so asserting it here locks the wire contract.
+ *
+ * @module factories/__tests__/claudePermissionServer.test.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  startClaudePermissionServer,
+  PERMISSION_PROMPT_TOOL_ID,
+  PERMISSION_TOOL_NAME,
+  type PermissionDecider,
+  type RunningPermissionServer,
+} from '../claudePermissionServer';
+
+/** Connect a fresh MCP client to a running permission server. */
+async function connect(server: RunningPermissionServer): Promise<Client> {
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await client.connect(new StreamableHTTPClientTransport(new URL(server.url)));
+  return client;
+}
+
+/** Parse the first text content block as the claude permission envelope. */
+function envelopeOf(result: { content?: Array<{ type: string; text?: string }> }): Record<string, unknown> {
+  const text = result.content?.find((c) => c.type === 'text')?.text ?? '{}';
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+async function withServer(
+  decide: PermissionDecider,
+  run: (client: Client, server: RunningPermissionServer) => Promise<void>,
+): Promise<void> {
+  const server = await startClaudePermissionServer(decide);
+  let client: Client | undefined;
+  try {
+    client = await connect(server);
+    await run(client, server);
+  } finally {
+    if (client) await client.close();
+    await server.close();
+  }
+}
+
+describe('startClaudePermissionServer', () => {
+  it('binds a loopback URL and exposes exactly the permission_prompt tool', async () => {
+    await withServer(
+      async () => ({ approved: true }),
+      async (client, server) => {
+        expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+        const { tools } = await client.listTools();
+        expect(tools.map((t) => t.name)).toEqual([PERMISSION_TOOL_NAME]);
+      },
+    );
+  });
+
+  it('exposes the fully-qualified tool id claude expects', () => {
+    expect(PERMISSION_PROMPT_TOOL_ID).toBe('mcp__styrby__permission_prompt');
+  });
+
+  it('routes (tool_name, input, tool_use_id) to the decider and returns allow', async () => {
+    const seen: Array<[string, Record<string, unknown>, string | undefined]> = [];
+    const decide: PermissionDecider = async (tool, input, id) => {
+      seen.push([tool, input, id]);
+      return { approved: true };
+    };
+    await withServer(decide, async (client) => {
+      const result = await client.callTool({
+        name: PERMISSION_TOOL_NAME,
+        arguments: { tool_name: 'Bash', input: { command: 'ls' }, tool_use_id: 'tu-1' },
+      });
+      // Decider saw the exact tool-use.
+      expect(seen).toEqual([['Bash', { command: 'ls' }, 'tu-1']]);
+      // allow echoes the input back as updatedInput (claude runs with this).
+      expect(envelopeOf(result)).toEqual({ behavior: 'allow', updatedInput: { command: 'ls' } });
+    });
+  });
+
+  it('returns deny with the decider message', async () => {
+    const decide: PermissionDecider = async () => ({ approved: false, message: 'Denied on mobile' });
+    await withServer(decide, async (client) => {
+      const result = await client.callTool({
+        name: PERMISSION_TOOL_NAME,
+        arguments: { tool_name: 'Edit', input: { file_path: '/x' }, tool_use_id: 'tu-2' },
+      });
+      expect(envelopeOf(result)).toEqual({ behavior: 'deny', message: 'Denied on mobile' });
+    });
+  });
+
+  it('honors a decider-supplied updatedInput on allow', async () => {
+    const decide: PermissionDecider = async () => ({ approved: true, updatedInput: { command: 'ls -la' } });
+    await withServer(decide, async (client) => {
+      const result = await client.callTool({
+        name: PERMISSION_TOOL_NAME,
+        arguments: { tool_name: 'Bash', input: { command: 'ls' }, tool_use_id: 'tu-3' },
+      });
+      expect(envelopeOf(result)).toEqual({ behavior: 'allow', updatedInput: { command: 'ls -la' } });
+    });
+  });
+
+  it('FAILS CLOSED (deny) when the decider throws', async () => {
+    const decide: PermissionDecider = async () => {
+      throw new Error('relay down');
+    };
+    await withServer(decide, async (client) => {
+      const result = await client.callTool({
+        name: PERMISSION_TOOL_NAME,
+        arguments: { tool_name: 'Bash', input: {}, tool_use_id: 'tu-4' },
+      });
+      expect(envelopeOf(result)).toMatchObject({ behavior: 'deny' });
+    });
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/claude.ts
+++ b/packages/styrby-cli/src/agent/factories/claude.ts
@@ -39,6 +39,13 @@ import type {
 } from '../core';
 import { agentRegistry } from '../core';
 import { StreamingAgentBackendBase } from '../StreamingAgentBackendBase';
+import {
+  startClaudePermissionServer,
+  PERMISSION_MCP_SERVER_NAME,
+  PERMISSION_PROMPT_TOOL_ID,
+  type RunningPermissionServer,
+  type PermissionDecision,
+} from './claudePermissionServer';
 
 // ============================================================================
 // Auth Mode Detection
@@ -248,6 +255,32 @@ export interface ClaudeBackendOptions extends AgentFactoryOptions {
   resumeSessionId?: string;
   /** Tool allowlist (e.g. ['Bash(git *)', 'Read']). */
   allowedTools?: string[];
+  /**
+   * Route every gated tool-use to the paired mobile device for an inline
+   * approve/deny decision (default `true`).
+   *
+   * WHY default on: this is the premium behavior — claude pauses at each
+   * non-allowlisted tool and asks, the same as Codex. When `true` the backend
+   * spawns claude with `--permission-mode default` + a `--permission-prompt-tool`
+   * pointed at an in-process MCP server (see {@link ClaudeBackend}). Set `false`
+   * for unattended/automation sessions that should run on a fixed
+   * {@link permissionMode} ('acceptEdits'/'bypassPermissions') without prompting.
+   * Tools in {@link allowedTools} are pre-approved and never prompt.
+   */
+  interactivePermissions?: boolean;
+  /**
+   * Per-tool approval timeout in ms (default 240000 = 4 min). On timeout the
+   * decision FAILS CLOSED (deny) so a tool never runs without an explicit
+   * approval and claude is never left blocked indefinitely.
+   */
+  permissionTimeoutMs?: number;
+  /**
+   * Tool names routed to mobile approval when {@link interactivePermissions} is
+   * on (default {@link DEFAULT_GATED_TOOLS}). Passed as claude's
+   * `permissions.ask` list so they prompt even if the user's local settings
+   * allow them. Read-only tools omitted here stay auto-allowed.
+   */
+  gatedTools?: string[];
   /** Extra `claude` CLI args (validated for shell-safety by the base class). */
   extraArgs?: string[];
 }
@@ -296,6 +329,24 @@ interface ClaudeStreamMessage {
 const CLAUDE_EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
 
 /**
+ * Tools routed to mobile approval by default in interactive sessions.
+ *
+ * WHY this set: these are the side-effecting / external tools (mutate the repo,
+ * run shell, reach the network). Read-only tools (Read/Glob/Grep) are left
+ * auto-allowed so a remote session is not death-by-a-thousand-prompts. Override
+ * via {@link ClaudeBackendOptions.gatedTools}.
+ *
+ * WHY a `permissions.ask` list (not just --permission-prompt-tool): claude only
+ * consults the permission-prompt tool for a tool-use that its rules don't
+ * already allow/deny. A user's `~/.claude/settings.json` `allow` list (e.g.
+ * `Bash(*)`) would otherwise auto-approve and silently bypass mobile approval.
+ * Permission precedence is deny > ask > allow, so putting these tools in `ask`
+ * (passed via --settings) forces the prompt -> our tool -> mobile, regardless of
+ * the user's local allow list. Verified live against claude 2.1.169.
+ */
+const DEFAULT_GATED_TOOLS = ['Bash', 'Edit', 'Write', 'NotebookEdit', 'WebFetch', 'WebSearch'];
+
+/**
  * Claude Code backend — clean-room managed spawn of the `claude` binary.
  *
  * WHY this reimplements the spawn technique instead of wrapping Happy's
@@ -324,12 +375,29 @@ export class ClaudeBackend extends StreamingAgentBackendBase {
    */
   private billingModel: BillingModel;
 
+  /** Whether per-tool decisions are routed to mobile (see options). */
+  private readonly interactivePermissions: boolean;
+  /** Per-tool approval timeout (fail-closed deny). */
+  private readonly permissionTimeoutMs: number;
+  /**
+   * Parked approval promises keyed by request id (claude's tool_use id, or a
+   * generated id). Resolved by {@link respondToPermission} with the relayed
+   * mobile decision — the same park-and-resolve pattern CodexBackend uses.
+   */
+  private readonly pendingApprovals = new Map<string, (d: PermissionDecision) => void>();
+  /** In-process MCP server hosting the permission-prompt tool (lazy). */
+  private permissionServer: RunningPermissionServer | null = null;
+  /** Temp `--mcp-config` file path registering the permission server (lazy). */
+  private mcpConfigPath: string | null = null;
+
   constructor(private readonly options: ClaudeBackendOptions) {
     super();
     // Detect subscription vs api-key once so every cost-report is classified
     // correctly (subscription => costUsd 0).
     this.billingModel = detectClaudeBillingModel();
     this.claudeSessionId = options.resumeSessionId ?? null;
+    this.interactivePermissions = options.interactivePermissions ?? true;
+    this.permissionTimeoutMs = options.permissionTimeoutMs ?? 240_000;
   }
 
   /**
@@ -381,9 +449,40 @@ export class ClaudeBackend extends StreamingAgentBackendBase {
       // --verbose is required for stream-json to emit the full event stream in
       // print mode (otherwise only the final result is printed).
       '--verbose',
-      '--permission-mode',
-      this.options.permissionMode ?? 'acceptEdits',
     ];
+
+    if (this.interactivePermissions) {
+      // Interactive per-tool approval: claude runs in 'default' mode (which gates
+      // tools) and routes every gated decision to our in-process permission MCP
+      // server via --permission-prompt-tool. The server's handler calls
+      // this.decide() -> emits permission-request -> awaits the mobile response.
+      // --strict-mcp-config keeps claude from also loading the user's own MCP
+      // servers (we only want ours for the prompt hook).
+      await this.ensurePermissionServer();
+      // WHY --settings with a permissions.ask list: forces the gated tools to
+      // prompt even if the user's ~/.claude/settings.json allows them (ask >
+      // allow). The prompt is delegated to our --permission-prompt-tool. Inline
+      // JSON (not a file) since spawn() passes args without a shell.
+      const gated = this.options.gatedTools ?? DEFAULT_GATED_TOOLS;
+      const settings = JSON.stringify({
+        permissions: { defaultMode: 'default', ask: gated, allow: [], deny: [] },
+      });
+      args.push(
+        '--permission-mode',
+        'default',
+        '--settings',
+        settings,
+        '--mcp-config',
+        this.mcpConfigPath as string,
+        '--strict-mcp-config',
+        '--permission-prompt-tool',
+        PERMISSION_PROMPT_TOOL_ID,
+      );
+    } else {
+      // Unattended/automation: fixed permission mode, no prompting.
+      args.push('--permission-mode', this.options.permissionMode ?? 'acceptEdits');
+    }
+
     if (this.options.model) args.push('--model', this.options.model);
     if (this.claudeSessionId) args.push('--resume', this.claudeSessionId);
     if (this.options.allowedTools?.length) {
@@ -527,10 +626,122 @@ export class ClaudeBackend extends StreamingAgentBackendBase {
     }
   }
 
-  // respondToPermission, waitForResponseComplete, onMessage/offMessage and
-  // dispose are inherited from StreamingAgentBackendBase. The session runs with
-  // a fixed --permission-mode, so the base emit-only permission default is
-  // correct (interactive per-tool mobile approval is a follow-up).
+  /**
+   * Lazily start the in-process permission MCP server and write its
+   * `--mcp-config` file. Idempotent: reused across prompts in the same session,
+   * torn down in {@link dispose}.
+   */
+  private async ensurePermissionServer(): Promise<void> {
+    if (this.permissionServer) return;
+    this.permissionServer = await startClaudePermissionServer((toolName, input, toolUseId) =>
+      this.decide(toolName, input, toolUseId),
+    );
+    // Register the in-process server as an HTTP MCP server claude connects to.
+    const config = {
+      mcpServers: {
+        [PERMISSION_MCP_SERVER_NAME]: { type: 'http', url: this.permissionServer.url },
+      },
+    };
+    this.mcpConfigPath = path.join(os.tmpdir(), `styrby-claude-mcp-${randomUUID()}.json`);
+    fs.writeFileSync(this.mcpConfigPath, JSON.stringify(config), 'utf8');
+    logger.debug(`[ClaudeBackend] permission MCP config at ${this.mcpConfigPath}`);
+  }
+
+  /**
+   * Decide whether claude may use a tool. Emits a `permission-request` and parks
+   * a promise resolved by {@link respondToPermission} when the mobile decision
+   * arrives. Fails CLOSED (deny) after {@link permissionTimeoutMs} so a tool is
+   * never auto-run and claude is never blocked indefinitely.
+   *
+   * @param toolName - The claude tool awaiting approval (e.g. 'Bash').
+   * @param input - The tool's input arguments (surfaced to mobile).
+   * @param toolUseId - Claude's tool_use id when present; the correlation key.
+   * @returns The decision once relayed back (or a timeout deny).
+   */
+  private decide(
+    toolName: string,
+    input: Record<string, unknown>,
+    toolUseId: string | undefined,
+  ): Promise<PermissionDecision> {
+    const id = toolUseId ?? randomUUID();
+    return new Promise<PermissionDecision>((resolve) => {
+      const timer = setTimeout(() => {
+        if (this.pendingApprovals.delete(id)) {
+          this.emit({ type: 'permission-response', id, approved: false });
+          resolve({ approved: false, message: 'Approval timed out' });
+        }
+      }, this.permissionTimeoutMs);
+      // Unref so a pending approval timer never keeps the event loop alive on
+      // shutdown (dispose drains pending approvals explicitly).
+      timer.unref?.();
+
+      this.pendingApprovals.set(id, (decision) => {
+        clearTimeout(timer);
+        resolve(decision);
+      });
+      this.emit({
+        type: 'permission-request',
+        id,
+        reason: `Claude wants to run: ${toolName}`,
+        payload: input,
+      });
+    });
+  }
+
+  /**
+   * Resolve a parked per-tool approval with the relayed mobile decision.
+   *
+   * Mirrors CodexBackend: look up the pending request by id, resolve its promise
+   * (unblocking the MCP permission-prompt handler so claude proceeds or skips the
+   * tool), and emit a `permission-response` for UI/analytics. Falls back to the
+   * base emit-only behavior when no request is parked (e.g. a non-interactive
+   * session, or a late/duplicate response).
+   *
+   * @param requestId - The id from the `permission-request` message.
+   * @param approved - Whether the user approved the tool.
+   */
+  override async respondToPermission(requestId: string, approved: boolean): Promise<void> {
+    const resolve = this.pendingApprovals.get(requestId);
+    if (resolve) {
+      this.pendingApprovals.delete(requestId);
+      resolve({ approved });
+      this.emit({ type: 'permission-response', id: requestId, approved });
+      return;
+    }
+    await super.respondToPermission(requestId, approved);
+  }
+
+  /**
+   * Tear down the permission server, remove its temp config, and deny any
+   * still-parked approvals so a blocked claude process can exit cleanly.
+   */
+  override async dispose(): Promise<void> {
+    // Deny outstanding approvals first so the MCP handlers return (allowing claude
+    // to finish) before we kill the server + child in super.dispose().
+    for (const resolve of this.pendingApprovals.values()) {
+      resolve({ approved: false, message: 'Session ended' });
+    }
+    this.pendingApprovals.clear();
+
+    if (this.permissionServer) {
+      try {
+        await this.permissionServer.close();
+      } catch {
+        /* best-effort teardown */
+      }
+      this.permissionServer = null;
+    }
+    if (this.mcpConfigPath) {
+      try {
+        fs.rmSync(this.mcpConfigPath, { force: true });
+      } catch {
+        /* best-effort cleanup */
+      }
+      this.mcpConfigPath = null;
+    }
+
+    await super.dispose();
+  }
 }
 
 /**
@@ -549,6 +760,7 @@ export function createClaudeBackend(options: ClaudeBackendOptions): ClaudeBacken
   logger.debug('[ClaudeBackend] Creating backend', {
     cwd: options.cwd,
     model: options.model,
+    interactivePermissions: options.interactivePermissions ?? true,
     permissionMode: options.permissionMode ?? 'acceptEdits',
   });
 

--- a/packages/styrby-cli/src/agent/factories/claudePermissionServer.ts
+++ b/packages/styrby-cli/src/agent/factories/claudePermissionServer.ts
@@ -1,0 +1,283 @@
+/**
+ * Claude Permission Server — in-process MCP host for per-tool approval
+ *
+ * Backs interactive per-tool mobile approval for the managed `claude` backend.
+ *
+ * ## Why this exists
+ *
+ * The `claude` binary, run headless with `--permission-mode default`, routes
+ * every gated tool-use decision to a single MCP tool named by
+ * `--permission-prompt-tool`. That tool receives `{ tool_name, input }` and must
+ * return `{ behavior: 'allow', updatedInput } | { behavior: 'deny', message }`.
+ * Claude blocks the tool until the prompt tool resolves. This is the same
+ * pause-and-ask shape Codex gets from its MCP elicitation handler.
+ *
+ * We host that prompt tool ourselves, **in-process**, so its handler can call
+ * straight back into the {@link import('./claude').ClaudeBackend} — emitting a
+ * `permission-request` AgentMessage and awaiting the relayed mobile decision —
+ * rather than going through a separate process or the Supabase round-trip. That
+ * keeps claude's approvals on the exact same inline relay + PermissionCard path
+ * every other agent uses.
+ *
+ * ## Why HTTP transport (not stdio)
+ *
+ * `--mcp-config` can register a server by either spawning a command (stdio) or
+ * connecting to a URL (http/sse). Stdio would run our tool handler in a child
+ * process with no access to the ClaudeBackend instance. An in-process HTTP
+ * server on localhost keeps the handler in the SAME process, so it can resolve
+ * the parked approval promise directly. The server binds to 127.0.0.1 on an
+ * ephemeral port (loopback only — never reachable off-box).
+ *
+ * @module factories/claudePermissionServer
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse, type Server as HttpServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '@/ui/logger';
+
+/**
+ * The MCP server name. Combined with the tool name to form the fully-qualified
+ * `--permission-prompt-tool` identifier claude expects: `mcp__<server>__<tool>`.
+ */
+export const PERMISSION_MCP_SERVER_NAME = 'styrby';
+
+/** The prompt tool's bare name. */
+export const PERMISSION_TOOL_NAME = 'permission_prompt';
+
+/**
+ * The fully-qualified tool id passed to `--permission-prompt-tool`.
+ * Format is claude's MCP tool convention: `mcp__<serverName>__<toolName>`.
+ */
+export const PERMISSION_PROMPT_TOOL_ID = `mcp__${PERMISSION_MCP_SERVER_NAME}__${PERMISSION_TOOL_NAME}`;
+
+/**
+ * A permission decision returned to claude for one gated tool-use.
+ *
+ * @property approved - true => claude runs the tool; false => claude skips it.
+ * @property updatedInput - Optional replacement tool input on approve. When
+ *   omitted the original input is echoed back unchanged (claude requires the
+ *   allow response to carry the input it should run with).
+ * @property message - Optional human-readable reason surfaced to claude on deny.
+ */
+export interface PermissionDecision {
+  approved: boolean;
+  updatedInput?: Record<string, unknown>;
+  message?: string;
+}
+
+/**
+ * Decide whether claude may use a tool. Implemented by ClaudeBackend: it emits a
+ * `permission-request`, parks a promise, and resolves it from the relayed mobile
+ * response (see `respondToPermission`).
+ *
+ * @param toolName - The claude tool claude wants to run (e.g. 'Bash', 'Edit').
+ * @param input - The tool's input arguments.
+ * @param toolUseId - Claude's tool_use id, when provided. Used as the stable
+ *   correlation id for the permission round-trip.
+ * @returns The user's decision once it arrives (or a deny on timeout/teardown).
+ */
+export type PermissionDecider = (
+  toolName: string,
+  input: Record<string, unknown>,
+  toolUseId: string | undefined,
+) => Promise<PermissionDecision>;
+
+/**
+ * A running permission server. Returned by {@link startClaudePermissionServer}.
+ *
+ * @property url - The MCP endpoint URL to register in `--mcp-config`.
+ * @property close - Tears down the HTTP server + all live MCP transports.
+ */
+export interface RunningPermissionServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+/**
+ * Input schema for the permission-prompt tool.
+ *
+ * Claude invokes the prompt tool with the tool it wants to run plus that tool's
+ * arguments. `tool_use_id` is the correlation handle; `permission_suggestions`
+ * is advisory metadata claude may attach (ignored here — the human decides).
+ */
+const PERMISSION_TOOL_INPUT = {
+  tool_name: z.string(),
+  input: z.record(z.unknown()).optional(),
+  tool_use_id: z.string().optional(),
+  permission_suggestions: z.unknown().optional(),
+};
+
+/**
+ * Build the MCP server that hosts the permission-prompt tool.
+ *
+ * The tool handler delegates the decision to `decide` and formats the result in
+ * claude's required `{ behavior }` envelope. Per the claude permission-prompt
+ * contract, the JSON payload is returned as a text content block.
+ *
+ * @param decide - The decision callback (ClaudeBackend's relay round-trip).
+ * @returns An unconnected McpServer.
+ */
+function buildPermissionMcpServer(decide: PermissionDecider): McpServer {
+  const server = new McpServer({ name: 'styrby-claude-permission', version: '1.0.0' });
+
+  server.registerTool(
+    PERMISSION_TOOL_NAME,
+    {
+      title: 'Styrby mobile permission prompt',
+      description:
+        'Claude permission-prompt-tool hook. Forwards the pending tool-use to the ' +
+        'paired mobile device for an inline approve/deny decision.',
+      inputSchema: PERMISSION_TOOL_INPUT,
+    },
+    async (args): Promise<{ content: Array<{ type: 'text'; text: string }> }> => {
+      const toolName = args.tool_name;
+      const input = (args.input as Record<string, unknown>) ?? {};
+      const toolUseId = args.tool_use_id;
+
+      let decision: PermissionDecision;
+      try {
+        decision = await decide(toolName, input, toolUseId);
+      } catch (err) {
+        // WHY deny on error: failing closed is the safe default for a permission
+        // gate. A decider that throws (teardown mid-flight, relay failure) must
+        // never be read by claude as an implicit allow.
+        logger.debug('[ClaudePermissionServer] decider threw — denying', err);
+        decision = { approved: false, message: 'Approval unavailable' };
+      }
+
+      // WHY this envelope shape: claude's --permission-prompt-tool contract reads
+      // the FIRST text content block as JSON. allow must echo the input claude
+      // should run with (updatedInput); deny carries an optional message.
+      const behavior = decision.approved
+        ? { behavior: 'allow' as const, updatedInput: decision.updatedInput ?? input }
+        : { behavior: 'deny' as const, message: decision.message ?? 'Denied on mobile' };
+
+      return { content: [{ type: 'text', text: JSON.stringify(behavior) }] };
+    },
+  );
+
+  return server;
+}
+
+/**
+ * Start the in-process permission MCP server on a loopback ephemeral port.
+ *
+ * The server speaks MCP over Streamable HTTP. Each MCP session (claude opens one)
+ * gets its own {@link StreamableHTTPServerTransport}, tracked by session id so
+ * follow-up GET (SSE) / DELETE requests route to the right transport.
+ *
+ * @param decide - The decision callback invoked for every gated tool-use.
+ * @returns The endpoint URL + a `close()` teardown.
+ *
+ * @example
+ * const srv = await startClaudePermissionServer((tool, input, id) => askMobile(tool, input, id));
+ * // register srv.url in --mcp-config, then `--permission-prompt-tool` = PERMISSION_PROMPT_TOOL_ID
+ * await srv.close();
+ */
+export async function startClaudePermissionServer(
+  decide: PermissionDecider,
+): Promise<RunningPermissionServer> {
+  // One McpServer instance; a transport per MCP session (claude opens exactly one
+  // for the lifetime of a prompt run, but we support N defensively).
+  const transports = new Map<string, StreamableHTTPServerTransport>();
+
+  /** Read and JSON-parse a request body (POST carries the JSON-RPC message). */
+  const readBody = (req: IncomingMessage): Promise<unknown> =>
+    new Promise((resolve) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        if (chunks.length === 0) return resolve(undefined);
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+        } catch {
+          resolve(undefined);
+        }
+      });
+      req.on('error', () => resolve(undefined));
+    });
+
+  const httpServer: HttpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+    void (async () => {
+      try {
+        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+        const existing = sessionId ? transports.get(sessionId) : undefined;
+
+        // GET (SSE stream) and DELETE (session teardown) route to an existing
+        // transport by session id; they carry no body.
+        if (req.method === 'GET' || req.method === 'DELETE') {
+          if (!existing) {
+            res.writeHead(400).end('Unknown MCP session');
+            return;
+          }
+          await existing.handleRequest(req, res);
+          return;
+        }
+
+        const body = await readBody(req);
+
+        if (existing) {
+          await existing.handleRequest(req, res, body);
+          return;
+        }
+
+        // No session yet: only an `initialize` request may open one.
+        if (isInitializeRequest(body)) {
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: (sid: string) => {
+              transports.set(sid, transport);
+            },
+          });
+          transport.onclose = () => {
+            if (transport.sessionId) transports.delete(transport.sessionId);
+          };
+          const server = buildPermissionMcpServer(decide);
+          await server.connect(transport);
+          await transport.handleRequest(req, res, body);
+          return;
+        }
+
+        res.writeHead(400).end('No valid MCP session');
+      } catch (err) {
+        logger.debug('[ClaudePermissionServer] request error', err);
+        if (!res.headersSent) res.writeHead(500).end('Permission server error');
+      }
+    })();
+  });
+
+  // Bind to loopback only on an ephemeral port. 127.0.0.1 (not 0.0.0.0) so the
+  // approval endpoint is never reachable off the host.
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const addr = httpServer.address();
+  if (!addr || typeof addr === 'string') {
+    httpServer.close();
+    throw new Error('Permission server failed to bind a TCP port');
+  }
+  const url = `http://127.0.0.1:${addr.port}/mcp`;
+  logger.debug(`[ClaudePermissionServer] listening at ${url}`);
+
+  return {
+    url,
+    close: async () => {
+      for (const t of transports.values()) {
+        try {
+          await t.close();
+        } catch {
+          /* best-effort transport teardown */
+        }
+      }
+      transports.clear();
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+      logger.debug('[ClaudePermissionServer] closed');
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Claude now **pauses at each side-effecting tool** (Bash/Edit/Write/NotebookEdit/WebFetch/WebSearch) and asks for **mobile approval** over the same inline `PermissionCard` flow Codex uses - instead of running unattended on a fixed `--permission-mode`. Read-only tools stay auto-allowed (no death-by-prompts).
- Keeps **binary-spawn** so Max/Pro **subscription billing stays intact** (the Agent SDK was rejected - it forces API-key billing).
- Reuses the existing **agent-agnostic** apiSession relay bridge + mobile `PermissionCard` with **zero changes** there.

## How it works
1. New `claudePermissionServer.ts` - an **in-process MCP server** (Streamable HTTP, loopback, ephemeral port) hosting a `permission_prompt` tool matching claude's `--permission-prompt-tool` contract (`{tool_name,input}` -> `{behavior}`).
2. `ClaudeBackend` spawns `claude` with `--permission-mode default`, `--permission-prompt-tool mcp__styrby__permission_prompt`, `--mcp-config` (temp file registering the server), and `--settings` carrying a `permissions.ask` list.
3. **The ask-list is the non-obvious key:** `--permission-prompt-tool` is only consulted for tool-uses the user's `~/.claude/settings.json` doesn't already allow. A local `Bash(*)` allow would silently bypass mobile approval. Permission precedence is **deny > ask > allow**, so the ask-list forces the prompt regardless of local config.
4. The MCP tool handler calls back into `ClaudeBackend` (codex-style park-promise + `respondToPermission`).
5. **Fail-closed:** a decider error or per-tool timeout (default 4 min) denies, so a tool never runs without explicit approval and claude never blocks forever.

## Changes
- `claudePermissionServer.ts` (new) + its test
- `claude.ts` - `ClaudeBackend` interactive default, decide/respondToPermission/dispose, spawn flags
- `claude-backend.test.ts` - interactive round-trip tests

## Verification
- **Live end-to-end against the real claude 2.1.169 binary** through the real `ClaudeBackend`: Write gated/prompted on the mobile seam, Read auto-allowed. (4 probes pinned down the ask-list precedence behavior.)
- +12 unit/integration tests (interactive round-trip + a real-MCP-client server suite incl. allow/deny/updatedInput/fail-closed).

## Test Plan
- [x] typecheck clean
- [x] full CLI suite **2717 passed**
- [x] build clean
- [x] live end-to-end verified against the real binary
- [ ] CI passes

🤖 Shipped via /gh-ship