### PR TITLE
fix(security): harden offline-queue RLS, claude permission server, arg-guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ scripts/__pycache__/
 .gh-ship-history.json
 .monitor-reports/
 .deps-audit.json
+.sec-ship-reports/
+.sec-ship-history.json

--- a/packages/styrby-cli/src/agent/factories/__tests__/claude-backend.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/claude-backend.test.ts
@@ -153,6 +153,21 @@ describe('spawn arg construction', () => {
     expect(args).toEqual(expect.arrayContaining(['--model', 'claude-opus-4-8', '--allowedTools', 'Read,Bash(git *)']));
   });
 
+  it('rejects arg-confusion values in model/allowedTools (SEC-CLIINJ-002)', async () => {
+    // A model that would be read as a flag must be rejected before spawn.
+    const b1 = makeBackend({ model: '--dangerously-skip-permissions' });
+    const s1 = await b1.backend.startSession();
+    await expect(b1.backend.sendPrompt(s1.sessionId, 'x')).rejects.toThrow(/arg-confusion guard/);
+
+    // A control char (newline smuggling) in an allowedTools entry is rejected;
+    // an internal space (e.g. "Bash(git *)") is NOT — that's a legitimate pattern.
+    const b2 = makeBackend({ allowedTools: ['Read', 'Bash\n--evil'] });
+    const s2 = await b2.backend.startSession();
+    await expect(b2.backend.sendPrompt(s2.sessionId, 'x')).rejects.toThrow(/arg-confusion guard/);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it('resumes the captured claude session_id on the next prompt', async () => {
     const { backend } = makeBackend();
     const { sessionId } = await backend.startSession();

--- a/packages/styrby-cli/src/agent/factories/__tests__/claudePermissionServer.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/claudePermissionServer.test.ts
@@ -60,7 +60,8 @@ describe('startClaudePermissionServer', () => {
     await withServer(
       async () => ({ approved: true }),
       async (client, server) => {
-        expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+        // URL carries an unguessable capability token in the path (SEC-CLAUDEPERM-001).
+        expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp\/[0-9a-f]{64}$/);
         const { tools } = await client.listTools();
         expect(tools.map((t) => t.name)).toEqual([PERMISSION_TOOL_NAME]);
       },
@@ -69,6 +70,24 @@ describe('startClaudePermissionServer', () => {
 
   it('exposes the fully-qualified tool id claude expects', () => {
     expect(PERMISSION_PROMPT_TOOL_ID).toBe('mcp__styrby__permission_prompt');
+  });
+
+  it('rejects requests that do not present the capability token (SEC-CLAUDEPERM-001)', async () => {
+    const server = await startClaudePermissionServer(async () => ({ approved: true }));
+    try {
+      const origin = new URL(server.url).origin;
+      // Correct host+port, wrong path (no/forged token) -> 404, never reaches the tool.
+      const wrong = await fetch(`${origin}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+      });
+      expect(wrong.status).toBe(404);
+      const forged = await fetch(`${origin}/mcp/${'0'.repeat(64)}`, { method: 'GET' });
+      expect(forged.status).toBe(404);
+    } finally {
+      await server.close();
+    }
   });
 
   it('routes (tool_name, input, tool_use_id) to the decider and returns allow', async () => {

--- a/packages/styrby-cli/src/agent/factories/claude.ts
+++ b/packages/styrby-cli/src/agent/factories/claude.ts
@@ -347,6 +347,31 @@ const CLAUDE_EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']
 const DEFAULT_GATED_TOOLS = ['Bash', 'Edit', 'Write', 'NotebookEdit', 'WebFetch', 'WebSearch'];
 
 /**
+ * Reject a structured CLI arg value that could be mis-read as a flag or smuggle
+ * control characters (SEC-CLIINJ-002, defense-in-depth).
+ *
+ * WHY: model / allowedTools / gatedTools / the captured --resume id originate
+ * partly from the mobile session config. They're passed as argv elements (spawn
+ * is shell:false, so shell injection is already impossible), but a value like
+ * `--dangerously-skip-permissions` would be ARG-confusion — claude would read it
+ * as a flag, not a data value. A leading `-` or any control char is never a
+ * legitimate model name / tool name / session id, so we fail closed.
+ *
+ * @param value - The candidate arg value.
+ * @param label - Field name for the error message.
+ * @throws {Error} when the value starts with `-` or contains whitespace.
+ */
+function assertSafeArgValue(value: string, label: string): void {
+  // Reject a leading '-' (would be read as a flag) or any control character
+  // (newline/tab smuggling). Internal spaces are allowed — a single argv element
+  // is not word-split, and legitimate tool patterns like "Bash(git *)" contain
+  // spaces.  - excludes the space ( ) by design.
+  if (value.startsWith('-') || /[\t\n\r\f\v\0]/.test(value)) {
+    throw new Error(`Unsafe ${label} value rejected (arg-confusion guard): ${JSON.stringify(value)}`);
+  }
+}
+
+/**
  * Claude Code backend — clean-room managed spawn of the `claude` binary.
  *
  * WHY this reimplements the spawn technique instead of wrapping Happy's
@@ -464,6 +489,7 @@ export class ClaudeBackend extends StreamingAgentBackendBase {
       // allow). The prompt is delegated to our --permission-prompt-tool. Inline
       // JSON (not a file) since spawn() passes args without a shell.
       const gated = this.options.gatedTools ?? DEFAULT_GATED_TOOLS;
+      for (const t of gated) assertSafeArgValue(t, 'gatedTools entry');
       const settings = JSON.stringify({
         permissions: { defaultMode: 'default', ask: gated, allow: [], deny: [] },
       });
@@ -483,9 +509,16 @@ export class ClaudeBackend extends StreamingAgentBackendBase {
       args.push('--permission-mode', this.options.permissionMode ?? 'acceptEdits');
     }
 
-    if (this.options.model) args.push('--model', this.options.model);
-    if (this.claudeSessionId) args.push('--resume', this.claudeSessionId);
+    if (this.options.model) {
+      assertSafeArgValue(this.options.model, 'model');
+      args.push('--model', this.options.model);
+    }
+    if (this.claudeSessionId) {
+      assertSafeArgValue(this.claudeSessionId, 'resume session id');
+      args.push('--resume', this.claudeSessionId);
+    }
     if (this.options.allowedTools?.length) {
+      for (const t of this.options.allowedTools) assertSafeArgValue(t, 'allowedTools entry');
       args.push('--allowedTools', this.options.allowedTools.join(','));
     }
 
@@ -643,7 +676,13 @@ export class ClaudeBackend extends StreamingAgentBackendBase {
       },
     };
     this.mcpConfigPath = path.join(os.tmpdir(), `styrby-claude-mcp-${randomUUID()}.json`);
-    fs.writeFileSync(this.mcpConfigPath, JSON.stringify(config), 'utf8');
+    // WHY mode 0o600 (SEC-CLAUDEPERM-002): the config holds the loopback URL of
+    // the permission server (the security gate's endpoint). On a shared/multi-user
+    // host, world-readable /tmp would let any local user discover the ephemeral
+    // port and reach the un-authenticated MCP tool. Owner-only read closes that
+    // discovery channel. The dir entry is created 0600 from the start (writeFileSync
+    // applies mode on create) so there is no world-readable window.
+    fs.writeFileSync(this.mcpConfigPath, JSON.stringify(config), { encoding: 'utf8', mode: 0o600 });
     logger.debug(`[ClaudeBackend] permission MCP config at ${this.mcpConfigPath}`);
   }
 

--- a/packages/styrby-cli/src/agent/factories/claudePermissionServer.ts
+++ b/packages/styrby-cli/src/agent/factories/claudePermissionServer.ts
@@ -32,7 +32,7 @@
  */
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server as HttpServer } from 'node:http';
-import { randomUUID } from 'node:crypto';
+import { randomUUID, randomBytes } from 'node:crypto';
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -185,6 +185,17 @@ export async function startClaudePermissionServer(
   // for the lifetime of a prompt run, but we support N defensively).
   const transports = new Map<string, StreamableHTTPServerTransport>();
 
+  // Capability-URL token (SEC-CLAUDEPERM-001): the endpoint path embeds an
+  // unguessable 256-bit token. claude connects to the full URL verbatim from its
+  // --mcp-config (which we write 0600), so the token rides along automatically —
+  // no header support needed. Any OTHER local process that reaches the loopback
+  // port but can't read the 0600 config file hits a path it can't guess and gets
+  // a 404, so it can neither call the permission tool (notification-spam /
+  // approver-phishing) nor learn what tools claude is running. Defense-in-depth
+  // atop loopback-only binding + ephemeral port + transient lifetime.
+  const capabilityToken = randomBytes(32).toString('hex');
+  const basePath = `/mcp/${capabilityToken}`;
+
   /** Read and JSON-parse a request body (POST carries the JSON-RPC message). */
   const readBody = (req: IncomingMessage): Promise<unknown> =>
     new Promise((resolve) => {
@@ -204,6 +215,15 @@ export async function startClaudePermissionServer(
   const httpServer: HttpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
     void (async () => {
       try {
+        // Capability check: reject any path that doesn't present the token.
+        // Constant-ish prefix check; the token is high-entropy so a timing side
+        // channel on the prefix compare is not meaningful here.
+        const reqPath = (req.url ?? '').split('?')[0];
+        if (reqPath !== basePath) {
+          res.writeHead(404).end('Not found');
+          return;
+        }
+
         const sessionId = req.headers['mcp-session-id'] as string | undefined;
         const existing = sessionId ? transports.get(sessionId) : undefined;
 
@@ -262,8 +282,8 @@ export async function startClaudePermissionServer(
     httpServer.close();
     throw new Error('Permission server failed to bind a TCP port');
   }
-  const url = `http://127.0.0.1:${addr.port}/mcp`;
-  logger.debug(`[ClaudePermissionServer] listening at ${url}`);
+  const url = `http://127.0.0.1:${addr.port}${basePath}`;
+  logger.debug(`[ClaudePermissionServer] listening on 127.0.0.1:${addr.port} (capability path)`);
 
   return {
     url,

--- a/packages/styrby-web/src/lib/encryption.ts
+++ b/packages/styrby-web/src/lib/encryption.ts
@@ -105,10 +105,16 @@ export async function getOrCreateWebKeyPair(): Promise<NaClKeyPair> {
   if (stored) {
     try {
       const parsed: StoredKeyPair = JSON.parse(stored);
-      cachedKeyPair = {
-        publicKey: await decodeBase64(parsed.publicKey),
-        secretKey: await decodeBase64(parsed.secretKey),
-      };
+      const publicKey = await decodeBase64(parsed.publicKey);
+      const secretKey = await decodeBase64(parsed.secretKey);
+      // SEC-CRYPTO-001 (parity with mobile): NaCl box keys are exactly 32 bytes.
+      // A stored value that decodes to any other length is corrupt (truncation,
+      // tampering, a format change) — using it would silently produce undecryptable
+      // ciphertext. Reject + regenerate rather than encrypt with a malformed key.
+      if (publicKey.length !== 32 || secretKey.length !== 32) {
+        throw new Error('stored keypair has invalid length');
+      }
+      cachedKeyPair = { publicKey, secretKey };
       return cachedKeyPair;
     } catch {
       // Corrupted keypair - regenerate

--- a/supabase/migrations/099_offline_queue_machine_ownership_rls.sql
+++ b/supabase/migrations/099_offline_queue_machine_ownership_rls.sql
@@ -1,0 +1,68 @@
+-- ============================================================================
+-- Migration 099: offline_command_queue — enforce machine_id + session_id ownership
+-- ============================================================================
+--
+-- SECURITY FIX (SEC-WEBMOB-001, /sec-ship --comprehensive 2026-06-10)
+--
+-- The offline_command_queue RLS policies (001_initial_schema.sql:1091-1106) gate
+-- every operation on `user_id = auth.uid()` ONLY. `machine_id` is
+-- `NOT NULL REFERENCES machines(id)` and `session_id` REFERENCES sessions(id),
+-- but NO policy verifies those rows belong to the caller. The FK is satisfied by
+-- ANY existing machine/session id, so an authenticated user could INSERT/UPDATE a
+-- queued command carrying another user's machine_id or session_id.
+--
+-- Impact is bounded (delivery is user_id-partitioned: the victim's CLI only drains
+-- rows WHERE user_id = victim, so a foreign-machine_id row sits inert in the
+-- attacker's own partition and is never delivered or read cross-user). The real
+-- exposure is a machine_id/session_id existence oracle (FK success/failure) plus
+-- audit-record integrity. Classified MEDIUM. This migration closes it at the
+-- correct layer (the write WITH CHECK) so the trust boundary is explicit rather
+-- than relying on delivery scoping downstream.
+--
+-- WHY only INSERT/UPDATE WITH CHECK (not SELECT/DELETE USING): SELECT and DELETE
+-- are already user_id-scoped, so no cross-user read/delete is possible. The IDOR
+-- is purely on the WRITTEN machine_id/session_id columns, which only the WITH
+-- CHECK clauses constrain. Legitimate clients (web useRelaySend / mobile
+-- offline-sync) always write their OWN machine_id, so this tightening is
+-- transparent to them.
+--
+-- WHY session_id allows NULL: command.session_id is nullable (a queued chat may
+-- predate session creation); a NULL session_id is owner-agnostic and safe.
+-- ============================================================================
+
+-- INSERT: caller's own user_id AND a machine they own AND (no session OR their session)
+DROP POLICY IF EXISTS "offline_queue_insert_own" ON offline_command_queue;
+CREATE POLICY "offline_queue_insert_own"
+  ON offline_command_queue FOR INSERT
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND machine_id IN (SELECT id FROM machines WHERE user_id = (SELECT auth.uid()))
+    AND (
+      session_id IS NULL
+      OR session_id IN (SELECT id FROM sessions WHERE user_id = (SELECT auth.uid()))
+    )
+    -- SEC-WEBMOB-004: a freshly-queued command is always 'pending'. Pinning the
+    -- INSERT status closes the mass-assignment gap where a client could enqueue a
+    -- row pre-marked 'completed'/'cancelled' (skipping delivery) or otherwise
+    -- forge queue state. The drain path updates status server-side afterward.
+    AND status = 'pending'
+  );
+
+-- UPDATE: same ownership constraint on both the visible row (USING) and the
+-- post-update row (WITH CHECK), so a row cannot be re-pointed at a foreign
+-- machine/session via UPDATE either.
+DROP POLICY IF EXISTS "offline_queue_update_own" ON offline_command_queue;
+CREATE POLICY "offline_queue_update_own"
+  ON offline_command_queue FOR UPDATE
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND machine_id IN (SELECT id FROM machines WHERE user_id = (SELECT auth.uid()))
+    AND (
+      session_id IS NULL
+      OR session_id IN (SELECT id FROM sessions WHERE user_id = (SELECT auth.uid()))
+    )
+  );
+
+-- SELECT + DELETE policies are unchanged (already user_id-scoped; no cross-user
+-- read/delete possible). Left in place by this migration.


### PR DESCRIPTION
## Summary
Batch 1 of 2 from \`/sec-ship --comprehensive\` (the relay private-channel fix ships as a separate PR for isolated device verification). Closes 5 findings on the new surface from PRs #339-#349. No HIGH findings here - those are addressed in the relay PR.

## Findings closed
| ID | Sev | Fix |
|---|---|---|
| SEC-WEBMOB-001 | MED | `migration 099`: offline_command_queue RLS now requires machine_id + session_id ownership (was user_id-only -> write-IDOR) |
| SEC-WEBMOB-004 | LOW | `migration 099`: pin `status='pending'` on insert (mass-assignment) |
| SEC-CLAUDEPERM-001 | MED | capability-URL token on the in-process permission MCP server (only claude, reading the 0600 mcp-config, can reach the approval tool) |
| SEC-CLAUDEPERM-002 | LOW | mcp-config temp file written `mode 0o600` |
| SEC-CLIINJ-002 | LOW | `assertSafeArgValue` arg-confusion guard on model/allowedTools/gatedTools/resume-id |
| SEC-CRYPTO-001 | LOW | web NaCl key 32-byte length validation (parity with mobile) |

## Migration note
`migration 099` is **already applied to prod** (verified: policies live on `offline_command_queue`). It's committed here so the repo matches the DB. No post-merge DB action needed.

## Changes
- `supabase/migrations/099_offline_queue_machine_ownership_rls.sql` (new)
- `claudePermissionServer.ts` + test (capability URL + 404 test)
- `claude.ts` (temp-file 0600 + arg-guard) + `claude-backend.test.ts` (+1 test)
- `packages/styrby-web/src/lib/encryption.ts` (key-length parity)
- `.gitignore` (sec-ship reports)

## Test Plan
- [x] CLI typecheck + 24 claude-backend + 7 permission-server tests
- [x] web typecheck + 18 encryption tests
- [x] migration 099 applied + verified on prod
- [ ] CI passes

🤖 Shipped via /gh-ship