### PR TITLE
fix(security): make relay channels private (SEC-RELAY-AUTH-001)

### DIFF
--- a/packages/styrby-shared/src/relay/client.ts
+++ b/packages/styrby-shared/src/relay/client.ts
@@ -159,6 +159,32 @@ export class RelayClient extends EventEmitter<RelayChannelEvents> {
   // --------------------------------------------------------------------------
 
   /**
+   * Push the current Supabase session's access token onto the Realtime socket so
+   * private-channel authorization (SEC-RELAY-AUTH-001 / migration 100) succeeds.
+   *
+   * Best-effort + defensive: tolerates a client that doesn't expose
+   * `auth.getSession` / `realtime.setAuth` (e.g. a test double) and a missing
+   * session. Failures are non-fatal — `subscribe()` then surfaces a
+   * `CHANNEL_ERROR` that `scheduleReconnect()` already classifies as an auth
+   * failure, so we never hang.
+   */
+  private async ensureRealtimeAuth(): Promise<void> {
+    try {
+      const supa = this.config.supabase as unknown as {
+        auth?: { getSession?: () => Promise<{ data: { session: { access_token?: string } | null } }> };
+        realtime?: { setAuth?: (token: string) => void | Promise<void> };
+      };
+      const token = (await supa.auth?.getSession?.())?.data?.session?.access_token;
+      if (token && supa.realtime?.setAuth) {
+        await supa.realtime.setAuth(token);
+        this.log('Realtime auth token set for private channel');
+      }
+    } catch (err) {
+      this.log('ensureRealtimeAuth (non-fatal):', err);
+    }
+  }
+
+  /**
    * Connect to the relay channel
    */
   async connect(): Promise<void> {
@@ -170,10 +196,30 @@ export class RelayClient extends EventEmitter<RelayChannelEvents> {
     this.setState('connecting');
 
     try {
+      // WHY (SEC-RELAY-AUTH-001): private channels authorize against the JWT on
+      // the Realtime socket. Explicitly push the current session's access token to
+      // Realtime before subscribing so authorization is guaranteed regardless of
+      // how each caller's client propagates auth — the CLI is a Node client with
+      // no browser auto-session, so relying on implicit propagation would risk a
+      // total relay outage. Best-effort: if there's no session (or the client
+      // doesn't expose realtime.setAuth) we proceed; subscribe surfaces a
+      // CHANNEL_ERROR that scheduleReconnect already handles as an auth failure.
+      await this.ensureRealtimeAuth();
+
       const channelName = getChannelName(this.config.userId, this.config.channelSuffix);
 
       this.channel = this.config.supabase.channel(channelName, {
         config: {
+          // WHY private: true (SEC-RELAY-AUTH-001): makes Supabase Realtime
+          // authorize every subscribe + broadcast/presence write against RLS on
+          // realtime.messages (migration 100), keyed to realtime.topic(). The
+          // broker then rejects any client trying to join or publish to a
+          // relay:{userId} topic that isn't their own — closing the public-
+          // broadcast hole where anyone knowing a userId could read all chat or
+          // forge a `chat` that drives the agent. Requires an authenticated JWT
+          // on the realtime connection (CLI uses its Supabase JWT session; web +
+          // mobile use the browser/device session) — all three already do.
+          private: true,
           presence: { key: this.config.deviceId },
           broadcast: { self: false }, // Don't receive own broadcasts
         },

--- a/supabase/migrations/100_relay_private_channel_authorization.sql
+++ b/supabase/migrations/100_relay_private_channel_authorization.sql
@@ -1,0 +1,64 @@
+-- ============================================================================
+-- Migration 100: Relay private-channel authorization (realtime.messages RLS)
+-- ============================================================================
+--
+-- SECURITY FIX (SEC-RELAY-AUTH-001, /sec-ship --comprehensive 2026-06-10)
+--
+-- The relay channel `relay:{userId}` was created as a PUBLIC Supabase Realtime
+-- broadcast channel (no `private: true`, no authorization). The only secret in
+-- the topic name is the userId UUID, so any authenticated client that learns a
+-- userId could:
+--   - subscribe and read all plaintext chat + tool I/O (confidentiality), and
+--   - broadcast forged messages — including a `chat` the CLI forwards to
+--     agent.sendPrompt() (integrity / agent-drive, RCE-class when a session runs
+--     acceptEdits/bypassPermissions).
+-- Only `permission_response` was nonce-gated (CLI-009); all other message types
+-- were trusted-by-arrival.
+--
+-- FIX (broker-enforced, both confidentiality + integrity): the RelayClient now
+-- opens the channel with `private: true`. For private channels, Supabase Realtime
+-- authorizes every subscribe (SELECT) and every broadcast/presence write (INSERT)
+-- against RLS on `realtime.messages`, keyed to `realtime.topic()`. These policies
+-- restrict each authenticated user to their OWN relay topic — the broker rejects
+-- any attempt to join or publish to another user's channel before app code runs.
+--
+-- WHY this does NOT affect other realtime usage: realtime.messages RLS applies
+-- ONLY to channels opened with `private: true`. The cost/session dashboards use
+-- postgres_changes subscriptions (gated by ordinary table RLS) and public
+-- channels, which bypass realtime.messages RLS entirely. Only the relay channel
+-- opts into private mode, so only the relay topic is gated here.
+--
+-- WHY both exact-match and `:%` LIKE: the topic is `relay:{userId}` today, with a
+-- forward-compatible `relay:{userId}:{suffix}` variant (deriveChannelSuffix). Both
+-- belong to the same owning user, so both are authorized for that user.
+--
+-- ROLLOUT ORDERING (zero-downtime): apply THIS migration BEFORE shipping the
+-- RelayClient `private: true` change. While clients are still public, these
+-- policies are inert (public channels ignore realtime.messages RLS). Once a
+-- client connects with private:true, the matching policy is already present, so
+-- it authorizes immediately. Old (public) and new (private) clients coexist with
+-- no outage window.
+-- ============================================================================
+
+-- realtime.messages has RLS enabled by default in Supabase; CREATE POLICY is
+-- additive. DROP IF EXISTS keeps this migration idempotent on re-run.
+
+DROP POLICY IF EXISTS "relay_own_topic_select" ON realtime.messages;
+CREATE POLICY "relay_own_topic_select"
+  ON realtime.messages
+  FOR SELECT
+  TO authenticated
+  USING (
+    realtime.topic() = ('relay:' || (SELECT auth.uid())::text)
+    OR realtime.topic() LIKE ('relay:' || (SELECT auth.uid())::text || ':%')
+  );
+
+DROP POLICY IF EXISTS "relay_own_topic_insert" ON realtime.messages;
+CREATE POLICY "relay_own_topic_insert"
+  ON realtime.messages
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    realtime.topic() = ('relay:' || (SELECT auth.uid())::text)
+    OR realtime.topic() LIKE ('relay:' || (SELECT auth.uid())::text || ':%')
+  );


### PR DESCRIPTION
## Summary
Batch 2 of 2 from \`/sec-ship --comprehensive\` - the one **HIGH** finding.

The relay channel \`relay:{userId}\` was a **public** Supabase broadcast channel (no \`private:true\`, no Realtime Authorization). Anyone who learned a userId UUID could **read all plaintext chat** and **broadcast a forged \`chat\`** the CLI forwards to \`agent.sendPrompt()\` (agent-drive, RCE-class when a session runs \`acceptEdits\`). Only \`permission_response\` was nonce-gated.

## Fix (broker-enforced)
- **RelayClient** opens the channel with \`private: true\` + \`ensureRealtimeAuth()\` (pushes the session JWT onto the Realtime socket before subscribe - de-risks the CLI Node client which has no browser auto-session).
- **migration 100** adds RLS on \`realtime.messages\` restricting each user to their own \`relay:{uid}\` topic for subscribe + publish. The broker rejects cross-user join/publish before app code runs.

Chose private channels over per-message signing because signing leaves **confidentiality** (read-all-chat) open; private channels close **both** read and write. One shared RelayClient = one change point for CLI + web + mobile.

## Rollout (already de-risked)
**migration 100 is already applied to prod** (verified: \`relay_own_topic_select\`/\`relay_own_topic_insert\` policies live on \`realtime.messages\`). Policies exist before this client deploys → zero-downtime.

## ⚠️ Post-merge: LIVE device verification required
After web auto-deploys (and CLI/mobile are rebuilt), verify a real pairing: CLI connects + mobile connects + chat flows both ways. If \`CHANNEL_ERROR\` appears, the JWT isn't reaching Realtime (\`ensureRealtimeAuth\` should prevent this, but confirm on a real device).

## Changes
- \`packages/styrby-shared/src/relay/client.ts\` (private:true + ensureRealtimeAuth)
- \`supabase/migrations/100_relay_private_channel_authorization.sql\` (already on prod)

## Test Plan
- [x] shared typecheck + 87 relay tests
- [x] CLI typecheck + 97 api tests; web + mobile typecheck
- [x] migration 100 applied + verified on prod
- [ ] CI passes
- [ ] **LIVE device-pairing verification (operator, post-deploy)**

🤖 Shipped via /gh-ship