### PR TITLE
fix(cli): verify + fix agent integrations against real binaries

### DIFF
--- a/packages/styrby-cli/src/agent/StreamingAgentBackendBase.ts
+++ b/packages/styrby-cli/src/agent/StreamingAgentBackendBase.ts
@@ -70,11 +70,20 @@ import { buildSafeEnv, validateExtraArgs } from '@/utils/safeEnv';
  * (Phase 0.3 — SOC2 CC7.2 reliable streaming).
  */
 const INSTALL_HINTS: Readonly<Record<string, string>> = Object.freeze({
+  // Install hints verified against the live npm registry 2026-06-10 (bin names
+  // confirmed). The three first-party CLIs (claude/codex/gemini) are included so
+  // a missing binary surfaces an actionable package name instead of a bare ENOENT.
+  claude: 'Install via: npm install -g @anthropic-ai/claude-code',
+  codex: 'Install via: npm install -g @openai/codex',
+  gemini: 'Install via: npm install -g @google/gemini-cli',
   aider: 'Install via: pip install aider-chat',
-  amp: 'Install via: npm install -g @sourcegraph/amp',
-  crush: 'Install via: brew install crush (or follow https://github.com/charmbracelet/crush)',
-  // Factory AI's Droid CLI ships as the npm package `droid`; the
-  // Factory-AI/factory monorepo is the source of truth.
+  // @sourcegraph/amp is a deprecated thin alias that re-exports @ampcode/cli;
+  // the alias is scheduled for removal — install the canonical package directly.
+  amp: 'Install via: npm install -g @ampcode/cli (or: curl -fsSL https://ampcode.com/install.sh | bash)',
+  // Crush ships from the Charmbracelet Homebrew tap (no top-level `crush` formula).
+  crush: 'Install via: brew install charmbracelet/tap/crush (or: npm install -g @charmland/crush)',
+  // Factory AI's Droid CLI ships as the npm package `droid` (verified Factory-owned,
+  // same publisher as @factory/cli — not a name-squat); Factory-AI/factory monorepo.
   droid: 'Install via: npm install -g droid (or see https://docs.factory.ai/cli)',
   // Goose was transferred from block/goose to aaif-goose/goose (LF, 2026-04-07).
   goose: 'Install via: see https://github.com/aaif-goose/goose for installation',

--- a/packages/styrby-cli/src/agent/__tests__/e2e/agentSmokeTests.test.ts
+++ b/packages/styrby-cli/src/agent/__tests__/e2e/agentSmokeTests.test.ts
@@ -66,26 +66,30 @@ const AGENT_TRANSCRIPTS = {
    * OpenCode emits JSONL events per line: assistant (text), tool_use, tool_result,
    * then a session event with cumulative cost/token data.
    */
+  // Real opencode `--format json` schema (verified vs live binary 2026-06-10):
+  // text events carry part.text; step_finish carries part.cost + part.tokens.
+  // (tool events omitted — opencode's real tool-event shape is unverified; see #30.)
   opencode: [
-    '{"type":"assistant","content":"I\'ll write a hello world to main.ts."}',
-    '{"type":"tool_use","tool_name":"write_file","tool_input":{"path":"main.ts","content":"console.log(\'Hello, world!\');"},"call_id":"tc-001"}',
-    '{"type":"tool_result","tool_name":"write_file","tool_result":{"success":true},"call_id":"tc-001"}',
-    '{"type":"session","session":{"id":"oc-sess-001","PromptTokens":312,"CompletionTokens":45,"Cost":0.001}}',
+    '{"type":"step_start","sessionID":"oc-sess-001","part":{"type":"step-start"}}',
+    '{"type":"text","sessionID":"oc-sess-001","part":{"type":"text","text":"I\'ll write a hello world to main.ts."}}',
+    '{"type":"step_finish","sessionID":"oc-sess-001","part":{"type":"step-finish","reason":"stop","cost":0.001,"tokens":{"input":312,"output":45}}}',
   ].join('\n'),
 
   /**
-   * Kilo transcript captured with:
-   *   kilo --message "write hello world to main.ts" --format json
-   * Includes a Memory Bank read event (Kilo's unique feature) followed by
-   * standard text/tool/tokens events.
+   * Kilo transcript — Kilo is an OpenCode fork, so its `--format json` envelope
+   * is `{ type, sessionID, part }` (same VERIFIED structure as opencode). The
+   * envelope + top-level sessionID + nested error payload were CONFIRMED against
+   * the real `kilo` binary (v7.3.41, 2026-06-11); see kilo.ts header.
+   * SCHEMA UNVERIFIED — needs keyed session (#30): the success-path text /
+   * step_finish part payloads below mirror opencode's verified shape on the
+   * fork assumption (no provider key available locally → 401 from the model).
+   * The invented memory_bank_read / tool_use / tokens / complete events the
+   * prior fixture used do NOT exist in the real binary and were removed.
    */
   kilo: [
-    '{"type":"memory_bank_read","memory_file":"activeContext.md","memory_content":"Current task: coding session"}',
-    '{"type":"text","content":"I\'ll write a hello world program to main.ts."}',
-    '{"type":"tool_use","tool_name":"write_file","tool_input":{"path":"main.ts","content":"console.log(\'Hello, world!\');"},"call_id":"kc-001"}',
-    '{"type":"tool_result","tool_name":"write_file","tool_result":{"success":true},"call_id":"kc-001"}',
-    '{"type":"tokens","usage":{"input_tokens":298,"output_tokens":38,"cost_usd":0.0008}}',
-    '{"type":"complete"}',
+    '{"type":"step_start","sessionID":"ses_kilo001","part":{"type":"step-start"}}',
+    '{"type":"text","sessionID":"ses_kilo001","part":{"type":"text","text":"I\'ll write a hello world program to main.ts."}}',
+    '{"type":"step_finish","sessionID":"ses_kilo001","part":{"type":"step-finish","reason":"stop","cost":0.0008,"tokens":{"input":298,"output":38}}}',
   ].join('\n'),
 
   /**
@@ -102,30 +106,26 @@ const AGENT_TRANSCRIPTS = {
   ].join('\n'),
 
   /**
-   * Amp transcript captured with:
-   *   amp chat --message "write hello world to main.ts" --format json --no-interactive
-   * Amp's deep mode is NOT active in this smoke test (uses standard mode).
+   * Amp transcript — Amp's `--stream-json` is documented as "Claude Code-compatible
+   * stream JSON format" (verified vs `amp --help`, binary 0.0.1781143784, 2026-06-11),
+   * so the factory reuses parseClaudeJsonlLine. Real events: an `assistant` line
+   * carrying message.content[].text + message.usage, then a final `result` line.
+   * Source command: `amp -x "write hello world to main.ts" --stream-json`.
    */
   amp: [
-    '{"type":"text","content":"I\'ll write a hello world program to main.ts."}',
-    '{"type":"tool_use","tool_name":"write_file","tool_input":{"path":"main.ts","content":"console.log(\'Hello, world!\');"},"call_id":"ac-001"}',
-    '{"type":"tool_result","tool_name":"write_file","tool_result":{"success":true},"call_id":"ac-001"}',
-    '{"type":"usage","usage":{"input_tokens":325,"output_tokens":42,"cost_usd":0.001}}',
-    '{"type":"done"}',
+    '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I\'ll write a hello world program to main.ts."}],"usage":{"input_tokens":325,"output_tokens":42}}}',
+    '{"type":"result","subtype":"success"}',
   ].join('\n'),
 
   /**
-   * Crush transcript captured with:
-   *   crush --message "write hello world to main.ts" --format json --no-tui
-   * Crush uses ACP-compatible JSON events with charm-style naming.
+   * Crush transcript — crush has NO machine-readable output mode (verified vs
+   * crush v0.76.0, 2026-06-10). `crush run --quiet` writes the model's reply to
+   * stdout as PLAIN TEXT. The factory does a plain-text stdout → model-output
+   * passthrough and emits NO cost-report (supportsTools:false, no usage source).
+   * So this transcript is raw text, not JSON.
+   * Source command: `crush run --quiet "write hello world to main.ts"`.
    */
-  crush: [
-    '{"type":"text_delta","delta":"I\'ll write a hello world to main.ts."}',
-    '{"type":"tool_call","tool":"write_file","args":{"path":"main.ts","content":"console.log(\'Hello, world!\');"},"call_id":"cc-001"}',
-    '{"type":"tool_result","tool":"write_file","output":{"success":true},"call_id":"cc-001"}',
-    '{"type":"usage","usage":{"input_tokens":289,"output_tokens":36,"cost_usd":0.0008}}',
-    '{"type":"done"}',
-  ].join('\n'),
+  crush: 'I\'ll write a hello world to main.ts.\nconsole.log(\'Hello, world!\');\nDone.',
 
   /**
    * Kiro transcript captured with:
@@ -142,16 +142,17 @@ const AGENT_TRANSCRIPTS = {
   ].join('\n'),
 
   /**
-   * Droid transcript captured with:
-   *   droid run --message "write hello world to main.ts" --format json
-   * Droid is BYOK via LiteLLM; it reports token counts from the provider.
+   * Droid transcript — VERIFIED stream-json schema (Claude-Code-shaped) captured
+   * from the real `droid` binary v0.144.2 via:
+   *   droid exec "write hello world to main.ts" --output-format stream-json
+   * Droid is Factory-hosted (not BYOK/LiteLLM). The result.usage block uses
+   * snake_case input_tokens/output_tokens and carries NO cost field — cost is
+   * derived downstream, so the emitted CostReport is always a styrby-estimate.
+   * (assistant/tool_use events are UNVERIFIED #30 and intentionally omitted.)
    */
   droid: [
-    '{"type":"text","content":"I\'ll create main.ts with a hello world."}',
-    '{"type":"tool_call","tool_name":"write_file","tool_input":{"path":"main.ts","content":"console.log(\'Hello, world!\');"},"call_id":"dc-001"}',
-    '{"type":"tool_result","tool_name":"write_file","tool_result":{"success":true},"call_id":"dc-001"}',
-    '{"type":"usage","usage":{"prompt_tokens":304,"completion_tokens":40,"cost_usd":0.0012}}',
-    '{"type":"done"}',
+    '{"type":"system","subtype":"init","session_id":"droid-smoke","tools":["Read","Edit","Create"],"model":"claude-opus-4-8","reasoning_effort":"high"}',
+    '{"type":"result","subtype":"success","is_error":false,"duration_ms":1200,"num_turns":1,"result":"Created main.ts with a hello world.","session_id":"droid-smoke","usage":{"input_tokens":304,"output_tokens":40,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}',
   ].join('\n'),
 } as const;
 
@@ -492,12 +493,13 @@ describe('E2E smoke — opencode', () => {
 /**
  * Kilo E2E smoke test.
  *
- * Kilo's unique feature is the Memory Bank. The transcript includes a
- * memory_bank_read event. Verifies: memory events surface as 'event' messages,
- * text streaming works, CostReport shape is correct.
+ * Kilo is an OpenCode fork: `--format json` emits `{ type, sessionID, part }`
+ * events. Verifies text streaming (part.text → model-output) and CostReport
+ * (part.cost + part.tokens on step_finish). The prior version asserted invented
+ * Memory Bank / tokens events the real binary does not emit (removed 2026-06-11).
  */
 describe('E2E smoke — kilo', () => {
-  it('spawns, parses JSONL with Memory Bank events, emits CostReport', async () => {
+  it('spawns, parses {type,sessionID,part} JSONL, emits CostReport', async () => {
     const { backend } = createKiloBackend({ cwd: '/project', model: 'claude-sonnet-4' });
     const messages = collectMessages(backend);
 
@@ -506,23 +508,17 @@ describe('E2E smoke — kilo', () => {
     resolveStreamingProcess(currentMockProcess, AGENT_TRANSCRIPTS.kilo);
     await promptPromise;
 
-    // 1. model-output captured from "text" events
+    // 1. model-output captured from "text" events (part.text)
     const textChunks = messages.filter((m: any) => m.type === 'model-output');
     expect(textChunks.length).toBeGreaterThan(0);
 
-    // 2. Memory Bank read surfaces as an 'event' message
-    const eventMessages = messages.filter((m: any) => m.type === 'event');
-    const memoryEvents = eventMessages.filter(
-      (m: any) => m.name === 'memory-bank-read' || m.name === 'memory_bank_read',
-    );
-    expect(memoryEvents.length).toBeGreaterThan(0);
-
-    // 3. CostReport emitted from "tokens" event
+    // 2. CostReport emitted from "step_finish" event (part.cost + part.tokens)
     const costReports = messages.filter((m: any) => m.type === 'cost-report');
     expect(costReports.length).toBeGreaterThan(0);
     const report = (costReports[0] as any).report;
     expect(report.agentType).toBe('kilo');
     expect(report.source).toBe('agent-reported');
+    expect(report.billingModel).toBe('api-key');
     expect(typeof report.inputTokens).toBe('number');
     expect(typeof report.outputTokens).toBe('number');
 
@@ -672,11 +668,14 @@ describe('E2E smoke — amp', () => {
 /**
  * Crush E2E smoke test.
  *
- * Crush outputs ACP-compatible JSON with events: text_delta, tool_call,
- * tool_result, usage, done. Verifies: text streaming, CostReport.
+ * Crush has NO machine-readable output mode (verified vs crush v0.76.0,
+ * 2026-06-10). `crush run` writes the model's reply to stdout as PLAIN TEXT, so
+ * the backend does a plain-text passthrough to `model-output` and emits NO
+ * cost/usage/tool events (supportsTools:false). This test asserts the plain-text
+ * passthrough and that no cost-report is fabricated.
  */
 describe('E2E smoke — crush', () => {
-  it('spawns, parses ACP JSON transcript, emits CostReport', async () => {
+  it('spawns, parses plain-text transcript, emits model-output (no cost-report)', async () => {
     const { backend } = createCrushBackend({ cwd: '/project', model: 'claude-sonnet-4' });
     const messages = collectMessages(backend);
 
@@ -685,17 +684,16 @@ describe('E2E smoke — crush', () => {
     resolveStreamingProcess(currentMockProcess, AGENT_TRANSCRIPTS.crush);
     await promptPromise;
 
-    // 1. model-output from "text_delta" events
+    // 1. plain-text stdout is forwarded verbatim as model-output deltas
     const textChunks = messages.filter((m: any) => m.type === 'model-output');
     expect(textChunks.length).toBeGreaterThan(0);
+    const fullText = textChunks.map((m: any) => m.textDelta).join('');
+    expect(fullText).toContain('hello world');
 
-    // 2. CostReport from "usage" event
+    // 2. crush has no cost-bearing output — verified 2026-06-10; it must NOT
+    //    fabricate a cost-report from plain text.
     const costReports = messages.filter((m: any) => m.type === 'cost-report');
-    expect(costReports.length).toBeGreaterThan(0);
-    const report = (costReports[0] as any).report;
-    expect(report.agentType).toBe('crush');
-    expect(report.source).toBe('agent-reported');
-    expect(typeof report.inputTokens).toBe('number');
+    expect(costReports.length).toBe(0);
 
     await backend.dispose();
   });
@@ -774,21 +772,22 @@ describe('E2E smoke — kiro', () => {
 });
 
 // ============================================================================
-// 8. Droid (Factory AI BYOK) — npm install -g droid
+// 8. Droid (Factory AI hosted) — https://docs.factory.ai/cli
 // ============================================================================
 
 /**
  * Droid E2E smoke test.
  *
- * Droid is BYOK via LiteLLM. It reports token usage and cost per request.
- * Verifies: text streaming, CostReport with LiteLLM-reported cost.
+ * Droid is Factory-hosted (not BYOK/LiteLLM). It is invoked via `droid exec`
+ * and emits Claude-Code-shaped stream-json. It reports token counts in the
+ * result event but NO cost, so the CostReport is a styrby-estimate.
+ * Verifies: result-text streaming + CostReport emission from the result usage.
  */
 describe('E2E smoke — droid', () => {
-  it('spawns, parses Droid JSONL, emits CostReport with LiteLLM cost', async () => {
+  it('spawns `droid exec`, parses stream-json, emits a CostReport', async () => {
     const { backend } = createDroidBackend({
       cwd: '/project',
-      model: 'claude-sonnet-4',
-      backend: 'anthropic',
+      model: 'claude-opus-4-8',
     });
     const messages = collectMessages(backend);
 
@@ -797,23 +796,23 @@ describe('E2E smoke — droid', () => {
     resolveStreamingProcess(currentMockProcess, AGENT_TRANSCRIPTS.droid);
     await promptPromise;
 
-    // 1. model-output from "text" events
+    // 1. model-output from the result event text
     const textChunks = messages.filter((m: any) => m.type === 'model-output');
     expect(textChunks.length).toBeGreaterThan(0);
 
-    // 2. CostReport from "usage" event
+    // 2. CostReport from the result usage block
     const costReports = messages.filter((m: any) => m.type === 'cost-report');
     expect(costReports.length).toBeGreaterThan(0);
     const report = (costReports[0] as any).report;
     expect(report.agentType).toBe('droid');
     expect(typeof report.inputTokens).toBe('number');
-    expect(typeof report.costUsd).toBe('number');
+    expect(report.source).toBe('styrby-estimate');
 
     await backend.dispose();
   });
 
   it('emits ENOENT as install hint when droid binary is missing', async () => {
-    const { backend } = createDroidBackend({ cwd: '/project', provider: 'anthropic' });
+    const { backend } = createDroidBackend({ cwd: '/project' });
     const messages = collectMessages(backend);
 
     const { sessionId } = await backend.startSession();
@@ -954,7 +953,7 @@ describe('Cross-agent contract — startSession emits starting status', () => {
     { name: 'amp', create: () => createAmpBackend({ cwd: '/p' }) },
     { name: 'crush', create: () => createCrushBackend({ cwd: '/p' }) },
     { name: 'kiro', create: () => createKiroBackend({ cwd: '/p' }) },
-    { name: 'droid', create: () => createDroidBackend({ cwd: '/p', backend: 'anthropic' }) },
+    { name: 'droid', create: () => createDroidBackend({ cwd: '/p' }) },
   ];
 
   for (const { name, create } of streamingFactories) {
@@ -1020,7 +1019,7 @@ describe('Cross-agent contract — sendPrompt emits idle after clean exit', () =
     },
     {
       name: 'droid',
-      create: () => createDroidBackend({ cwd: '/p', backend: 'anthropic' }),
+      create: () => createDroidBackend({ cwd: '/p' }),
       transcript: AGENT_TRANSCRIPTS.droid,
     },
   ];
@@ -1077,11 +1076,9 @@ describe('Cross-agent contract — CostReport shape', () => {
       create: () => createAmpBackend({ cwd: '/p', model: 'claude-sonnet-4' }),
       transcript: AGENT_TRANSCRIPTS.amp,
     },
-    {
-      name: 'crush',
-      create: () => createCrushBackend({ cwd: '/p', model: 'claude-sonnet-4' }),
-      transcript: AGENT_TRANSCRIPTS.crush,
-    },
+    // crush EXCLUDED: crush has no cost-bearing output — verified 2026-06-10.
+    // Its `crush run` plain-text mode emits no usage/cost event, so the backend
+    // (correctly) never emits a CostReport. It cannot satisfy the shape contract.
     {
       name: 'goose',
       create: () => createGooseBackend({ cwd: '/p', model: 'claude-sonnet-4' }),

--- a/packages/styrby-cli/src/agent/__tests__/e2e/longRunningSession.test.ts
+++ b/packages/styrby-cli/src/agent/__tests__/e2e/longRunningSession.test.ts
@@ -110,8 +110,8 @@ function resolveProcess(proc: MockProcess, transcript: string): void {
 const MINIMAL_AIDER = '> Tokens: 100 sent, 20 received, cost: $0.001';
 
 const MINIMAL_OPENCODE = [
-  '{"type":"assistant","content":"Done."}',
-  '{"type":"session","session":{"id":"oc-loop","PromptTokens":100,"CompletionTokens":20,"Cost":0.001}}',
+  '{"type":"text","sessionID":"oc-loop","part":{"type":"text","text":"Done."}}',
+  '{"type":"step_finish","sessionID":"oc-loop","part":{"type":"step-finish","cost":0.001,"tokens":{"input":100,"output":20}}}',
 ].join('\n');
 
 const MINIMAL_GOOSE = [

--- a/packages/styrby-cli/src/agent/__tests__/e2e/reconnectMidStream.test.ts
+++ b/packages/styrby-cli/src/agent/__tests__/e2e/reconnectMidStream.test.ts
@@ -224,11 +224,6 @@ const MID_TOOL_CALL_TRANSCRIPTS = {
     '{"type":"tool_use","tool_name":"write_file","tool_input":{"path":"main.ts","content":"console.log(\'Hello!\');"},"call_id":"tc-001"}',
     // No tool_result — killed here
   ].join('\n') + '\n',
-  kilo: [
-    '{"type":"text","content":"Writing hello world..."}',
-    '{"type":"tool_use","tool_name":"write_file","tool_input":{"path":"main.ts","content":"console.log(\'Hello!\');"},"call_id":"kc-001"}',
-    // No tool_result — killed here
-  ].join('\n') + '\n',
   goose: [
     '{"type":"message","content":"Creating file..."}',
     '{"type":"tool_call","tool":"write_file","input":{"path":"main.ts","content":"console.log(\'Hello!\');"},"call_id":"gc-001"}',
@@ -263,7 +258,7 @@ describe('Reconnect: streaming backends — mid-text disconnect (scenario 1)', (
     { name: 'amp', create: () => createAmpBackend({ cwd: '/p' }), partial: PARTIAL_TRANSCRIPTS.amp },
     { name: 'crush', create: () => createCrushBackend({ cwd: '/p' }), partial: PARTIAL_TRANSCRIPTS.crush },
     { name: 'kiro', create: () => createKiroBackend({ cwd: '/p' }), partial: PARTIAL_TRANSCRIPTS.kiro },
-    { name: 'droid', create: () => createDroidBackend({ cwd: '/p', backend: 'anthropic' }), partial: PARTIAL_TRANSCRIPTS.droid },
+    { name: 'droid', create: () => createDroidBackend({ cwd: '/p' }), partial: PARTIAL_TRANSCRIPTS.droid },
   ] as const;
 
   for (const { name, create, partial } of cases) {
@@ -298,9 +293,14 @@ describe('Reconnect: streaming backends — mid-text disconnect (scenario 1)', (
 // ============================================================================
 
 describe('Reconnect: streaming backends — mid-tool-call disconnect (scenario 2)', () => {
+  // NOTE: opencode removed from this scenario 2026-06-10, and kilo removed
+  // 2026-06-10 (#30). Both assert a `tool-call` is emitted mid-stream, but their
+  // real tool-event schema is not yet verified against the live binary (kilo is
+  // an OpenCode fork whose rewritten factory no longer maps the invented
+  // `tool_use` event), so the backends correctly emit no tool-call. Re-add with
+  // a real fixture once a tool-triggering session is captured (#30). goose still
+  // covers the mid-tool-call error-status behavior.
   const cases = [
-    { name: 'opencode', create: () => createOpenCodeBackend({ cwd: '/p' }), partial: MID_TOOL_CALL_TRANSCRIPTS.opencode },
-    { name: 'kilo', create: () => createKiloBackend({ cwd: '/p' }), partial: MID_TOOL_CALL_TRANSCRIPTS.kilo },
     { name: 'goose', create: () => createGooseBackend({ cwd: '/p' }), partial: MID_TOOL_CALL_TRANSCRIPTS.goose },
   ] as const;
 

--- a/packages/styrby-cli/src/agent/factories/__tests__/amp.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/amp.test.ts
@@ -1,13 +1,22 @@
 /**
- * Tests for the Amp agent backend factory (Sourcegraph).
+ * Tests for the Amp agent backend factory (ampcode.com).
  *
  * Covers:
  * - `createAmpBackend` factory function
  * - `registerAmpAgent` registry integration
- * - `AmpBackend` class: session lifecycle, subprocess management,
- *   JSONL output parsing, deep mode sub-agent event tracking,
- *   token/cost accumulation across sub-agents, fs-edit detection,
- *   error handling, cancellation, permission response, and disposal.
+ * - `AmpBackend` class: session lifecycle, subprocess management, the REAL
+ *   `amp -x "<prompt>" --stream-json` invocation (verified against
+ *   `amp --help`), Claude Code-compatible stream-json parsing, AMP_API_KEY-only
+ *   auth injection, error handling, cancellation, and disposal.
+ *
+ * Stream-json schema source: `amp --help` documents `--stream-json` as
+ * "Claude Code-compatible stream JSON format", so the event shape is the same
+ * newline-delimited `{type:'assistant',message:{content:[...],usage:{...}}}` /
+ * `{type:'result'}` schema the `claude` factory parses. The exact bytes could
+ * NOT be captured live (running `amp -x ... --stream-json` triggers `amp login`
+ * with no AMP_API_KEY available) — see #30. Tests therefore assert the
+ * claude-compatible shape; any assertion needing real keyed output is skipped
+ * with a reason.
  *
  * All child_process and logger calls are mocked so no real Amp binary
  * is required.
@@ -17,15 +26,18 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before the module under test is imported
 // ---------------------------------------------------------------------------
 
-function makeStream() {
-  const emitter = new EventEmitter() as EventEmitter & { write?: ReturnType<typeof vi.fn> };
-  emitter.write = vi.fn();
-  return emitter;
+// WHY PassThrough (not a bare EventEmitter): the rewritten AmpBackend consumes
+// stdout via the base class's node:readline `streamLines()`, which requires a
+// real Readable (`resume`/`pause`/`read`). PassThrough exposes the full Readable
+// API while still letting tests push bytes via `.write()` / `.emit('data', buf)`.
+function makeStream(): PassThrough {
+  return new PassThrough();
 }
 
 function makeMockProcess() {
@@ -79,59 +91,67 @@ function collectMessages(backend: ReturnType<typeof createAmpBackend>['backend']
 }
 
 /**
- * Simulate Amp output: emit lines as stdout data events, then close the process.
+ * Simulate Amp stream-json output: write newline-delimited lines to the stdout
+ * PassThrough (so the backend's readline emits 'line' events), end the streams,
+ * then fire the process 'close' on the next tick.
+ *
+ * WHY nextTick (mirrors aider.test): 'close' must fire AFTER readline has flushed
+ * the buffered lines, otherwise the close handler resolves before any line is
+ * parsed and the emitted-message assertions race.
  */
 function simulateProcess(proc: MockProcess, lines: string[] = [], exitCode = 0) {
   for (const line of lines) {
-    (proc.stdout as EventEmitter).emit('data', Buffer.from(line + '\n'));
+    (proc.stdout as PassThrough).write(line + '\n');
   }
-  proc.emit('close', exitCode);
+  (proc.stdout as PassThrough).end();
+  (proc.stderr as PassThrough).end();
+  process.nextTick(() => proc.emit('close', exitCode));
 }
 
-// ---- Amp event builders ----
+// ---- Amp stream-json event builders (Claude Code-compatible schema) ----
+// Source: `amp --help` ("Claude Code-compatible stream JSON format") + the
+// verified claude factory schema. See module header / #30.
 
-function ampText(content: string): string {
-  return JSON.stringify({ type: 'text', content });
+/** assistant line carrying a text block. */
+function ampAssistantText(text: string, model = 'amp-default'): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { model, content: [{ type: 'text', text }] },
+  });
 }
 
-function ampToolUse(toolName: string, callId: string, input?: Record<string, unknown>): string {
-  return JSON.stringify({ type: 'tool_use', tool_name: toolName, call_id: callId, tool_input: input });
+/** assistant line carrying a tool_use block. */
+function ampToolUse(toolName: string, id: string, input?: Record<string, unknown>): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', name: toolName, id, input }] },
+  });
 }
 
-function ampToolResult(
-  toolName: string,
-  callId: string,
-  result: unknown,
-  toolInput?: Record<string, unknown>
-): string {
-  return JSON.stringify({ type: 'tool_result', tool_name: toolName, call_id: callId, tool_result: result, tool_input: toolInput });
+/** user line echoing a tool_result block (Claude Code shape). */
+function ampToolResult(toolUseId: string, content: unknown): string {
+  return JSON.stringify({
+    type: 'user',
+    message: { content: [{ type: 'tool_result', tool_use_id: toolUseId, content }] },
+  });
 }
 
-function ampSubAgentStart(subAgentId: string, description?: string): string {
-  return JSON.stringify({ type: 'sub_agent_start', sub_agent_id: subAgentId, sub_agent_description: description });
-}
-
-function ampSubAgentComplete(subAgentId: string): string {
-  return JSON.stringify({ type: 'sub_agent_complete', sub_agent_id: subAgentId });
-}
-
-function ampUsage(usage: {
+/** assistant line whose usage block drives cost extraction. */
+function ampAssistantUsage(usage: {
   input_tokens?: number;
   output_tokens?: number;
-  cache_read_tokens?: number;
-  cache_write_tokens?: number;
-  cost_usd?: number;
-  sub_agent_id?: string;
-}): string {
-  return JSON.stringify({ type: 'usage', usage });
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+}, model = 'amp-default'): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { model, usage, content: [] },
+  });
 }
 
-function ampError(error: string): string {
-  return JSON.stringify({ type: 'error', error });
-}
-
-function ampDone(): string {
-  return JSON.stringify({ type: 'done' });
+/** terminal result line. */
+function ampResult(): string {
+  return JSON.stringify({ type: 'result' });
 }
 
 const BASE_OPTIONS: AmpBackendOptions = {
@@ -306,7 +326,7 @@ describe('AmpBackend — session lifecycle', () => {
 // ===========================================================================
 
 describe('AmpBackend — sendPrompt arguments', () => {
-  it('spawns amp with "chat", "--message", and "--format json" flags', async () => {
+  it('spawns amp in execute mode with -x <prompt> --stream-json', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -316,14 +336,13 @@ describe('AmpBackend — sendPrompt arguments', () => {
 
     const [cmd, args] = mockSpawn.mock.calls[0];
     expect(cmd).toBe('amp');
-    expect(args).toContain('chat');
-    expect(args).toContain('--message');
-    expect(args).toContain('Analyze the auth module');
-    expect(args).toContain('--format');
-    expect(args).toContain('json');
+    // -x must be immediately followed by the prompt (positional message form).
+    expect(args[0]).toBe('-x');
+    expect(args[1]).toBe('Analyze the auth module');
+    expect(args).toContain('--stream-json');
   });
 
-  it('includes --no-interactive flag by default', async () => {
+  it('does NOT use the invented "chat"/"--message"/"--format" flags', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -332,11 +351,14 @@ describe('AmpBackend — sendPrompt arguments', () => {
     await promptPromise;
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('--no-interactive');
+    expect(args).not.toContain('chat');
+    expect(args).not.toContain('--message');
+    expect(args).not.toContain('--format');
+    expect(args).not.toContain('--no-interactive');
   });
 
-  it('includes --model flag when model is specified', async () => {
-    const { backend } = createAmpBackend({ ...BASE_OPTIONS, model: 'claude-opus-4' });
+  it('includes --mode when a mode is specified', async () => {
+    const { backend } = createAmpBackend({ ...BASE_OPTIONS, mode: 'deep' });
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
@@ -344,11 +366,11 @@ describe('AmpBackend — sendPrompt arguments', () => {
     await promptPromise;
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('--model');
-    expect(args).toContain('claude-opus-4');
+    expect(args).toContain('--mode');
+    expect(args).toContain('deep');
   });
 
-  it('does NOT include --model when model is omitted', async () => {
+  it('does NOT include --mode when mode is omitted', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -357,23 +379,11 @@ describe('AmpBackend — sendPrompt arguments', () => {
     await promptPromise;
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).not.toContain('--model');
+    expect(args).not.toContain('--mode');
   });
 
-  it('includes --deep flag when deepMode is enabled', async () => {
-    const { backend } = createAmpBackend({ ...BASE_OPTIONS, deepMode: true });
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess);
-    await promptPromise;
-
-    const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('--deep');
-  });
-
-  it('does NOT include --deep when deepMode is false', async () => {
-    const { backend } = createAmpBackend({ ...BASE_OPTIONS, deepMode: false });
+  it('does NOT include the invented --deep / --max-agents / --session flags', async () => {
+    const { backend } = createAmpBackend({ ...BASE_OPTIONS, mode: 'deep' });
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
@@ -382,50 +392,14 @@ describe('AmpBackend — sendPrompt arguments', () => {
 
     const [, args] = mockSpawn.mock.calls[0];
     expect(args).not.toContain('--deep');
-  });
-
-  it('includes --max-agents when deepMode is enabled with maxSubAgents', async () => {
-    const { backend } = createAmpBackend({ ...BASE_OPTIONS, deepMode: true, maxSubAgents: 6 });
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess);
-    await promptPromise;
-
-    const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('--max-agents');
-    expect(args).toContain('6');
-  });
-
-  it('does NOT include --max-agents when deepMode is disabled', async () => {
-    const { backend } = createAmpBackend({ ...BASE_OPTIONS, deepMode: false, maxSubAgents: 6 });
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess);
-    await promptPromise;
-
-    const [, args] = mockSpawn.mock.calls[0];
     expect(args).not.toContain('--max-agents');
-  });
-
-  it('includes --session flag when resumeSessionId is provided', async () => {
-    const { backend } = createAmpBackend({ ...BASE_OPTIONS, resumeSessionId: 'sess-abc-123' });
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess);
-    await promptPromise;
-
-    const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('--session');
-    expect(args).toContain('sess-abc-123');
+    expect(args).not.toContain('--session');
   });
 
   it('appends extraArgs to the spawn call', async () => {
     const { backend } = createAmpBackend({
       ...BASE_OPTIONS,
-      extraArgs: ['--debug', '--timeout', '300'],
+      extraArgs: ['--effort', 'high'],
     });
     const { sessionId } = await backend.startSession();
 
@@ -434,12 +408,11 @@ describe('AmpBackend — sendPrompt arguments', () => {
     await promptPromise;
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('--debug');
-    expect(args).toContain('--timeout');
-    expect(args).toContain('300');
+    expect(args).toContain('--effort');
+    expect(args).toContain('high');
   });
 
-  it('sets ANTHROPIC_API_KEY and AMP_API_KEY when apiKey is provided', async () => {
+  it('injects ONLY AMP_API_KEY (no cross-vendor ANTHROPIC_API_KEY leak)', async () => {
     const { backend } = createAmpBackend({ ...BASE_OPTIONS, apiKey: 'amp-key-456' });
     const { sessionId } = await backend.startSession();
 
@@ -448,8 +421,9 @@ describe('AmpBackend — sendPrompt arguments', () => {
     await promptPromise;
 
     const [, , spawnOptions] = mockSpawn.mock.calls[0];
-    expect(spawnOptions.env.ANTHROPIC_API_KEY).toBe('amp-key-456');
     expect(spawnOptions.env.AMP_API_KEY).toBe('amp-key-456');
+    // SECURITY: the Amp token must NOT be forwarded to the Anthropic var.
+    expect(spawnOptions.env.ANTHROPIC_API_KEY).toBeUndefined();
   });
 
   it('passes cwd to spawn options', async () => {
@@ -485,81 +459,84 @@ describe('AmpBackend — sendPrompt arguments', () => {
 });
 
 // ===========================================================================
-// AmpBackend — JSONL output parsing and event emission
+// AmpBackend — stream-json parsing and event emission (Claude-compatible)
 // ===========================================================================
 
-describe('AmpBackend — JSONL output parsing and event emission', () => {
-  it('emits model-output message for type=text events', async () => {
+describe('AmpBackend — stream-json parsing and event emission', () => {
+  it('emits model-output for an assistant text block', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [ampText('Here is your refactored code.')]);
+    simulateProcess(currentMockProcess, [ampAssistantText('Here is your refactored code.')]);
     await promptPromise;
 
     const outputs = messages.filter((m: any) => m.type === 'model-output');
     expect(outputs.length).toBeGreaterThan(0);
-    const text = outputs.map((m: any) => m.textDelta).join('');
+    // Claude-compatible parser emits fullText (not incremental textDelta).
+    const text = outputs.map((m: any) => m.fullText).join('');
     expect(text).toContain('Here is your refactored code.');
   });
 
-  it('does not emit model-output when text content is absent', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [JSON.stringify({ type: 'text' })]);
-    await promptPromise;
-
-    expect(messages.filter((m: any) => m.type === 'model-output').length).toBe(0);
-  });
-
-  it('emits tool-call message for type=tool_use events', async () => {
+  it('does not emit model-output when an assistant block has no text', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     simulateProcess(currentMockProcess, [
-      ampToolUse('search_files', 'call-10', { pattern: '*.ts' }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text' }] } }),
+    ]);
+    await promptPromise;
+
+    expect(messages.filter((m: any) => m.type === 'model-output').length).toBe(0);
+  });
+
+  it('emits tool-call for an assistant tool_use block', async () => {
+    const { backend } = createAmpBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, [
+      ampToolUse('Grep', 'call-10', { pattern: '*.ts' }),
     ]);
     await promptPromise;
 
     const toolCalls = messages.filter((m: any) => m.type === 'tool-call');
     expect(toolCalls.length).toBe(1);
     const call = toolCalls[0] as any;
-    expect(call.toolName).toBe('search_files');
+    expect(call.toolName).toBe('Grep');
     expect(call.callId).toBe('call-10');
     expect(call.args.pattern).toBe('*.ts');
   });
 
-  it('emits tool-result message for type=tool_result events', async () => {
+  it('emits tool-result for a user tool_result block', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     simulateProcess(currentMockProcess, [
-      ampToolResult('read_file', 'call-11', 'const x = 1;', { path: 'src/index.ts' }),
+      ampToolResult('call-11', 'const x = 1;'),
     ]);
     await promptPromise;
 
     const toolResults = messages.filter((m: any) => m.type === 'tool-result');
     expect(toolResults.length).toBe(1);
-    expect((toolResults[0] as any).toolName).toBe('read_file');
     expect((toolResults[0] as any).callId).toBe('call-11');
+    expect((toolResults[0] as any).result).toBe('const x = 1;');
   });
 
-  it('emits fs-edit message when tool_result uses a write tool', async () => {
+  it('emits fs-edit when an assistant tool_use is a Write with file_path', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     simulateProcess(currentMockProcess, [
-      ampToolResult('write_file', 'call-12', 'ok', { path: 'src/payments.ts' }),
+      ampToolUse('Write', 'call-12', { file_path: 'src/payments.ts' }),
     ]);
     await promptPromise;
 
@@ -567,18 +544,18 @@ describe('AmpBackend — JSONL output parsing and event emission', () => {
     expect(fsEdits.length).toBe(1);
     const edit = fsEdits[0] as any;
     expect(edit.path).toBe('src/payments.ts');
-    expect(edit.description).toContain('write_file');
+    expect(edit.description).toContain('Write');
     expect(edit.description).toContain('src/payments.ts');
   });
 
-  it('emits fs-edit for edit_file tool with file_path input key', async () => {
+  it('emits fs-edit for an Edit tool with path input key', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     simulateProcess(currentMockProcess, [
-      ampToolResult('edit_file', 'call-13', 'ok', { file_path: 'lib/db.ts' }),
+      ampToolUse('Edit', 'call-13', { path: 'lib/db.ts' }),
     ]);
     await promptPromise;
 
@@ -594,169 +571,38 @@ describe('AmpBackend — JSONL output parsing and event emission', () => {
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     simulateProcess(currentMockProcess, [
-      ampToolResult('execute_command', 'call-14', 'exit 0'),
+      ampToolUse('Bash', 'call-14', { command: 'ls' }),
     ]);
     await promptPromise;
 
     expect(messages.filter((m: any) => m.type === 'fs-edit').length).toBe(0);
   });
 
-  it('emits sub-agent-start event message when sub_agent_start is received', async () => {
+  it('emits a cost-report from an assistant usage block (via shared claude parser)', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     simulateProcess(currentMockProcess, [
-      ampSubAgentStart('agent-1', 'Analyzing src/auth module'),
+      ampAssistantUsage({ input_tokens: 500, output_tokens: 200, cache_read_input_tokens: 50 }),
     ]);
     await promptPromise;
 
-    const events = messages.filter((m: any) => m.type === 'event' && m.name === 'sub-agent-start');
-    expect(events.length).toBe(1);
-    const evt = events[0] as any;
-    expect(evt.payload.subAgentId).toBe('agent-1');
-    expect(evt.payload.description).toBe('Analyzing src/auth module');
-    expect(evt.payload.activeCount).toBe(1);
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports.length).toBe(1);
+    const r = (reports[0] as any).report;
+    expect(r.inputTokens).toBe(500);
+    expect(r.outputTokens).toBe(200);
+    expect(r.cacheReadTokens).toBe(50);
   });
 
-  it('emits sub-agent-complete event and decrements active count', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      ampSubAgentStart('agent-1', 'Analyzing src/auth'),
-      ampSubAgentStart('agent-2', 'Analyzing src/payments'),
-      ampSubAgentComplete('agent-1'),
-    ]);
-    await promptPromise;
-
-    const completeEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'sub-agent-complete'
-    );
-    expect(completeEvents.length).toBe(1);
-    const evt = completeEvents[0] as any;
-    expect(evt.payload.subAgentId).toBe('agent-1');
-    // One sub-agent remains active
-    expect(evt.payload.activeCount).toBe(1);
-  });
-
-  it('correctly tracks multiple concurrent sub-agents', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      ampSubAgentStart('agent-1'),
-      ampSubAgentStart('agent-2'),
-      ampSubAgentStart('agent-3'),
-      ampSubAgentComplete('agent-2'),
-      ampSubAgentComplete('agent-3'),
-    ]);
-    await promptPromise;
-
-    const startEvents = messages.filter((m: any) => m.type === 'event' && m.name === 'sub-agent-start');
-    const completeEvents = messages.filter((m: any) => m.type === 'event' && m.name === 'sub-agent-complete');
-
-    expect(startEvents.length).toBe(3);
-    expect(completeEvents.length).toBe(2);
-
-    // After 2 completions, 1 agent remains
-    const lastComplete = completeEvents.at(-1) as any;
-    expect(lastComplete.payload.activeCount).toBe(1);
-  });
-
-  it('emits token-count message from usage events', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      ampUsage({ input_tokens: 500, output_tokens: 200, cache_read_tokens: 50, cost_usd: 0.0075 }),
-    ]);
-    await promptPromise;
-
-    const tokenMessages = messages.filter((m: any) => m.type === 'token-count');
-    expect(tokenMessages.length).toBe(1);
-    const tm = tokenMessages[0] as any;
-    expect(tm.inputTokens).toBe(500);
-    expect(tm.outputTokens).toBe(200);
-    expect(tm.cacheReadTokens).toBe(50);
-    expect(tm.costUsd).toBeCloseTo(0.0075);
-  });
-
-  it('accumulates token usage across multiple usage events (sub-agent deep mode)', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      ampUsage({ input_tokens: 300, output_tokens: 100, cost_usd: 0.002, sub_agent_id: 'agent-1' }),
-      ampUsage({ input_tokens: 250, output_tokens: 80, cost_usd: 0.0015, sub_agent_id: 'agent-2' }),
-      ampUsage({ input_tokens: 400, output_tokens: 120, cost_usd: 0.003 }),
-    ]);
-    await promptPromise;
-
-    const tokenMessages = messages.filter((m: any) => m.type === 'token-count');
-    expect(tokenMessages.length).toBe(3);
-
-    const last = tokenMessages.at(-1) as any;
-    expect(last.inputTokens).toBe(950);
-    expect(last.outputTokens).toBe(300);
-    expect(last.costUsd).toBeCloseTo(0.0065);
-  });
-
-  it('includes sub_agent_id in token-count message for sub-agent attribution', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      ampUsage({ input_tokens: 100, output_tokens: 40, cost_usd: 0.001, sub_agent_id: 'agent-3' }),
-    ]);
-    await promptPromise;
-
-    const tokenMsg = messages.find((m: any) => m.type === 'token-count') as any;
-    expect(tokenMsg.subAgentId).toBe('agent-3');
-  });
-
-  it('emits error status for type=error events', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [ampError('Anthropic API rate limit exceeded')]);
-    await promptPromise;
-
-    const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
-    expect(errorStatuses.length).toBeGreaterThan(0);
-    expect((errorStatuses[0] as any).detail).toContain('rate limit');
-  });
-
-  it('emits idle status and clears sub-agents for type=done events', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      ampSubAgentStart('agent-1'),
-      ampDone(),
-    ]);
-    await promptPromise;
-
-    const idleStatuses = messages.filter(
-      (m: any) => m.type === 'status' && m.status === 'idle'
-    );
-    expect(idleStatuses.length).toBeGreaterThan(0);
-  });
+  // SKIP (#30 — needs keyed session): The exact field name Amp uses for an
+  // agent-reported USD cost (claude's stream-json carries no per-line cost; the
+  // total only appears on the `result` line) could not be byte-verified without
+  // a live keyed run. The shared claude parser sets costUsd=0 from usage lines,
+  // so a precise per-event cost assertion would be testing an unverified shape.
+  it.skip('reports a precise per-event USD cost (UNVERIFIED — needs keyed amp session, #30)', () => {});
 
   it('ignores non-JSON stdout lines without crashing', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
@@ -765,8 +611,7 @@ describe('AmpBackend — JSONL output parsing and event emission', () => {
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     simulateProcess(currentMockProcess, [
       'Initializing Amp...',
-      '--- deep mode ---',
-      ampText('Done.'),
+      ampAssistantText('Done.'),
     ]);
 
     await expect(promptPromise).resolves.not.toThrow();
@@ -779,7 +624,7 @@ describe('AmpBackend — JSONL output parsing and event emission', () => {
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     simulateProcess(currentMockProcess, [
       '{ broken',
-      ampText('Recovered.'),
+      ampAssistantText('Recovered.'),
     ]);
 
     await expect(promptPromise).resolves.not.toThrow();
@@ -790,7 +635,7 @@ describe('AmpBackend — JSONL output parsing and event emission', () => {
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
-    const fullLine = ampText('Chunked response from Amp');
+    const fullLine = ampAssistantText('Chunked response from Amp');
     const half1 = fullLine.slice(0, Math.floor(fullLine.length / 2));
     const half2 = fullLine.slice(Math.floor(fullLine.length / 2)) + '\n';
 
@@ -801,17 +646,17 @@ describe('AmpBackend — JSONL output parsing and event emission', () => {
     await promptPromise;
 
     const outputs = messages.filter((m: any) => m.type === 'model-output');
-    const text = outputs.map((m: any) => m.textDelta).join('');
+    const text = outputs.map((m: any) => m.fullText).join('');
     expect(text).toContain('Chunked response from Amp');
   });
 
-  it('emits idle status after process exits cleanly', async () => {
+  it('emits idle status after the result line + clean exit', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [], 0);
+    simulateProcess(currentMockProcess, [ampResult()], 0);
     await promptPromise;
 
     const lastStatus = messages
@@ -819,32 +664,6 @@ describe('AmpBackend — JSONL output parsing and event emission', () => {
       .at(-1) as any;
 
     expect(lastStatus?.status).toBe('idle');
-  });
-
-  it('extracts session_id from events and stores for persistence', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    // Emit a text message that includes a session_id (Amp provides this for persistence)
-    simulateProcess(currentMockProcess, [
-      JSON.stringify({ type: 'text', content: 'hello', session_id: 'amp-persist-session-xyz' }),
-    ]);
-    await promptPromise;
-
-    // Verify the session continues to work (ampSessionId is stored internally)
-    const nextProcess = makeMockProcess();
-    mockSpawn.mockReturnValue(nextProcess);
-
-    const promptPromise2 = backend.sendPrompt(sessionId, 'follow-up');
-    simulateProcess(nextProcess);
-    await promptPromise2;
-
-    // The second spawn should include --session with the stored amp session ID
-    const secondCall = mockSpawn.mock.calls[1];
-    const [, args] = secondCall;
-    expect(args).toContain('--session');
-    expect(args).toContain('amp-persist-session-xyz');
   });
 });
 
@@ -880,39 +699,12 @@ describe('AmpBackend — error handling', () => {
     expect(errorStatus.detail).toContain('code 3');
   });
 
-  it('emits error status when stderr contains "Error"', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    (currentMockProcess.stderr as EventEmitter).emit(
-      'data',
-      Buffer.from('Error: Anthropic API key invalid'),
-    );
-    simulateProcess(currentMockProcess, [], 0);
-    await promptPromise;
-
-    const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
-    expect(errorStatuses.length).toBeGreaterThan(0);
-  });
-
-  it('emits error status when stderr contains "failed"', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    (currentMockProcess.stderr as EventEmitter).emit(
-      'data',
-      Buffer.from('Sub-agent failed: context window exceeded'),
-    );
-    simulateProcess(currentMockProcess, [], 0);
-    await promptPromise;
-
-    const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
-    expect(errorStatuses.length).toBeGreaterThan(0);
-  });
+  // WHY removed: the prior factory scanned stderr text for "Error"/"failed" and
+  // synthesized an error status. The rewrite mirrors ClaudeBackend — stderr is
+  // debug-logged only; real failures surface via a non-zero exit code (covered
+  // above) or the process 'error' event (covered below). Heuristic stderr-string
+  // matching produced false-positive error frames (e.g. amp printing a benign
+  // "no errors found" line), so it is intentionally gone.
 
   it('rejects sendPrompt when the spawned process emits an "error" event', async () => {
     const { backend } = createAmpBackend(BASE_OPTIONS);
@@ -1060,25 +852,11 @@ describe('AmpBackend — respondToPermission', () => {
     expect(permMsg.approved).toBe(false);
   });
 
-  it('writes "y\\n" to stdin when approved=true and process is running', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-
-    backend.sendPrompt(sessionId, 'task').catch(() => {});
-    await backend.respondToPermission('req-amp-3', true);
-
-    expect(currentMockProcess.stdin.write).toHaveBeenCalledWith('y\n');
-  });
-
-  it('writes "n\\n" to stdin when approved=false and process is running', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-
-    backend.sendPrompt(sessionId, 'task').catch(() => {});
-    await backend.respondToPermission('req-amp-4', false);
-
-    expect(currentMockProcess.stdin.write).toHaveBeenCalledWith('n\n');
-  });
+  // WHY removed (2 tests): the prior factory wrote 'y\n'/'n\n' to amp's stdin to
+  // answer an interactive permission prompt. That flow does not exist — execute
+  // mode (`amp -x`) is non-interactive and is spawned with stdin ignored. The
+  // base StreamingAgentBackendBase.respondToPermission is emit-only (verified by
+  // the two tests above), which is the correct behavior for amp.
 });
 
 // ===========================================================================
@@ -1099,21 +877,29 @@ describe('AmpBackend — waitForResponseComplete', () => {
 // ===========================================================================
 
 /**
- * Tests for the unified CostReport event added to Amp usage events.
+ * Tests for the unified CostReport event emitted from Amp's stream-json usage.
  *
- * WHY: migration 022 persists billing_model / source / raw_agent_payload.
- * Amp always emits agent-reported with billingModel=api-key. When sub_agent_id
- * is present it must appear in rawAgentPayload for sub-agent cost attribution.
+ * WHY: migration 022 persists billing_model / source / raw_agent_payload. Amp is
+ * BYOK (AMP_API_KEY) so it always emits source=agent-reported, billingModel=
+ * api-key. The report is built by re-stamping the shared claude parser's output
+ * with agentType='amp', so the schema stays single-owner.
+ *
+ * SCHEMA NOTE (#30): usage field names mirror claude's verified stream-json
+ * (`input_tokens` / `cache_read_input_tokens` / etc.). Not byte-verified against
+ * a real keyed amp run — see the cost-precision skip in the parsing describe.
  */
 describe('AmpBackend — cost-report emission', () => {
-  it('emits cost-report with billingModel=api-key and source=agent-reported on usage event', async () => {
+  it('emits cost-report with billingModel=api-key and source=agent-reported on a usage line', async () => {
     const { backend } = createAmpBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
     simulateProcess(currentMockProcess, [
-      ampUsage({ input_tokens: 800, output_tokens: 300, cache_read_tokens: 50, cost_usd: 0.012 }),
+      ampAssistantUsage(
+        { input_tokens: 800, output_tokens: 300, cache_read_input_tokens: 50 },
+        'claude-sonnet-4',
+      ),
     ]);
     await promptPromise;
 
@@ -1129,19 +915,19 @@ describe('AmpBackend — cost-report emission', () => {
     expect(r.report.rawAgentPayload).not.toBeNull();
   });
 
-  it('includes sub_agent_id in rawAgentPayload when usage event has sub_agent_id', async () => {
-    const { backend } = createAmpBackend(BASE_OPTIONS);
+  it('re-stamps the report model from options when provided', async () => {
+    const { backend } = createAmpBackend({ ...BASE_OPTIONS, model: 'amp-smart' });
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'deep task');
+    const promptPromise = backend.sendPrompt(sessionId, 'task');
     simulateProcess(currentMockProcess, [
-      ampUsage({ input_tokens: 300, output_tokens: 100, cost_usd: 0.005, sub_agent_id: 'sub-xyz' }),
+      ampAssistantUsage({ input_tokens: 300, output_tokens: 100 }, 'some-other-model'),
     ]);
     await promptPromise;
 
     const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    expect(r.report.rawAgentPayload?.sub_agent_id).toBe('sub-xyz');
+    expect(r.report.model).toBe('amp-smart');
   });
 
   it('cost-report has messageId=null (Amp does not expose per-message IDs)', async () => {
@@ -1150,7 +936,9 @@ describe('AmpBackend — cost-report emission', () => {
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [ampUsage({ cost_usd: 0.003 })]);
+    simulateProcess(currentMockProcess, [
+      ampAssistantUsage({ input_tokens: 10, output_tokens: 5 }),
+    ]);
     await promptPromise;
 
     const r = messages.find((m: any) => m.type === 'cost-report') as any;

--- a/packages/styrby-cli/src/agent/factories/__tests__/crush.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/crush.test.ts
@@ -1,14 +1,19 @@
 /**
  * Tests for the Crush agent backend factory (Charmbracelet).
  *
- * Covers:
- * - `createCrushBackend` factory function
- * - `registerCrushAgent` registry integration
- * - `CrushBackend` class: session lifecycle, subprocess management,
- *   ACP-compatible JSON event parsing, charm-style ANSI output handling,
- *   token/cost accumulation, fs-edit detection from charm tool names,
- *   status mapping, error handling, cancellation, permission response,
- *   and disposal.
+ * REALITY CHECK (crush v0.76.0, verified 2026-06-10):
+ * - Headless invocation is `crush run [flags] <prompt>` (prompt is a positional
+ *   argument). Verified flags: --quiet, --model, --session, --continue, --cwd,
+ *   --data-dir, --debug, --verbose, --small-model.
+ * - crush has NO JSON/ACP output mode. `crush run` emits the model's reply as
+ *   PLAIN TEXT on stdout. There is no --format/--no-tui/--message/--provider
+ *   flag and no `{text_delta, usage, tool_call, done}` event schema.
+ *
+ * Because of that, this suite covers ONLY verified behavior: the real spawn
+ * argv, plain-text stdout -> model-output passthrough, exit-code handling,
+ * cancellation, dispose, and env-key injection. The previous suite's
+ * invented-ACP-event blocks (tool events, usage/cost events, status/done JSON
+ * events) are removed/skipped with a reason — they tested a fabricated schema.
  *
  * All child_process and logger calls are mocked so no real Crush binary
  * is required.
@@ -80,49 +85,14 @@ function collectMessages(backend: ReturnType<typeof createCrushBackend>['backend
 }
 
 /**
- * Simulate Crush output: emit lines as stdout data events, then close the process.
+ * Simulate `crush run` output: emit plain-text chunks as stdout data events,
+ * then close the process. (crush emits plain text, NOT line-framed JSON.)
  */
-function simulateProcess(proc: MockProcess, lines: string[] = [], exitCode = 0) {
-  for (const line of lines) {
-    (proc.stdout as EventEmitter).emit('data', Buffer.from(line + '\n'));
+function simulateProcess(proc: MockProcess, chunks: string[] = [], exitCode = 0) {
+  for (const chunk of chunks) {
+    (proc.stdout as EventEmitter).emit('data', Buffer.from(chunk));
   }
   proc.emit('close', exitCode);
-}
-
-// ---- Crush ACP event builders ----
-
-function crushTextDelta(delta: string): string {
-  return JSON.stringify({ type: 'text_delta', delta });
-}
-
-function crushToolCall(tool: string, callId: string, args?: Record<string, unknown>): string {
-  return JSON.stringify({ type: 'tool_call', tool, call_id: callId, args });
-}
-
-function crushToolResult(tool: string, callId: string, output: unknown, args?: Record<string, unknown>): string {
-  return JSON.stringify({ type: 'tool_result', tool, call_id: callId, output, args });
-}
-
-function crushUsage(usage: {
-  input_tokens?: number;
-  output_tokens?: number;
-  cache_read_input_tokens?: number;
-  cache_creation_input_tokens?: number;
-  cost_usd?: number;
-}): string {
-  return JSON.stringify({ type: 'usage', usage });
-}
-
-function crushStatus(state: string): string {
-  return JSON.stringify({ type: 'status', state });
-}
-
-function crushError(message: string): string {
-  return JSON.stringify({ type: 'error', message });
-}
-
-function crushDone(): string {
-  return JSON.stringify({ type: 'done' });
 }
 
 const BASE_OPTIONS: CrushBackendOptions = {
@@ -163,6 +133,13 @@ describe('createCrushBackend', () => {
     expect(model).toBeUndefined();
   });
 
+  it('reports supportsTools=false (crush has no structured tool events)', () => {
+    const { metadata } = createCrushBackend(BASE_OPTIONS);
+
+    expect(metadata?.supportsTools).toBe(false);
+    expect(metadata?.supportsStreaming).toBe(true);
+  });
+
   it('returns a backend implementing the full AgentBackend interface', () => {
     const { backend } = createCrushBackend(BASE_OPTIONS);
 
@@ -180,10 +157,9 @@ describe('createCrushBackend', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('includes noTui, provider, and sessionName options', () => {
+  it('accepts provider and sessionName options', () => {
     const { backend } = createCrushBackend({
       ...BASE_OPTIONS,
-      noTui: true,
       provider: 'anthropic',
       sessionName: 'my-session',
     });
@@ -290,11 +266,11 @@ describe('CrushBackend — session lifecycle', () => {
 });
 
 // ===========================================================================
-// CrushBackend — sendPrompt
+// CrushBackend — sendPrompt (VERIFIED `crush run` invocation)
 // ===========================================================================
 
-describe('CrushBackend — sendPrompt', () => {
-  it('spawns crush with --message, --format json, --no-tui flags', async () => {
+describe('CrushBackend — sendPrompt invocation', () => {
+  it('spawns `crush run --quiet <prompt>` with the prompt as a trailing positional', async () => {
     const { backend } = createCrushBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -302,56 +278,47 @@ describe('CrushBackend — sendPrompt', () => {
     simulateProcess(currentMockProcess);
     await sendPromise;
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'crush',
-      expect.arrayContaining(['--message', 'Refactor auth', '--format', 'json', '--no-tui']),
-      expect.any(Object)
-    );
+    const [bin, args] = mockSpawn.mock.calls[0] as [string, string[], unknown];
+    expect(bin).toBe('crush');
+    // Subcommand first, prompt last (positional).
+    expect(args[0]).toBe('run');
+    expect(args).toContain('--quiet');
+    expect(args[args.length - 1]).toBe('Refactor auth');
+    // The fabricated flags must NOT be present.
+    expect(args).not.toContain('--message');
+    expect(args).not.toContain('--format');
+    expect(args).not.toContain('--no-tui');
+    expect(args).not.toContain('--provider');
   });
 
-  it('includes --model flag when model is specified', async () => {
-    const { backend } = createCrushBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
+  it('includes --model flag (before the positional prompt) when model is specified', async () => {
+    const { backend } = createCrushBackend({ ...BASE_OPTIONS, model: 'anthropic/claude-sonnet-4' });
     const { sessionId } = await backend.startSession();
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
     simulateProcess(currentMockProcess);
     await sendPromise;
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'crush',
-      expect.arrayContaining(['--model', 'claude-sonnet-4']),
-      expect.any(Object)
-    );
-  });
-
-  it('includes --provider flag when provider is specified', async () => {
-    const { backend } = createCrushBackend({ ...BASE_OPTIONS, provider: 'anthropic' });
-    const { sessionId } = await backend.startSession();
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess);
-    await sendPromise;
-
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'crush',
-      expect.arrayContaining(['--provider', 'anthropic']),
-      expect.any(Object)
-    );
+    const args = (mockSpawn.mock.calls[0] as any[])[1] as string[];
+    const modelIdx = args.indexOf('--model');
+    expect(modelIdx).toBeGreaterThanOrEqual(0);
+    expect(args[modelIdx + 1]).toBe('anthropic/claude-sonnet-4');
+    // Prompt stays the trailing positional.
+    expect(args[args.length - 1]).toBe('Hello');
   });
 
   it('includes --session flag when sessionName is specified', async () => {
-    const { backend } = createCrushBackend({ ...BASE_OPTIONS, sessionName: 'my-project' });
+    const { backend } = createCrushBackend({ ...BASE_OPTIONS, sessionName: 'sess-123' });
     const { sessionId } = await backend.startSession();
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
     simulateProcess(currentMockProcess);
     await sendPromise;
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'crush',
-      expect.arrayContaining(['--session', 'my-project']),
-      expect.any(Object)
-    );
+    const args = (mockSpawn.mock.calls[0] as any[])[1] as string[];
+    const sessIdx = args.indexOf('--session');
+    expect(sessIdx).toBeGreaterThanOrEqual(0);
+    expect(args[sessIdx + 1]).toBe('sess-123');
   });
 
   it('throws when sendPrompt is called with wrong sessionId', async () => {
@@ -379,7 +346,7 @@ describe('CrushBackend — sendPrompt', () => {
     await expect(sendPromise).rejects.toThrow('Crush exited with code 1');
   });
 
-  it('passes extraArgs after validation', async () => {
+  it('passes extraArgs (validated) before the positional prompt', async () => {
     const { backend } = createCrushBackend({ ...BASE_OPTIONS, extraArgs: ['--verbose'] });
     const { sessionId } = await backend.startSession();
 
@@ -387,11 +354,10 @@ describe('CrushBackend — sendPrompt', () => {
     simulateProcess(currentMockProcess);
     await sendPromise;
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'crush',
-      expect.arrayContaining(['--verbose']),
-      expect.any(Object)
-    );
+    const args = (mockSpawn.mock.calls[0] as any[])[1] as string[];
+    expect(args).toContain('--verbose');
+    expect(args.indexOf('--verbose')).toBeLessThan(args.length - 1);
+    expect(args[args.length - 1]).toBe('Hello');
   });
 
   it('rejects extraArgs with shell metacharacters', async () => {
@@ -462,20 +428,17 @@ describe('CrushBackend — sendPrompt', () => {
 });
 
 // ===========================================================================
-// CrushBackend — ACP event parsing (text_delta)
+// CrushBackend — plain-text stdout passthrough (VERIFIED behavior)
 // ===========================================================================
 
-describe('CrushBackend — text_delta events', () => {
-  it('emits model-output messages for text_delta events', async () => {
+describe('CrushBackend — plain-text stdout', () => {
+  it('emits each stdout chunk verbatim as a model-output delta', async () => {
     const { backend } = createCrushBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [
-      crushTextDelta('Hello, '),
-      crushTextDelta('world!'),
-    ]);
+    simulateProcess(currentMockProcess, ['Hello, ', 'world!']);
     await sendPromise;
 
     const textMessages = messages.filter((m: any) => m.type === 'model-output');
@@ -484,281 +447,71 @@ describe('CrushBackend — text_delta events', () => {
     expect((textMessages[1] as any).textDelta).toBe('world!');
   });
 
-  it('ignores text_delta events with empty delta', async () => {
+  it('passes through plain text that happens to start with "{" (no JSON parsing)', async () => {
+    // WHY: the old impl swallowed non-JSON and parsed JSON. The real crush emits
+    // plain prose; a line beginning with "{" must still surface verbatim.
     const { backend } = createCrushBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [
-      JSON.stringify({ type: 'text_delta' }), // no delta field
-    ]);
+    simulateProcess(currentMockProcess, ['{ "this": "is just text crush printed" }']);
     await sendPromise;
 
     const textMessages = messages.filter((m: any) => m.type === 'model-output');
-    expect(textMessages).toHaveLength(0);
+    expect(textMessages).toHaveLength(1);
+    expect((textMessages[0] as any).textDelta).toContain('is just text crush printed');
   });
-});
 
-// ===========================================================================
-// CrushBackend — ACP event parsing (tool_call / tool_result)
-// ===========================================================================
-
-describe('CrushBackend — tool events', () => {
-  it('emits tool-call messages for tool_call events', async () => {
+  it('emits "idle" status on clean (code 0) exit', async () => {
     const { backend } = createCrushBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
 
-    const sendPromise = backend.sendPrompt(sessionId, 'Edit a file');
-    simulateProcess(currentMockProcess, [
-      crushToolCall('read_file', 'call-1', { path: '/project/src/index.ts' }),
-    ]);
+    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
+    simulateProcess(currentMockProcess, ['done thinking'], 0);
     await sendPromise;
 
-    const toolCalls = messages.filter((m: any) => m.type === 'tool-call');
-    expect(toolCalls).toHaveLength(1);
-    expect((toolCalls[0] as any).toolName).toBe('read_file');
-    expect((toolCalls[0] as any).callId).toBe('call-1');
+    const statuses = messages.filter((m: any) => m.type === 'status').map((m: any) => m.status);
+    expect(statuses).toContain('idle');
   });
 
-  it('emits tool-result messages for tool_result events', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Edit a file');
-    simulateProcess(currentMockProcess, [
-      crushToolResult('read_file', 'call-1', 'file contents here'),
-    ]);
-    await sendPromise;
-
-    const toolResults = messages.filter((m: any) => m.type === 'tool-result');
-    expect(toolResults).toHaveLength(1);
-    expect((toolResults[0] as any).toolName).toBe('read_file');
-    expect((toolResults[0] as any).result).toBe('file contents here');
-  });
-
-  it('emits fs-edit message for file-writing tool results', async () => {
+  it('does NOT emit usage/cost/tool/fs-edit events (crush has no schema for them)', async () => {
     const { backend } = createCrushBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
 
     const sendPromise = backend.sendPrompt(sessionId, 'Write a file');
-    simulateProcess(currentMockProcess, [
-      crushToolResult('write_file', 'call-2', 'ok', { path: '/project/src/utils.ts' }),
-    ]);
+    simulateProcess(currentMockProcess, ['I wrote the file for you.']);
     await sendPromise;
 
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(1);
-    expect((fsEdits[0] as any).path).toBe('/project/src/utils.ts');
-  });
-
-  it('emits fs-edit for "edit" tools', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Edit file');
-    simulateProcess(currentMockProcess, [
-      crushToolResult('edit_file', 'call-3', 'done', { file_path: '/project/app.ts' }),
-    ]);
-    await sendPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(1);
-    expect((fsEdits[0] as any).path).toBe('/project/app.ts');
-  });
-
-  it('does NOT emit fs-edit for non-file-editing tools', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Run shell command');
-    simulateProcess(currentMockProcess, [
-      crushToolResult('run_command', 'call-4', 'output here'),
-    ]);
-    await sendPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(0);
-  });
-
-  it('does not emit fs-edit if file path is not found in args', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Write file');
-    simulateProcess(currentMockProcess, [
-      // write_file tool result but no path info in args
-      crushToolResult('write_file', 'call-5', 'ok'),
-    ]);
-    await sendPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(0);
+    expect(messages.filter((m: any) => m.type === 'token-count')).toHaveLength(0);
+    expect(messages.filter((m: any) => m.type === 'cost-report')).toHaveLength(0);
+    expect(messages.filter((m: any) => m.type === 'tool-call')).toHaveLength(0);
+    expect(messages.filter((m: any) => m.type === 'tool-result')).toHaveLength(0);
+    expect(messages.filter((m: any) => m.type === 'fs-edit')).toHaveLength(0);
   });
 });
 
 // ===========================================================================
-// CrushBackend — token/cost accumulation (usage events)
+// SKIPPED — invented ACP event schema (no machine-readable crush output exists)
 // ===========================================================================
 
-describe('CrushBackend — usage events', () => {
-  it('emits token-count messages with cumulative totals', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [
-      crushUsage({ input_tokens: 100, output_tokens: 50, cost_usd: 0.005 }),
-    ]);
-    await sendPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect(tokenCounts).toHaveLength(1);
-    expect((tokenCounts[0] as any).inputTokens).toBe(100);
-    expect((tokenCounts[0] as any).outputTokens).toBe(50);
-    expect((tokenCounts[0] as any).costUsd).toBeCloseTo(0.005);
+// SCHEMA UNVERIFIED: crush v0.76.0 has NO JSON/ACP output mode (`crush run`
+// emits plain text). These blocks tested a fabricated `{text_delta, tool_call,
+// tool_result, usage, status, done}` event stream that the real binary does not
+// produce. They stay skipped (not deleted) as a record of what would need a
+// keyed crush session to verify before any structured parsing is reintroduced
+// (#30 — needs auth + captured real `--verbose`/`--debug` output).
+describe.skip('CrushBackend — ACP JSON event parsing (FABRICATED SCHEMA — see #30)', () => {
+  it('tool_call / tool_result events', () => {
+    // No verified source. Requires keyed session capture (#30).
   });
-
-  it('accumulates token counts across multiple usage events', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [
-      crushUsage({ input_tokens: 100, output_tokens: 50 }),
-      crushUsage({ input_tokens: 200, output_tokens: 75 }),
-    ]);
-    await sendPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    const last = tokenCounts[tokenCounts.length - 1] as any;
-    expect(last.inputTokens).toBe(300);
-    expect(last.outputTokens).toBe(125);
+  it('usage / cost-report events', () => {
+    // No verified source. crush exposes no per-turn usage event. (#30)
   });
-
-  it('tracks cache tokens from usage events', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [
-      crushUsage({
-        input_tokens: 100,
-        output_tokens: 50,
-        cache_read_input_tokens: 80,
-        cache_creation_input_tokens: 20,
-        cost_usd: 0.01,
-      }),
-    ]);
-    await sendPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    const tc = tokenCounts[0] as any;
-    expect(tc.cacheReadTokens).toBe(80);
-    expect(tc.cacheWriteTokens).toBe(20);
-  });
-
-  it('resets token counts on new session', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId: s1 } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const send1 = backend.sendPrompt(s1, 'First');
-    simulateProcess(currentMockProcess, [crushUsage({ input_tokens: 500 })]);
-    await send1;
-
-    currentMockProcess = makeMockProcess();
-    mockSpawn.mockReturnValue(currentMockProcess);
-
-    const { sessionId: s2 } = await backend.startSession();
-    const send2 = backend.sendPrompt(s2, 'Second');
-    simulateProcess(currentMockProcess, [crushUsage({ input_tokens: 100 })]);
-    await send2;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    // Last event should reflect only the second session's accumulation
-    const lastCount = tokenCounts[tokenCounts.length - 1] as any;
-    expect(lastCount.inputTokens).toBe(100);
-  });
-});
-
-// ===========================================================================
-// CrushBackend — status events
-// ===========================================================================
-
-describe('CrushBackend — status events', () => {
-  it('maps "loading" state to "starting"', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [crushStatus('loading')]);
-    await sendPromise;
-
-    const statuses = messages.filter((m: any) => m.type === 'status').map((m: any) => m.status);
-    expect(statuses).toContain('starting');
-  });
-
-  it('maps "thinking" state to "running"', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [crushStatus('thinking')]);
-    await sendPromise;
-
-    const statuses = messages.filter((m: any) => m.type === 'status').map((m: any) => m.status);
-    expect(statuses).toContain('running');
-  });
-
-  it('maps "executing" state to "running"', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [crushStatus('executing')]);
-    await sendPromise;
-
-    const statuses = messages.filter((m: any) => m.type === 'status').map((m: any) => m.status);
-    expect(statuses).toContain('running');
-  });
-
-  it('maps "done" state to "idle"', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [crushStatus('done')]);
-    await sendPromise;
-
-    const statuses = messages.filter((m: any) => m.type === 'status').map((m: any) => m.status);
-    expect(statuses).toContain('idle');
-  });
-
-  it('emits "idle" on "done" event', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [crushDone()]);
-    await sendPromise;
-
-    const statuses = messages.filter((m: any) => m.type === 'status').map((m: any) => m.status);
-    expect(statuses).toContain('idle');
+  it('status / done JSON events', () => {
+    // No verified source. Status is implied by exit code, not JSON events. (#30)
   });
 });
 
@@ -767,22 +520,6 @@ describe('CrushBackend — status events', () => {
 // ===========================================================================
 
 describe('CrushBackend — error handling', () => {
-  it('emits error status on "error" events', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [crushError('Provider API rate limit exceeded')]);
-    await sendPromise;
-
-    const errorStatuses = messages.filter(
-      (m: any) => m.type === 'status' && m.status === 'error'
-    );
-    expect(errorStatuses.length).toBeGreaterThan(0);
-    expect((errorStatuses[0] as any).detail).toContain('rate limit');
-  });
-
   it('emits error status on process spawn error', async () => {
     const { backend } = createCrushBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
@@ -791,7 +528,7 @@ describe('CrushBackend — error handling', () => {
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
     currentMockProcess.emit('error', new Error('spawn crush ENOENT'));
 
-    await expect(sendPromise).rejects.toThrow('spawn crush ENOENT');
+    await expect(sendPromise).rejects.toThrow();
 
     const errorStatuses = messages.filter(
       (m: any) => m.type === 'status' && m.status === 'error'
@@ -799,13 +536,18 @@ describe('CrushBackend — error handling', () => {
     expect(errorStatuses.length).toBeGreaterThan(0);
   });
 
-  it('emits error status on stderr output containing "Error"', async () => {
+  it('emits error status on stderr output containing "Error" (crush ANSI error box)', async () => {
     const { backend } = createCrushBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    (currentMockProcess.stderr as EventEmitter).emit('data', Buffer.from('Error: config not found\n'));
+    // Real crush prints a styled "ERROR" box to stderr; our handler matches
+    // case-insensitively on error keywords.
+    (currentMockProcess.stderr as EventEmitter).emit(
+      'data',
+      Buffer.from('  ERROR  Agent processing failed: forbidden\n')
+    );
     simulateProcess(currentMockProcess);
     await sendPromise;
 
@@ -813,20 +555,6 @@ describe('CrushBackend — error handling', () => {
       (m: any) => m.type === 'status' && m.status === 'error'
     );
     expect(errorStatuses.length).toBeGreaterThan(0);
-  });
-
-  it('ignores non-JSON stdout lines gracefully', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [
-      '  \x1b[32m✓\x1b[0m Loading context...', // charm ANSI progress line
-      '────────────────────────────────', // charm box drawing
-    ]);
-
-    // Should not throw
-    await expect(sendPromise).resolves.toBeUndefined();
   });
 });
 
@@ -899,18 +627,11 @@ describe('CrushBackend — permission response', () => {
     expect((permResponses[0] as any).approved).toBe(false);
   });
 
-  it('writes "y\\n" to stdin when approved and process is running', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Dangerous operation');
-    // Process is running but not yet closed
-
-    await backend.respondToPermission?.('req-789', true);
-
-    expect(currentMockProcess.stdin.write).toHaveBeenCalledWith('y\n');
-    currentMockProcess.emit('close', 0);
-    await sendPromise;
+  // SCHEMA UNVERIFIED: the old test asserted a y\n stdin write. crush's headless
+  // `run` mode has no confirmed over-stdin permission protocol (permissions are
+  // config/--yolo driven), so we no longer fabricate that write. (#30)
+  it.skip('writes "y\\n" to stdin when approved (UNVERIFIED crush permission channel — see #30)', () => {
+    // Requires a keyed session to confirm whether crush ever prompts over stdin.
   });
 });
 
@@ -965,19 +686,6 @@ describe('CrushBackend — message handler registration', () => {
     expect(received).toHaveLength(0);
   });
 
-  it('disposed backend does not emit to handlers', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    await backend.startSession();
-    await backend.dispose();
-
-    const received: unknown[] = [];
-    backend.onMessage((msg) => received.push(msg));
-
-    // Try to trigger an event after dispose (should be silent)
-    const countBefore = received.length;
-    expect(received.length).toBe(countBefore);
-  });
-
   it('handler errors do not break other handlers', async () => {
     const { backend } = createCrushBackend(BASE_OPTIONS);
     const goodMessages: unknown[] = [];
@@ -1011,128 +719,5 @@ describe('CrushBackend — dispose', () => {
 
     // Should not throw
     await expect(backend.dispose()).resolves.toBeUndefined();
-  });
-
-  it('clears message listeners on dispose', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const received: unknown[] = [];
-    backend.onMessage((msg) => received.push(msg));
-    await backend.dispose();
-
-    const countAfterDispose = received.length;
-    // Even if we could trigger events, no new ones should arrive
-    expect(received.length).toBe(countAfterDispose);
-  });
-});
-
-// ===========================================================================
-// CrushBackend — line buffer handling
-// ===========================================================================
-
-describe('CrushBackend — line buffer handling', () => {
-  it('handles JSON split across multiple data events', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-
-    // Split a JSON event across two data chunks (simulates Node.js stream chunking)
-    const json = crushTextDelta('Hello, world!');
-    const half1 = json.slice(0, Math.floor(json.length / 2));
-    const half2 = json.slice(Math.floor(json.length / 2)) + '\n';
-
-    (currentMockProcess.stdout as EventEmitter).emit('data', Buffer.from(half1));
-    (currentMockProcess.stdout as EventEmitter).emit('data', Buffer.from(half2));
-    currentMockProcess.emit('close', 0);
-    await sendPromise;
-
-    const textMessages = messages.filter((m: any) => m.type === 'model-output');
-    expect(textMessages).toHaveLength(1);
-    expect((textMessages[0] as any).textDelta).toBe('Hello, world!');
-  });
-
-  it('flushes remaining buffer on process close', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-
-    // Emit JSON without trailing newline (simulates unterminated line in buffer)
-    const json = crushTextDelta('Final chunk');
-    (currentMockProcess.stdout as EventEmitter).emit('data', Buffer.from(json));
-    currentMockProcess.emit('close', 0);
-    await sendPromise;
-
-    const textMessages = messages.filter((m: any) => m.type === 'model-output');
-    expect(textMessages).toHaveLength(1);
-  });
-});
-
-// ===========================================================================
-// CrushBackend — cost-report emission
-// ===========================================================================
-
-/**
- * Tests for the unified CostReport event added to Crush usage events.
- *
- * WHY: migration 022 requires billing_model / source / raw_agent_payload.
- * Crush always emits agent-reported because its usage event always carries the
- * full cost breakdown from the Sourcegraph backend.
- */
-describe('CrushBackend — cost-report emission', () => {
-  it('emits cost-report with billingModel=api-key and source=agent-reported on usage event', async () => {
-    const { backend } = createCrushBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      crushUsage({
-        input_tokens: 1000,
-        output_tokens: 400,
-        cache_read_input_tokens: 60,
-        cache_creation_input_tokens: 20,
-        cost_usd: 0.018,
-      }),
-    ]);
-    await promptPromise;
-
-    const reports = messages.filter((m: any) => m.type === 'cost-report');
-    expect(reports.length).toBeGreaterThanOrEqual(1);
-    const r = reports[0] as any;
-    expect(r.report.billingModel).toBe('api-key');
-    expect(r.report.source).toBe('agent-reported');
-    expect(r.report.agentType).toBe('crush');
-    expect(r.report.inputTokens).toBe(1000);
-    expect(r.report.outputTokens).toBe(400);
-    expect(r.report.cacheReadTokens).toBe(60);
-    expect(r.report.cacheWriteTokens).toBe(20);
-    expect(r.report.rawAgentPayload).not.toBeNull();
-  });
-
-  it('emits one cost-report per usage event with per-event incremental token counts', async () => {
-    const { backend } = createCrushBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      crushUsage({ input_tokens: 200, output_tokens: 80, cost_usd: 0.002 }),
-      crushUsage({ input_tokens: 300, output_tokens: 120, cost_usd: 0.003 }),
-    ]);
-    await promptPromise;
-
-    const reports = messages.filter((m: any) => m.type === 'cost-report');
-    // WHY: Each cost-report carries the incremental tokens from a single usage
-    // event, not session-accumulated totals. The cost-reporter sums them server-side.
-    expect(reports.length).toBe(2);
-    const r1 = reports[0] as any;
-    expect(r1.report.inputTokens).toBe(200);
-    expect(r1.report.outputTokens).toBe(80);
-    const r2 = reports[1] as any;
-    expect(r2.report.inputTokens).toBe(300);
-    expect(r2.report.outputTokens).toBe(120);
   });
 });

--- a/packages/styrby-cli/src/agent/factories/__tests__/droid.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/droid.test.ts
@@ -1,14 +1,22 @@
 /**
- * Tests for the Droid agent backend factory (BYOK).
+ * Tests for the Droid agent backend factory (Factory-hosted `droid` CLI).
  *
  * Covers:
  * - `createDroidBackend` factory function
  * - `registerDroidAgent` registry integration
  * - `DroidBackend` class: session lifecycle, subprocess management,
- *   JSONL output parsing, BYOK API key injection, multi-backend model resolution,
- *   LiteLLM cost estimation from token counts, backend_switch events,
- *   fs-edit detection, error handling, cancellation, permission response,
- *   and disposal.
+ *   stream-json output parsing, Factory API key injection, `droid exec`
+ *   invocation form, result/usage handling, error handling, cancellation,
+ *   permission response, and disposal.
+ *
+ * Invocation + the system/error/result event schema are VERIFIED against the
+ * real `droid` binary (v0.144.2, `droid exec --help` + a real unauthenticated
+ * `droid exec ... -o stream-json` capture, 2026-06-10).
+ *
+ * assistant/tool (tool_use / tool_result) events are UNVERIFIED — they could
+ * not be captured without Factory auth (#30). Those test blocks are
+ * `describe.skip`'d with a reason and exercise the best-effort Claude-Code-shaped
+ * parser only as documentation of intended behavior, NOT as proof it works.
  *
  * All child_process and logger calls are mocked so no real Droid binary
  * is required.
@@ -89,46 +97,67 @@ function simulateProcess(proc: MockProcess, lines: string[] = [], exitCode = 0) 
   proc.emit('close', exitCode);
 }
 
-// ---- Droid JSONL event builders ----
+// ---- Droid stream-json event builders (VERIFIED schema) ----
 
-function droidText(content: string): string {
-  return JSON.stringify({ type: 'text', content });
+/**
+ * `{"type":"system","subtype":"init", model, session_id, tools}`
+ * VERIFIED: captured from a real `droid exec ... -o stream-json` run.
+ */
+function droidInit(model: string, sessionId = 'droid-sess-xyz'): string {
+  return JSON.stringify({
+    type: 'system',
+    subtype: 'init',
+    cwd: '/project',
+    session_id: sessionId,
+    tools: ['Read', 'Edit', 'Create'],
+    model,
+    reasoning_effort: 'high',
+  });
 }
 
-function droidToolCall(toolName: string, callId: string, toolInput?: Record<string, unknown>): string {
-  return JSON.stringify({ type: 'tool_call', tool_name: toolName, call_id: callId, tool_input: toolInput });
+/**
+ * `{"type":"error","source","message","timestamp","session_id"}`
+ * VERIFIED: captured from a real run (auth-failure path).
+ */
+function droidError(message: string, sessionId = 'droid-sess-xyz'): string {
+  return JSON.stringify({
+    type: 'error',
+    source: 'cli',
+    message,
+    timestamp: 1781148934831,
+    session_id: sessionId,
+  });
 }
 
-function droidToolResult(
-  toolName: string,
-  callId: string,
-  result: unknown,
-  toolInput?: Record<string, unknown>
-): string {
-  return JSON.stringify({ type: 'tool_result', tool_name: toolName, call_id: callId, tool_result: result, tool_input: toolInput });
-}
-
-function droidUsage(usage: {
-  prompt_tokens?: number;
-  completion_tokens?: number;
-  cache_read_tokens?: number;
-  cache_write_tokens?: number;
-  cost_usd?: number;
-  model?: string;
+/**
+ * `{"type":"result","subtype","is_error","result","session_id","usage":{...}}`
+ * VERIFIED: usage field names are Claude-Code snake_case
+ * (input_tokens / output_tokens / cache_read_input_tokens / cache_creation_input_tokens).
+ */
+function droidResult(opts: {
+  result?: string;
+  isError?: boolean;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+  sessionId?: string;
 }): string {
-  return JSON.stringify({ type: 'usage', usage });
-}
-
-function droidBackendSwitch(newBackend?: string, newModel?: string): string {
-  return JSON.stringify({ type: 'backend_switch', new_backend: newBackend, new_model: newModel });
-}
-
-function droidError(error: string): string {
-  return JSON.stringify({ type: 'error', error });
-}
-
-function droidDone(): string {
-  return JSON.stringify({ type: 'done' });
+  return JSON.stringify({
+    type: 'result',
+    subtype: opts.isError ? 'failure' : 'success',
+    is_error: opts.isError ?? false,
+    duration_ms: 1234,
+    num_turns: 1,
+    result: opts.result ?? 'Done',
+    session_id: opts.sessionId ?? 'droid-sess-xyz',
+    usage: {
+      input_tokens: opts.inputTokens ?? 0,
+      output_tokens: opts.outputTokens ?? 0,
+      cache_read_input_tokens: opts.cacheReadTokens ?? 0,
+      cache_creation_input_tokens: opts.cacheCreationTokens ?? 0,
+    },
+  });
 }
 
 const BASE_OPTIONS: DroidBackendOptions = {
@@ -156,11 +185,11 @@ afterEach(() => {
 
 describe('createDroidBackend', () => {
   it('returns a backend instance and resolved model when model is provided', () => {
-    const { backend, model } = createDroidBackend({ ...BASE_OPTIONS, model: 'gpt-4o' });
+    const { backend, model } = createDroidBackend({ ...BASE_OPTIONS, model: 'claude-opus-4-8' });
 
     expect(backend).toBeDefined();
     expect(typeof backend.startSession).toBe('function');
-    expect(model).toBe('gpt-4o');
+    expect(model).toBe('claude-opus-4-8');
   });
 
   it('returns undefined model when no model is specified', () => {
@@ -186,20 +215,14 @@ describe('createDroidBackend', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('accepts backend option', () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, backend: 'anthropic' });
+  it('accepts autoLevel option', () => {
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, autoLevel: 'medium' });
 
     expect(backend).toBeDefined();
   });
 
-  it('accepts apiKeys map for multiple providers', () => {
-    const { backend } = createDroidBackend({
-      ...BASE_OPTIONS,
-      apiKeys: {
-        ANTHROPIC_API_KEY: 'sk-ant-test',
-        OPENAI_API_KEY: 'sk-test',
-      },
-    });
+  it('accepts factoryApiKey option', () => {
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, factoryApiKey: 'fk-test' });
 
     expect(backend).toBeDefined();
   });
@@ -208,6 +231,15 @@ describe('createDroidBackend', () => {
     const { backend } = createDroidBackend({
       ...BASE_OPTIONS,
       resumeSessionId: 'existing-session-123',
+    });
+
+    expect(backend).toBeDefined();
+  });
+
+  it('accepts forkSessionId for session forking', () => {
+    const { backend } = createDroidBackend({
+      ...BASE_OPTIONS,
+      forkSessionId: 'fork-from-456',
     });
 
     expect(backend).toBeDefined();
@@ -298,11 +330,11 @@ describe('DroidBackend — session lifecycle', () => {
 });
 
 // ===========================================================================
-// DroidBackend — sendPrompt
+// DroidBackend — sendPrompt invocation (VERIFIED `droid exec` form)
 // ===========================================================================
 
-describe('DroidBackend — sendPrompt', () => {
-  it('spawns the droid binary with correct arguments', async () => {
+describe('DroidBackend — sendPrompt invocation', () => {
+  it('spawns `droid exec <prompt> --output-format stream-json`', async () => {
     const { backend } = createDroidBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -312,26 +344,36 @@ describe('DroidBackend — sendPrompt', () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       'droid',
-      expect.arrayContaining(['chat', '--message', 'Review the auth module', '--format', 'json']),
+      expect.arrayContaining([
+        'exec',
+        'Review the auth module',
+        '--output-format',
+        'stream-json',
+      ]),
       expect.objectContaining({ cwd: '/project' })
     );
   });
 
-  it('passes --backend flag when backend is specified', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, backend: 'openai' });
+  it('uses a POSITIONAL prompt (no --message flag) and no legacy chat subcommand', async () => {
+    const { backend } = createDroidBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'Use OpenAI');
+    const promptPromise = backend.sendPrompt(sessionId, 'Hello');
     simulateProcess(currentMockProcess);
     await promptPromise;
 
     const args = mockSpawn.mock.calls[0][1] as string[];
-    expect(args).toContain('--backend');
-    expect(args).toContain('openai');
+    expect(args[0]).toBe('exec');
+    expect(args[1]).toBe('Hello'); // prompt is positional, immediately after `exec`
+    expect(args).not.toContain('chat');
+    expect(args).not.toContain('--message');
+    expect(args).not.toContain('--no-interactive');
+    expect(args).not.toContain('--backend');
+    expect(args).not.toContain('--format');
   });
 
-  it('passes --model flag when model is specified', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'claude-opus-4' });
+  it('passes -m flag when model is specified', async () => {
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'gpt-5.5' });
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'Analyze deeply');
@@ -339,76 +381,36 @@ describe('DroidBackend — sendPrompt', () => {
     await promptPromise;
 
     const args = mockSpawn.mock.calls[0][1] as string[];
-    expect(args).toContain('--model');
-    expect(args).toContain('claude-opus-4');
+    expect(args).toContain('-m');
+    expect(args).toContain('gpt-5.5');
   });
 
-  // Provider-scoped API key injection (audit 2026-05-05 HIGH fix).
-  // Droid was the same fan-out class as goose/crush/kilo — fixed in the
-  // same pass since the directive said "fix everything, nothing deferred".
-
-  it('anthropic key (sk-ant-): injects ONLY ANTHROPIC_API_KEY', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, apiKey: 'sk-ant-real' });
+  it('passes --auto flag when autoLevel is specified', async () => {
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, autoLevel: 'high' });
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'BYOK test');
+    const promptPromise = backend.sendPrompt(sessionId, 'Deploy');
     simulateProcess(currentMockProcess);
     await promptPromise;
 
-    const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<string, string>;
-    expect(spawnEnv.ANTHROPIC_API_KEY).toBe('sk-ant-real');
-    expect(spawnEnv.OPENAI_API_KEY).toBeUndefined();
-    expect(spawnEnv.GOOGLE_API_KEY).toBeUndefined();
-    expect(spawnEnv.MISTRAL_API_KEY).toBeUndefined();
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    expect(args).toContain('--auto');
+    expect(args).toContain('high');
   });
 
-  it('openai key (sk-): injects ONLY OPENAI_API_KEY', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, apiKey: 'sk-openai-real' });
+  it('does NOT pass --auto when autoLevel is omitted (read-only default)', async () => {
+    const { backend } = createDroidBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'BYOK test');
+    const promptPromise = backend.sendPrompt(sessionId, 'Read only');
     simulateProcess(currentMockProcess);
     await promptPromise;
 
-    const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<string, string>;
-    expect(spawnEnv.OPENAI_API_KEY).toBe('sk-openai-real');
-    expect(spawnEnv.ANTHROPIC_API_KEY).toBeUndefined();
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    expect(args).not.toContain('--auto');
   });
 
-  it('google key (AIza): injects ONLY GOOGLE/GEMINI keys', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, apiKey: 'AIzaSyDroid' });
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'BYOK test');
-    simulateProcess(currentMockProcess);
-    await promptPromise;
-
-    const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<string, string>;
-    expect(spawnEnv.GOOGLE_API_KEY).toBe('AIzaSyDroid');
-    expect(spawnEnv.GEMINI_API_KEY).toBe('AIzaSyDroid');
-    expect(spawnEnv.OPENAI_API_KEY).toBeUndefined();
-  });
-
-  it('injects apiKeys map overriding individual providers', async () => {
-    const { backend } = createDroidBackend({
-      ...BASE_OPTIONS,
-      apiKeys: {
-        ANTHROPIC_API_KEY: 'ant-key',
-        OPENAI_API_KEY: 'oai-key',
-      },
-    });
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Multi-provider test');
-    simulateProcess(currentMockProcess);
-    await promptPromise;
-
-    const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<string, string>;
-    expect(spawnEnv.ANTHROPIC_API_KEY).toBe('ant-key');
-    expect(spawnEnv.OPENAI_API_KEY).toBe('oai-key');
-  });
-
-  it('passes --session when resumeSessionId is provided', async () => {
+  it('passes -s with resumeSessionId on first prompt', async () => {
     const { backend } = createDroidBackend({ ...BASE_OPTIONS, resumeSessionId: 'existing-456' });
     const { sessionId } = await backend.startSession();
 
@@ -417,8 +419,56 @@ describe('DroidBackend — sendPrompt', () => {
     await promptPromise;
 
     const args = mockSpawn.mock.calls[0][1] as string[];
-    expect(args).toContain('--session');
+    expect(args).toContain('-s');
     expect(args).toContain('existing-456');
+  });
+
+  it('passes --fork with forkSessionId (taking precedence over resume)', async () => {
+    const { backend } = createDroidBackend({
+      ...BASE_OPTIONS,
+      forkSessionId: 'fork-789',
+    });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Branch off');
+    simulateProcess(currentMockProcess);
+    await promptPromise;
+
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    expect(args).toContain('--fork');
+    expect(args).toContain('fork-789');
+    expect(args).not.toContain('-s');
+  });
+
+  it('injects FACTORY_API_KEY into the subprocess env (not as a CLI flag)', async () => {
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, factoryApiKey: 'fk-real-key' });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Auth test');
+    simulateProcess(currentMockProcess);
+    await promptPromise;
+
+    const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<string, string>;
+    expect(spawnEnv.FACTORY_API_KEY).toBe('fk-real-key');
+
+    // Droid is Factory-hosted, NOT a multi-provider BYOK proxy: no provider keys.
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    expect(args).not.toContain('fk-real-key'); // never on the command line
+  });
+
+  it('does NOT inject provider keys (Droid is not BYOK/LiteLLM)', async () => {
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, factoryApiKey: 'fk-x' });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'No provider keys');
+    simulateProcess(currentMockProcess);
+    await promptPromise;
+
+    const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<string, string>;
+    expect(spawnEnv.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(spawnEnv.OPENAI_API_KEY).toBeUndefined();
+    expect(spawnEnv.GOOGLE_API_KEY).toBeUndefined();
+    expect(spawnEnv.MISTRAL_API_KEY).toBeUndefined();
   });
 
   it('throws when sendPrompt is called with wrong sessionId', async () => {
@@ -451,84 +501,88 @@ describe('DroidBackend — sendPrompt', () => {
 });
 
 // ===========================================================================
-// DroidBackend — JSONL output parsing
+// DroidBackend — stream-json output parsing (VERIFIED events)
 // ===========================================================================
 
-describe('DroidBackend — JSONL output parsing', () => {
-  it('emits model-output for text events', async () => {
+describe('DroidBackend — stream-json parsing (verified events)', () => {
+  it('captures the resolved model from the init system event', async () => {
+    // Request one model; Droid's init advertises another. The cost-report must
+    // reflect the model Droid actually used (from init), per the result event.
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'gpt-5.5' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'init test');
+    simulateProcess(currentMockProcess, [
+      droidInit('claude-opus-4-8'),
+      droidResult({ inputTokens: 100, outputTokens: 50 }),
+    ]);
+    await promptPromise;
+
+    const report = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(report.report.model).toBe('claude-opus-4-8');
+  });
+
+  it('emits model-output from the result event text', async () => {
     const { backend } = createDroidBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'Generate code');
-    simulateProcess(currentMockProcess, [droidText('Here is the implementation')]);
+    simulateProcess(currentMockProcess, [
+      droidInit('claude-opus-4-8'),
+      droidResult({ result: 'Here is the implementation' }),
+    ]);
     await promptPromise;
 
     const outputMsgs = messages.filter((m: any) => m.type === 'model-output');
-    expect(outputMsgs).toHaveLength(1);
-    expect((outputMsgs[0] as any).textDelta).toBe('Here is the implementation');
+    expect(outputMsgs.length).toBeGreaterThanOrEqual(1);
+    expect((outputMsgs[outputMsgs.length - 1] as any).textDelta).toBe('Here is the implementation');
   });
 
-  it('emits tool-call for tool_call events', async () => {
-    const { backend } = createDroidBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Read file');
-    simulateProcess(currentMockProcess, [
-      droidToolCall('read_file', 'call-1', { path: '/src/main.ts' }),
-    ]);
-    await promptPromise;
-
-    const toolCalls = messages.filter((m: any) => m.type === 'tool-call');
-    expect(toolCalls).toHaveLength(1);
-    expect((toolCalls[0] as any).toolName).toBe('read_file');
-    expect((toolCalls[0] as any).callId).toBe('call-1');
-    expect((toolCalls[0] as any).args).toEqual({ path: '/src/main.ts' });
-  });
-
-  it('emits tool-result for tool_result events', async () => {
-    const { backend } = createDroidBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'List files');
-    simulateProcess(currentMockProcess, [
-      droidToolResult('list_files', 'call-2', ['file1.ts', 'file2.ts']),
-    ]);
-    await promptPromise;
-
-    const toolResults = messages.filter((m: any) => m.type === 'tool-result');
-    expect(toolResults).toHaveLength(1);
-    expect((toolResults[0] as any).toolName).toBe('list_files');
-    expect((toolResults[0] as any).callId).toBe('call-2');
-  });
-
-  it('emits idle status for done events', async () => {
+  it('emits idle status after a successful result event', async () => {
     const { backend } = createDroidBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'Final task');
-    simulateProcess(currentMockProcess, [droidDone()]);
+    simulateProcess(currentMockProcess, [droidResult({ result: 'ok' })]);
     await promptPromise;
 
     const idleStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'idle');
     expect(idleStatuses.length).toBeGreaterThan(0);
   });
 
-  it('emits error status for error events', async () => {
+  it('emits error status for a top-level error event', async () => {
     const { backend } = createDroidBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'Cause error');
-    simulateProcess(currentMockProcess, [droidError('API rate limit exceeded')]);
+    simulateProcess(currentMockProcess, [
+      droidError('Authentication failed. Please log in using /login or set a valid FACTORY_API_KEY environment variable.'),
+    ]);
     await promptPromise;
 
     const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
     expect(errorStatuses).toHaveLength(1);
-    expect((errorStatuses[0] as any).detail).toBe('API rate limit exceeded');
+    expect((errorStatuses[0] as any).detail).toContain('Authentication failed');
+  });
+
+  it('emits error status for a result event with is_error=true', async () => {
+    const { backend } = createDroidBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Failing run');
+    simulateProcess(currentMockProcess, [
+      droidResult({ isError: true, result: 'rate limit exceeded' }),
+    ]);
+    await promptPromise;
+
+    const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
+    expect(errorStatuses.length).toBeGreaterThan(0);
+    expect((errorStatuses[errorStatuses.length - 1] as any).detail).toContain('rate limit');
   });
 
   it('ignores non-JSON lines without crashing', async () => {
@@ -538,143 +592,80 @@ describe('DroidBackend — JSONL output parsing', () => {
 
     const promptPromise = backend.sendPrompt(sessionId, 'Hello');
     simulateProcess(currentMockProcess, [
-      'Droid v2.0.0 initializing...',
-      droidText('Response content'),
+      'Droid v0.144.2 initializing...',
+      droidResult({ result: 'Response content' }),
       '',
     ]);
     await promptPromise;
 
     const outputMsgs = messages.filter((m: any) => m.type === 'model-output');
-    expect(outputMsgs).toHaveLength(1);
+    expect(outputMsgs.length).toBeGreaterThanOrEqual(1);
   });
 });
 
 // ===========================================================================
-// DroidBackend — LiteLLM cost estimation
+// DroidBackend — usage / cost-report from the result event (VERIFIED schema)
 // ===========================================================================
 
-describe('DroidBackend — LiteLLM cost estimation', () => {
-  it('uses provided cost_usd when available (no estimation needed)', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'gpt-4o' });
+describe('DroidBackend — usage + cost-report', () => {
+  it('reads VERIFIED snake_case usage fields from the result event', async () => {
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'claude-opus-4-8' });
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'Query with known cost');
+    const promptPromise = backend.sendPrompt(sessionId, 'Usage test');
     simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 1000, completion_tokens: 500, cost_usd: 0.075 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect(tokenCounts).toHaveLength(1);
-    expect((tokenCounts[0] as any).costUsd).toBeCloseTo(0.075, 5);
-    expect((tokenCounts[0] as any).inputTokens).toBe(1000);
-    expect((tokenCounts[0] as any).outputTokens).toBe(500);
-  });
-
-  it('estimates cost from claude-sonnet-4 pricing when cost_usd is not provided', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Sonnet estimation');
-    // 1000 input tokens at $0.003/1K + 500 output tokens at $0.015/1K = $0.003 + $0.0075 = $0.0105
-    simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 1000, completion_tokens: 500 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect((tokenCounts[0] as any).costUsd).toBeCloseTo(0.0105, 4);
-  });
-
-  it('estimates cost from gpt-4o pricing', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'gpt-4o' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'GPT estimation');
-    // 2000 input tokens at $0.0025/1K + 1000 output tokens at $0.01/1K = $0.005 + $0.01 = $0.015
-    simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 2000, completion_tokens: 1000 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect((tokenCounts[0] as any).costUsd).toBeCloseTo(0.015, 4);
-  });
-
-  it('uses default pricing for unknown model', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'unknown-model-xyz' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Unknown model');
-    simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 1000, completion_tokens: 1000 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    // Default pricing: $0.002/1K input + $0.008/1K output = $0.002 + $0.008 = $0.01
-    expect((tokenCounts[0] as any).costUsd).toBeCloseTo(0.01, 4);
-    expect((tokenCounts[0] as any).costUsd).toBeGreaterThan(0);
-  });
-
-  it('accumulates cost across multiple usage events', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'gpt-4o-mini' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    let promptPromise = backend.sendPrompt(sessionId, 'First');
-    simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 1000, completion_tokens: 500, cost_usd: 0.01 }),
-    ]);
-    await promptPromise;
-
-    currentMockProcess = makeMockProcess();
-    mockSpawn.mockReturnValue(currentMockProcess);
-
-    promptPromise = backend.sendPrompt(sessionId, 'Second');
-    simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 1000, completion_tokens: 500, cost_usd: 0.02 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    const lastTokenCount = tokenCounts[tokenCounts.length - 1] as any;
-    expect(lastTokenCount.costUsd).toBeCloseTo(0.03, 5);
-  });
-
-  it('tracks cache tokens when provided', async () => {
-    const { backend } = createDroidBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Cached request');
-    simulateProcess(currentMockProcess, [
-      droidUsage({
-        prompt_tokens: 1000,
-        completion_tokens: 200,
-        cache_read_tokens: 500,
-        cache_write_tokens: 100,
-        cost_usd: 0.005,
+      droidInit('claude-opus-4-8'),
+      droidResult({
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadTokens: 200,
+        cacheCreationTokens: 100,
       }),
     ]);
     await promptPromise;
 
     const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect((tokenCounts[0] as any).cacheReadTokens).toBe(500);
+    expect(tokenCounts).toHaveLength(1);
+    expect((tokenCounts[0] as any).inputTokens).toBe(1000);
+    expect((tokenCounts[0] as any).outputTokens).toBe(500);
+    expect((tokenCounts[0] as any).cacheReadTokens).toBe(200);
     expect((tokenCounts[0] as any).cacheWriteTokens).toBe(100);
   });
 
-  it('resets cost accumulators on each startSession', async () => {
+  it('emits a cost-report with source=styrby-estimate (Droid never reports cost)', async () => {
+    // WHY: Droid's verified result.usage block has NO cost field. Cost is
+    // derived downstream, so every Droid cost-report is a styrby-estimate.
+    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'claude-opus-4-8' });
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Cost test');
+    simulateProcess(currentMockProcess, [
+      droidInit('claude-opus-4-8'),
+      droidResult({ inputTokens: 800, outputTokens: 300 }),
+    ]);
+    await promptPromise;
+
+    const report = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(report).toBeDefined();
+    expect(report.report.agentType).toBe('droid');
+    expect(report.report.billingModel).toBe('api-key');
+    expect(report.report.source).toBe('styrby-estimate');
+    expect(report.report.inputTokens).toBe(800);
+    expect(report.report.outputTokens).toBe(300);
+    // rawAgentPayload carries the real usage block for downstream pricing.
+    expect(report.report.rawAgentPayload).not.toBeNull();
+    expect((report.report.rawAgentPayload as any).input_tokens).toBe(800);
+  });
+
+  it('resets token accumulators on each startSession', async () => {
     const { backend } = createDroidBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
 
     let { sessionId } = await backend.startSession();
     let promptPromise = backend.sendPrompt(sessionId, 'First session');
-    simulateProcess(currentMockProcess, [droidUsage({ cost_usd: 1.00 })]);
+    simulateProcess(currentMockProcess, [droidResult({ inputTokens: 5000, outputTokens: 5000 })]);
     await promptPromise;
 
     messages.length = 0;
@@ -683,167 +674,93 @@ describe('DroidBackend — LiteLLM cost estimation', () => {
 
     ({ sessionId } = await backend.startSession());
     promptPromise = backend.sendPrompt(sessionId, 'Second session');
-    simulateProcess(currentMockProcess, [droidUsage({ cost_usd: 0.05 })]);
+    simulateProcess(currentMockProcess, [droidResult({ inputTokens: 10, outputTokens: 20 })]);
     await promptPromise;
 
     const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    const lastTokenCount = tokenCounts[tokenCounts.length - 1] as any;
-    expect(lastTokenCount.costUsd).toBeCloseTo(0.05, 5);
+    const last = tokenCounts[tokenCounts.length - 1] as any;
+    expect(last.inputTokens).toBe(10);
+    expect(last.outputTokens).toBe(20);
   });
 });
 
 // ===========================================================================
-// DroidBackend — backend_switch events
+// DroidBackend — assistant/tool events (UNVERIFIED — schema needs keyed session)
 // ===========================================================================
 
-describe('DroidBackend — backend_switch events', () => {
-  it('emits event with backend switch details', async () => {
+/**
+ * These events (assistant text deltas, tool_use, tool_result) could NOT be
+ * captured because the test machine has no Factory auth (#30). The parser
+ * branches are written best-effort against the Claude-Code stream-json schema
+ * that Droid's init event advertises, but until a real keyed session confirms
+ * the exact envelope, we do NOT claim these work — hence `.skip`.
+ *
+ * To unskip: capture a real `droid exec "..." -o stream-json` run with a valid
+ * FACTORY_API_KEY, paste the actual assistant/tool_use/tool_result lines as the
+ * builders below, and verify the assertions hold.
+ */
+describe.skip('DroidBackend — assistant/tool events (UNVERIFIED, needs keyed session #30)', () => {
+  function droidAssistantText(text: string): string {
+    return JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } });
+  }
+  function droidAssistantToolUse(name: string, id: string, input: Record<string, unknown>): string {
+    return JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', name, id, input }] },
+    });
+  }
+  function droidUserToolResult(name: string, toolUseId: string, content: unknown, input?: Record<string, unknown>): string {
+    return JSON.stringify({
+      type: 'user',
+      message: { content: [{ type: 'tool_result', name, tool_use_id: toolUseId, content, input }] },
+    });
+  }
+
+  it('emits model-output from assistant text blocks', async () => {
     const { backend } = createDroidBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'Switch backends');
-    simulateProcess(currentMockProcess, [
-      droidBackendSwitch('openai', 'gpt-4o'),
-    ]);
+    const promptPromise = backend.sendPrompt(sessionId, 'stream');
+    simulateProcess(currentMockProcess, [droidAssistantText('partial answer'), droidResult({})]);
     await promptPromise;
 
-    const backendSwitchEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'backend-switch'
-    );
-    expect(backendSwitchEvents).toHaveLength(1);
-    expect((backendSwitchEvents[0] as any).payload.newBackend).toBe('openai');
-    expect((backendSwitchEvents[0] as any).payload.newModel).toBe('gpt-4o');
+    const outputs = messages.filter((m: any) => m.type === 'model-output');
+    expect(outputs.some((m: any) => m.textDelta === 'partial answer')).toBe(true);
   });
 
-  it('updates currentModel after backend_switch for subsequent cost estimation', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    // Switch to gpt-4o and then get usage
-    let promptPromise = backend.sendPrompt(sessionId, 'Switch then estimate');
-    simulateProcess(currentMockProcess, [
-      droidBackendSwitch('openai', 'gpt-4o'),
-    ]);
-    await promptPromise;
-
-    currentMockProcess = makeMockProcess();
-    mockSpawn.mockReturnValue(currentMockProcess);
-
-    promptPromise = backend.sendPrompt(sessionId, 'Post-switch usage');
-    // 2000 input + 1000 output with gpt-4o pricing = $0.005 + $0.01 = $0.015
-    simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 2000, completion_tokens: 1000, model: 'gpt-4o' }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect(tokenCounts.length).toBeGreaterThan(0);
-    const lastTokenCount = tokenCounts[tokenCounts.length - 1] as any;
-    expect(lastTokenCount.costUsd).toBeCloseTo(0.015, 4);
-  });
-
-  it('handles backend_switch with only new_backend (no model)', async () => {
+  it('emits tool-call from assistant tool_use blocks', async () => {
     const { backend } = createDroidBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'Switch backend only');
+    const promptPromise = backend.sendPrompt(sessionId, 'use a tool');
     simulateProcess(currentMockProcess, [
-      droidBackendSwitch('google'),
+      droidAssistantToolUse('Read', 'tu-1', { path: '/src/main.ts' }),
+      droidResult({}),
     ]);
     await promptPromise;
 
-    const switchEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'backend-switch'
-    );
-    expect(switchEvents).toHaveLength(1);
-    expect((switchEvents[0] as any).payload.newBackend).toBe('google');
+    const calls = messages.filter((m: any) => m.type === 'tool-call');
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as any).toolName).toBe('Read');
   });
-});
 
-// ===========================================================================
-// DroidBackend — fs-edit detection
-// ===========================================================================
-
-describe('DroidBackend — fs-edit detection', () => {
-  it('emits fs-edit for write tool results', async () => {
+  it('emits fs-edit for write tool_result blocks', async () => {
     const { backend } = createDroidBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'Write component');
+    const promptPromise = backend.sendPrompt(sessionId, 'write a file');
     simulateProcess(currentMockProcess, [
-      droidToolResult('write_file', 'call-1', 'success', { path: '/src/Button.tsx' }),
+      droidUserToolResult('Edit', 'tu-2', 'ok', { path: '/src/Button.tsx' }),
+      droidResult({}),
     ]);
     await promptPromise;
 
     const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
     expect(fsEdits).toHaveLength(1);
     expect((fsEdits[0] as any).path).toBe('/src/Button.tsx');
-    expect((fsEdits[0] as any).description).toContain('write_file');
-  });
-
-  it('emits fs-edit for edit tool results', async () => {
-    const { backend } = createDroidBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Edit config');
-    simulateProcess(currentMockProcess, [
-      droidToolResult('edit_file', 'call-2', 'ok', { file_path: '/config.ts' }),
-    ]);
-    await promptPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(1);
-    expect((fsEdits[0] as any).path).toBe('/config.ts');
-  });
-
-  it('emits fs-edit for str_replace tool results', async () => {
-    const { backend } = createDroidBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Replace string');
-    simulateProcess(currentMockProcess, [
-      droidToolResult('str_replace', 'call-3', 'replaced', { path: '/utils.ts' }),
-    ]);
-    await promptPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(1);
-  });
-
-  it('does NOT emit fs-edit for read_file tool results', async () => {
-    const { backend } = createDroidBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Read source');
-    simulateProcess(currentMockProcess, [
-      droidToolResult('read_file', 'call-4', 'content here', { path: '/src/auth.ts' }),
-    ]);
-    await promptPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(0);
-  });
-
-  it('does NOT emit fs-edit when tool result has no path in input', async () => {
-    const { backend } = createDroidBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Pathless write');
-    simulateProcess(currentMockProcess, [
-      droidToolResult('write_file', 'call-5', 'ok', { content: 'data' }),
-    ]);
-    await promptPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(0);
   });
 });
 
@@ -944,7 +861,7 @@ describe('DroidBackend — message handler management', () => {
 
     const { sessionId } = await backend.startSession();
     const promptPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [droidText('World')]);
+    simulateProcess(currentMockProcess, [droidResult({ result: 'World' })]);
     await promptPromise;
 
     expect(received.some((m: any) => m.type === 'model-output')).toBe(true);
@@ -960,7 +877,7 @@ describe('DroidBackend — message handler management', () => {
 
     const { sessionId } = await backend.startSession();
     const promptPromise = backend.sendPrompt(sessionId, 'Hidden');
-    simulateProcess(currentMockProcess, [droidText('Invisible')]);
+    simulateProcess(currentMockProcess, [droidResult({ result: 'Invisible' })]);
     await promptPromise;
 
     const modelOutputs = received.filter((m: any) => m.type === 'model-output');
@@ -977,7 +894,7 @@ describe('DroidBackend — message handler management', () => {
 
     const { sessionId } = await backend.startSession();
     const promptPromise = backend.sendPrompt(sessionId, 'Broadcast');
-    simulateProcess(currentMockProcess, [droidText('To all')]);
+    simulateProcess(currentMockProcess, [droidResult({ result: 'To all' })]);
     await promptPromise;
 
     expect(received1.some((m: any) => m.type === 'model-output')).toBe(true);
@@ -993,7 +910,7 @@ describe('DroidBackend — message handler management', () => {
 
     const { sessionId } = await backend.startSession();
     const promptPromise = backend.sendPrompt(sessionId, 'Resilient');
-    simulateProcess(currentMockProcess, [droidText('Still works')]);
+    simulateProcess(currentMockProcess, [droidResult({ result: 'Still works' })]);
     await promptPromise;
 
     expect(received.some((m: any) => m.type === 'model-output')).toBe(true);
@@ -1069,7 +986,7 @@ describe('DroidBackend — extra args validation', () => {
   it('passes validated extra args to droid', async () => {
     const { backend } = createDroidBackend({
       ...BASE_OPTIONS,
-      extraArgs: ['--verbose', '--max-tokens', '4096'],
+      extraArgs: ['--reasoning-effort', 'high'],
     });
     const { sessionId } = await backend.startSession();
 
@@ -1078,9 +995,8 @@ describe('DroidBackend — extra args validation', () => {
     await promptPromise;
 
     const args = mockSpawn.mock.calls[0][1] as string[];
-    expect(args).toContain('--verbose');
-    expect(args).toContain('--max-tokens');
-    expect(args).toContain('4096');
+    expect(args).toContain('--reasoning-effort');
+    expect(args).toContain('high');
   });
 
   it('throws for extra args containing shell metacharacters', async () => {
@@ -1095,96 +1011,32 @@ describe('DroidBackend — extra args validation', () => {
 });
 
 // ===========================================================================
-// DroidBackend — session_id tracking
+// DroidBackend — session_id tracking across prompts
 // ===========================================================================
 
 describe('DroidBackend — session_id tracking', () => {
-  it('uses session_id from Droid output in subsequent prompts', async () => {
+  it('uses the session_id from Droid output to resume on subsequent prompts', async () => {
     const { backend } = createDroidBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
-    // First prompt — Droid returns a session_id
+    // First prompt — Droid emits init + result carrying a session_id
     let promptPromise = backend.sendPrompt(sessionId, 'First message');
     simulateProcess(currentMockProcess, [
-      JSON.stringify({ type: 'text', content: 'Hello', session_id: 'droid-sess-abc' }),
-      droidDone(),
+      droidInit('claude-opus-4-8', 'droid-sess-abc'),
+      droidResult({ result: 'Hello', sessionId: 'droid-sess-abc' }),
     ]);
     await promptPromise;
 
     currentMockProcess = makeMockProcess();
     mockSpawn.mockReturnValue(currentMockProcess);
 
-    // Second prompt — should pass --session droid-sess-abc
+    // Second prompt — should pass `-s droid-sess-abc`
     promptPromise = backend.sendPrompt(sessionId, 'Second message');
     simulateProcess(currentMockProcess);
     await promptPromise;
 
     const args = mockSpawn.mock.calls[1][1] as string[];
-    expect(args).toContain('--session');
+    expect(args).toContain('-s');
     expect(args).toContain('droid-sess-abc');
-  });
-});
-
-// ===========================================================================
-// DroidBackend — cost-report emission
-// ===========================================================================
-
-/**
- * Tests for the unified CostReport event emitted by Droid usage events.
- *
- * WHY: Droid mirrors Goose's pattern — source='agent-reported' with rawAgentPayload
- * when cost_usd is present; source='styrby-estimate' with rawAgentPayload=null
- * when cost_usd is absent.
- */
-describe('DroidBackend — cost-report emission', () => {
-  it('emits cost-report with source=agent-reported when usage event has cost_usd', async () => {
-    const { backend } = createDroidBackend({ ...BASE_OPTIONS, model: 'droid-v2' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 1200, completion_tokens: 600, cost_usd: 0.045 }),
-    ]);
-    await promptPromise;
-
-    const reports = messages.filter((m: any) => m.type === 'cost-report');
-    expect(reports.length).toBeGreaterThanOrEqual(1);
-    const r = reports[0] as any;
-    expect(r.report.billingModel).toBe('api-key');
-    expect(r.report.source).toBe('agent-reported');
-    expect(r.report.agentType).toBe('droid');
-    expect(r.report.rawAgentPayload).not.toBeNull();
-  });
-
-  it('emits cost-report with source=styrby-estimate and rawAgentPayload=null when cost_usd is absent', async () => {
-    const { backend } = createDroidBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 800, completion_tokens: 300 }),
-    ]);
-    await promptPromise;
-
-    const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    expect(r.report.source).toBe('styrby-estimate');
-    expect(r.report.rawAgentPayload).toBeNull();
-  });
-
-  it('cost-report costUsd reflects the agent-provided value', async () => {
-    const { backend } = createDroidBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      droidUsage({ prompt_tokens: 500, completion_tokens: 200, cost_usd: 0.022 }),
-    ]);
-    await promptPromise;
-
-    const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    expect(r.report.costUsd).toBeCloseTo(0.022);
   });
 });

--- a/packages/styrby-cli/src/agent/factories/__tests__/goose.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/goose.test.ts
@@ -5,12 +5,23 @@
  * - `createGooseBackend` factory function
  * - `registerGooseAgent` registry integration
  * - `GooseBackend` class: session lifecycle, subprocess management,
- *   JSONL output parsing, cost/token extraction from MCP usage events,
- *   fs-edit detection from tool names, sub-agent event passthrough,
- *   error handling, cancellation, permission response, and disposal.
+ *   stream-json output parsing, cost/token extraction, fs-edit detection from
+ *   tool names, error handling, cancellation, permission response, disposal.
  *
  * All child_process and logger calls are mocked so no real Goose binary
  * is required.
+ *
+ * INVOCATION is verified against the real `goose run --help` (binary v1.37.0,
+ * 2026-06-10): `goose run -t <prompt> --output-format stream-json
+ * [--no-session] [--model] [--provider] [--name]`. The OLD `--format jsonl` +
+ * `--no-interactive` flags were invented and have been removed.
+ *
+ * PARSER schema is UNVERIFIED (#30): the local box has no provider configured,
+ * so a real `stream-json` event stream could not be captured. The event-shape
+ * tests below (cost/usage especially) exercise a BEST-GUESS schema and are
+ * marked `describe.skip` / `it.skip` with that reason until #30 captures real
+ * output. They are kept (not deleted) so they activate the moment the schema is
+ * confirmed.
  *
  * @module factories/__tests__/goose.test.ts
  */
@@ -334,7 +345,10 @@ describe('GooseBackend — session lifecycle', () => {
  * Tests for sendPrompt — verifies correct CLI arguments are passed to spawn.
  */
 describe('GooseBackend — sendPrompt arguments', () => {
-  it('spawns goose with "run", "--text", and "--format jsonl" flags', async () => {
+  it('spawns goose with "run", "--text", and real "--output-format stream-json" flags', async () => {
+    // VERIFIED against `goose run --help` (v1.37.0): the headless invocation is
+    // `goose run -t <prompt> --output-format stream-json`. The invented
+    // `--format jsonl` flag does not exist.
     const { backend } = createGooseBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -347,11 +361,17 @@ describe('GooseBackend — sendPrompt arguments', () => {
     expect(args).toContain('run');
     expect(args).toContain('--text');
     expect(args).toContain('Refactor auth module');
-    expect(args).toContain('--format');
-    expect(args).toContain('jsonl');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('stream-json');
+    // The invented flags must NOT be present.
+    expect(args).not.toContain('--format');
+    expect(args).not.toContain('jsonl');
+    expect(args).not.toContain('--no-interactive');
   });
 
-  it('includes --no-interactive flag by default', async () => {
+  it('includes --no-session by default (ephemeral automated run)', async () => {
+    // `goose run` is already non-interactive; there is no --no-interactive flag.
+    // We pass --no-session so automated runs do not litter the session DB.
     const { backend } = createGooseBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -360,10 +380,10 @@ describe('GooseBackend — sendPrompt arguments', () => {
     await promptPromise;
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('--no-interactive');
+    expect(args).toContain('--no-session');
   });
 
-  it('omits --no-interactive flag when nonInteractive is explicitly false', async () => {
+  it('omits --no-session when nonInteractive is explicitly false (keep session file)', async () => {
     const { backend } = createGooseBackend({ ...BASE_OPTIONS, nonInteractive: false });
     const { sessionId } = await backend.startSession();
 
@@ -372,7 +392,21 @@ describe('GooseBackend — sendPrompt arguments', () => {
     await promptPromise;
 
     const [, args] = mockSpawn.mock.calls[0];
-    expect(args).not.toContain('--no-interactive');
+    expect(args).not.toContain('--no-session');
+  });
+
+  it('omits --no-session when a sessionName is provided (named session wins)', async () => {
+    const { backend } = createGooseBackend({ ...BASE_OPTIONS, sessionName: 'keep-me' });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess);
+    await promptPromise;
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args).not.toContain('--no-session');
+    expect(args).toContain('--name');
+    expect(args).toContain('keep-me');
   });
 
   it('includes --model flag when model option is set', async () => {
@@ -531,10 +565,19 @@ describe('GooseBackend — sendPrompt arguments', () => {
 // ===========================================================================
 
 /**
- * Tests for JSONL parsing: message events, tool calls, tool results, fs-edits,
- * cost tracking, status events, and finish events.
+ * Tests for stream-json parsing: message events, tool calls, tool results,
+ * fs-edits, cost tracking, status events, finish events.
+ *
+ * SKIPPED (#30): every test in this block asserts a BEST-GUESS event schema
+ * (`{type:'message'|'tool_call'|'tool_result'|'cost'|'status'|'finish', ...}`)
+ * that could NOT be confirmed against real `goose run --output-format
+ * stream-json` output — the local box has no provider configured, so no authed
+ * session was capturable. These tests are retained (not deleted) and will be
+ * un-skipped once #30 captures the real schema. The parser-plumbing tests that
+ * do NOT depend on the event schema (non-JSON tolerance, partial buffering,
+ * clean exit) live in the error-handling block below and remain active.
  */
-describe('GooseBackend — JSONL output parsing and event emission', () => {
+describe.skip('GooseBackend — stream-json parsing (schema unverified #30)', () => {
   it('emits model-output message for type=message events', async () => {
     const { backend } = createGooseBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
@@ -793,6 +836,19 @@ describe('GooseBackend — JSONL output parsing and event emission', () => {
     expect(text).toContain('Hello from Goose');
   });
 
+});
+
+// ===========================================================================
+// GooseBackend — process plumbing (schema-independent)
+// ===========================================================================
+
+/**
+ * Tests for stream plumbing that does NOT depend on the (unverified #30) event
+ * schema: clean-exit status, non-JSON tolerance, and partial-line buffering.
+ * These remain active because they validate the spawn/close lifecycle and the
+ * line buffer, which are correct regardless of what JSON goose actually emits.
+ */
+describe('GooseBackend — process plumbing (schema-independent)', () => {
   it('emits idle status after process exits cleanly', async () => {
     const { backend } = createGooseBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
@@ -807,6 +863,27 @@ describe('GooseBackend — JSONL output parsing and event emission', () => {
       .at(-1) as any;
 
     expect(lastStatus?.status).toBe('idle');
+  });
+
+  it('ignores non-JSON stdout lines without crashing', async () => {
+    // Schema-independent: any non-`{`-prefixed line is dropped to a debug log.
+    const { backend } = createGooseBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, ['Loading Goose...', '   ', 'plain text line']);
+
+    await expect(promptPromise).resolves.not.toThrow();
+  });
+
+  it('handles partial/malformed JSON lines without crashing', async () => {
+    const { backend } = createGooseBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'hello');
+    simulateProcess(currentMockProcess, ['{ incomplete json', 'another non-json line']);
+
+    await expect(promptPromise).resolves.not.toThrow();
   });
 });
 
@@ -1103,8 +1180,12 @@ describe('GooseBackend — waitForResponseComplete', () => {
  * WHY: migration 022 columns require billing_model / source / raw_agent_payload.
  * When Goose provides cost_usd the source is 'agent-reported' with rawAgentPayload.
  * When cost_usd is absent, source falls back to 'styrby-estimate' and rawAgentPayload is null.
+ *
+ * SKIPPED (#30): depends on the assumed `{type:'cost', usage:{cost_usd}}` event
+ * shape, which is UNVERIFIED against real goose stream-json output. Un-skip once
+ * #30 confirms how goose actually surfaces token usage.
  */
-describe('GooseBackend — cost-report emission', () => {
+describe.skip('GooseBackend — cost-report emission (schema unverified #30)', () => {
   it('emits cost-report with source=agent-reported when cost event has cost_usd', async () => {
     const { backend } = createGooseBackend({ ...BASE_OPTIONS, model: 'claude-opus-4' });
     const messages = collectMessages(backend);

--- a/packages/styrby-cli/src/agent/factories/__tests__/kilo.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/kilo.test.ts
@@ -1,24 +1,25 @@
 /**
- * Tests for the Kilo agent backend factory (Community, 500+ models, Memory Bank).
+ * Tests for the Kilo agent backend factory.
+ *
+ * Kilo is an OpenCode fork. Its headless surface (`kilo run <message> --format
+ * json`) and event envelope (`{ type, sessionID, part }`) were VERIFIED against
+ * the real `kilo` binary (v7.3.41, 2026-06-11) via `kilo --help` /
+ * `kilo run --help` and a live `kilo run "say OK" --format json --auto` (which
+ * returned a real `error` event envelope). See kilo.ts header for the full
+ * confirmed-facts table.
+ *
+ * SCHEMA UNVERIFIED — needs keyed session (#30): the success-path `text` and
+ * `step_finish` `part` payloads could not be captured (no provider credentials
+ * locally → 401 PAID_MODEL_AUTH_REQUIRED). Those tests assert the OpenCode-fork
+ * shape on the well-founded fork assumption and are tagged for re-verification.
  *
  * Covers:
- * - `createKiloBackend` factory function
- * - `registerKiloAgent` registry integration
- * - `KiloBackend` class: session lifecycle, subprocess management,
- *   JSON output parsing, Memory Bank read/write event tracking and emission,
- *   token/cost accumulation, fs-edit detection, error handling,
- *   cancellation, permission response, and disposal.
+ * - `createKiloBackend` factory + `registerKiloAgent` registry integration
+ * - session lifecycle, real spawn args, provider-scoped key injection
+ * - JSON parsing: text → model-output, step_finish → cost-report, error event
+ * - error handling, cancellation, permission response, disposal, line buffering
  *
- * Memory Bank tests verify:
- * - memory_bank_read events emit 'memory-bank-read' event messages
- * - memory_bank_write events emit 'memory-bank-write' event messages
- * - cumulative read/write tracking across a session
- * - memory bank is reset on new session
- * - memoryBankEnabled flag passes correct CLI args
- * - memoryBankPath flag passes correct CLI args
- *
- * All child_process and logger calls are mocked so no real Kilo binary
- * is required.
+ * All child_process and logger calls are mocked so no real Kilo binary is required.
  *
  * @module factories/__tests__/kilo.test.ts
  */
@@ -96,49 +97,41 @@ function simulateProcess(proc: MockProcess, lines: string[] = [], exitCode = 0) 
   proc.emit('close', exitCode);
 }
 
-// ---- Kilo event builders ----
+// ---- Real Kilo event builders (`{ type, sessionID, part }` envelope) ----
 
-function kiloText(content: string): string {
-  return JSON.stringify({ type: 'text', content });
+/** text event: assistant output rides in part.text (OpenCode-fork shape, #30). */
+function kiloText(text: string, sessionID = 'ses_test'): string {
+  return JSON.stringify({ type: 'text', sessionID, part: { type: 'text', text } });
 }
 
-function kiloToolUse(toolName: string, callId: string, toolInput?: Record<string, unknown>): string {
-  return JSON.stringify({ type: 'tool_use', tool_name: toolName, call_id: callId, tool_input: toolInput });
-}
-
-function kiloToolResult(
-  toolName: string,
-  callId: string,
-  toolResult: unknown,
-  toolInput?: Record<string, unknown>
+/** step_finish event: usage rides on part.cost + part.tokens (OpenCode-fork shape, #30). */
+function kiloStepFinish(
+  opts: { cost?: number; input?: number; output?: number; cacheRead?: number; cacheWrite?: number },
+  sessionID = 'ses_test',
 ): string {
-  return JSON.stringify({ type: 'tool_result', tool_name: toolName, call_id: callId, tool_result: toolResult, tool_input: toolInput });
+  return JSON.stringify({
+    type: 'step_finish',
+    sessionID,
+    part: {
+      type: 'step-finish',
+      reason: 'stop',
+      cost: opts.cost,
+      tokens: {
+        input: opts.input,
+        output: opts.output,
+        cache: { read: opts.cacheRead, write: opts.cacheWrite },
+      },
+    },
+  });
 }
 
-function kiloMemoryBankRead(memoryFile: string, content?: string): string {
-  return JSON.stringify({ type: 'memory_bank_read', memory_file: memoryFile, memory_content: content });
-}
-
-function kiloMemoryBankWrite(memoryFile: string, section?: string, content?: string): string {
-  return JSON.stringify({ type: 'memory_bank_write', memory_file: memoryFile, memory_section: section, memory_content: content });
-}
-
-function kiloTokens(usage: {
-  input_tokens?: number;
-  output_tokens?: number;
-  cache_read_tokens?: number;
-  cache_write_tokens?: number;
-  cost_usd?: number;
-}): string {
-  return JSON.stringify({ type: 'tokens', usage });
-}
-
-function kiloError(error: string): string {
-  return JSON.stringify({ type: 'error', error });
-}
-
-function kiloComplete(): string {
-  return JSON.stringify({ type: 'complete' });
+/** error event: VERIFIED nested shape error.data.message (captured from real binary). */
+function kiloError(message: string, sessionID = 'ses_test'): string {
+  return JSON.stringify({
+    type: 'error',
+    sessionID,
+    error: { name: 'APIError', data: { message } },
+  });
 }
 
 const BASE_OPTIONS: KiloBackendOptions = {
@@ -166,11 +159,11 @@ afterEach(() => {
 
 describe('createKiloBackend', () => {
   it('returns a backend instance and resolved model when model is provided', () => {
-    const { backend, model } = createKiloBackend({ ...BASE_OPTIONS, model: 'gpt-4o' });
+    const { backend, model } = createKiloBackend({ ...BASE_OPTIONS, model: 'openai/gpt-4o' });
 
     expect(backend).toBeDefined();
     expect(typeof backend.startSession).toBe('function');
-    expect(model).toBe('gpt-4o');
+    expect(model).toBe('openai/gpt-4o');
   });
 
   it('returns undefined model when no model is specified', () => {
@@ -196,21 +189,10 @@ describe('createKiloBackend', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('accepts memoryBankEnabled, memoryBankPath, and apiBaseUrl options', () => {
-    const { backend } = createKiloBackend({
-      ...BASE_OPTIONS,
-      memoryBankEnabled: true,
-      memoryBankPath: '/custom/memory',
-      apiBaseUrl: 'http://localhost:11434/v1',
-    });
-
-    expect(backend).toBeDefined();
-  });
-
   it('accepts resumeSessionId option', () => {
     const { backend } = createKiloBackend({
       ...BASE_OPTIONS,
-      resumeSessionId: 'prev-session-uuid',
+      resumeSessionId: 'ses_prev',
     });
 
     expect(backend).toBeDefined();
@@ -301,11 +283,11 @@ describe('KiloBackend — session lifecycle', () => {
 });
 
 // ===========================================================================
-// KiloBackend — sendPrompt
+// KiloBackend — sendPrompt (REAL CLI surface)
 // ===========================================================================
 
 describe('KiloBackend — sendPrompt', () => {
-  it('spawns kilo with run --prompt --output json --no-interactive flags', async () => {
+  it('spawns kilo with the run subcommand, positional prompt, --format json --auto', async () => {
     const { backend } = createKiloBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -313,14 +295,13 @@ describe('KiloBackend — sendPrompt', () => {
     simulateProcess(currentMockProcess);
     await sendPromise;
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'kilo',
-      expect.arrayContaining(['run', '--prompt', 'Add user auth', '--output', 'json', '--no-interactive']),
-      expect.any(Object)
-    );
+    // VERIFIED real surface: `kilo run <message> --format json --auto`.
+    // The prompt is POSITIONAL — there is no --prompt flag.
+    const args = (mockSpawn.mock.calls[0] as any[])[1] as string[];
+    expect(args.slice(0, 5)).toEqual(['run', 'Add user auth', '--format', 'json', '--auto']);
   });
 
-  it('enables memory bank with --memory-bank flag by default', async () => {
+  it('does NOT pass the invented --prompt / --output / --no-interactive / --memory-bank flags', async () => {
     const { backend } = createKiloBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -328,53 +309,18 @@ describe('KiloBackend — sendPrompt', () => {
     simulateProcess(currentMockProcess);
     await sendPromise;
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'kilo',
-      expect.arrayContaining(['--memory-bank']),
-      expect.any(Object)
-    );
-  });
-
-  it('disables memory bank with --no-memory-bank when memoryBankEnabled is false', async () => {
-    const { backend } = createKiloBackend({ ...BASE_OPTIONS, memoryBankEnabled: false });
-    const { sessionId } = await backend.startSession();
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess);
-    await sendPromise;
-
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'kilo',
-      expect.arrayContaining(['--no-memory-bank']),
-      expect.any(Object)
-    );
-
-    // Confirm --memory-bank is NOT in args
-    const spawnArgs = (mockSpawn.mock.calls[0] as any[])[1] as string[];
-    expect(spawnArgs).not.toContain('--memory-bank');
-  });
-
-  it('includes --memory-bank-path when memoryBankPath is specified', async () => {
-    const { backend } = createKiloBackend({
-      ...BASE_OPTIONS,
-      memoryBankEnabled: true,
-      memoryBankPath: '/custom/memory',
-    });
-    const { sessionId } = await backend.startSession();
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess);
-    await sendPromise;
-
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'kilo',
-      expect.arrayContaining(['--memory-bank-path', '/custom/memory']),
-      expect.any(Object)
-    );
+    const args = (mockSpawn.mock.calls[0] as any[])[1] as string[];
+    expect(args).not.toContain('--prompt');
+    expect(args).not.toContain('--output');
+    expect(args).not.toContain('--no-interactive');
+    expect(args).not.toContain('--memory-bank');
+    expect(args).not.toContain('--no-memory-bank');
+    expect(args).not.toContain('--api-base');
+    expect(args).not.toContain('--resume');
   });
 
   it('includes --model flag when model is specified', async () => {
-    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'ollama/llama3' });
+    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'anthropic/claude-sonnet-4' });
     const { sessionId } = await backend.startSession();
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
@@ -383,13 +329,13 @@ describe('KiloBackend — sendPrompt', () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       'kilo',
-      expect.arrayContaining(['--model', 'ollama/llama3']),
+      expect.arrayContaining(['--model', 'anthropic/claude-sonnet-4']),
       expect.any(Object)
     );
   });
 
-  it('includes --api-base flag when apiBaseUrl is specified', async () => {
-    const { backend } = createKiloBackend({ ...BASE_OPTIONS, apiBaseUrl: 'http://localhost:11434/v1' });
+  it('includes --session flag when resumeSessionId is specified', async () => {
+    const { backend } = createKiloBackend({ ...BASE_OPTIONS, resumeSessionId: 'ses_prev' });
     const { sessionId } = await backend.startSession();
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
@@ -398,24 +344,29 @@ describe('KiloBackend — sendPrompt', () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       'kilo',
-      expect.arrayContaining(['--api-base', 'http://localhost:11434/v1']),
+      expect.arrayContaining(['--session', 'ses_prev']),
       expect.any(Object)
     );
   });
 
-  it('includes --resume flag when resumeSessionId is specified', async () => {
-    const { backend } = createKiloBackend({ ...BASE_OPTIONS, resumeSessionId: 'prev-session' });
+  it('captures sessionID from events and passes --session on the next prompt', async () => {
+    const { backend } = createKiloBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess);
-    await sendPromise;
+    const send1 = backend.sendPrompt(sessionId, 'first');
+    simulateProcess(currentMockProcess, [kiloText('ok', 'ses_captured')]);
+    await send1;
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'kilo',
-      expect.arrayContaining(['--resume', 'prev-session']),
-      expect.any(Object)
-    );
+    currentMockProcess = makeMockProcess();
+    mockSpawn.mockReturnValue(currentMockProcess);
+
+    const send2 = backend.sendPrompt(sessionId, 'second');
+    simulateProcess(currentMockProcess);
+    await send2;
+
+    const args = (mockSpawn.mock.calls[1] as any[])[1] as string[];
+    expect(args).toContain('--session');
+    expect(args).toContain('ses_captured');
   });
 
   // Provider-scoped API key injection (audit 2026-05-05 HIGH fix).
@@ -491,273 +442,15 @@ describe('KiloBackend — sendPrompt', () => {
 });
 
 // ===========================================================================
-// KiloBackend — Memory Bank read events
-// ===========================================================================
-
-describe('KiloBackend — Memory Bank read events', () => {
-  it('emits memory-bank-read event when memory_bank_read message is received', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Help me with auth');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankRead('projectbrief.md', '# My Project\nAn e-commerce app...'),
-    ]);
-    await sendPromise;
-
-    const memReadEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-read'
-    );
-    expect(memReadEvents).toHaveLength(1);
-    expect((memReadEvents[0] as any).payload.file).toBe('projectbrief.md');
-  });
-
-  it('includes content preview in the memory-bank-read payload', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Help');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankRead('activeContext.md', 'Current task: implement login'),
-    ]);
-    await sendPromise;
-
-    const event = (messages.find(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-read'
-    ) as any);
-    expect(event.payload.contentPreview).toBe('Current task: implement login');
-  });
-
-  it('tracks cumulative read count across multiple reads', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Help');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankRead('projectbrief.md'),
-      kiloMemoryBankRead('activeContext.md'),
-      kiloMemoryBankRead('systemPatterns.md'),
-    ]);
-    await sendPromise;
-
-    const memReadEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-read'
-    );
-    expect(memReadEvents).toHaveLength(3);
-    expect((memReadEvents[2] as any).payload.totalReads).toBe(3);
-  });
-
-  it('includes all previously read files in allFiles list', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Help');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankRead('projectbrief.md'),
-      kiloMemoryBankRead('activeContext.md'),
-    ]);
-    await sendPromise;
-
-    const lastReadEvent = (messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-read'
-    ) as any[]).at(-1);
-
-    expect(lastReadEvent.payload.allFiles).toContain('projectbrief.md');
-    expect(lastReadEvent.payload.allFiles).toContain('activeContext.md');
-  });
-
-  it('ignores memory_bank_read events with no memory_file', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Help');
-    simulateProcess(currentMockProcess, [
-      JSON.stringify({ type: 'memory_bank_read' }), // no memory_file
-    ]);
-    await sendPromise;
-
-    const memReadEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-read'
-    );
-    expect(memReadEvents).toHaveLength(0);
-  });
-
-  it('resets memory bank reads on new session', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId: s1 } = await backend.startSession();
-
-    const sendPromise1 = backend.sendPrompt(s1, 'First');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankRead('projectbrief.md'),
-      kiloMemoryBankRead('activeContext.md'),
-    ]);
-    await sendPromise1;
-
-    // Start new session — memory reads should reset
-    currentMockProcess = makeMockProcess();
-    mockSpawn.mockReturnValue(currentMockProcess);
-
-    const { sessionId: s2 } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise2 = backend.sendPrompt(s2, 'Second');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankRead('systemPatterns.md'),
-    ]);
-    await sendPromise2;
-
-    const memReadEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-read'
-    );
-    // Only 1 read from the second session, not 3 total
-    expect(memReadEvents).toHaveLength(1);
-    expect((memReadEvents[0] as any).payload.totalReads).toBe(1);
-  });
-});
-
-// ===========================================================================
-// KiloBackend — Memory Bank write events
-// ===========================================================================
-
-describe('KiloBackend — Memory Bank write events', () => {
-  it('emits memory-bank-write event when memory_bank_write message is received', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Add auth');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankWrite('activeContext.md', 'progress', 'Implementing JWT auth...'),
-    ]);
-    await sendPromise;
-
-    const memWriteEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-write'
-    );
-    expect(memWriteEvents).toHaveLength(1);
-    expect((memWriteEvents[0] as any).payload.file).toBe('activeContext.md');
-  });
-
-  it('includes section info in the memory-bank-write payload', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Add auth');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankWrite('systemPatterns.md', 'decisions', 'Use bcrypt for password hashing'),
-    ]);
-    await sendPromise;
-
-    const event = (messages.find(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-write'
-    ) as any);
-    expect(event.payload.section).toBe('decisions');
-    expect(event.payload.contentPreview).toBe('Use bcrypt for password hashing');
-  });
-
-  it('tracks cumulative write count across multiple writes', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Build feature');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankWrite('activeContext.md', 'progress'),
-      kiloMemoryBankWrite('systemPatterns.md', 'decisions'),
-      kiloMemoryBankWrite('progress.md', 'status'),
-    ]);
-    await sendPromise;
-
-    const memWriteEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-write'
-    );
-    expect(memWriteEvents).toHaveLength(3);
-    expect((memWriteEvents[2] as any).payload.totalWrites).toBe(3);
-  });
-
-  it('deduplicates file names in allFiles list for writes', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Build feature');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankWrite('activeContext.md', 'progress'),
-      kiloMemoryBankWrite('activeContext.md', 'status'), // same file twice
-    ]);
-    await sendPromise;
-
-    const lastWriteEvent = (messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-write'
-    ) as any[]).at(-1);
-
-    // allFiles should deduplicate 'activeContext.md'
-    const occurrences = lastWriteEvent.payload.allFiles.filter(
-      (f: string) => f === 'activeContext.md'
-    );
-    expect(occurrences).toHaveLength(1);
-  });
-
-  it('ignores memory_bank_write events with no memory_file', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Build');
-    simulateProcess(currentMockProcess, [
-      JSON.stringify({ type: 'memory_bank_write' }), // no memory_file
-    ]);
-    await sendPromise;
-
-    const memWriteEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-write'
-    );
-    expect(memWriteEvents).toHaveLength(0);
-  });
-
-  it('resets memory bank writes on new session', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId: s1 } = await backend.startSession();
-
-    const sendPromise1 = backend.sendPrompt(s1, 'First');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankWrite('activeContext.md'),
-      kiloMemoryBankWrite('systemPatterns.md'),
-    ]);
-    await sendPromise1;
-
-    currentMockProcess = makeMockProcess();
-    mockSpawn.mockReturnValue(currentMockProcess);
-
-    const { sessionId: s2 } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise2 = backend.sendPrompt(s2, 'Second');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankWrite('progress.md'),
-    ]);
-    await sendPromise2;
-
-    const memWriteEvents = messages.filter(
-      (m: any) => m.type === 'event' && m.name === 'memory-bank-write'
-    );
-    expect(memWriteEvents).toHaveLength(1);
-    expect((memWriteEvents[0] as any).payload.totalWrites).toBe(1);
-  });
-});
-
-// ===========================================================================
-// KiloBackend — text events
+// KiloBackend — text events (part.text → model-output)
+//
+// SCHEMA UNVERIFIED — needs keyed session (#30): the part.text success-path
+// shape mirrors OpenCode's verified schema on the fork assumption; re-verify
+// against a real keyed Kilo session.
 // ===========================================================================
 
 describe('KiloBackend — text events', () => {
-  it('emits model-output messages for text events', async () => {
+  it('emits model-output (fullText) from part.text on text events', async () => {
     const { backend } = createKiloBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
@@ -771,208 +464,83 @@ describe('KiloBackend — text events', () => {
 
     const textMessages = messages.filter((m: any) => m.type === 'model-output');
     expect(textMessages).toHaveLength(2);
-    expect((textMessages[0] as any).textDelta).toBe('I will help you with that. ');
-    expect((textMessages[1] as any).textDelta).toBe('Let me read the codebase.');
-  });
-});
-
-// ===========================================================================
-// KiloBackend — tool events
-// ===========================================================================
-
-describe('KiloBackend — tool events', () => {
-  it('emits tool-call messages for tool_use events', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Read a file');
-    simulateProcess(currentMockProcess, [
-      kiloToolUse('read_file', 'call-1', { path: '/project/src/index.ts' }),
-    ]);
-    await sendPromise;
-
-    const toolCalls = messages.filter((m: any) => m.type === 'tool-call');
-    expect(toolCalls).toHaveLength(1);
-    expect((toolCalls[0] as any).toolName).toBe('read_file');
-    expect((toolCalls[0] as any).callId).toBe('call-1');
+    expect((textMessages[0] as any).fullText).toBe('I will help you with that. ');
+    expect((textMessages[1] as any).fullText).toBe('Let me read the codebase.');
   });
 
-  it('emits tool-result messages for tool_result events', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Read file');
-    simulateProcess(currentMockProcess, [
-      kiloToolResult('read_file', 'call-1', 'file contents'),
-    ]);
-    await sendPromise;
-
-    const toolResults = messages.filter((m: any) => m.type === 'tool-result');
-    expect(toolResults).toHaveLength(1);
-    expect((toolResults[0] as any).result).toBe('file contents');
-  });
-
-  it('emits fs-edit for write_file tool results', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Write file');
-    simulateProcess(currentMockProcess, [
-      kiloToolResult('write_file', 'call-2', 'ok', { path: '/project/src/auth.ts' }),
-    ]);
-    await sendPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(1);
-    expect((fsEdits[0] as any).path).toBe('/project/src/auth.ts');
-  });
-
-  it('emits fs-edit for edit_file tool results', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Edit file');
-    simulateProcess(currentMockProcess, [
-      kiloToolResult('edit_file', 'call-3', 'done', { file_path: '/project/app.ts' }),
-    ]);
-    await sendPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(1);
-    expect((fsEdits[0] as any).path).toBe('/project/app.ts');
-  });
-
-  it('does NOT emit fs-edit for read-only tools', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Read file');
-    simulateProcess(currentMockProcess, [
-      kiloToolResult('read_file', 'call-1', 'contents'),
-      kiloToolResult('run_command', 'call-2', 'ls output'),
-    ]);
-    await sendPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(0);
-  });
-});
-
-// ===========================================================================
-// KiloBackend — token/cost accumulation (tokens events)
-// ===========================================================================
-
-describe('KiloBackend — tokens events', () => {
-  it('emits token-count messages with cumulative totals', async () => {
+  it('ignores text events without part.text', async () => {
     const { backend } = createKiloBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
     simulateProcess(currentMockProcess, [
-      kiloTokens({ input_tokens: 100, output_tokens: 50, cost_usd: 0.005 }),
+      JSON.stringify({ type: 'text', sessionID: 'ses_test', part: { type: 'text' } }),
+    ]);
+    await sendPromise;
+
+    expect(messages.filter((m: any) => m.type === 'model-output')).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// KiloBackend — step_finish events (cost-report)
+//
+// SCHEMA UNVERIFIED — needs keyed session (#30): part.cost + part.tokens shape
+// mirrors OpenCode's verified schema on the fork assumption.
+// ===========================================================================
+
+describe('KiloBackend — step_finish / cost-report', () => {
+  it('emits token-count and cost-report from a step_finish event', async () => {
+    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'anthropic/claude-sonnet-4' });
+    const { sessionId } = await backend.startSession();
+    const messages = collectMessages(backend);
+
+    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
+    simulateProcess(currentMockProcess, [
+      kiloStepFinish({ cost: 0.0123, input: 600, output: 250, cacheRead: 40, cacheWrite: 0 }),
     ]);
     await sendPromise;
 
     const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
     expect(tokenCounts).toHaveLength(1);
-    expect((tokenCounts[0] as any).inputTokens).toBe(100);
-    expect((tokenCounts[0] as any).outputTokens).toBe(50);
-    expect((tokenCounts[0] as any).costUsd).toBeCloseTo(0.005);
+    expect((tokenCounts[0] as any).inputTokens).toBe(600);
+    expect((tokenCounts[0] as any).outputTokens).toBe(250);
+
+    const reports = messages.filter((m: any) => m.type === 'cost-report');
+    expect(reports).toHaveLength(1);
+    const r = (reports[0] as any).report;
+    expect(r.agentType).toBe('kilo');
+    expect(r.source).toBe('agent-reported');
+    expect(r.billingModel).toBe('api-key');
+    expect(r.costUsd).toBe(0.0123);
+    expect(r.inputTokens).toBe(600);
+    expect(r.outputTokens).toBe(250);
+    expect(r.cacheReadTokens).toBe(40);
+    expect(r.cacheWriteTokens).toBe(0);
   });
 
-  it('accumulates token counts across multiple tokens events', async () => {
+  it('cost-report timestamp is a valid ISO 8601 string', async () => {
     const { backend } = createKiloBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [
-      kiloTokens({ input_tokens: 100, output_tokens: 50 }),
-      kiloTokens({ input_tokens: 200, output_tokens: 80 }),
-    ]);
+    simulateProcess(currentMockProcess, [kiloStepFinish({ cost: 0.001, input: 10, output: 5 })]);
     await sendPromise;
 
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    const last = tokenCounts[tokenCounts.length - 1] as any;
-    expect(last.inputTokens).toBe(300);
-    expect(last.outputTokens).toBe(130);
-  });
-
-  it('tracks cache tokens from tokens events', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [
-      kiloTokens({
-        input_tokens: 100,
-        output_tokens: 50,
-        cache_read_tokens: 60,
-        cache_write_tokens: 15,
-      }),
-    ]);
-    await sendPromise;
-
-    const tc = (messages.filter((m: any) => m.type === 'token-count')[0]) as any;
-    expect(tc.cacheReadTokens).toBe(60);
-    expect(tc.cacheWriteTokens).toBe(15);
-  });
-
-  it('resets token counts on new session', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId: s1 } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const send1 = backend.sendPrompt(s1, 'First');
-    simulateProcess(currentMockProcess, [kiloTokens({ input_tokens: 500 })]);
-    await send1;
-
-    currentMockProcess = makeMockProcess();
-    mockSpawn.mockReturnValue(currentMockProcess);
-
-    const { sessionId: s2 } = await backend.startSession();
-    const send2 = backend.sendPrompt(s2, 'Second');
-    simulateProcess(currentMockProcess, [kiloTokens({ input_tokens: 100 })]);
-    await send2;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    const lastCount = tokenCounts[tokenCounts.length - 1] as any;
-    expect(lastCount.inputTokens).toBe(100);
+    const r = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(r).toBeDefined();
+    expect(new Date(r.report.timestamp).toISOString()).toBe(r.report.timestamp);
   });
 });
 
 // ===========================================================================
-// KiloBackend — complete event
+// KiloBackend — error events (VERIFIED nested error.data.message shape)
 // ===========================================================================
 
-describe('KiloBackend — complete event', () => {
-  it('emits "idle" status on complete event', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [kiloComplete()]);
-    await sendPromise;
-
-    const statuses = messages.filter((m: any) => m.type === 'status').map((m: any) => m.status);
-    expect(statuses).toContain('idle');
-  });
-});
-
-// ===========================================================================
-// KiloBackend — error handling
-// ===========================================================================
-
-describe('KiloBackend — error handling', () => {
-  it('emits error status on "error" events', async () => {
+describe('KiloBackend — error events', () => {
+  it('emits error status with the nested error.data.message detail', async () => {
     const { backend } = createKiloBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
@@ -985,23 +553,41 @@ describe('KiloBackend — error handling', () => {
       (m: any) => m.type === 'status' && m.status === 'error'
     );
     expect(errorStatuses.length).toBeGreaterThan(0);
-    expect((errorStatuses[0] as any).detail).toContain('timeout');
+    expect((errorStatuses[0] as any).detail).toBe('Model API timeout');
   });
 
-  it('emits error status on process spawn error', async () => {
+  it('falls back to error.name when error.data.message is absent', async () => {
     const { backend } = createKiloBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
     const messages = collectMessages(backend);
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
-    currentMockProcess.emit('error', new Error('spawn kilo ENOENT'));
+    simulateProcess(currentMockProcess, [
+      JSON.stringify({ type: 'error', sessionID: 'ses_test', error: { name: 'APIError' } }),
+    ]);
+    await sendPromise;
 
-    await expect(sendPromise).rejects.toThrow('spawn kilo ENOENT');
+    const errorStatus = messages.find(
+      (m: any) => m.type === 'status' && m.status === 'error'
+    ) as any;
+    expect(errorStatus.detail).toBe('APIError');
+  });
+
+  it('emits error status on process spawn error (ENOENT install hint)', async () => {
+    const { backend } = createKiloBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+    const messages = collectMessages(backend);
+
+    const sendPromise = backend.sendPrompt(sessionId, 'Hello').catch(() => {});
+    const err = Object.assign(new Error('spawn kilo ENOENT'), { code: 'ENOENT' });
+    currentMockProcess.emit('error', err);
+    await sendPromise;
 
     const errorStatuses = messages.filter(
       (m: any) => m.type === 'status' && m.status === 'error'
     );
     expect(errorStatuses.length).toBeGreaterThan(0);
+    expect((errorStatuses[0] as any).detail).toMatch(/not installed/i);
   });
 
   it('ignores non-JSON stdout lines without crashing', async () => {
@@ -1010,8 +596,8 @@ describe('KiloBackend — error handling', () => {
 
     const sendPromise = backend.sendPrompt(sessionId, 'Hello');
     simulateProcess(currentMockProcess, [
-      'Kilo v1.2.3 starting...',
-      'Loading memory bank...',
+      'Kilo v7.3.41 starting...',
+      'Loading config...',
     ]);
 
     await expect(sendPromise).resolves.toBeUndefined();
@@ -1056,7 +642,10 @@ describe('KiloBackend — cancellation', () => {
 });
 
 // ===========================================================================
-// KiloBackend — permission response
+// KiloBackend — permission response (inherited emit-only behavior)
+//
+// Kilo runs headless with `--auto`, so there is no interactive y/n stdin
+// protocol. The base class default just emits a permission-response message.
 // ===========================================================================
 
 describe('KiloBackend — permission response', () => {
@@ -1073,28 +662,15 @@ describe('KiloBackend — permission response', () => {
     expect((permResponses[0] as any).approved).toBe(true);
   });
 
-  it('writes "y\\n" to stdin when approved and process is running', async () => {
+  it('emits permission-response with approved=false', async () => {
     const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
+    await backend.startSession();
+    const messages = collectMessages(backend);
 
-    const sendPromise = backend.sendPrompt(sessionId, 'Run shell command');
-    await backend.respondToPermission?.('req-456', true);
+    await backend.respondToPermission?.('req-456', false);
 
-    expect(currentMockProcess.stdin.write).toHaveBeenCalledWith('y\n');
-    currentMockProcess.emit('close', 0);
-    await sendPromise;
-  });
-
-  it('writes "n\\n" to stdin when denied', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Dangerous op');
-    await backend.respondToPermission?.('req-789', false);
-
-    expect(currentMockProcess.stdin.write).toHaveBeenCalledWith('n\n');
-    currentMockProcess.emit('close', 0);
-    await sendPromise;
+    const permResponses = messages.filter((m: any) => m.type === 'permission-response');
+    expect((permResponses[0] as any).approved).toBe(false);
   });
 });
 
@@ -1115,24 +691,6 @@ describe('KiloBackend — dispose', () => {
     await backend.dispose();
 
     await expect(backend.dispose()).resolves.toBeUndefined();
-  });
-
-  it('resets memory bank tracking on dispose', async () => {
-    const { backend } = createKiloBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-    const messages = collectMessages(backend);
-
-    const sendPromise = backend.sendPrompt(sessionId, 'Build feature');
-    simulateProcess(currentMockProcess, [
-      kiloMemoryBankRead('projectbrief.md'),
-      kiloMemoryBankWrite('activeContext.md'),
-    ]);
-    await sendPromise;
-
-    await backend.dispose();
-    // After dispose, no further events should arrive
-    const countAfter = messages.length;
-    expect(messages.length).toBe(countAfter);
   });
 
   it('clears message listeners on dispose', async () => {
@@ -1223,111 +781,25 @@ describe('KiloBackend — line buffer handling', () => {
 
     const textMessages = messages.filter((m: any) => m.type === 'model-output');
     expect(textMessages).toHaveLength(1);
-    expect((textMessages[0] as any).textDelta).toBe('Split JSON content');
-  });
-});
-
-// ===========================================================================
-// KiloBackend — cost-report emission
-// ===========================================================================
-
-/**
- * Tests for the unified CostReport event emitted by Kilo token events.
- *
- * WHY: Kilo supports local (Ollama / local-* models) and cloud models.
- * Local models → billingModel='free', costUsd=0.
- * Cloud models → billingModel='api-key', source determined by presence of cost_usd.
- */
-describe('KiloBackend — cost-report emission (cloud model)', () => {
-  it('emits billingModel=api-key and source=agent-reported when cost_usd is present', async () => {
-    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      kiloTokens({ input_tokens: 600, output_tokens: 250, cache_read_tokens: 40, cost_usd: 0.009 }),
-    ]);
-    await promptPromise;
-
-    const reports = messages.filter((m: any) => m.type === 'cost-report');
-    expect(reports.length).toBeGreaterThanOrEqual(1);
-    const r = reports[0] as any;
-    expect(r.report.billingModel).toBe('api-key');
-    expect(r.report.source).toBe('agent-reported');
-    expect(r.report.agentType).toBe('kilo');
-    expect(r.report.costUsd).toBe(0.009);
-    expect(r.report.inputTokens).toBe(600);
-    expect(r.report.cacheReadTokens).toBe(40);
+    expect((textMessages[0] as any).fullText).toBe('Split JSON content');
   });
 
-  it('emits billingModel=api-key and source=styrby-estimate when cost_usd is absent', async () => {
-    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
-    const messages = collectMessages(backend);
+  it('processes a buffered incomplete line on process close', async () => {
+    const { backend } = createKiloBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      kiloTokens({ input_tokens: 400, output_tokens: 100 }),
-    ]);
-    await promptPromise;
-
-    const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    expect(r.report.billingModel).toBe('api-key');
-    expect(r.report.source).toBe('styrby-estimate');
-  });
-});
-
-describe('KiloBackend — cost-report emission (local / Ollama model)', () => {
-  it('emits billingModel=free and costUsd=0 for ollama model names', async () => {
-    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'ollama/llama3' });
     const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      kiloTokens({ input_tokens: 300, output_tokens: 120, cost_usd: 0 }),
-    ]);
-    await promptPromise;
+    const sendPromise = backend.sendPrompt(sessionId, 'Hello');
+    // Emit without trailing newline so it stays in the line buffer until close.
+    (currentMockProcess.stdout as EventEmitter).emit(
+      'data',
+      Buffer.from(kiloText('buffered')),
+    );
+    currentMockProcess.emit('close', 0);
+    await sendPromise;
 
-    const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    expect(r.report.billingModel).toBe('free');
-    expect(r.report.costUsd).toBe(0);
-  });
-
-  it('emits billingModel=free for local- prefixed model names', async () => {
-    const { backend } = createKiloBackend({ ...BASE_OPTIONS, model: 'local-mistral-7b' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      kiloTokens({ input_tokens: 200, output_tokens: 80 }),
-    ]);
-    await promptPromise;
-
-    const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    expect(r.report.billingModel).toBe('free');
-    expect(r.report.costUsd).toBe(0);
-  });
-
-  it('emits billingModel=free when apiBaseUrl points to localhost', async () => {
-    const { backend } = createKiloBackend({
-      ...BASE_OPTIONS,
-      model: 'llama3',
-      apiBaseUrl: 'http://localhost:11434',
-    });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      kiloTokens({ input_tokens: 100, output_tokens: 50 }),
-    ]);
-    await promptPromise;
-
-    const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    expect(r.report.billingModel).toBe('free');
-    expect(r.report.costUsd).toBe(0);
+    const textMessages = messages.filter((m: any) => m.type === 'model-output');
+    expect(textMessages).toHaveLength(1);
+    expect((textMessages[0] as any).fullText).toBe('buffered');
   });
 });

--- a/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
@@ -257,18 +257,22 @@ describe('OpenCodeBackend — session lifecycle', () => {
 // ---------------------------------------------------------------------------
 
 describe('OpenCodeBackend — sendPrompt', () => {
-  it('passes --format json and --non-interactive to spawn', async () => {
+  it('uses the `run` subcommand with a positional prompt + --format json (verified CLI surface)', async () => {
     const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
     const { sessionId } = await backend.startSession();
     const promptPromise = backend.sendPrompt(sessionId, 'write a test');
     setImmediate(() => closeProcess(0));
     await promptPromise;
 
-    expect(spawn).toHaveBeenCalledWith(
-      'opencode',
-      expect.arrayContaining(['--format', 'json', '--message', 'write a test', '--non-interactive']),
-      expect.any(Object),
-    );
+    // Real opencode: `opencode run <message> --format json` (no --message flag,
+    // no --non-interactive flag — those were invented and would launch the TUI).
+    // Read THIS test's spawn (the most recent) — the mock accumulates calls across
+    // tests, so calls[0] would be an earlier test's invocation.
+    const calls = (spawn as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const args = calls[calls.length - 1][1] as string[];
+    expect(args.slice(0, 4)).toEqual(['run', 'write a test', '--format', 'json']);
+    expect(args).not.toContain('--message');
+    expect(args).not.toContain('--non-interactive');
     await backend.dispose();
   });
 
@@ -383,19 +387,20 @@ describe('OpenCodeBackend — JSON-line parsing', () => {
     return { backend, messages, sessionId, promptPromise };
   }
 
-  it('emits model-output for assistant messages', async () => {
+  it('emits model-output (fullText) for real `text` events', async () => {
     const { messages, promptPromise } = await setupWithRunningPrompt();
-    emitStdout(JSON.stringify({ type: 'assistant', content: 'Hello world' }));
+    // Real opencode text event: { type:'text', sessionID, part:{ type:'text', text } }
+    emitStdout(JSON.stringify({ type: 'text', sessionID: 'ses_1', part: { type: 'text', text: 'Hello world' } }));
     setImmediate(() => closeProcess(0));
     await promptPromise;
 
     const msg = messages.find((m: any) => m.type === 'model-output');
-    expect(msg).toMatchObject({ type: 'model-output', textDelta: 'Hello world' });
+    expect(msg).toMatchObject({ type: 'model-output', fullText: 'Hello world' });
   });
 
-  it('ignores assistant messages without content', async () => {
+  it('ignores text events without part.text', async () => {
     const { messages, promptPromise } = await setupWithRunningPrompt();
-    emitStdout(JSON.stringify({ type: 'assistant' }));
+    emitStdout(JSON.stringify({ type: 'text', sessionID: 'ses_1', part: { type: 'text' } }));
     setImmediate(() => closeProcess(0));
     await promptPromise;
 
@@ -434,7 +439,7 @@ describe('OpenCodeBackend — JSON-line parsing', () => {
 
   it('handles partial lines across multiple data chunks', async () => {
     const { messages, promptPromise } = await setupWithRunningPrompt();
-    const full = JSON.stringify({ type: 'assistant', content: 'streamed' });
+    const full = JSON.stringify({ type: 'text', sessionID: 'ses_1', part: { type: 'text', text: 'streamed' } });
     // Split arbitrarily in the middle (no trailing newline on first chunk)
     lastFakeProcess.stdout.emit('data', Buffer.from(full.slice(0, 10)));
     lastFakeProcess.stdout.emit('data', Buffer.from(full.slice(10) + '\n'));
@@ -442,7 +447,7 @@ describe('OpenCodeBackend — JSON-line parsing', () => {
     await promptPromise;
 
     const msg = messages.find((m: any) => m.type === 'model-output');
-    expect(msg).toMatchObject({ type: 'model-output', textDelta: 'streamed' });
+    expect(msg).toMatchObject({ type: 'model-output', fullText: 'streamed' });
   });
 
   it('processes buffered incomplete line on process close', async () => {
@@ -450,19 +455,42 @@ describe('OpenCodeBackend — JSON-line parsing', () => {
     // Emit without trailing newline so it stays in lineBuffer
     lastFakeProcess.stdout.emit(
       'data',
-      Buffer.from(JSON.stringify({ type: 'assistant', content: 'buffered' })),
+      Buffer.from(JSON.stringify({ type: 'text', sessionID: 'ses_1', part: { type: 'text', text: 'buffered' } })),
     );
     setImmediate(() => closeProcess(0));
     await promptPromise;
 
     const msg = messages.find((m: any) => m.type === 'model-output');
-    expect(msg).toMatchObject({ type: 'model-output', textDelta: 'buffered' });
+    expect(msg).toMatchObject({ type: 'model-output', fullText: 'buffered' });
+  });
+
+  it('emits a cost-report from a real `step_finish` event', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    emitStdout(JSON.stringify({
+      type: 'step_finish',
+      sessionID: 'ses_1',
+      part: { type: 'step-finish', reason: 'stop', cost: 0.0123, tokens: { input: 11346, output: 17, cache: { read: 5, write: 0 } } },
+    }));
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const cost = messages.find((m: any) => m.type === 'cost-report') as any;
+    expect(cost?.report).toMatchObject({
+      agentType: 'opencode', source: 'agent-reported', billingModel: 'api-key',
+      costUsd: 0.0123, inputTokens: 11346, outputTokens: 17, cacheReadTokens: 5, cacheWriteTokens: 0,
+    });
   });
 });
 
 // ---------------------------------------------------------------------------
 
-describe('OpenCodeBackend — tool-use event routing', () => {
+// SKIPPED 2026-06-10: these tests assert an INVENTED opencode event schema
+// (`tool_use`/`tool_result` with `tool_name`/`call_id`/`tool_input`). The real
+// opencode `--format json` output uses `{type, sessionID, part}` events and was
+// verified against the live binary; the real tool-event shape has NOT been
+// captured yet (needs a tool-triggering session). Un-skip + rewrite against the
+// real schema as part of the per-agent protocol-verification task (#30).
+describe.skip('OpenCodeBackend — tool-use event routing', () => {
   async function setupWithRunningPrompt() {
     const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
     const { messages } = collectMessages(backend);
@@ -580,7 +608,10 @@ describe('OpenCodeBackend — tool-use event routing', () => {
 
 // ---------------------------------------------------------------------------
 
-describe('OpenCodeBackend — status mapping', () => {
+// SKIPPED 2026-06-10: asserts invented `{type:'status'}` / `{type:'error'}`
+// events that real opencode does not emit (status is driven by process
+// lifecycle, not parsed events). Rewrite against the real schema under #30.
+describe.skip('OpenCodeBackend — status mapping', () => {
   async function setupWithRunningPrompt() {
     const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
     const { messages } = collectMessages(backend);
@@ -638,7 +669,11 @@ describe('OpenCodeBackend — status mapping', () => {
 
 // ---------------------------------------------------------------------------
 
-describe('OpenCodeBackend — cost and token extraction', () => {
+// SKIPPED 2026-06-10: asserts the invented `{type:'session', Cost, PromptTokens,
+// CompletionTokens}` event. Real opencode reports usage on `step_finish`
+// (part.cost + part.tokens) — covered now by the "emits a cost-report from a real
+// step_finish event" test in the JSON-line-parsing block. Rewrite/retire under #30.
+describe.skip('OpenCodeBackend — cost and token extraction', () => {
   it('emits token-count from session messages', async () => {
     const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
     const { messages } = collectMessages(backend);
@@ -936,7 +971,10 @@ describe('OpenCodeBackend — stderr handling', () => {
  * These tests assert that cost-report events carry the correct shape so
  * cost-reporter can persist them without data loss.
  */
-describe('OpenCodeBackend — cost-report emission', () => {
+// SKIPPED 2026-06-10: asserts cost-report from the invented `{type:'session',
+// Cost}` event. Real `step_finish`-driven cost-report is covered in the
+// JSON-line-parsing block. Rewrite/retire under #30.
+describe.skip('OpenCodeBackend — cost-report emission', () => {
   it('emits cost-report with billingModel=api-key and source=agent-reported when session has Cost', async () => {
     const { backend } = createOpenCodeBackend({ cwd: '/tmp/project', model: 'claude-sonnet-4' });
     const { messages } = collectMessages(backend);

--- a/packages/styrby-cli/src/agent/factories/amp.ts
+++ b/packages/styrby-cli/src/agent/factories/amp.ts
@@ -1,28 +1,41 @@
 /**
- * Amp Backend - Amp CLI agent adapter (Sourcegraph)
+ * Amp Backend - Amp CLI agent adapter (Sourcegraph / ampcode.com)
  *
- * This module provides a factory function for creating an Amp backend.
- * Amp is an AI coding agent by Sourcegraph that supports "deep mode" with
- * sub-agents for parallelized code analysis and editing tasks.
+ * This module provides a factory function for creating an Amp backend. Amp is
+ * an AI coding agent run headlessly via `amp -x "<message>"` (execute mode).
  *
- * Key characteristics:
- * - Binary name: `amp` (installed via npm or direct download from sourcegraph.com)
- * - Config: `~/.config/amp/config.json`
- * - Output: structured JSON with sub-agent event payloads
- * - Cost tracking: token usage from response metadata per sub-agent
- * - Deep mode: spawns multiple sub-agents for parallel analysis
- * - Supports streaming output via --stream flag
+ * Key characteristics (ALL verified against the installed `amp --help`,
+ * binary 0.0.1781143784-g47b692, 2026-06-11):
+ * - Binary name: `amp` (on PATH)
+ * - Config: `~/.config/amp/settings.json`
+ * - Auth: `AMP_API_KEY` env var (Amp's own access token from
+ *   https://ampcode.com/settings) — NOT ANTHROPIC_API_KEY. `amp login` /
+ *   `amp logout` manage stored credentials; `AMP_API_KEY` overrides.
+ * - Headless run: `amp -x "<message>"` (positional message; alias `--execute`).
+ *   There is NO `chat` subcommand.
+ * - JSON output: `amp -x "<message>" --stream-json` emits, per `--help`,
+ *   "Claude Code-compatible stream JSON format". i.e. the SAME newline-delimited
+ *   stream-json shape the `claude` binary emits — `{type:'assistant',
+ *   message:{content:[{type:'text'|'thinking',...}],usage:{input_tokens,...}}}`
+ *   then a final `{type:'result'}`.
+ * - Agent mode: `-m/--mode deep|rush|smart` (controls model, system prompt,
+ *   tool selection). There is NO `--deep` / `--max-agents` flag.
  *
- * WHY Amp: Sourcegraph's Amp is differentiated by its "deep mode" which
- * parallelizes code context gathering across multiple sub-agents. This enables
- * more accurate edits on large codebases. Styrby users who work on large
- * monorepos benefit from Amp's ability to read multiple files simultaneously.
+ * Because the parser mirrors claude's stream-json (the formats are documented
+ * as compatible), it reuses {@link parseClaudeJsonlLine} from the claude factory
+ * for cost extraction so there is a single source of truth for the schema.
+ *
+ * SCHEMA NOTE (#30): The exact `--stream-json` bytes could NOT be captured in
+ * this session because `amp -x ... --stream-json` triggers `amp login` (no
+ * AMP_API_KEY / stored credential available). The schema below is taken from
+ * the `--help` contract ("Claude Code-compatible") and the claude factory's
+ * verified parser. Fields beyond that contract are NOT invented. Re-verify
+ * against real keyed output when an Amp credential is available.
  *
  * @see https://ampcode.com
  * @module factories/amp
  */
 
-import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import type {
   AgentBackend,
@@ -33,58 +46,59 @@ import type {
 } from '../core';
 import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
-import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
-import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
+import { StreamingAgentBackendBase } from '../StreamingAgentBackendBase';
 import type { CostReport } from '@styrby/shared/cost';
+import { parseClaudeJsonlLine } from './claude';
 
 // ============================================================================
 // Types
 // ============================================================================
 
 /**
+ * Amp agent mode, passed via `-m/--mode`.
+ *
+ * Verified from `amp --help`: "Set the agent mode (deep, rush, smart) — controls
+ * the model, system prompt, and tool selection". `deep` is the high-reasoning
+ * mode (may require `amp.experimental.modes: ["deep"]` in settings), `rush` is
+ * the fast/cheap mode, `smart` is the balanced default. We do NOT default this
+ * so Amp uses its own configured default unless the caller opts in.
+ */
+export type AmpMode = 'deep' | 'rush' | 'smart';
+
+/**
  * Options for creating an Amp backend.
  */
 export interface AmpBackendOptions extends AgentFactoryOptions {
   /**
-   * Amp API key from sourcegraph.com/amp.
-   * Maps to ANTHROPIC_API_KEY or AMP_API_KEY environment variable.
-   * Amp can use Anthropic models or its own Sourcegraph-hosted models.
+   * Amp access token (from https://ampcode.com/settings).
+   * Injected ONLY as the `AMP_API_KEY` environment variable — Amp's own
+   * documented auth var. It is NOT a cross-vendor model key, so it is never
+   * fanned out to ANTHROPIC_API_KEY / OPENAI_API_KEY (that would leak the token
+   * to non-Amp model endpoints during startup validation).
    */
   apiKey?: string;
 
   /**
-   * Model to use (e.g., 'claude-sonnet-4', 'claude-opus-4').
-   * Amp defaults to Claude Sonnet. Override for faster/cheaper options.
+   * Model override. Amp does not expose a generic `--model` flag in execute
+   * mode (model selection is driven by `--mode`); this field is retained for
+   * metadata/reporting only and is NOT passed to the CLI. Left here so cost
+   * reports can attribute a model name when the caller knows it.
    */
   model?: string;
 
   /**
-   * Enable deep mode for parallelized sub-agent analysis.
+   * Agent mode passed via `-m/--mode` (deep | rush | smart).
    *
-   * WHY: Deep mode spawns multiple sub-agents to gather context from different
-   * parts of the codebase simultaneously. This produces better edits on large
-   * codebases but uses more tokens. Disabled by default for cost predictability.
-   * Default: false
+   * WHY: This is Amp's real reasoning/cost dial (replaces the invented
+   * `--deep`/`--max-agents` flags). Omitted by default so Amp uses its own
+   * configured default mode.
    */
-  deepMode?: boolean;
+  mode?: AmpMode;
 
   /**
-   * Maximum number of sub-agents to spawn in deep mode.
-   * Only applies when deepMode is true. Default: 4
-   */
-  maxSubAgents?: number;
-
-  /**
-   * Additional Amp CLI arguments.
-   * See: https://ampcode.com/docs/cli
+   * Additional Amp CLI arguments, appended after the validated base flags.
    */
   extraArgs?: string[];
-
-  /**
-   * Session ID to resume (Amp supports persistent sessions).
-   * When provided, Amp will resume the session's context and history.
-   */
-  resumeSessionId?: string;
 }
 
 /**
@@ -103,128 +117,51 @@ export interface AmpBackendResult {
 }
 
 // ============================================================================
-// JSON Output Parsing
+// Stream-JSON Output Parsing (Claude Code-compatible)
 // ============================================================================
 
 /**
- * Amp JSON output message types.
+ * A single Amp `--stream-json` line.
  *
- * WHY: Amp outputs structured JSON with a type discriminator field.
- * Each message type has a specific payload structure that maps to
- * different AgentMessage variants in our abstraction layer.
+ * SCHEMA SOURCE (#30 — needs keyed session to byte-verify): `amp --help` states
+ * `--stream-json` produces "Claude Code-compatible stream JSON format". This
+ * type therefore mirrors the verified claude stream-json shape (see
+ * {@link ClaudeStreamMessage} in factories/claude.ts): a leading `system`/init
+ * line, one or more `assistant`/`user` lines carrying message content + tool
+ * use/results + a `usage` block, and a final `result` line. Typed loosely
+ * because only a subset of fields is consumed. NO Amp-specific fields are
+ * invented here — if Amp emits extensions (e.g. thinking blocks via
+ * `--stream-json-thinking`), they surface through the same `content[]` array.
  */
-interface AmpJsonMessage {
-  type:
-    | 'text'
-    | 'tool_use'
-    | 'tool_result'
-    | 'sub_agent_start'
-    | 'sub_agent_complete'
-    | 'usage'
-    | 'error'
-    | 'done';
-  /** Text content for 'text' events */
-  content?: string;
-  /** Tool name for 'tool_use' and 'tool_result' events */
-  tool_name?: string;
-  /** Tool input arguments for 'tool_use' events */
-  tool_input?: Record<string, unknown>;
-  /** Tool result for 'tool_result' events */
-  tool_result?: unknown;
-  /** Unique call ID for correlating tool_use to tool_result */
-  call_id?: string;
-  /** Sub-agent identifier for deep mode events */
-  sub_agent_id?: string;
-  /** Sub-agent description for deep mode events */
-  sub_agent_description?: string;
-  /** Token usage metadata for 'usage' events */
-  usage?: AmpUsageMetadata;
-  /** Error message for 'error' events */
-  error?: string;
-  /** Session ID for session persistence */
+interface AmpStreamMessage {
+  type: 'system' | 'assistant' | 'user' | 'result' | string;
+  subtype?: string;
+  /** Amp's own thread/session id when present (used for continuity/debug). */
   session_id?: string;
+  message?: {
+    role?: string;
+    model?: string;
+    content?: Array<{
+      type: string;
+      text?: string;
+      thinking?: string;
+      name?: string;
+      input?: Record<string, unknown>;
+      id?: string;
+      tool_use_id?: string;
+      content?: unknown;
+    }>;
+  };
 }
 
 /**
- * Token usage metadata from Amp response metadata.
+ * Tool names that mutate files, for fs-edit surfacing on mobile.
  *
- * WHY: Amp reports per-request and per-sub-agent token usage.
- * We accumulate all sub-agent usage to give users an accurate total,
- * since deep mode sub-agents each consume tokens independently.
+ * WHY this exact set: Amp's stream-json is Claude Code-compatible, so its tool
+ * names match Claude Code's built-in edit tools. Mirrors the claude factory's
+ * CLAUDE_EDIT_TOOLS rather than guessing snake_case names that Amp does not emit.
  */
-interface AmpUsageMetadata {
-  /** Input/prompt tokens for this request */
-  input_tokens?: number;
-  /** Output/completion tokens for this request */
-  output_tokens?: number;
-  /** Cache read tokens (Anthropic prompt caching) */
-  cache_read_tokens?: number;
-  /** Cache write tokens (Anthropic prompt caching) */
-  cache_write_tokens?: number;
-  /** Estimated cost in USD */
-  cost_usd?: number;
-  /** Which sub-agent generated this usage (for deep mode) */
-  sub_agent_id?: string;
-}
-
-/**
- * Parse a single JSON line from Amp's output.
- *
- * @param line - A single line of Amp stdout (expected to be JSON)
- * @returns Parsed AmpJsonMessage or null if the line is not valid JSON
- */
-function parseAmpJsonLine(line: string): AmpJsonMessage | null {
-  const trimmed = line.trim();
-  if (!trimmed || !trimmed.startsWith('{')) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(trimmed) as AmpJsonMessage;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Extract the file path from an Amp tool input.
- *
- * Amp uses different parameter names for file paths depending on the tool.
- * This function checks common field names to extract the path.
- *
- * @param toolInput - The tool input arguments
- * @returns File path string or null if not found
- */
-function extractFilePath(toolInput?: Record<string, unknown>): string | null {
-  if (!toolInput) return null;
-  return (
-    (toolInput.path as string) ??
-    (toolInput.file_path as string) ??
-    (toolInput.filename as string) ??
-    (toolInput.target as string) ??
-    null
-  );
-}
-
-/**
- * Determine if an Amp tool call results in a file system edit.
- *
- * @param toolName - The Amp tool name
- * @returns true if this tool writes or modifies files
- */
-function isAmpFileEditTool(toolName: string): boolean {
-  const fileEditPatterns = [
-    'write',
-    'edit',
-    'create_file',
-    'patch',
-    'str_replace',
-    'apply_diff',
-    'modify',
-  ];
-  const lowerTool = toolName.toLowerCase();
-  return fileEditPatterns.some((pattern) => lowerTool.includes(pattern));
-}
+const AMP_EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit', 'create_file']);
 
 // ============================================================================
 // AmpBackend Class
@@ -233,221 +170,110 @@ function isAmpFileEditTool(toolName: string): boolean {
 /**
  * Amp Backend implementation.
  *
- * Spawns Amp as a subprocess with JSON output and parses the structured
- * messages. Handles deep mode sub-agent events, token accumulation across
- * sub-agents, and session persistence.
+ * Spawns `amp -x "<prompt>" --stream-json` and parses the Claude Code-compatible
+ * stream-json output line by line (the same line-based pattern claude/opencode/
+ * aider use via {@link StreamingAgentBackendBase}). Cost extraction reuses the
+ * claude factory's {@link parseClaudeJsonlLine} so the schema has one owner.
  */
 class AmpBackend extends StreamingAgentBackendBase {
   protected readonly logTag = 'AmpBackend';
+  /** Amp's own thread/session id, captured from any line that carries it. */
   private ampSessionId: string | null = null;
-  private lineBuffer = '';
-  private inputTokens = 0;
-  private outputTokens = 0;
-  private cacheReadTokens = 0;
-  private cacheWriteTokens = 0;
-  private totalCostUsd = 0;
-  // WHY: Track active sub-agents in deep mode so we can emit appropriate
-  // status messages (e.g., "Running 3 sub-agents") on the mobile app.
-  private activeSubAgents = new Set<string>();
 
   constructor(private options: AmpBackendOptions) {
     super();
   }
 
   /**
-   * Handle a parsed Amp JSON message and emit AgentMessages.
+   * Parse one stream-json line: emit a cost-report if it carries usage, then map
+   * its content to {@link AgentMessage}s. Mirrors ClaudeBackend.handleLine since
+   * Amp's `--stream-json` is documented as Claude Code-compatible.
    *
-   * WHY: Amp's deep mode introduces sub_agent_start/sub_agent_complete events
-   * that don't have a direct counterpart in the AgentMessage union. We map
-   * them to 'event' messages so the mobile app can show deep mode activity
-   * without needing to know Amp-specific internals.
+   * SCHEMA NOTE (#30): not byte-verified against real keyed Amp output (see the
+   * module header). The cost path delegates to the verified claude parser; the
+   * content mapping mirrors the verified claude content schema.
    *
-   * @param msg - The parsed Amp JSON message
+   * @param line - A single stream-json line from amp stdout.
    */
-  private handleAmpMessage(msg: AmpJsonMessage): void {
-    // Extract session ID if Amp provides one (for persistence)
-    if (msg.session_id) {
-      this.ampSessionId = msg.session_id;
+  private handleLine(line: string): void {
+    if (!line.trim()) return;
+
+    // Cost extraction reuses the shared claude parser, then we re-stamp the
+    // agentType/model/billingModel for Amp. Amp is BYOK (AMP_API_KEY) so its
+    // billing model is always 'api-key' — there is no subscription pass-through.
+    const claudeReport = parseClaudeJsonlLine(line, this.sessionId ?? '', 'api-key');
+    if (claudeReport) {
+      const report: CostReport = {
+        ...claudeReport,
+        agentType: 'amp',
+        model: this.options.model ?? claudeReport.model,
+        billingModel: 'api-key',
+      };
+      this.emit({ type: 'cost-report', report });
     }
 
+    let msg: AmpStreamMessage;
+    try {
+      msg = JSON.parse(line) as AmpStreamMessage;
+    } catch {
+      logger.debug('[AmpBackend] Non-JSON stdout line ignored');
+      return;
+    }
+
+    // Capture Amp's thread id from any line that carries it (debug/continuity).
+    if (typeof msg.session_id === 'string') this.ampSessionId = msg.session_id;
+
     switch (msg.type) {
-      case 'text':
-        if (msg.content) {
-          this.emit({ type: 'model-output', textDelta: msg.content });
-        }
-        break;
-
-      case 'tool_use':
-        if (msg.tool_name && msg.call_id) {
-          this.emit({
-            type: 'tool-call',
-            toolName: msg.tool_name,
-            args: msg.tool_input ?? {},
-            callId: msg.call_id,
-          });
-        }
-        break;
-
-      case 'tool_result':
-        if (msg.call_id && msg.tool_name) {
-          this.emit({
-            type: 'tool-result',
-            toolName: msg.tool_name,
-            result: msg.tool_result,
-            callId: msg.call_id,
-          });
-
-          // Detect file edits and emit fs-edit event
-          if (isAmpFileEditTool(msg.tool_name)) {
-            const filePath = extractFilePath(msg.tool_input);
-            if (filePath) {
-              this.emit({
-                type: 'fs-edit',
-                description: `${msg.tool_name}: ${filePath}`,
-                path: filePath,
-              });
+      case 'assistant':
+        for (const block of msg.message?.content ?? []) {
+          if (block.type === 'text' && block.text) {
+            this.emit({ type: 'model-output', fullText: block.text });
+          } else if (block.type === 'thinking' && block.thinking) {
+            // Surfaced only when run with --stream-json-thinking; treated as
+            // model output so the mobile UI can show the reasoning trace.
+            this.emit({ type: 'model-output', fullText: block.thinking });
+          } else if (block.type === 'tool_use' && block.id) {
+            this.emit({
+              type: 'tool-call',
+              toolName: block.name ?? 'unknown',
+              args: block.input ?? {},
+              callId: block.id,
+            });
+            // Surface file mutations so the mobile UI can show a diff affordance.
+            if (block.name && AMP_EDIT_TOOLS.has(block.name)) {
+              const input = block.input ?? {};
+              const filePath = (input.file_path as string) ?? (input.path as string);
+              if (filePath) {
+                this.emit({ type: 'fs-edit', description: `${block.name}: ${filePath}`, path: filePath });
+              }
             }
           }
         }
-        break;
-
-      case 'sub_agent_start':
-        // WHY: Deep mode spawns sub-agents for parallel analysis. We track
-        // them so the mobile app can show "Deep mode: analyzing X files..."
-        // status text instead of appearing hung during long analysis phases.
-        if (msg.sub_agent_id) {
-          this.activeSubAgents.add(msg.sub_agent_id);
-          this.emit({
-            type: 'event',
-            name: 'sub-agent-start',
-            payload: {
-              subAgentId: msg.sub_agent_id,
-              description: msg.sub_agent_description ?? 'Analyzing codebase',
-              activeCount: this.activeSubAgents.size,
-            },
-          });
-        }
-        break;
-
-      case 'sub_agent_complete':
-        // WHY: Remove the completed sub-agent from the active set and notify
-        // the mobile app. When activeCount reaches 0, the main agent resumes.
-        if (msg.sub_agent_id) {
-          this.activeSubAgents.delete(msg.sub_agent_id);
-          this.emit({
-            type: 'event',
-            name: 'sub-agent-complete',
-            payload: {
-              subAgentId: msg.sub_agent_id,
-              activeCount: this.activeSubAgents.size,
-            },
-          });
-        }
-        break;
-
-      case 'usage':
-        // WHY: Amp emits usage events after each model response (including
-        // per-sub-agent usage in deep mode). We accumulate all usage so
-        // the total token count reflects the full cost of the deep analysis.
-        if (msg.usage) {
-          const incrInput = msg.usage.input_tokens ?? 0;
-          const incrOutput = msg.usage.output_tokens ?? 0;
-          const incrCacheRead = msg.usage.cache_read_tokens ?? 0;
-          const incrCacheWrite = msg.usage.cache_write_tokens ?? 0;
-          const incrCost = msg.usage.cost_usd ?? 0;
-
-          this.inputTokens += incrInput;
-          this.outputTokens += incrOutput;
-          this.cacheReadTokens += incrCacheRead;
-          this.cacheWriteTokens += incrCacheWrite;
-          this.totalCostUsd += incrCost;
-
-          // Emit legacy token-count (keep for existing consumers)
-          this.emit({
-            type: 'token-count',
-            inputTokens: this.inputTokens,
-            outputTokens: this.outputTokens,
-            cacheReadTokens: this.cacheReadTokens,
-            cacheWriteTokens: this.cacheWriteTokens,
-            costUsd: this.totalCostUsd,
-            // Include sub-agent attribution for deep mode cost visibility
-            subAgentId: msg.usage.sub_agent_id,
-          });
-
-          // WHY: Emit unified CostReport for cost-reporter. Amp always reports
-          // agent-provided cost_usd. Include sub_agent_id in rawAgentPayload so
-          // deep-mode attribution is preserved in the audit trail.
-          const rawPayload: Record<string, unknown> = { ...(msg.usage as unknown as Record<string, unknown>) };
-          if (msg.usage.sub_agent_id) {
-            rawPayload.sub_agent_id = msg.usage.sub_agent_id;
+        return;
+      case 'user':
+        // Amp echoes tool results back as a user message (Claude Code shape).
+        for (const block of msg.message?.content ?? []) {
+          if (block.type === 'tool_result' && block.tool_use_id) {
+            this.emit({
+              type: 'tool-result',
+              toolName: 'tool',
+              result: block.content,
+              callId: block.tool_use_id,
+            });
           }
-          const costReport: CostReport = {
-            sessionId: this.sessionId ?? '',
-            messageId: null,
-            agentType: 'amp',
-            model: this.options.model ?? 'unknown',
-            timestamp: new Date().toISOString(),
-            source: 'agent-reported',
-            billingModel: 'api-key',
-            costUsd: incrCost,
-            inputTokens: incrInput,
-            outputTokens: incrOutput,
-            cacheReadTokens: incrCacheRead,
-            cacheWriteTokens: incrCacheWrite,
-            rawAgentPayload: rawPayload,
-          };
-          this.emit({ type: 'cost-report', report: costReport });
         }
-        break;
-
-      case 'error':
-        this.emit({
-          type: 'status',
-          status: 'error',
-          detail: msg.error ?? 'Amp encountered an error',
-        });
-        break;
-
-      case 'done':
-        // WHY: Amp emits 'done' when the response is fully complete,
-        // including after all sub-agents finish in deep mode.
-        this.activeSubAgents.clear();
-        this.emit({ type: 'status', status: 'idle' });
-        break;
-
+        return;
+      case 'result':
+        // Final line; the close handler emits idle. Nothing extra to map here.
+        return;
       default:
-        logger.debug('[AmpBackend] Unknown message type:', msg);
-    }
-  }
-
-  /**
-   * Process stdout data, buffering partial lines.
-   *
-   * @param data - Raw buffer chunk from process stdout
-   */
-  private processStdout(data: Buffer): void {
-    const text = data.toString();
-    // SECURITY: Cap line buffer size to prevent memory exhaustion
-    this.lineBuffer = safeBufferAppend(this.lineBuffer, text);
-
-    const lines = this.lineBuffer.split('\n');
-    this.lineBuffer = lines.pop() ?? '';
-
-    for (const line of lines) {
-      const msg = parseAmpJsonLine(line);
-      if (msg) {
-        this.handleAmpMessage(msg);
-      } else if (line.trim()) {
-        logger.debug('[AmpBackend] Non-JSON stdout:', line);
-      }
+        // system/init and any future line types: no content to surface.
+        return;
     }
   }
 
   /**
    * Start a new Amp session.
-   *
-   * Resets all token/cost accumulators and sub-agent tracking.
-   * If a resumeSessionId was provided in options, Amp will resume that session.
    *
    * @param initialPrompt - Optional prompt to send immediately after session start
    * @returns Promise resolving to the session information
@@ -459,14 +285,7 @@ class AmpBackend extends StreamingAgentBackendBase {
     }
 
     this.sessionId = randomUUID();
-    this.ampSessionId = this.options.resumeSessionId ?? null;
-    this.inputTokens = 0;
-    this.outputTokens = 0;
-    this.cacheReadTokens = 0;
-    this.cacheWriteTokens = 0;
-    this.totalCostUsd = 0;
-    this.lineBuffer = '';
-    this.activeSubAgents.clear();
+    this.ampSessionId = null;
 
     this.emit({ type: 'status', status: 'starting' });
 
@@ -505,164 +324,78 @@ class AmpBackend extends StreamingAgentBackendBase {
     // Reset run-scoped state (clears the cancelled flag) so this run's exit is
     // classified correctly by the close handler (audit 2026-06-09 fix #6).
     this.beginRun();
-
-    this.lineBuffer = '';
-    this.activeSubAgents.clear();
     this.emit({ type: 'status', status: 'running' });
 
-    // Build Amp command arguments
-    const args: string[] = [
-      'chat',           // Amp subcommand for one-shot chat
-      '--message',
-      prompt,
-      '--format',
-      'json',           // Request structured JSON output
-      '--no-interactive', // Prevent blocking on stdin for confirmations
-    ];
+    // Build Amp execute-mode argv. ALL flags verified against `amp --help`:
+    //   -x <message>     headless execute mode (positional prompt)
+    //   --stream-json    Claude Code-compatible newline-delimited JSON output
+    //   -m <mode>        agent mode (deep|rush|smart) when opted in
+    // There is NO `chat` subcommand and NO --deep/--max-agents/--format/
+    // --no-interactive/--session flag — those were invented and are removed.
+    const args: string[] = ['-x', prompt, '--stream-json'];
 
-    // Resume existing session for context continuity
-    if (this.ampSessionId) {
-      args.push('--session', this.ampSessionId);
-    }
-
-    // Model override
-    if (this.options.model) {
-      args.push('--model', this.options.model);
-    }
-
-    // Deep mode — spawns sub-agents for parallel codebase analysis
-    if (this.options.deepMode) {
-      args.push('--deep');
-      if (this.options.maxSubAgents) {
-        args.push('--max-agents', String(this.options.maxSubAgents));
-      }
-    }
-
-    // Extra args (validated for shell safety — SEC-ARGS-001)
-    if (this.options.extraArgs) {
-      args.push(...validateExtraArgs(this.options.extraArgs));
+    // Agent mode (deep | rush | smart). Omitted -> Amp uses its configured default.
+    if (this.options.mode) {
+      args.push('--mode', this.options.mode);
     }
 
     logger.debug(`[AmpBackend] Spawning amp with args:`, args);
 
     return new Promise<void>((resolve, reject) => {
-      try {
-        // SECURITY: Use buildSafeEnv() instead of spreading process.env to prevent
-        // leaking secrets (SUPABASE_SERVICE_ROLE_KEY, DATABASE_URL, etc.) to Amp.
-        this.process = spawn('amp', args, {
-          cwd: this.options.cwd,
-          env: buildSafeEnv({
-            ...this.options.env,
-            // WHY: Amp uses ANTHROPIC_API_KEY for Claude models and AMP_API_KEY
-            // for Sourcegraph-hosted models. We set the provided key under both
-            // names so users don't need separate keys for different model choices.
-            ...(this.options.apiKey
-              ? {
-                  ANTHROPIC_API_KEY: this.options.apiKey,
-                  AMP_API_KEY: this.options.apiKey,
-                }
-              : {}),
-          }),
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
+      const child = this.spawnAgent({
+        command: 'amp',
+        args,
+        cwd: this.options.cwd,
+        // SECURITY: Inject the Amp token ONLY as AMP_API_KEY — Amp's own
+        // documented auth var (verified in `amp --help` env section). The prior
+        // code also set ANTHROPIC_API_KEY, leaking the token to the Anthropic
+        // endpoint during startup validation (cross-vendor key disclosure). Amp
+        // is single-vendor BYOK, so resolveApiKeyEnv()'s multi-provider sniffing
+        // does not apply; a single explicit var is the correct, leak-free fix.
+        extraEnv: {
+          ...this.options.env,
+          ...(this.options.apiKey ? { AMP_API_KEY: this.options.apiKey } : {}),
+        },
+        // extraArgs validated for shell-safety by the base class (SEC-ARGS-001).
+        userExtraArgs: this.options.extraArgs,
+        // The prompt is passed via `-x`, not stdin. Ignore stdin so amp does not
+        // wait on input that never comes. stdout/stderr stay piped for parsing.
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
 
-        if (!this.process.stdout || !this.process.stderr) {
-          throw new Error('Failed to create stdio pipes');
-        }
-
-        // Handle stdout — JSON messages
-        this.process.stdout.on('data', (data: Buffer) => {
-          this.processStdout(data);
-        });
-
-        // Handle stderr — Amp diagnostic messages
-        this.process.stderr.on('data', (data: Buffer) => {
-          const text = data.toString();
-          logger.debug(`[AmpBackend] stderr: ${text.trim()}`);
-
-          if (
-            text.includes('Error') ||
-            text.includes('error') ||
-            text.includes('Exception') ||
-            text.includes('failed')
-          ) {
-            this.emit({
-              type: 'status',
-              status: 'error',
-              detail: text.trim(),
-            });
-          }
-        });
-
-        // Handle process exit
-        this.process.on('close', (code) => {
-          logger.debug(`[AmpBackend] Process exited with code: ${code}`);
-
-          // Flush remaining buffer
-          if (this.lineBuffer.trim()) {
-            const msg = parseAmpJsonLine(this.lineBuffer);
-            if (msg) {
-              this.handleAmpMessage(msg);
-            }
-            this.lineBuffer = '';
-          }
-
-          this.activeSubAgents.clear();
-
-          if (code === 0) {
-            this.emit({ type: 'status', status: 'idle' });
-            resolve();
-          } else if (this.wasCancelled()) {
-            // Intentional user cancel (or dispose) SIGTERM'd the process, which
-            // surfaces here as a non-zero/null exit. Emit a clean idle status and
-            // resolve instead of a spurious agent error (audit 2026-06-09 fix #6).
-            this.emit({ type: 'status', status: 'idle' });
-            resolve();
-          } else {
-            this.emit({
-              type: 'status',
-              status: 'error',
-              detail: `Amp exited with code ${code}`,
-            });
-            reject(new Error(`Amp exited with code ${code}`));
-          }
-
-          this.process = null;
-        });
-
-        // Handle process spawn errors
-        // WHY (Phase 0.3 / SOC2 CC7.2): Surface friendly install hint on
-        // ENOENT instead of raw "spawn ... ENOENT" Node error.
-        this.process.on('error', (err: NodeJS.ErrnoException) => {
-          if (err.code === 'ENOENT') {
-            const message = formatInstallHint('amp');
-            logger.warn(`[AmpBackend] ${message}`);
-            this.emit({ type: 'status', status: 'error', detail: message });
-            reject(new Error(message));
-            return;
-          }
-          logger.error(`[AmpBackend] Process error:`, err);
-          this.emit({ type: 'status', status: 'error', detail: err.message });
-          reject(err);
-        });
-      } catch (error) {
-        const err = error instanceof Error ? error : new Error(String(error));
-        this.emit({
-          type: 'status',
-          status: 'error',
-          detail: err.message,
-        });
-        reject(err);
+      if (child.stdout) {
+        this.streamLines(child.stdout, (line) => this.handleLine(line));
       }
+      if (child.stderr) {
+        child.stderr.on('data', (data: Buffer) => {
+          logger.debug(`[AmpBackend] stderr: ${data.toString().trim()}`);
+        });
+      }
+
+      child.on('close', (code) => {
+        logger.debug(`[AmpBackend] Process exited with code: ${code}`);
+        this.process = null;
+        this.clearCancelTimer();
+        if (code === 0 || this.wasCancelled()) {
+          // wasCancelled(): an intentional user cancel/dispose SIGTERM'd the
+          // process; treat the resulting non-zero exit as a clean stop, not a
+          // crash (audit 2026-06-09 fix #6).
+          this.emit({ type: 'status', status: 'idle' });
+          resolve();
+        } else {
+          const detail = `Amp exited with code ${code}`;
+          this.emit({ type: 'status', status: 'error', detail });
+          reject(new Error(detail));
+        }
+      });
+
+      // ENOENT -> friendly install hint; other spawn errors forwarded.
+      this.attachInstallHintErrorHandler(child, 'amp', reject);
     });
   }
 
   /**
-   * Cancel the current Amp operation.
-   *
-   * WHY: In deep mode, Amp may have spawned multiple sub-agent processes.
-   * SIGTERM propagates to Amp's child processes via the process group, so
-   * all sub-agents are terminated when we kill the main Amp process.
+   * Cancel the in-flight prompt (SIGTERM, then SIGKILL escalation via the base).
    *
    * @param sessionId - The active session ID to cancel
    * @throws {Error} When session ID does not match the active session
@@ -683,53 +416,15 @@ class AmpBackend extends StreamingAgentBackendBase {
       this.scheduleForceKill();
     }
 
-    this.activeSubAgents.clear();
     this.emit({ type: 'status', status: 'idle' });
   }
 
-  /**
-   * Respond to an Amp permission request.
-   *
-   * Amp may request permission for shell execution and file system operations.
-   * In non-interactive mode (--no-interactive), Amp auto-approves. This method
-   * handles the response for cases where permission requests surface through
-   * the MCP protocol.
-   *
-   * @param requestId - The ID of the permission request
-   * @param approved - Whether the user approved the request
-   */
-  async respondToPermission(requestId: string, approved: boolean): Promise<void> {
-    this.emit({
-      type: 'permission-response',
-      id: requestId,
-      approved,
-    });
+  // respondToPermission inherited from StreamingAgentBackendBase: amp execute
+  // mode (-x) runs non-interactively with no stdin permission prompt, so the
+  // emit-only base behavior is correct (the prior y/n stdin write targeted a
+  // --no-interactive interactive flow that does not exist).
 
-    // Write response to stdin if process is active (for interactive permission flow)
-    if (this.process?.stdin && !this.process.killed) {
-      const response = approved ? 'y\n' : 'n\n';
-      try {
-        this.process.stdin.write(response);
-      } catch {
-        // Stdin may be closed — safe to ignore
-      }
-    }
-  }
-
-  // waitForResponseComplete inherited from StreamingAgentBackendBase.
-
-  /**
-   * Clean up Amp-specific state and defer the rest to the base class.
-   *
-   * Base dispose() (StreamingAgentBackendBase) handles: SIGTERM of the active
-   * process, clearing the cancel timer (SOC2 CC7.2 event-loop hygiene), and
-   * dropping application-level listener references so handler closures are
-   * GC-eligible.
-   */
-  async dispose(): Promise<void> {
-    this.activeSubAgents.clear();
-    await super.dispose();
-  }
+  // waitForResponseComplete + dispose inherited from StreamingAgentBackendBase.
 }
 
 // ============================================================================
@@ -739,29 +434,22 @@ class AmpBackend extends StreamingAgentBackendBase {
 /**
  * Create an Amp backend.
  *
- * Amp is an AI coding agent by Sourcegraph with optional deep mode that
- * parallelizes codebase analysis using multiple sub-agents.
- *
- * The amp binary must be installed and available in PATH.
- * Install via: `npm install -g @sourcegraph/amp` or download from ampcode.com
+ * Amp (ampcode.com) is an AI coding agent run headlessly via
+ * `amp -x "<prompt>" --stream-json`. The `amp` binary must be installed and on
+ * PATH, and authenticated via `amp login` or the `AMP_API_KEY` env var.
  *
  * @param options - Configuration options for the backend
  * @returns AmpBackendResult with backend instance and resolved model
  *
  * @example
  * ```ts
- * // Standard mode
- * const { backend } = createAmpBackend({
- *   cwd: '/path/to/project',
- *   model: 'claude-sonnet-4',
- * });
+ * // Default mode
+ * const { backend } = createAmpBackend({ cwd: '/path/to/project' });
  *
- * // Deep mode for large codebase analysis
+ * // Deep agent mode for harder tasks (amp --mode deep)
  * const { backend } = createAmpBackend({
  *   cwd: '/path/to/monorepo',
- *   model: 'claude-opus-4',
- *   deepMode: true,
- *   maxSubAgents: 6,
+ *   mode: 'deep',
  * });
  *
  * const { sessionId } = await backend.startSession();
@@ -773,9 +461,7 @@ export function createAmpBackend(options: AmpBackendOptions): AmpBackendResult {
     cwd: options.cwd,
     model: options.model,
     hasApiKey: !!options.apiKey,
-    deepMode: options.deepMode,
-    maxSubAgents: options.maxSubAgents,
-    resumeSessionId: options.resumeSessionId,
+    mode: options.mode,
   });
 
   return {
@@ -785,7 +471,7 @@ export function createAmpBackend(options: AmpBackendOptions): AmpBackendResult {
       modelSource: options.model ? 'explicit' : 'default',
       supportsStreaming: true,
       supportsTools: true,
-      deepMode: !!options.deepMode,
+      mode: options.mode ?? 'default',
     },
   };
 }

--- a/packages/styrby-cli/src/agent/factories/crush.ts
+++ b/packages/styrby-cli/src/agent/factories/crush.ts
@@ -2,20 +2,27 @@
  * Crush Backend - Crush CLI agent adapter (Charmbracelet)
  *
  * This module provides a factory function for creating a Crush backend.
- * Crush is an AI coding agent by Charmbracelet, designed for terminal-native
- * aesthetics with ACP-compatible communication and charm-style TUI output.
+ * Crush is a Bubbletea TUI coding agent by Charmbracelet.
  *
- * Key characteristics:
+ * Key characteristics (VERIFIED against crush v0.76.0, 2026-06-10):
  * - Binary name: `crush` (installed via Homebrew or direct download from charm.sh)
- * - Config: `~/.config/crush/config.yaml`
- * - Output: ACP-compatible JSON events with charm-style ANSI terminal decorations
- * - Cost tracking: token usage in `usage` events from the ACP response stream
- * - Protocol: ACP-compatible (Agent Communication Protocol), charm-style TUI
- * - Built for terminal purists — outputs rich ANSI, bold colors, box drawings
+ * - Headless invocation: `crush run [prompt...]` — runs a single prompt
+ *   non-interactively and exits. The prompt is a POSITIONAL argument (or piped
+ *   on stdin). Verified from `crush run --help`.
+ * - Real `run` flags (verified): -C/--continue, -c/--cwd, -D/--data-dir,
+ *   -d/--debug, -m/--model, -q/--quiet (hide spinner), -s/--session,
+ *   --small-model, -v/--verbose. There is NO -h-listed --format/--no-tui/
+ *   --message/--provider flag.
+ * - Output: PLAIN TEXT. `crush run` writes the model's textual response to
+ *   stdout (suitable for piping/redirecting per the help examples, e.g.
+ *   `crush run "..." > README.md`). Status/spinner/error chrome goes to stderr
+ *   as styled ANSI boxes. There is NO machine-readable (JSON/ACP) output mode.
  *
- * WHY Crush: Charmbracelet has a passionate developer following (they built Bubbletea,
- * Gum, Lip Gloss). Crush captures that audience and differentiates Styrby by supporting
- * a visually rich terminal experience. The ACP compatibility means integration is clean.
+ * WHY only plain-text mapping: crush exposes no structured event stream, so we
+ * cannot reliably surface per-token usage, tool calls, or cost. We treat the
+ * whole stdout as assistant text (`model-output`) and rely on exit code for
+ * completion. Usage/cost/tool/fs-edit events are intentionally NOT emitted
+ * because crush provides no verified source for them (see #30).
  *
  * @see https://github.com/charmbracelet/crush
  * @module factories/crush
@@ -35,7 +42,6 @@ import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { resolveApiKeyEnv, type ApiKeyProvider } from '@/utils/apiKeyProvider';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
-import type { CostReport } from '@styrby/shared/cost';
 
 // ============================================================================
 // Types
@@ -53,29 +59,27 @@ export interface CrushBackendOptions extends AgentFactoryOptions {
   apiKey?: string;
 
   /**
-   * Model to use (e.g., 'claude-sonnet-4', 'gpt-4o').
-   * Defaults to Crush's configured default from ~/.config/crush/config.yaml.
+   * Model to use. Passed verbatim to `crush run --model`. Crush accepts either
+   * a bare model name or `provider/model` to disambiguate (e.g.
+   * 'anthropic/claude-sonnet-4'). Defaults to Crush's configured default in
+   * ~/.config/crush/crush.json.
+   *
+   * WHY no separate `provider` option: crush v0.76.0 has no `--provider` flag.
+   * The provider is selected either via the `provider/model` model string or by
+   * crush's own config / detected env keys.
    */
   model?: string;
 
   /**
-   * LLM provider name (e.g., 'anthropic', 'openai').
-   * Passed as --provider flag. Defaults to Crush's config file setting.
+   * LLM provider hint, used ONLY to pick which API-key env var to inject
+   * (ANTHROPIC_API_KEY vs OPENAI_API_KEY). It is NOT passed to crush as a flag
+   * because no such flag exists. Default: sniffed from the apiKey prefix.
    */
   provider?: string;
 
   /**
-   * Whether to disable Crush's interactive TUI mode.
-   *
-   * WHY: Crush renders a full-screen TUI by default (Charmbracelet style).
-   * In Styrby's non-interactive mode, we suppress the TUI and get JSON output
-   * so the mobile app can render its own UI. Default: true
-   */
-  noTui?: boolean;
-
-  /**
-   * Session name for resuming an existing Crush session.
-   * Crush maintains persistent session history by name.
+   * Existing crush session ID to continue. Passed to `crush run --session <id>`
+   * (verified flag). Crush persists sessions in its data dir.
    */
   sessionName?: string;
 
@@ -99,129 +103,26 @@ export interface CrushBackendResult {
 }
 
 // ============================================================================
-// JSON Output Parsing
+// Output Parsing
 // ============================================================================
-
-/**
- * Crush ACP-compatible JSON event types.
- *
- * WHY: Crush outputs ACP-compatible JSON events to stdout when running with
- * --no-tui --format json. These map directly onto our AgentMessage union type.
- * The ACP spec guarantees stable event names so we can parse them reliably.
- */
-interface CrushJsonEvent {
-  /**
-   * ACP-compatible event type discriminator.
-   * Crush uses lower_snake_case names per the ACP spec.
-   */
-  type:
-    | 'text_delta'
-    | 'tool_call'
-    | 'tool_result'
-    | 'usage'
-    | 'error'
-    | 'status'
-    | 'done';
-  /** Text content delta for 'text_delta' events */
-  delta?: string;
-  /** Tool name for 'tool_call' / 'tool_result' events */
-  tool?: string;
-  /** Tool input arguments for 'tool_call' events */
-  args?: Record<string, unknown>;
-  /** Tool output for 'tool_result' events */
-  output?: unknown;
-  /** Unique call ID for correlating tool_call to tool_result */
-  call_id?: string;
-  /** Token usage metadata for 'usage' events */
-  usage?: CrushUsageMetadata;
-  /** Error message for 'error' events */
-  message?: string;
-  /** Status string for 'status' events */
-  state?: string;
-}
-
-/**
- * Token usage metadata from Crush ACP usage events.
- *
- * WHY: Crush embeds token usage in ACP usage events after each model turn.
- * We extract this to give Styrby users accurate cost tracking.
- */
-interface CrushUsageMetadata {
-  /** Input/prompt tokens consumed */
-  input_tokens?: number;
-  /** Output/completion tokens generated */
-  output_tokens?: number;
-  /** Cache read tokens (Anthropic prompt caching) */
-  cache_read_input_tokens?: number;
-  /** Cache write tokens (Anthropic prompt caching) */
-  cache_creation_input_tokens?: number;
-  /** Estimated cost in USD from Crush's internal billing calculator */
-  cost_usd?: number;
-}
-
-/**
- * Parse a single JSON event line from Crush's ACP output.
- *
- * @param line - A single line of Crush stdout (expected to be JSON)
- * @returns Parsed CrushJsonEvent or null if the line is not valid JSON
- */
-function parseCrushJsonLine(line: string): CrushJsonEvent | null {
-  const trimmed = line.trim();
-  if (!trimmed || !trimmed.startsWith('{')) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(trimmed) as CrushJsonEvent;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Detect file system edits from Crush tool names.
- *
- * WHY: Crush uses charm-style tool naming that may include stylistic prefixes
- * (e.g., "charm_write_file", "edit_file"). We detect the common patterns so
- * the mobile app can show file modification notifications.
- *
- * @param toolName - The ACP tool name from the tool_call event
- * @returns true if this tool modifies the file system
- */
-function isCrushFileEditTool(toolName: string): boolean {
-  const fileEditPatterns = [
-    'write',
-    'create',
-    'edit',
-    'patch',
-    'modify',
-    'str_replace',
-    'apply',
-    'overwrite',
-  ];
-  const lower = toolName.toLowerCase();
-  return fileEditPatterns.some((pattern) => lower.includes(pattern));
-}
-
-/**
- * Extract file path from a Crush tool input.
- *
- * Crush uses different parameter names across tools. This function checks
- * common field names for robustness.
- *
- * @param args - Tool input arguments
- * @returns File path string or null if not found
- */
-function extractCrushFilePath(args?: Record<string, unknown>): string | null {
-  if (!args) return null;
-  return (
-    (args.path as string) ??
-    (args.file_path as string) ??
-    (args.filename as string) ??
-    (args.target as string) ??
-    null
-  );
-}
+//
+// SCHEMA UNVERIFIED — crush exposes NO machine-readable output mode.
+//
+// crush v0.76.0 `crush run` writes the model's response to stdout as PLAIN
+// TEXT (verified from `crush run --help`: the examples redirect stdout straight
+// into README files). There is no --format json / --no-tui / ACP event stream.
+// The previous implementation parsed a fabricated `{text_delta, usage, tool_call,
+// done}` ACP schema that does not exist in the real binary.
+//
+// Consequently this backend can only surface the assistant's text. Token usage,
+// per-call cost, tool-call/tool-result, and fs-edit events have NO verified
+// source in crush's output and are intentionally NOT emitted. Wiring them up
+// requires a keyed crush session to capture real `--verbose`/`--debug` output
+// and confirm whether any structured signal is recoverable — tracked in #30.
+//
+// NOTE: a future verified path could parse `crush run --verbose` logs or query
+// `crush session`/`crush stats` subcommands for usage. Do NOT add such parsing
+// until the real output has been captured and confirmed against the binary.
 
 // ============================================================================
 // CrushBackend Class
@@ -230,185 +131,44 @@ function extractCrushFilePath(args?: Record<string, unknown>): string | null {
 /**
  * Crush Backend implementation.
  *
- * Spawns Crush as a subprocess with ACP-compatible JSON output and parses the
- * structured events. Handles session lifecycle, cost tracking, and file edit
- * detection from charm-style tool names.
+ * Spawns `crush run <prompt>` as a one-shot subprocess and streams its stdout
+ * (the model's plain-text response) to the mobile app as `model-output`. Crush
+ * has no structured/JSON output mode, so this backend does NOT emit usage,
+ * cost, tool, or fs-edit events (see the "Output Parsing" note above + #30).
  */
 class CrushBackend extends StreamingAgentBackendBase {
   protected readonly logTag = 'CrushBackend';
-  private lineBuffer = '';
-  private inputTokens = 0;
-  private outputTokens = 0;
-  private cacheReadTokens = 0;
-  private cacheWriteTokens = 0;
-  private totalCostUsd = 0;
+
+  // SECURITY: bounded buffer guards against a runaway process flooding stdout
+  // without newlines. We still emit incrementally (per data chunk) so the user
+  // sees output as it streams; the buffer only caps unbounded growth.
+  private outputBuffer = '';
 
   constructor(private options: CrushBackendOptions) {
     super();
   }
 
   /**
-   * Process a parsed Crush ACP JSON event and emit the corresponding AgentMessage.
+   * Process stdout data from `crush run`.
    *
-   * WHY: Crush's ACP-compatible output maps cleanly onto the AgentMessage union.
-   * This explicit mapping makes it easy to track API changes in Crush's output format.
-   *
-   * @param event - The parsed Crush JSON event
-   */
-  private handleCrushEvent(event: CrushJsonEvent): void {
-    switch (event.type) {
-      case 'text_delta':
-        if (event.delta) {
-          this.emit({ type: 'model-output', textDelta: event.delta });
-        }
-        break;
-
-      case 'tool_call':
-        if (event.tool && event.call_id) {
-          this.emit({
-            type: 'tool-call',
-            toolName: event.tool,
-            args: event.args ?? {},
-            callId: event.call_id,
-          });
-        }
-        break;
-
-      case 'tool_result':
-        if (event.call_id && event.tool) {
-          this.emit({
-            type: 'tool-result',
-            toolName: event.tool,
-            result: event.output,
-            callId: event.call_id,
-          });
-
-          // Detect file system edits and emit fs-edit notification
-          if (isCrushFileEditTool(event.tool)) {
-            const filePath = extractCrushFilePath(event.args);
-            if (filePath) {
-              this.emit({
-                type: 'fs-edit',
-                description: `${event.tool}: ${filePath}`,
-                path: filePath,
-              });
-            }
-          }
-        }
-        break;
-
-      case 'usage':
-        // WHY: Crush emits a usage event after each model turn with ACP usage data.
-        // We accumulate across the session so the mobile app shows a running total.
-        if (event.usage) {
-          const incrInput = event.usage.input_tokens ?? 0;
-          const incrOutput = event.usage.output_tokens ?? 0;
-          const incrCacheRead = event.usage.cache_read_input_tokens ?? 0;
-          const incrCacheWrite = event.usage.cache_creation_input_tokens ?? 0;
-          const incrCost = event.usage.cost_usd ?? 0;
-
-          this.inputTokens += incrInput;
-          this.outputTokens += incrOutput;
-          this.cacheReadTokens += incrCacheRead;
-          this.cacheWriteTokens += incrCacheWrite;
-          this.totalCostUsd += incrCost;
-
-          // Emit legacy token-count (keep for existing consumers)
-          this.emit({
-            type: 'token-count',
-            inputTokens: this.inputTokens,
-            outputTokens: this.outputTokens,
-            cacheReadTokens: this.cacheReadTokens,
-            cacheWriteTokens: this.cacheWriteTokens,
-            costUsd: this.totalCostUsd,
-          });
-
-          // WHY: Emit unified CostReport. Crush always reports agent-provided
-          // cost_usd via ACP, so source is always 'agent-reported'.
-          const costReport: CostReport = {
-            sessionId: this.sessionId ?? '',
-            messageId: null,
-            agentType: 'crush',
-            model: this.options.model ?? 'unknown',
-            timestamp: new Date().toISOString(),
-            source: 'agent-reported',
-            billingModel: 'api-key',
-            costUsd: incrCost,
-            inputTokens: incrInput,
-            outputTokens: incrOutput,
-            cacheReadTokens: incrCacheRead,
-            cacheWriteTokens: incrCacheWrite,
-            rawAgentPayload: event.usage as unknown as Record<string, unknown>,
-          };
-          this.emit({ type: 'cost-report', report: costReport });
-        }
-        break;
-
-      case 'error':
-        this.emit({
-          type: 'status',
-          status: 'error',
-          detail: event.message ?? 'Crush encountered an error',
-        });
-        break;
-
-      case 'status':
-        // WHY: Crush emits status events to communicate phase transitions
-        // (loading context, thinking, executing tools). We map them to our
-        // normalized status types for the mobile app status bar.
-        if (event.state) {
-          const statusMap: Record<string, 'starting' | 'running' | 'idle' | 'stopped' | 'error'> =
-            {
-              loading: 'starting',
-              thinking: 'running',
-              executing: 'running',
-              idle: 'idle',
-              done: 'idle',
-              stopped: 'stopped',
-              error: 'error',
-            };
-          const mapped = statusMap[event.state] ?? 'running';
-          this.emit({ type: 'status', status: mapped });
-        }
-        break;
-
-      case 'done':
-        // WHY: ACP 'done' signals the end of a complete agent response turn.
-        // Map to 'idle' so the mobile app knows it can send the next message.
-        this.emit({ type: 'status', status: 'idle' });
-        break;
-
-      default:
-        logger.debug('[CrushBackend] Unknown event type:', event);
-    }
-  }
-
-  /**
-   * Process stdout data, buffering partial lines until a newline is received.
-   *
-   * WHY: Node.js streams deliver data in chunks that may span line boundaries.
-   * We buffer until we see a newline before attempting to parse JSON.
+   * Crush emits the assistant's reply as plain text (no JSON event framing).
+   * We forward each chunk verbatim as a `model-output` delta so the mobile app
+   * can render the response as it streams.
    *
    * @param data - Raw buffer chunk from process stdout
    */
   private processStdout(data: Buffer): void {
     const text = data.toString();
-    // SECURITY: Cap line buffer size to prevent memory exhaustion from
-    // a misbehaving agent sending continuous data without newlines.
-    this.lineBuffer = safeBufferAppend(this.lineBuffer, text);
 
-    const lines = this.lineBuffer.split('\n');
-    // The last element may be an incomplete line — keep it in the buffer
-    this.lineBuffer = lines.pop() ?? '';
+    // SECURITY: cap retained buffer size to prevent memory exhaustion from a
+    // misbehaving agent that never stops writing. safeBufferAppend trims to the
+    // configured ceiling; we only use the buffer for the cap, not re-parsing.
+    this.outputBuffer = safeBufferAppend(this.outputBuffer, text);
 
-    for (const line of lines) {
-      const event = parseCrushJsonLine(line);
-      if (event) {
-        this.handleCrushEvent(event);
-      } else if (line.trim()) {
-        // Non-JSON output (charm-style ANSI decorations, progress bars) — log only
-        logger.debug('[CrushBackend] Non-JSON stdout:', line);
-      }
+    if (text) {
+      // WHY plain passthrough: crush has no structured event schema, so the raw
+      // text IS the model output. No per-event usage/tool data is recoverable.
+      this.emit({ type: 'model-output', textDelta: text });
     }
   }
 
@@ -428,12 +188,7 @@ class CrushBackend extends StreamingAgentBackendBase {
     }
 
     this.sessionId = randomUUID();
-    this.inputTokens = 0;
-    this.outputTokens = 0;
-    this.cacheReadTokens = 0;
-    this.cacheWriteTokens = 0;
-    this.totalCostUsd = 0;
-    this.lineBuffer = '';
+    this.outputBuffer = '';
 
     this.emit({ type: 'status', status: 'starting' });
 
@@ -452,8 +207,9 @@ class CrushBackend extends StreamingAgentBackendBase {
   /**
    * Send a prompt to Crush.
    *
-   * Spawns a Crush subprocess with ACP JSON output mode. Uses --no-tui to
-   * suppress the charm TUI and get structured JSON events on stdout.
+   * Spawns `crush run <prompt>` — crush's verified non-interactive mode. The
+   * prompt is passed as a positional argument; crush writes the model's reply
+   * as plain text to stdout, which we forward as `model-output`.
    *
    * @param sessionId - The active session ID (must match startSession result)
    * @param prompt - The user's prompt text
@@ -472,44 +228,41 @@ class CrushBackend extends StreamingAgentBackendBase {
     // classified correctly by the close handler (audit 2026-06-09 fix #6).
     this.beginRun();
 
-    this.lineBuffer = '';
+    this.outputBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
-    // Build Crush command arguments
-    const args: string[] = [
-      '--message',  // Pass the prompt as a message argument (non-interactive)
-      prompt,
-      '--format',
-      'json',       // Request ACP-compatible JSON output for parsing
-    ];
+    // Build verified `crush run` command. Subcommand FIRST, then flags, then the
+    // prompt as a trailing positional argument (`crush run [prompt...]`).
+    const args: string[] = ['run'];
 
-    // WHY: Suppress charm's full-screen TUI. In Styrby's relay mode, Crush runs
-    // as a headless subprocess. The TUI would capture the terminal and prevent
-    // stdout from flowing to our parser. --no-tui routes output to stdout as JSON.
-    const noTui = this.options.noTui !== false;
-    if (noTui) {
-      args.push('--no-tui');
-    }
+    // -q/--quiet hides crush's spinner chrome so stdout carries only the model's
+    // text (verified flag). We always want this in headless relay mode.
+    args.push('--quiet');
 
-    // Model override
+    // -m/--model: bare name or `provider/model` (verified flag).
     if (this.options.model) {
       args.push('--model', this.options.model);
     }
 
-    // Provider override
-    if (this.options.provider) {
-      args.push('--provider', this.options.provider);
-    }
-
-    // Resume an existing named session
+    // -s/--session: continue an existing crush session by ID (verified flag).
     if (this.options.sessionName) {
       args.push('--session', this.options.sessionName);
     }
 
-    // Extra args (validated for shell safety — SEC-ARGS-001)
+    // WHY no --provider/--format/--no-tui: those flags do NOT exist on crush
+    // v0.76.0 `run`. Provider selection happens via the model string and the
+    // injected API-key env var below.
+
+    // Extra args (validated for shell safety — SEC-ARGS-001). These go before
+    // the positional prompt so flag-style extras parse correctly.
     if (this.options.extraArgs) {
       args.push(...validateExtraArgs(this.options.extraArgs));
     }
+
+    // The prompt is the trailing positional argument: `crush run [flags] <prompt>`.
+    // It is passed as a single argv element (no shell), so spaces/quotes in the
+    // prompt are safe and need no escaping.
+    args.push(prompt);
 
     logger.debug(`[CrushBackend] Spawning crush with args:`, args);
 
@@ -538,7 +291,7 @@ class CrushBackend extends StreamingAgentBackendBase {
           throw new Error('Failed to create stdio pipes');
         }
 
-        // Handle stdout — ACP JSON events from Crush
+        // Handle stdout — plain-text model response from `crush run`
         this.process.stdout.on('data', (data: Buffer) => {
           this.processStdout(data);
         });
@@ -566,14 +319,9 @@ class CrushBackend extends StreamingAgentBackendBase {
         this.process.on('close', (code) => {
           logger.debug(`[CrushBackend] Process exited with code: ${code}`);
 
-          // Flush any remaining buffered output
-          if (this.lineBuffer.trim()) {
-            const event = parseCrushJsonLine(this.lineBuffer);
-            if (event) {
-              this.handleCrushEvent(event);
-            }
-            this.lineBuffer = '';
-          }
+          // stdout is emitted incrementally in processStdout(); there is no
+          // line-framed buffer to flush. Just clear the size-cap buffer.
+          this.outputBuffer = '';
 
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });
@@ -658,8 +406,12 @@ class CrushBackend extends StreamingAgentBackendBase {
   /**
    * Respond to a Crush permission request.
    *
-   * Crush may request permission for shell execution or dangerous file operations.
-   * In --no-tui mode with ACP protocol, we write the response to stdin.
+   * SCHEMA UNVERIFIED — crush's headless `run` mode has no confirmed interactive
+   * permission protocol. Crush governs tool permissions via its config and the
+   * `--yolo` flag, not an over-stdin y/n exchange we can verify. We therefore
+   * only emit the `permission-response` event for app-side bookkeeping and do
+   * NOT fabricate a stdin write. If a real permission channel is discovered with
+   * a keyed session (#30), wire it here against verified behavior.
    *
    * @param requestId - The ID of the permission request from Crush
    * @param approved - Whether the user approved the request
@@ -670,15 +422,6 @@ class CrushBackend extends StreamingAgentBackendBase {
       id: requestId,
       approved,
     });
-
-    if (this.process?.stdin && !this.process.killed) {
-      const response = approved ? 'y\n' : 'n\n';
-      try {
-        this.process.stdin.write(response);
-      } catch {
-        // Stdin may already be closed — safe to ignore
-      }
-    }
   }
 
   // waitForResponseComplete and dispose inherited from
@@ -693,9 +436,10 @@ class CrushBackend extends StreamingAgentBackendBase {
 /**
  * Create a Crush backend.
  *
- * Crush is an AI coding agent by Charmbracelet with ACP-compatible JSON output
- * and charm-style terminal aesthetics. It integrates cleanly via the --no-tui
- * flag which routes ACP events to stdout for structured parsing.
+ * Crush is a Bubbletea TUI coding agent by Charmbracelet. We drive its verified
+ * headless `crush run <prompt>` mode, which writes the model's plain-text reply
+ * to stdout. Crush has no JSON/structured output mode, so this backend surfaces
+ * model text only (no usage/cost/tool events — see #30).
  *
  * The crush binary must be installed and available in PATH.
  * Install via: `brew install charmbracelet/tap/crush`
@@ -723,7 +467,6 @@ export function createCrushBackend(options: CrushBackendOptions): CrushBackendRe
     model: options.model,
     provider: options.provider,
     hasApiKey: !!options.apiKey,
-    noTui: options.noTui,
     sessionName: options.sessionName,
   });
 
@@ -732,8 +475,11 @@ export function createCrushBackend(options: CrushBackendOptions): CrushBackendRe
     model: options.model,
     metadata: {
       modelSource: options.model ? 'explicit' : 'default',
+      // WHY false: crush emits no structured tool-call/tool-result events in
+      // headless `run` mode, so we surface no tool data to the app. Streaming
+      // is true because stdout text arrives incrementally.
       supportsStreaming: true,
-      supportsTools: true,
+      supportsTools: false,
     },
   };
 }

--- a/packages/styrby-cli/src/agent/factories/droid.ts
+++ b/packages/styrby-cli/src/agent/factories/droid.ts
@@ -1,27 +1,48 @@
 /**
- * Droid Backend - Droid CLI agent adapter (BYOK)
+ * Droid Backend - Factory's `droid` CLI agent adapter.
  *
  * This module provides a factory function for creating a Droid backend.
- * Droid is a Bring Your Own Key (BYOK) AI coding agent that supports multiple
- * LLM backends through the LiteLLM proxy protocol. Users supply their own API
- * keys for any supported provider.
+ * Droid is Factory AI's terminal coding agent. It runs against Factory's
+ * hosted models (Claude, GPT, Gemini, and Factory "Droid Core" models) and
+ * authenticates via a Factory account login or a `FACTORY_API_KEY`.
  *
- * Key characteristics:
- * - Binary name: `droid` (installed via `npm install -g droid` or
- *   `curl -fsSL https://app.factory.ai/cli | sh`, or `brew install --cask droid`)
- * - Config: `~/.config/droid/config.yaml`
- * - Output: structured JSON lines via stdout
- * - Cost tracking: varies by backend model, uses LiteLLM pricing tables for estimates
- * - BYOK: users bring their own API keys for Anthropic, OpenAI, Google, Mistral, etc.
- * - Multi-backend: switches LLM backends per session without reinstallation
+ * Key characteristics (all verified against the real `droid` binary v0.144.2
+ * via `droid --help` / `droid exec --help`, 2026-06-10):
+ * - Binary name: `droid`
+ * - Headless invocation: `droid exec [prompt]` (positional prompt). There is
+ *   NO `chat` subcommand, NO `--message`, NO `--no-interactive`, NO `--backend`.
+ * - Output format flag: `-o, --output-format <format>` with three valid
+ *   values: `text` (default), `json`, and `stream-json`. We use `stream-json`
+ *   for incremental NDJSON events.
+ * - Session resume: `-s, --session-id <id>` (continue) / `--fork <id>` (fork).
+ * - Model override: `-m, --model <id>` (default `claude-opus-4-8`).
+ * - Autonomy is OFF by default (read-only). `--auto low|medium|high` raises it.
+ *   Styrby keeps the default read-only posture unless the caller opts in via
+ *   `autoLevel`, mirroring how we gate write access for the other adapters.
  *
- * WHY BYOK matters: Enterprise users often have negotiated API rates or on-prem
- * model deployments. Droid lets them use Styrby's mobile UX without being locked
- * into any single provider pricing. LiteLLM pricing is used as the fallback
- * estimator when the backend does not report token costs directly.
+ * AUTHENTICATION NOTE: Droid is Factory-hosted, not a generic BYOK/LiteLLM
+ * proxy. The single credential it reads from the environment is
+ * `FACTORY_API_KEY` (or an interactive `droid` login). The earlier assumption
+ * that Droid was a LiteLLM multi-provider BYOK agent (injecting
+ * ANTHROPIC_API_KEY / OPENAI_API_KEY / etc.) was WRONG and has been removed.
  *
- * @see https://docs.factory.ai/cli/getting-started/quickstart
- * @see https://github.com/Factory-AI/factory
+ * OUTPUT SCHEMA — verification status:
+ * - VERIFIED (captured from a real unauthenticated run, 2026-06-10):
+ *     {"type":"system","subtype":"init", session_id, tools:[...], model, reasoning_effort}
+ *     {"type":"error", source, message, timestamp, session_id}
+ *     {"type":"result", subtype:"success"|"failure", is_error, duration_ms,
+ *       num_turns, result, session_id,
+ *       usage:{ input_tokens, output_tokens,
+ *               cache_read_input_tokens, cache_creation_input_tokens }}
+ *   This is the Claude-Code stream-json schema (snake_case usage fields).
+ * - UNVERIFIED (could not capture — no Factory auth on this machine, #30):
+ *     assistant/text-delta events and tool_use / tool_result events. Droid's
+ *     `stream-json` is Claude-Code-shaped, so we parse the Claude-Code
+ *     `{"type":"assistant", message:{ content:[...] }}` envelope, but those
+ *     branches are marked UNVERIFIED below and MUST be re-confirmed against a
+ *     keyed session before we claim they work.
+ *
+ * @see https://docs.factory.ai/cli/getting-started/overview
  * @module factories/droid
  */
 
@@ -37,156 +58,67 @@ import type {
 import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
-import { resolveApiKeyEnv } from '@/utils/apiKeyProvider';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
 import type { CostReport } from '@styrby/shared/cost';
-
-// ============================================================================
-// LiteLLM Pricing Table
-// ============================================================================
-
-/**
- * LiteLLM-compatible pricing estimates per 1000 tokens in USD.
- *
- * WHY: Droid supports many model backends, each with different pricing.
- * Rather than requiring Droid to report costs, we estimate from the model
- * name using the LiteLLM pricing database as the authoritative source.
- * These are estimates — actual billing depends on the user's provider contract.
- *
- * Prices are per 1000 tokens (input, output).
- * Source: https://docs.litellm.ai/docs/completion/token_usage#8-token-usage
- */
-const LITELLM_PRICING: Record<string, { inputPer1K: number; outputPer1K: number }> = {
-  // Anthropic Claude models
-  'claude-opus-4': { inputPer1K: 0.015, outputPer1K: 0.075 },
-  'claude-sonnet-4': { inputPer1K: 0.003, outputPer1K: 0.015 },
-  'claude-haiku-3-5': { inputPer1K: 0.0008, outputPer1K: 0.004 },
-  // OpenAI GPT models
-  'gpt-4o': { inputPer1K: 0.0025, outputPer1K: 0.01 },
-  'gpt-4o-mini': { inputPer1K: 0.00015, outputPer1K: 0.0006 },
-  'gpt-4-turbo': { inputPer1K: 0.01, outputPer1K: 0.03 },
-  'o1': { inputPer1K: 0.015, outputPer1K: 0.06 },
-  'o3-mini': { inputPer1K: 0.0011, outputPer1K: 0.0044 },
-  // Google Gemini models
-  'gemini-2.0-flash': { inputPer1K: 0.0001, outputPer1K: 0.0004 },
-  'gemini-2.5-pro': { inputPer1K: 0.00125, outputPer1K: 0.005 },
-  // Mistral models
-  'mistral-large': { inputPer1K: 0.002, outputPer1K: 0.006 },
-  'mistral-small': { inputPer1K: 0.0002, outputPer1K: 0.0006 },
-};
-
-/**
- * Default pricing used when the model is unknown.
- *
- * WHY: Unknown models should not silently report $0.00 cost, which would
- * cause users to underestimate spending. Using a mid-range default errs
- * on the side of slight overestimation, which is safer for budgeting.
- */
-const DEFAULT_PRICING = { inputPer1K: 0.002, outputPer1K: 0.008 };
-
-/**
- * Estimate cost in USD from token counts using LiteLLM pricing.
- *
- * @param model - The model identifier (partial matches are supported)
- * @param inputTokens - Number of input/prompt tokens
- * @param outputTokens - Number of output/completion tokens
- * @returns Estimated cost in USD
- *
- * @example
- * estimateCostFromTokens('claude-sonnet-4', 1000, 500)
- * // Returns: 0.003 + 0.0075 = 0.0105 USD
- */
-function estimateCostFromTokens(
-  model: string,
-  inputTokens: number,
-  outputTokens: number
-): number {
-  // WHY: Try exact match first, then partial match for model family variants
-  // (e.g., 'claude-sonnet-4-20250514' should match 'claude-sonnet-4').
-  const exactPricing = LITELLM_PRICING[model];
-  if (exactPricing) {
-    return (
-      (inputTokens / 1000) * exactPricing.inputPer1K +
-      (outputTokens / 1000) * exactPricing.outputPer1K
-    );
-  }
-
-  // Partial match: find the longest pricing key that is a prefix of the model name
-  let bestMatch: string | null = null;
-  for (const key of Object.keys(LITELLM_PRICING)) {
-    if (model.includes(key) || key.includes(model)) {
-      if (!bestMatch || key.length > bestMatch.length) {
-        bestMatch = key;
-      }
-    }
-  }
-
-  const pricing = bestMatch ? LITELLM_PRICING[bestMatch] : DEFAULT_PRICING;
-  return (
-    (inputTokens / 1000) * pricing.inputPer1K +
-    (outputTokens / 1000) * pricing.outputPer1K
-  );
-}
 
 // ============================================================================
 // Types
 // ============================================================================
 
 /**
+ * Autonomy level for `droid exec --auto <level>`.
+ *
+ * Droid runs read-only by default; raising autonomy lets the agent write files
+ * (`low`), run dev commands (`medium`), or perform production operations
+ * (`high`). Verified via `droid exec --help`.
+ */
+export type DroidAutoLevel = 'low' | 'medium' | 'high';
+
+/**
  * Options for creating a Droid backend.
  */
 export interface DroidBackendOptions extends AgentFactoryOptions {
   /**
-   * API key for the target LLM provider.
+   * Factory API key (`FACTORY_API_KEY`).
    *
-   * WHY: Droid is BYOK — users supply their own API keys. The key is injected
-   * into the subprocess environment under the provider-specific variable name.
-   * This is the primary API key; secondary keys can be passed via apiKeys map.
+   * WHY: Droid is Factory-hosted. Unlike the BYOK adapters, it does NOT accept
+   * provider keys (Anthropic/OpenAI/etc.) — it authenticates only against
+   * Factory. When omitted, Droid falls back to the interactive login stored in
+   * `~/.factory`. Injected via the environment, never a CLI flag, so it never
+   * appears in `ps aux`.
    */
-  apiKey?: string;
+  factoryApiKey?: string;
 
   /**
-   * Provider-specific API keys for multi-backend sessions.
-   *
-   * WHY: Some users run Droid with multiple backends in the same session
-   * (e.g., using GPT-4o for fast responses and Claude for refactoring).
-   * Each provider needs its own key.
-   *
-   * @example
-   * apiKeys: {
-   *   ANTHROPIC_API_KEY: 'sk-ant-...',
-   *   OPENAI_API_KEY: 'sk-...',
-   * }
-   */
-  apiKeys?: Record<string, string>;
-
-  /**
-   * LLM backend to use (e.g., 'anthropic', 'openai', 'google', 'mistral').
-   * Passed as --backend flag. Defaults to Droid's config.yaml setting.
-   */
-  backend?: string;
-
-  /**
-   * Model to use (e.g., 'claude-sonnet-4', 'gpt-4o').
-   * Droid uses the configured default model for the selected backend.
+   * Model to use (e.g., 'claude-opus-4-8', 'gpt-5.5', 'gemini-3.1-pro-preview').
+   * Passed as `-m/--model`. Defaults to Droid's own default (`claude-opus-4-8`).
    */
   model?: string;
 
   /**
-   * Whether to run in non-interactive mode (always true for Styrby).
-   * Prevents Droid from prompting for user confirmation.
-   * Default: true
+   * Autonomy level (`--auto low|medium|high`).
+   *
+   * WHY: Droid defaults to read-only. Omitting this keeps the safe default;
+   * the mobile/relay layer decides when to grant write access, matching how the
+   * other adapters gate file mutation.
    */
-  nonInteractive?: boolean;
+  autoLevel?: DroidAutoLevel;
 
   /**
-   * Session ID to resume (Droid supports persistent sessions).
-   * When provided, Droid will resume that session's conversation context.
+   * Session ID to resume (`-s/--session-id`). When set, Droid continues that
+   * session's conversation context. Requires a prompt (enforced by Droid).
    */
   resumeSessionId?: string;
 
   /**
-   * Additional Droid CLI arguments.
+   * Session ID to fork (`--fork`). Copies the source session's history into a
+   * new local session, then continues on the forked branch. Mutually exclusive
+   * with `resumeSessionId` at the CLI level; if both are set, fork wins.
+   */
+  forkSessionId?: string;
+
+  /**
+   * Additional Droid CLI arguments (validated for shell safety).
    * See: https://docs.factory.ai/cli
    */
   extraArgs?: string[];
@@ -205,67 +137,74 @@ export interface DroidBackendResult {
 }
 
 // ============================================================================
-// JSON Output Parsing
+// stream-json Output Schema (Claude-Code-shaped)
 // ============================================================================
 
 /**
- * Droid JSON output message types.
+ * Usage block reported by Droid's `result` event.
  *
- * WHY: Droid follows the LiteLLM output format, which is a superset of the
- * OpenAI Chat Completions streaming format. Messages include token usage data
- * that we use to compute costs via the LiteLLM pricing table.
+ * VERIFIED: captured from a real `droid exec ... -o stream-json` / `-o json`
+ * run (2026-06-10). Field names are Claude-Code snake_case:
+ *   { input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens }
+ *
+ * Droid does NOT report a cost field in this block. Cost is therefore derived
+ * by Styrby's central cost layer from token counts + the resolved Factory model,
+ * NOT from a LiteLLM table here (the old hardcoded LITELLM_PRICING table was
+ * removed — it was never part of Droid's real output and produced misleading
+ * numbers for Factory-hosted models).
  */
-interface DroidJsonMessage {
-  type:
-    | 'text'
-    | 'tool_call'
-    | 'tool_result'
-    | 'usage'
-    | 'error'
-    | 'done'
-    | 'backend_switch';
-  /** Text content for text events */
-  content?: string;
-  /** Tool name for tool_call and tool_result events */
-  tool_name?: string;
-  /** Tool input arguments */
-  tool_input?: Record<string, unknown>;
-  /** Tool result for tool_result events */
-  tool_result?: unknown;
-  /** Unique call ID correlating tool_call to tool_result */
-  call_id?: string;
-  /** Token usage for usage events */
-  usage?: DroidUsageMetadata;
-  /** Error message for error events */
-  error?: string;
-  /** The newly active backend for backend_switch events */
-  new_backend?: string;
-  /** The model within the new backend */
-  new_model?: string;
-  /** Session ID for persistence */
-  session_id?: string;
+interface DroidUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
 }
 
 /**
- * Token usage metadata from Droid LiteLLM-compatible output.
+ * A single content block inside a Claude-Code `assistant` message.
  *
- * WHY: Droid reports standard token counts but the cost depends on which
- * backend and model were used. We compute cost using our LITELLM_PRICING table
- * rather than relying on Droid to report costs, since the BYOK model means
- * users may have custom pricing through their provider contracts.
+ * UNVERIFIED (#30): the assistant/tool envelope was not captured (no auth).
+ * Shape is inferred from the Claude-Code stream-json schema that Droid's
+ * init event advertises (tools list + `model` mirror Claude Code exactly).
+ * Treat as best-effort until a keyed session confirms it.
  */
-interface DroidUsageMetadata {
-  /** Input tokens for this request */
-  prompt_tokens?: number;
-  /** Output tokens for this request */
-  completion_tokens?: number;
-  /** Cache read tokens (provider-specific) */
-  cache_read_tokens?: number;
-  /** Cache write tokens (provider-specific) */
-  cache_write_tokens?: number;
-  /** Pre-computed cost in USD (used if available, otherwise estimated) */
-  cost_usd?: number;
-  /** Which backend/model generated this usage (for multi-backend sessions) */
+interface DroidContentBlock {
+  type?: string;
+  /** text for `{type:'text'}` blocks */
+  text?: string;
+  /** tool name for `{type:'tool_use'}` blocks */
+  name?: string;
+  /** tool call id for `{type:'tool_use'}` blocks */
+  id?: string;
+  /** tool input for `{type:'tool_use'}` blocks */
+  input?: Record<string, unknown>;
+  /** correlating id for `{type:'tool_result'}` blocks */
+  tool_use_id?: string;
+  /** result payload for `{type:'tool_result'}` blocks */
+  content?: unknown;
+}
+
+/**
+ * A parsed line of Droid `stream-json` / `json` output.
+ *
+ * `system`/`init`, `error`, and `result` are VERIFIED. `assistant`/`user`
+ * (which carry the content blocks above) are UNVERIFIED (#30).
+ */
+interface DroidStreamMessage {
+  type?: 'system' | 'assistant' | 'user' | 'result' | 'error';
+  subtype?: string;
+  session_id?: string;
+  /** result event: assistant's final text */
+  result?: string;
+  /** result event: whether the run errored */
+  is_error?: boolean;
+  /** result event: token usage */
+  usage?: DroidUsage;
+  /** error event: human-readable message */
+  message?: string | { content?: DroidContentBlock[] };
+  /** error event: origin (e.g. 'cli') */
+  source?: string;
+  /** init event: model id */
   model?: string;
 }
 
@@ -273,16 +212,16 @@ interface DroidUsageMetadata {
  * Parse a single JSON line from Droid's output.
  *
  * @param line - A single line of Droid stdout (expected to be JSON)
- * @returns Parsed DroidJsonMessage or null if the line is not valid JSON
+ * @returns Parsed DroidStreamMessage or null if the line is not valid JSON
  */
-function parseDroidJsonLine(line: string): DroidJsonMessage | null {
+function parseDroidJsonLine(line: string): DroidStreamMessage | null {
   const trimmed = line.trim();
   if (!trimmed || !trimmed.startsWith('{')) {
     return null;
   }
 
   try {
-    return JSON.parse(trimmed) as DroidJsonMessage;
+    return JSON.parse(trimmed) as DroidStreamMessage;
   } catch {
     return null;
   }
@@ -291,10 +230,9 @@ function parseDroidJsonLine(line: string): DroidJsonMessage | null {
 /**
  * Extract a file path from Droid tool input arguments.
  *
- * Droid normalizes tool input across different LLM backends, but field names
- * may still vary. We check multiple common names to extract the path.
+ * UNVERIFIED (#30): field names inferred from Claude-Code tool schemas.
  *
- * @param toolInput - Tool input arguments from a tool_call event
+ * @param toolInput - Tool input arguments from a tool_use block
  * @returns File path string or null if not found
  */
 function extractDroidFilePath(toolInput?: Record<string, unknown>): string | null {
@@ -311,14 +249,18 @@ function extractDroidFilePath(toolInput?: Record<string, unknown>): string | nul
 /**
  * Determine if a Droid tool call modifies the file system.
  *
- * @param toolName - The Droid tool name (normalized by LiteLLM)
+ * UNVERIFIED (#30): tool-name patterns inferred from Droid's advertised tool
+ * list (Edit, Create, ApplyPatch) plus common Claude-Code tool names.
+ *
+ * @param toolName - The tool name from a tool_use block
  * @returns true if this tool writes or modifies files
  */
 function isDroidFileEditTool(toolName: string): boolean {
   const fileEditPatterns = [
     'write',
     'edit',
-    'create_file',
+    'create',
+    'applypatch',
     'patch',
     'str_replace',
     'apply_diff',
@@ -336,9 +278,10 @@ function isDroidFileEditTool(toolName: string): boolean {
 /**
  * Droid Backend implementation.
  *
- * Spawns Droid as a subprocess with JSON output and parses LiteLLM-compatible
- * events. Handles multi-backend sessions, BYOK key injection, and cost estimation
- * from the LiteLLM pricing table for unified cost reporting.
+ * Spawns `droid exec` with `--output-format stream-json` and parses the
+ * Claude-Code-shaped NDJSON event stream. Token usage is taken from the
+ * VERIFIED `result` event; cost is left to Styrby's central cost layer
+ * (Droid does not self-report cost).
  */
 class DroidBackend extends StreamingAgentBackendBase {
   protected readonly logTag = 'DroidBackend';
@@ -348,9 +291,8 @@ class DroidBackend extends StreamingAgentBackendBase {
   private outputTokens = 0;
   private cacheReadTokens = 0;
   private cacheWriteTokens = 0;
-  private totalCostUsd = 0;
-  // WHY: Track the current active backend model so we can use the correct
-  // LiteLLM pricing for cost estimation after backend_switch events.
+  // WHY: Track the resolved model so the emitted CostReport carries the model
+  // the central cost layer needs to price the run.
   private currentModel: string | undefined;
 
   constructor(private options: DroidBackendOptions) {
@@ -359,148 +301,181 @@ class DroidBackend extends StreamingAgentBackendBase {
   }
 
   /**
-   * Handle a parsed Droid JSON message and emit AgentMessages.
+   * Handle a parsed Droid stream-json message and emit AgentMessages.
    *
-   * WHY: The backend_switch event is Droid-specific — it fires when the BYOK
-   * session switches to a different LLM backend mid-conversation. We track the
-   * new model so subsequent cost estimates use the correct LiteLLM pricing.
-   *
-   * @param msg - The parsed Droid JSON message
+   * @param msg - The parsed Droid stream message
    */
-  private handleDroidMessage(msg: DroidJsonMessage): void {
+  private handleDroidMessage(msg: DroidStreamMessage): void {
     if (msg.session_id) {
       this.droidSessionId = msg.session_id;
     }
 
     switch (msg.type) {
-      case 'text':
-        if (msg.content) {
-          this.emit({ type: 'model-output', textDelta: msg.content });
+      case 'system':
+        // VERIFIED: {"type":"system","subtype":"init", model, session_id, tools}
+        // WHY: the init event is the authoritative source of the model Droid
+        // actually resolved (it may differ from our requested model if Droid
+        // applied a default). Capture it for accurate cost attribution.
+        if (msg.subtype === 'init' && msg.model) {
+          this.currentModel = msg.model;
         }
         break;
 
-      case 'tool_call':
-        if (msg.tool_name && msg.call_id) {
-          this.emit({
-            type: 'tool-call',
-            toolName: msg.tool_name,
-            args: msg.tool_input ?? {},
-            callId: msg.call_id,
-          });
-        }
+      case 'assistant':
+        // UNVERIFIED (#30): assistant content-block envelope not captured under
+        // a keyed session. Parsed best-effort per the Claude-Code schema.
+        this.handleAssistantBlocks(msg);
         break;
 
-      case 'tool_result':
-        if (msg.call_id && msg.tool_name) {
-          this.emit({
-            type: 'tool-result',
-            toolName: msg.tool_name,
-            result: msg.tool_result,
-            callId: msg.call_id,
-          });
-
-          // Detect file edits from tool name and emit fs-edit event
-          if (isDroidFileEditTool(msg.tool_name)) {
-            const filePath = extractDroidFilePath(msg.tool_input);
-            if (filePath) {
-              this.emit({
-                type: 'fs-edit',
-                description: `${msg.tool_name}: ${filePath}`,
-                path: filePath,
-              });
-            }
-          }
-        }
+      case 'user':
+        // UNVERIFIED (#30): `user` events carry tool_result blocks in the
+        // Claude-Code schema. Parsed best-effort.
+        this.handleToolResultBlocks(msg);
         break;
 
-      case 'usage':
-        // WHY: Droid emits usage after each model response. If cost_usd is
-        // provided by the backend, prefer it. Otherwise, estimate from
-        // token counts using the LiteLLM pricing table. This handles the
-        // common case where the LLM provider reports tokens but not cost.
-        if (msg.usage) {
-          const usageModel = msg.usage.model ?? this.currentModel ?? 'unknown';
-          const newInput = msg.usage.prompt_tokens ?? 0;
-          const newOutput = msg.usage.completion_tokens ?? 0;
-          const newCacheRead = msg.usage.cache_read_tokens ?? 0;
-          const newCacheWrite = msg.usage.cache_write_tokens ?? 0;
-
-          this.inputTokens += newInput;
-          this.outputTokens += newOutput;
-          this.cacheReadTokens += newCacheRead;
-          this.cacheWriteTokens += newCacheWrite;
-
-          const hasAgentCost = msg.usage.cost_usd !== undefined;
-          const incrCost = hasAgentCost
-            ? msg.usage.cost_usd!
-            : estimateCostFromTokens(usageModel, newInput, newOutput);
-          this.totalCostUsd += incrCost;
-
-          // Emit legacy token-count (keep for existing consumers)
-          this.emit({
-            type: 'token-count',
-            inputTokens: this.inputTokens,
-            outputTokens: this.outputTokens,
-            cacheReadTokens: this.cacheReadTokens,
-            cacheWriteTokens: this.cacheWriteTokens,
-            costUsd: this.totalCostUsd,
-          });
-
-          // WHY: Emit unified CostReport. source='agent-reported' when Droid's
-          // LiteLLM backend provides cost_usd directly; 'styrby-estimate' when
-          // we compute it from the LiteLLM pricing table (BYOK model).
-          // rawAgentPayload=null for estimates (schema refinement 3).
-          const costReport: CostReport = {
-            sessionId: this.sessionId ?? '',
-            messageId: null,
-            agentType: 'droid',
-            model: usageModel,
-            timestamp: new Date().toISOString(),
-            source: hasAgentCost ? 'agent-reported' : 'styrby-estimate',
-            billingModel: 'api-key',
-            costUsd: incrCost,
-            inputTokens: newInput,
-            outputTokens: newOutput,
-            cacheReadTokens: newCacheRead,
-            cacheWriteTokens: newCacheWrite,
-            rawAgentPayload: hasAgentCost ? (msg.usage as unknown as Record<string, unknown>) : null,
-          };
-          this.emit({ type: 'cost-report', report: costReport });
-        }
-        break;
-
-      case 'backend_switch':
-        // WHY: Droid can switch LLM backends mid-session. When this happens,
-        // we update currentModel so future cost estimates use the correct pricing.
-        // We also emit an event so the mobile app can show "Switched to GPT-4o".
-        if (msg.new_backend || msg.new_model) {
-          const switchedModel = msg.new_model ?? msg.new_backend ?? 'unknown';
-          this.currentModel = switchedModel;
-          this.emit({
-            type: 'event',
-            name: 'backend-switch',
-            payload: {
-              newBackend: msg.new_backend,
-              newModel: msg.new_model,
-            },
-          });
-        }
+      case 'result':
+        // VERIFIED: final event carrying usage + the assistant's full text.
+        this.handleResult(msg);
         break;
 
       case 'error':
+        // VERIFIED: {"type":"error","source","message","timestamp","session_id"}
         this.emit({
           type: 'status',
           status: 'error',
-          detail: msg.error ?? 'Droid encountered an error',
+          detail: typeof msg.message === 'string' ? msg.message : 'Droid encountered an error',
         });
         break;
 
-      case 'done':
-        this.emit({ type: 'status', status: 'idle' });
-        break;
-
       default:
-        logger.debug('[DroidBackend] Unknown message type:', msg);
+        logger.debug('[DroidBackend] Unhandled message type:', msg);
+    }
+  }
+
+  /**
+   * Emit model-output / tool-call events from a (UNVERIFIED) assistant message.
+   *
+   * @param msg - An `assistant` stream message
+   */
+  private handleAssistantBlocks(msg: DroidStreamMessage): void {
+    const blocks =
+      msg.message && typeof msg.message === 'object' ? msg.message.content ?? [] : [];
+
+    for (const block of blocks) {
+      if (block.type === 'text' && block.text) {
+        this.emit({ type: 'model-output', textDelta: block.text });
+      } else if (block.type === 'tool_use' && block.name && block.id) {
+        this.emit({
+          type: 'tool-call',
+          toolName: block.name,
+          args: block.input ?? {},
+          callId: block.id,
+        });
+      }
+    }
+  }
+
+  /**
+   * Emit tool-result / fs-edit events from a (UNVERIFIED) user message.
+   *
+   * @param msg - A `user` stream message carrying tool_result blocks
+   */
+  private handleToolResultBlocks(msg: DroidStreamMessage): void {
+    const blocks =
+      msg.message && typeof msg.message === 'object' ? msg.message.content ?? [] : [];
+
+    for (const block of blocks) {
+      if (block.type === 'tool_result' && block.tool_use_id) {
+        this.emit({
+          type: 'tool-result',
+          toolName: block.name ?? 'unknown',
+          result: block.content,
+          callId: block.tool_use_id,
+        });
+
+        if (block.name && isDroidFileEditTool(block.name)) {
+          const filePath = extractDroidFilePath(block.input);
+          if (filePath) {
+            this.emit({
+              type: 'fs-edit',
+              description: `${block.name}: ${filePath}`,
+              path: filePath,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Handle the VERIFIED `result` event: emit final text, token counts, and a
+   * unified CostReport.
+   *
+   * @param msg - A `result` stream message
+   */
+  private handleResult(msg: DroidStreamMessage): void {
+    // Emit the assistant's final text if present (the result event carries the
+    // full answer even when streaming deltas weren't captured).
+    if (typeof msg.result === 'string' && msg.result) {
+      this.emit({ type: 'model-output', textDelta: msg.result });
+    }
+
+    if (msg.usage) {
+      // VERIFIED usage field names (Claude-Code snake_case).
+      const newInput = msg.usage.input_tokens ?? 0;
+      const newOutput = msg.usage.output_tokens ?? 0;
+      const newCacheRead = msg.usage.cache_read_input_tokens ?? 0;
+      const newCacheWrite = msg.usage.cache_creation_input_tokens ?? 0;
+
+      this.inputTokens += newInput;
+      this.outputTokens += newOutput;
+      this.cacheReadTokens += newCacheRead;
+      this.cacheWriteTokens += newCacheWrite;
+
+      const usageModel = this.currentModel ?? 'unknown';
+
+      // Emit legacy token-count (keep for existing consumers). Droid does not
+      // report cost, so costUsd is left 0 here; the central cost layer prices it.
+      this.emit({
+        type: 'token-count',
+        inputTokens: this.inputTokens,
+        outputTokens: this.outputTokens,
+        cacheReadTokens: this.cacheReadTokens,
+        cacheWriteTokens: this.cacheWriteTokens,
+        costUsd: 0,
+      });
+
+      // WHY: Emit unified CostReport with source='styrby-estimate' because
+      // Droid never reports cost_usd — pricing is always derived downstream
+      // from token counts + the Factory model. rawAgentPayload carries the
+      // real usage block so the cost layer can re-derive if needed.
+      const costReport: CostReport = {
+        sessionId: this.sessionId ?? '',
+        messageId: null,
+        agentType: 'droid',
+        model: usageModel,
+        timestamp: new Date().toISOString(),
+        source: 'styrby-estimate',
+        billingModel: 'api-key',
+        costUsd: 0,
+        inputTokens: newInput,
+        outputTokens: newOutput,
+        cacheReadTokens: newCacheRead,
+        cacheWriteTokens: newCacheWrite,
+        rawAgentPayload: msg.usage as unknown as Record<string, unknown>,
+      };
+      this.emit({ type: 'cost-report', report: costReport });
+    }
+
+    // The result event terminates the turn.
+    if (msg.is_error) {
+      this.emit({
+        type: 'status',
+        status: 'error',
+        detail: typeof msg.result === 'string' ? msg.result : 'Droid run failed',
+      });
+    } else {
+      this.emit({ type: 'status', status: 'idle' });
     }
   }
 
@@ -530,8 +505,8 @@ class DroidBackend extends StreamingAgentBackendBase {
   /**
    * Start a new Droid session.
    *
-   * Resets all token/cost accumulators. If a resumeSessionId was provided
-   * in options, Droid will resume that session's conversation context.
+   * Resets all token accumulators. If a resumeSessionId/forkSessionId was
+   * provided in options, the first prompt will continue/fork that session.
    *
    * @param initialPrompt - Optional prompt to send immediately after session start
    * @returns Promise resolving to the session information
@@ -543,13 +518,12 @@ class DroidBackend extends StreamingAgentBackendBase {
     }
 
     this.sessionId = randomUUID();
-    this.droidSessionId = this.options.resumeSessionId ?? null;
+    this.droidSessionId = this.options.resumeSessionId ?? this.options.forkSessionId ?? null;
     this.currentModel = this.options.model;
     this.inputTokens = 0;
     this.outputTokens = 0;
     this.cacheReadTokens = 0;
     this.cacheWriteTokens = 0;
-    this.totalCostUsd = 0;
     this.lineBuffer = '';
 
     this.emit({ type: 'status', status: 'starting' });
@@ -567,10 +541,55 @@ class DroidBackend extends StreamingAgentBackendBase {
   }
 
   /**
+   * Build the `droid exec` argument vector for a prompt.
+   *
+   * Real form (verified `droid exec --help`, v0.144.2):
+   *   droid exec <prompt> --output-format stream-json [--fork <id> | -s <id>]
+   *     [-m <model>] [--auto <level>] [...extraArgs]
+   *
+   * @param prompt - The user's prompt text (positional argument)
+   * @returns The argv array passed to spawn (excluding the binary name)
+   */
+  private buildArgs(prompt: string): string[] {
+    const args: string[] = [
+      'exec',
+      prompt, // positional prompt — NOT a --message flag
+      '--output-format',
+      'stream-json', // incremental NDJSON events (verified valid choice)
+    ];
+
+    // Session continuation: fork takes precedence over resume (they share the
+    // same underlying session-id; both require a prompt, which we always pass).
+    if (this.options.forkSessionId) {
+      args.push('--fork', this.options.forkSessionId);
+    } else if (this.droidSessionId) {
+      args.push('-s', this.droidSessionId);
+    }
+
+    // Model override (-m/--model). Default is claude-opus-4-8 when omitted.
+    if (this.options.model) {
+      args.push('-m', this.options.model);
+    }
+
+    // Autonomy: omit to keep Droid's safe read-only default; only raise when
+    // the caller explicitly opts in.
+    if (this.options.autoLevel) {
+      args.push('--auto', this.options.autoLevel);
+    }
+
+    // Extra args (validated for shell safety — SEC-ARGS-001)
+    if (this.options.extraArgs) {
+      args.push(...validateExtraArgs(this.options.extraArgs));
+    }
+
+    return args;
+  }
+
+  /**
    * Send a prompt to Droid.
    *
-   * Spawns a Droid subprocess with JSON output. BYOK API keys are injected
-   * via environment variables so they are never logged in process arguments.
+   * Spawns `droid exec`. The Factory API key (if supplied) is injected via the
+   * environment so it never appears in process arguments.
    *
    * @param sessionId - The active session ID (must match startSession result)
    * @param prompt - The user's prompt text
@@ -592,75 +611,26 @@ class DroidBackend extends StreamingAgentBackendBase {
     this.lineBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
-    // Build Droid command arguments
-    const args: string[] = [
-      'chat',             // Droid subcommand for one-shot prompt
-      '--message',
-      prompt,
-      '--format',
-      'json',             // Request structured JSON output
-      '--no-interactive', // Prevent blocking on stdin
-    ];
-
-    // Resume an existing session for context continuity
-    if (this.droidSessionId) {
-      args.push('--session', this.droidSessionId);
-    }
-
-    // Backend override
-    if (this.options.backend) {
-      args.push('--backend', this.options.backend);
-    }
-
-    // Model override
-    if (this.options.model) {
-      args.push('--model', this.options.model);
-    }
-
-    // Extra args (validated for shell safety — SEC-ARGS-001)
-    if (this.options.extraArgs) {
-      args.push(...validateExtraArgs(this.options.extraArgs));
-    }
+    const args = this.buildArgs(prompt);
 
     logger.debug(`[DroidBackend] Spawning droid with args:`, args);
 
-    // Build the API key environment overrides.
-    // WHY: BYOK keys must be passed as environment variables, not CLI flags,
-    // to prevent them from appearing in process lists (ps aux).
-    //
-    // SECURITY (audit 2026-05-05 HIGH fix): the previous "inject under every
-    // provider name" pattern leaked sk-ant-* keys to OpenAI / Google /
-    // Mistral validation endpoints. resolveApiKeyEnv() restricts to the
-    // detected provider; the apiKeys map below still allows callers that
-    // genuinely DO have multi-provider keys to pass them explicitly.
-    const apiKeyEnv: Record<string, string> = {
-      ...resolveApiKeyEnv(
-        this.options.apiKey,
-        ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_API_KEY', 'MISTRAL_API_KEY'],
-        // Droid options don't expose an explicit provider yet; rely on sniff.
-        undefined,
-        'DroidBackend',
-      ),
-    };
-    // SECURITY: Only forward keys that look like API key env vars.
-    // Without this check, a malicious caller could inject LD_PRELOAD,
-    // DYLD_INSERT_LIBRARIES, or other vars that alter process behavior.
-    if (this.options.apiKeys) {
-      const API_KEY_PATTERN = /^[A-Z][A-Z0-9_]*_(API_KEY|KEY|TOKEN|SECRET)$/;
-      for (const [key, value] of Object.entries(this.options.apiKeys)) {
-        if (API_KEY_PATTERN.test(key)) {
-          apiKeyEnv[key] = value;
-        } else {
-          logger.warn(`[DroidBackend] Ignoring non-API-key env var in apiKeys: "${key}"`);
-        }
-      }
+    // Build the Factory API key environment override.
+    // WHY: Droid authenticates against Factory only (FACTORY_API_KEY). It is
+    // NOT a multi-provider BYOK proxy, so we do NOT inject ANTHROPIC_API_KEY /
+    // OPENAI_API_KEY / etc. (the prior fan-out was based on a wrong assumption
+    // about Droid being a LiteLLM agent). The key goes in the environment, not
+    // a CLI flag, to keep it out of `ps aux`.
+    const apiKeyEnv: Record<string, string> = {};
+    if (this.options.factoryApiKey) {
+      apiKeyEnv.FACTORY_API_KEY = this.options.factoryApiKey;
     }
 
     return new Promise<void>((resolve, reject) => {
       try {
         // SECURITY: Use buildSafeEnv() to prevent leaking internal Styrby
-        // secrets to the Droid subprocess. Only allowlisted system vars and
-        // explicitly injected BYOK keys are forwarded.
+        // secrets to the Droid subprocess. Only allowlisted system vars and the
+        // explicitly injected Factory key are forwarded.
         this.process = spawn('droid', args, {
           cwd: this.options.cwd,
           env: buildSafeEnv({
@@ -674,7 +644,7 @@ class DroidBackend extends StreamingAgentBackendBase {
           throw new Error('Failed to create stdio pipes');
         }
 
-        // Handle stdout — JSON messages from Droid
+        // Handle stdout — stream-json messages from Droid
         this.process.stdout.on('data', (data: Buffer) => {
           this.processStdout(data);
         });
@@ -762,7 +732,7 @@ class DroidBackend extends StreamingAgentBackendBase {
   /**
    * Cancel the current Droid operation.
    *
-   * WHY: Droid may be mid-stream with an LLM API call when cancelled.
+   * WHY: Droid may be mid-stream with a model API call when cancelled.
    * SIGTERM allows Droid to close its HTTP connection cleanly and avoid
    * billing the user for a partial response.
    *
@@ -791,8 +761,9 @@ class DroidBackend extends StreamingAgentBackendBase {
   /**
    * Respond to a Droid permission request.
    *
-   * In non-interactive mode (--no-interactive), Droid auto-approves most actions.
-   * This method handles responses for the interactive permission flow.
+   * NOTE: `droid exec` is non-interactive — permissions are governed by the
+   * `--auto` level, not an interactive y/n prompt. This handler remains for
+   * interface compatibility and best-effort stdin signalling.
    *
    * @param requestId - The ID of the permission request
    * @param approved - Whether the user approved the request
@@ -826,34 +797,24 @@ class DroidBackend extends StreamingAgentBackendBase {
 /**
  * Create a Droid backend.
  *
- * Droid is a BYOK AI coding agent supporting multiple LLM backends through
- * the LiteLLM proxy protocol. Users supply their own API keys for maximum
- * flexibility. Cost tracking uses LiteLLM pricing tables as fallback estimates.
+ * Droid is Factory AI's hosted terminal coding agent. It is invoked headlessly
+ * via `droid exec <prompt> --output-format stream-json` and authenticates
+ * against Factory (interactive login or `FACTORY_API_KEY`). Cost is derived
+ * downstream from the token counts in Droid's `result` event.
  *
  * The droid binary must be installed and available in PATH.
- * Install via: `npm install -g droid` (other methods at https://docs.factory.ai/cli)
+ * Install via: https://docs.factory.ai/cli/getting-started/overview
  *
  * @param options - Configuration options for the backend
  * @returns DroidBackendResult with backend instance and resolved model
  *
  * @example
  * ```ts
- * // Use with Anthropic API key
  * const { backend } = createDroidBackend({
  *   cwd: '/path/to/project',
- *   backend: 'anthropic',
- *   model: 'claude-sonnet-4',
- *   apiKey: process.env.ANTHROPIC_API_KEY,
- * });
- *
- * // Use with multiple provider keys
- * const { backend } = createDroidBackend({
- *   cwd: '/path/to/project',
- *   model: 'gpt-4o',
- *   apiKeys: {
- *     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
- *     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
- *   },
+ *   model: 'claude-opus-4-8',
+ *   factoryApiKey: process.env.FACTORY_API_KEY,
+ *   autoLevel: 'medium',
  * });
  *
  * const { sessionId } = await backend.startSession();
@@ -864,10 +825,10 @@ export function createDroidBackend(options: DroidBackendOptions): DroidBackendRe
   logger.debug('[Droid] Creating backend with options:', {
     cwd: options.cwd,
     model: options.model,
-    backend: options.backend,
-    hasApiKey: !!options.apiKey,
-    hasApiKeys: !!(options.apiKeys && Object.keys(options.apiKeys).length > 0),
+    autoLevel: options.autoLevel,
+    hasFactoryApiKey: !!options.factoryApiKey,
     resumeSessionId: options.resumeSessionId,
+    forkSessionId: options.forkSessionId,
   });
 
   return {

--- a/packages/styrby-cli/src/agent/factories/goose.ts
+++ b/packages/styrby-cli/src/agent/factories/goose.ts
@@ -6,13 +6,22 @@
  * licensed under Apache 2.0. It uses the Model Context Protocol (MCP)
  * for tool interactions and outputs structured JSON event lines.
  *
- * Key characteristics:
- * - Binary name: `goose` (installed via `pip install goose-ai` or homebrew)
- * - Config: `~/.config/goose/config.yaml`
- * - Output: JSONL (one JSON object per line) via MCP protocol
- * - Cost tracking: token usage embedded in MCP response metadata
- * - Supports MCP servers for extensible tool integrations
- * - Each run is a session with a persistent session ID
+ * Key characteristics (verified against the real `goose` binary v1.37.0,
+ * 2026-06-10 — `goose --help` / `goose run --help`):
+ * - Binary name: `goose` (a single self-contained Rust binary; NOT a pip/brew
+ *   `goose-ai` package — that is a different, unrelated project). Install per
+ *   https://github.com/aaif-goose/goose (download script / release artifact).
+ * - Config: `~/.config/goose/config.yaml` (provider + model live here)
+ * - Headless run: `goose run -t/--text <prompt>` (or `-i -` to read the prompt
+ *   from stdin). `run` is non-interactive by DEFAULT; `-s/--interactive` opts
+ *   *into* an interactive session afterward. There is NO `--no-interactive`
+ *   flag (the old code invented one).
+ * - Structured output: `--output-format <text|json|stream-json>` (default
+ *   `text`). There is NO `--format jsonl` flag (the old code invented one).
+ *   We request `stream-json` for incremental parsing.
+ * - `--no-session` runs without writing a session file (good for automation).
+ * - Model / provider overrides: `--model <M>` / `--provider <P>`.
+ * - Session naming / resume: `-n/--name <NAME>` (+ `-r/--resume`).
  *
  * WHY Apache 2.0 matters: Goose's license allows us to integrate it as a
  * backend without license compatibility concerns. We must retain the Goose
@@ -21,6 +30,14 @@
  * Repo transferred 2026-04-07 from Block to the AI Alliance / Linux Foundation
  * (`block/goose` → `aaif-goose/goose`). GitHub redirects the old URL but new
  * docs and releases land at the new home.
+ *
+ * SCHEMA STATUS (#30 — UNVERIFIED): the per-line event schema emitted by
+ * `--output-format stream-json` could NOT be captured because the local
+ * environment has no provider configured (`goose run` aborts with "No provider
+ * configured. Run 'goose configure' first."). The parser below maps a BEST-
+ * GUESS event shape and is explicitly flagged as needing a real keyed session
+ * to confirm. Until then, NON-JSON / unknown lines fall through harmlessly to a
+ * debug log — the invocation is correct even if the parser is not yet proven.
  *
  * @see https://github.com/aaif-goose/goose
  * @module factories/goose
@@ -70,8 +87,11 @@ export interface GooseBackendOptions extends AgentFactoryOptions {
   provider?: string;
 
   /**
-   * Whether to disable interactive mode (always true for Styrby).
-   * Goose's --non-interactive flag prevents it from prompting for user input.
+   * Retained for API/back-compat. `goose run` is already non-interactive by
+   * default (it does NOT have a `--no-interactive` flag — the old code invented
+   * one). When this is left at its default (true) we additionally pass
+   * `--no-session` so automated runs do not litter the session DB. Set to
+   * `false` to keep a persistent session file (e.g. to later `--resume`).
    * Default: true
    */
   nonInteractive?: boolean;
@@ -106,11 +126,26 @@ export interface GooseBackendResult {
 // ============================================================================
 
 /**
- * Goose JSONL output event types.
+ * Goose `--output-format stream-json` event types.
  *
- * WHY: Goose outputs structured JSON lines via its MCP integration.
- * Each line represents a distinct event (message, tool call, cost data, etc.).
- * These types mirror Goose's actual output format so we can parse it reliably.
+ * SCHEMA UNVERIFIED (#30): goose emits one JSON object per line when
+ * `--output-format stream-json` is set, but the exact field names + the set of
+ * `type` values below are a BEST-GUESS. They could not be confirmed because the
+ * local box has no provider configured, so no real authed run could be
+ * captured. In particular:
+ *   - The `{ type: 'cost', usage: { cost_usd } }` shape is ASSUMED. goose's
+ *     internal model tracks tokens via session-DB columns
+ *     (`accumulated_input_tokens` / `accumulated_output_tokens` / `total_tokens`
+ *     / `accumulated_cost`) and an Anthropic-style `Usage` block
+ *     (`input_tokens`, `output_tokens`, `cache_read_input_tokens`,
+ *     `cache_creation_input_tokens`) — but whether a per-line `type:'cost'`
+ *     event with a `cost_usd` field is actually emitted is NOT confirmed.
+ *   - `message` / `tool_call` / `tool_result` / `error` / `status` / `finish`
+ *     are likewise best-guess `type` discriminants.
+ * TODO(#30): once a keyed `goose configure` session is available, capture real
+ * `stream-json` output and replace these guesses with the verified schema.
+ * Until then the parser is intentionally tolerant: unknown lines are logged and
+ * dropped rather than throwing, so a wrong guess degrades gracefully.
  */
 interface GooseJsonEvent {
   type: 'message' | 'tool_call' | 'tool_result' | 'cost' | 'error' | 'status' | 'finish';
@@ -309,8 +344,14 @@ class GooseBackend extends StreamingAgentBackendBase {
         break;
 
       case 'cost':
-        // WHY: Goose emits a cost event after each model response with MCP usage data.
-        // We accumulate these across the session for accurate total cost reporting.
+        // SCHEMA UNVERIFIED (#30): this assumes goose emits a per-line
+        // `{ type:'cost', usage:{...} }` event with an optional `cost_usd`.
+        // That shape is NOT confirmed against a real authed run (see the
+        // GooseJsonEvent doc). If goose instead surfaces usage on a different
+        // event (e.g. a final `finish`/`result` line carrying accumulated
+        // tokens), this branch will simply never fire and no cost is reported —
+        // a graceful degradation, not a crash. Revisit once #30 captures the
+        // real stream-json output.
         if (event.usage) {
           const prevCostUsd = this.totalCostUsd;
           this.inputTokens += event.usage.input_tokens ?? 0;
@@ -459,8 +500,10 @@ class GooseBackend extends StreamingAgentBackendBase {
   /**
    * Send a prompt to Goose.
    *
-   * Spawns a Goose subprocess with the prompt. Uses --format jsonl to get
-   * structured output. Uses --non-interactive to prevent blocking on stdin.
+   * Spawns `goose run -t <prompt> --output-format stream-json` (plus
+   * `--no-session` for ephemeral runs). `run` is non-interactive by default, so
+   * no stdin blocking occurs. See the real flags documented in the module
+   * header (verified against `goose run --help`, v1.37.0).
    *
    * @param sessionId - The active session ID (must match the one from startSession)
    * @param prompt - The user's prompt text
@@ -482,35 +525,43 @@ class GooseBackend extends StreamingAgentBackendBase {
     this.lineBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
-    // Build Goose command arguments
+    // Build Goose command arguments.
+    //
+    // VERIFIED against `goose run --help` (binary v1.37.0, 2026-06-10):
+    //   goose run -t <prompt> --output-format stream-json [--no-session]
+    //             [--model M] [--provider P] [-n NAME]
+    //
+    // `run` is one-shot + non-interactive by default. `--output-format` accepts
+    // text | json | stream-json (default text); we request stream-json for
+    // incremental line-by-line parsing. NOTE: the previously-used `--format
+    // jsonl` and `--no-interactive` flags DO NOT EXIST and have been removed.
     const args: string[] = [
-      'run',          // Subcommand for running a one-shot prompt
-      '--text',       // Pass prompt as text argument (non-interactive)
+      'run',                      // one-shot, non-interactive headless run
+      '--text',                   // pass the prompt inline (alias: -t)
       prompt,
-      '--format',
-      'jsonl',        // Request structured JSONL output for parsing
+      '--output-format',
+      'stream-json',              // line-delimited JSON events (schema unverified, #30)
     ];
 
-    // WHY: Always run non-interactively. Goose may prompt for user input
-    // in interactive mode (e.g., permission requests). Since the mobile app
-    // handles permissions via the permission-request/response message flow,
-    // we auto-approve at the CLI level and rely on the server-side flow.
-    const nonInteractive = this.options.nonInteractive !== false;
-    if (nonInteractive) {
-      args.push('--no-interactive');
+    // WHY: by default we also pass --no-session so automated mobile-driven runs
+    // do not accumulate session files in goose's local sqlite DB. Callers that
+    // want a resumable session (sessionName / --resume) set nonInteractive:false
+    // to keep the session file. This replaces the invented --no-interactive
+    // flag; `run` is already non-interactive regardless.
+    const useEphemeralSession = this.options.nonInteractive !== false;
+    if (useEphemeralSession && !this.options.sessionName) {
+      args.push('--no-session');
     }
 
-    // Add model if specified
+    // Override the configured provider/model for this run (real flags).
     if (this.options.model) {
       args.push('--model', this.options.model);
     }
-
-    // Add provider if specified
     if (this.options.provider) {
       args.push('--provider', this.options.provider);
     }
 
-    // Resume an existing session if session name is provided
+    // Name (and implicitly enable) a persistent session for later --resume.
     if (this.options.sessionName) {
       args.push('--name', this.options.sessionName);
     }
@@ -738,9 +789,10 @@ class GooseBackend extends StreamingAgentBackendBase {
  * 2026-04-07. Apache 2.0. Uses Model Context Protocol (MCP) for tool
  * integrations and outputs structured JSONL events.
  *
- * The goose binary must be installed and available in PATH.
- * Install via: `pip install goose-ai` or `brew install pivotal/tap/goose-ai`
- * (See https://github.com/aaif-goose/goose for current install instructions.)
+ * The goose binary must be installed and available in PATH (it is a single
+ * self-contained Rust binary, NOT the unrelated `goose-ai` pip/brew package).
+ * See https://github.com/aaif-goose/goose for the current install script /
+ * release artifacts.
  *
  * @param options - Configuration options for the backend
  * @returns GooseBackendResult with backend instance and resolved model

--- a/packages/styrby-cli/src/agent/factories/kilo.ts
+++ b/packages/styrby-cli/src/agent/factories/kilo.ts
@@ -1,28 +1,28 @@
 /**
- * Kilo Backend - Kilo CLI agent adapter (Community, 500+ models)
+ * Kilo Backend - Kilo CLI agent adapter (OpenCode fork, 500+ models)
  *
  * This module provides a factory function for creating a Kilo backend.
- * Kilo is a community-driven AI coding agent designed for maximum model
- * flexibility (500+ supported models) and a unique Memory Bank feature
- * that persists structured knowledge across sessions.
+ * Kilo is a fork of OpenCode (https://github.com/Kilo-Org/kilocode) with the
+ * same headless CLI surface: `kilo run <message> --format json` emits
+ * newline-delimited JSON events.
  *
- * Key characteristics:
- * - Binary name: `kilo` (installed via npm or direct download)
- * - Config: `~/.config/kilo/config.json`
- * - Output: Custom JSON protocol with Memory Bank read/write events
- * - Cost tracking: token usage in `tokens` events from JSON stream
- * - Memory Bank: persists project knowledge (architecture, decisions, patterns)
- *   across agent restarts — users never re-explain the same context twice
- * - 500+ models: any OpenAI-compatible API endpoint can be used as a backend
+ * Key characteristics (VERIFIED against the real `kilo` binary, v7.3.41,
+ * 2026-06-11 via `kilo --help` / `kilo run --help`):
+ * - Binary name: `kilo`
+ * - Headless: `kilo run <message..>` — POSITIONAL message (no `--prompt` flag)
+ * - `--format` accepts `default | json` (json = raw JSON events)
+ * - `-m/--model` (provider/model format), `-s/--session <id>`, `-c/--continue`,
+ *   `--fork`, `--auto` (auto-approve permissions for pipeline use)
+ * - There is NO `--output`, NO `--no-interactive`, NO `--memory-bank`,
+ *   NO `--api-base`, NO `--resume`. Those were invented by the prior adapter.
  *
- * WHY Kilo: Kilo's Memory Bank feature is a significant differentiator.
- * Users who work on long-running projects can persist context that survives
- * agent restarts. Styrby surfaces Memory Bank events so mobile users can see
- * what was remembered and recalled — turning a hidden feature into a visible UX win.
- *
- * WHY 500+ models: Kilo's model agnosticism attracts users who run local models
- * (Ollama, LM Studio) or use specialized providers. This segment is underserved
- * by Claude/Codex-specific tools.
+ * WHY the rewrite (2026-06-11): the previous adapter spawned
+ * `kilo run --prompt <p> --output json --no-interactive --memory-bank` and
+ * parsed a fabricated `tokens` / `memory_bank_read` / `memory_bank_write`
+ * JSON protocol. None of those flags or event types exist in the real binary,
+ * so the adapter would have failed to launch headless and emitted nothing.
+ * Kilo is an OpenCode fork, so the real event schema mirrors OpenCode's
+ * verified `{ type, sessionID, part }` shape (see opencode.ts).
  *
  * @see https://github.com/Kilo-Org/kilocode
  * @module factories/kilo
@@ -42,36 +42,7 @@ import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { resolveApiKeyEnv, type ApiKeyProvider } from '@/utils/apiKeyProvider';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
-import type { CostReport, BillingModel } from '@styrby/shared/cost';
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/**
- * Detect whether the Kilo session is using a local/free model.
- *
- * WHY: Kilo supports 500+ models including local ones via Ollama and LM Studio.
- * Local models have zero marginal cost — charging users for them would be wrong.
- * We detect local usage by matching the model name pattern or checking whether
- * the apiBaseUrl resolves to localhost/127.0.0.1.
- *
- * @param model - Model identifier (e.g., 'ollama/llama3', 'local-codellama')
- * @param apiBaseUrl - Optional API base URL (e.g., 'http://localhost:11434/v1')
- * @returns true when the model is local/free-tier
- */
-function isKiloLocalModel(model: string | undefined, apiBaseUrl: string | undefined): boolean {
-  if (model && /ollama|^local-/i.test(model)) return true;
-  if (apiBaseUrl) {
-    try {
-      const url = new URL(apiBaseUrl);
-      return url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1';
-    } catch {
-      // Invalid URL - not local
-    }
-  }
-  return false;
-}
+import type { CostReport } from '@styrby/shared/cost';
 
 // ============================================================================
 // Types
@@ -83,49 +54,21 @@ function isKiloLocalModel(model: string | undefined, apiBaseUrl: string | undefi
 export interface KiloBackendOptions extends AgentFactoryOptions {
   /**
    * API key for the LLM provider.
-   * Kilo supports any OpenAI-compatible endpoint, so this key is used
-   * with whatever provider is configured in ~/.config/kilo/config.json.
+   * Kilo supports many providers; the key is injected under the env-var
+   * name(s) for its detected/declared provider (see `provider`).
    */
   apiKey?: string;
 
   /**
-   * Model identifier (e.g., 'gpt-4o', 'claude-sonnet-4', 'ollama/llama3').
-   * Kilo supports 500+ models via OpenAI-compatible APIs.
-   * Defaults to Kilo's configured default from config.json.
+   * Model identifier in Kilo's `provider/model` format (e.g. 'anthropic/claude-sonnet-4',
+   * 'openai/gpt-4o', 'ollama/llama3'). Passed via `-m/--model`.
+   * Defaults to Kilo's configured default.
    */
   model?: string;
 
   /**
-   * OpenAI-compatible API base URL.
-   * WHY: Kilo supports any endpoint (Ollama, LM Studio, Together, etc.).
-   * Pass this to override the default OpenAI endpoint in config.
-   * Example: 'http://localhost:11434/v1' for Ollama.
-   */
-  apiBaseUrl?: string;
-
-  /**
-   * Whether to enable Memory Bank for this session.
-   *
-   * WHY: Memory Bank persists project context (architecture decisions,
-   * coding patterns, team conventions) across sessions in structured markdown
-   * files. Enabling it means Kilo will read from and write to the Memory Bank
-   * automatically, reducing repetitive context-setting for long-running projects.
-   * Default: true (this is Kilo's primary differentiator)
-   */
-  memoryBankEnabled?: boolean;
-
-  /**
-   * Path to the Memory Bank directory.
-   * WHY: Kilo stores Memory Bank files in .kilo/memory/ by default within
-   * the project directory. Some teams prefer a shared location (e.g., a
-   * network drive or git-tracked folder). Override with a custom path.
-   * Defaults to <cwd>/.kilo/memory/
-   */
-  memoryBankPath?: string;
-
-  /**
-   * Session ID to resume (Kilo supports resuming sessions with Memory Bank context).
-   * When provided, Kilo loads the Memory Bank for that session's project.
+   * Session ID to resume. Passed via `-s/--session <id>`.
+   * VERIFIED real flag (`kilo run --help`).
    */
   resumeSessionId?: string;
 
@@ -137,11 +80,10 @@ export interface KiloBackendOptions extends AgentFactoryOptions {
   /**
    * Explicit LLM provider for the BYOK key.
    *
-   * WHY (audit 2026-05-05 HIGH fix): Kilo speaks OpenAI-compatible APIs but
-   * supports many backends. Without an explicit provider hint, the previous
-   * code injected the user's key into OPENAI_API_KEY + ANTHROPIC_API_KEY +
-   * KILO_API_KEY simultaneously — which leaked sk-ant-* keys to Anthropic-
-   * compatible providers' validation calls (logged as rejected keys).
+   * WHY (audit 2026-05-05 HIGH fix): Kilo supports many backends. Without an
+   * explicit provider hint, the previous code injected the user's key into
+   * OPENAI_API_KEY + ANTHROPIC_API_KEY + KILO_API_KEY simultaneously — which
+   * leaked sk-ant-* keys to Anthropic-compatible providers' validation calls.
    *
    * If unset, the factory sniffs the key prefix and falls back to legacy
    * fan-out only when sniffing fails (with a deprecation warning).
@@ -166,76 +108,67 @@ export interface KiloBackendResult {
 // ============================================================================
 
 /**
- * Kilo JSON output message types.
+ * Kilo `--format json` event shape.
  *
- * WHY: Kilo's custom JSON protocol includes Memory Bank events alongside
- * standard agent events. These are the key differentiator from other agents
- * and give Styrby unique data to surface in the mobile app.
+ * Kilo is an OpenCode fork, so its event envelope is `{ type, sessionID, part }`
+ * — the same structure as OpenCode's VERIFIED schema (opencode.ts). The
+ * top-level envelope (`type`, top-level `sessionID`, nested event payload) was
+ * CONFIRMED directly against the real `kilo` binary (v7.3.41, 2026-06-11): an
+ * unauthenticated `kilo run "say OK" --format json --auto` emitted
+ * `{"type":"error","timestamp":...,"sessionID":"ses_...","error":{"name":...,"data":{...}}}`.
+ *
+ * SCHEMA UNVERIFIED — needs keyed session (#30): the success-path `text` and
+ * `step_finish` `part` payloads (part.text / part.cost / part.tokens) could NOT
+ * be captured because the local install has no provider credentials (the model
+ * returns 401 PAID_MODEL_AUTH_REQUIRED). The `text`/`step_finish` handling below
+ * mirrors OpenCode's verified shape on the well-founded assumption that the fork
+ * preserves it; it must be re-verified against a real keyed Kilo session.
  */
+interface KiloTokens {
+  input?: number;
+  output?: number;
+  reasoning?: number;
+  cache?: { read?: number; write?: number };
+}
+interface KiloPart {
+  /** Part discriminator: 'step-start' | 'text' | 'step-finish' | tool parts. */
+  type?: string;
+  /** Assistant text (present on `text` events — UNVERIFIED for Kilo, see #30). */
+  text?: string;
+  /** Step cost in USD (present on `step-finish` — UNVERIFIED for Kilo, see #30). */
+  cost?: number;
+  /** Token usage for the step (present on `step-finish` — UNVERIFIED, see #30). */
+  tokens?: KiloTokens;
+  /** Stop reason (present on `step-finish`). */
+  reason?: string;
+}
+/**
+ * Error payload (VERIFIED against the real binary, 2026-06-11): error events
+ * carry a nested `error: { name, data: { message, ... } }` object — NOT a flat
+ * `error` string. The prior adapter assumed a flat string and would have shown
+ * `undefined` as the error detail.
+ */
+interface KiloErrorPayload {
+  name?: string;
+  data?: { message?: string };
+}
 interface KiloJsonMessage {
-  type:
-    | 'text'
-    | 'tool_use'
-    | 'tool_result'
-    | 'memory_bank_read'
-    | 'memory_bank_write'
-    | 'tokens'
-    | 'error'
-    | 'complete';
-  /** Text content for 'text' events */
-  content?: string;
-  /** Tool name for 'tool_use' and 'tool_result' events */
-  tool_name?: string;
-  /** Tool input for 'tool_use' events */
-  tool_input?: Record<string, unknown>;
-  /** Tool result for 'tool_result' events */
-  tool_result?: unknown;
-  /** Unique call ID for correlating tool_use to tool_result */
-  call_id?: string;
-  /**
-   * Memory Bank file that was read for 'memory_bank_read' events.
-   * WHY: Kilo reads structured markdown files (e.g., projectbrief.md,
-   * activeContext.md) at session start and before complex tasks.
-   * Surfacing the filename tells users which memory was recalled.
-   */
-  memory_file?: string;
-  /** Content read from or written to the Memory Bank */
-  memory_content?: string;
-  /** Memory Bank section being written (e.g., 'decisions', 'patterns') */
-  memory_section?: string;
-  /** Token usage for 'tokens' events */
-  usage?: KiloUsageMetadata;
-  /** Error message for 'error' events */
-  error?: string;
+  /** Event type: 'text' | 'step_finish' | 'step_start' | 'error' | …. */
+  type: string;
+  /** Session id, present on every event (used for `--session` resume). VERIFIED. */
+  sessionID?: string;
+  part?: KiloPart;
+  /** Present on `error` events. VERIFIED nested shape. */
+  error?: KiloErrorPayload;
 }
 
 /**
- * Token usage metadata from Kilo's 'tokens' events.
- *
- * WHY: Kilo reports token usage after each model request. The model-agnostic
- * design means the cost calculation depends on which provider/model is active.
- * We pass raw token counts to Styrby's cost engine for accurate billing.
- */
-interface KiloUsageMetadata {
-  /** Input/prompt tokens consumed */
-  input_tokens?: number;
-  /** Output/completion tokens generated */
-  output_tokens?: number;
-  /** Cache read tokens (if the underlying provider supports caching) */
-  cache_read_tokens?: number;
-  /** Cache write tokens (if the underlying provider supports caching) */
-  cache_write_tokens?: number;
-  /** Estimated cost in USD (Kilo calculates based on configured model pricing) */
-  cost_usd?: number;
-}
-
-/**
- * Parse a single JSON message line from Kilo's output.
+ * Parse a single JSON line from Kilo's `--format json` output.
  *
  * @param line - A single line of Kilo stdout (expected to be JSON)
  * @returns Parsed KiloJsonMessage or null if the line is not valid JSON
  */
-function parseKiloJsonLine(line: string): KiloJsonMessage | null {
+function parseKiloJson(line: string): KiloJsonMessage | null {
   const trimmed = line.trim();
   if (!trimmed || !trimmed.startsWith('{')) {
     return null;
@@ -248,47 +181,6 @@ function parseKiloJsonLine(line: string): KiloJsonMessage | null {
   }
 }
 
-/**
- * Detect file system edits from Kilo tool names.
- *
- * Kilo uses standard file operation tool names consistent with OpenAI
- * function calling conventions.
- *
- * @param toolName - The Kilo tool name from the tool_use event
- * @returns true if this tool writes or modifies files
- */
-function isKiloFileEditTool(toolName: string): boolean {
-  const fileEditPatterns = [
-    'write_file',
-    'create_file',
-    'edit_file',
-    'patch_file',
-    'str_replace',
-    'apply_patch',
-    'modify_file',
-    'overwrite_file',
-  ];
-  const lower = toolName.toLowerCase();
-  return fileEditPatterns.some((pattern) => lower.includes(pattern));
-}
-
-/**
- * Extract file path from Kilo tool input arguments.
- *
- * @param toolInput - Tool input arguments
- * @returns File path string or null if not found
- */
-function extractKiloFilePath(toolInput?: Record<string, unknown>): string | null {
-  if (!toolInput) return null;
-  return (
-    (toolInput.path as string) ??
-    (toolInput.file_path as string) ??
-    (toolInput.filename as string) ??
-    (toolInput.target as string) ??
-    null
-  );
-}
-
 // ============================================================================
 // KiloBackend Class
 // ============================================================================
@@ -296,31 +188,17 @@ function extractKiloFilePath(toolInput?: Record<string, unknown>): string | null
 /**
  * Kilo Backend implementation.
  *
- * Spawns Kilo as a subprocess with JSON output and parses structured messages.
- * Handles standard agent events plus Kilo-specific Memory Bank read/write events.
- * Memory Bank events are emitted as 'event' messages with names 'memory-bank-read'
- * and 'memory-bank-write' so the mobile app can surface them as special cards.
+ * Spawns Kilo as a subprocess with `--format json` and parses the
+ * newline-delimited `{ type, sessionID, part }` events emitted by the
+ * OpenCode-fork CLI.
  */
 class KiloBackend extends StreamingAgentBackendBase {
   protected readonly logTag = 'KiloBackend';
-  private lineBuffer = '';
+  private kiloSessionId: string | null = null;
   private inputTokens = 0;
   private outputTokens = 0;
-  private cacheReadTokens = 0;
-  private cacheWriteTokens = 0;
-  private totalCostUsd = 0;
-  /**
-   * WHY: Track Memory Bank reads during a session so the mobile app can display
-   * a "Memory recalled: N files" indicator. Power users care about which context
-   * Kilo loaded — showing it builds trust in the Memory Bank feature.
-   */
-  private memoryBankReads: string[] = [];
-  /**
-   * WHY: Track Memory Bank writes so the mobile app can display a "Memory updated"
-   * notification. This makes the feature visible — users know their context is
-   * being persisted, which differentiates Kilo from stateless agents.
-   */
-  private memoryBankWrites: string[] = [];
+  private totalCost = 0;
+  private lineBuffer = '';
 
   constructor(private options: KiloBackendOptions) {
     super();
@@ -329,171 +207,88 @@ class KiloBackend extends StreamingAgentBackendBase {
   /**
    * Handle a parsed Kilo JSON message and emit the corresponding AgentMessages.
    *
-   * WHY: Kilo's Memory Bank events (memory_bank_read, memory_bank_write) are
-   * unique to Kilo. We emit them as 'event' messages so the mobile app can
-   * render special Memory Bank cards without needing Kilo-specific code in
-   * the mobile layer — the event name is the only Kilo-specific thing that
-   * leaks to the mobile app.
-   *
    * @param msg - The parsed Kilo JSON message
    */
-  private handleKiloMessage(msg: KiloJsonMessage): void {
+  private handleJsonMessage(msg: KiloJsonMessage): void {
+    // sessionID rides on EVERY event (VERIFIED); capture it so follow-up
+    // prompts resume the same Kilo session via `--session`.
+    if (msg.sessionID) this.kiloSessionId = msg.sessionID;
+
     switch (msg.type) {
-      case 'text':
-        if (msg.content) {
-          this.emit({ type: 'model-output', textDelta: msg.content });
-        }
+      case 'text': {
+        // SCHEMA UNVERIFIED — needs keyed session (#30): assistant output is
+        // assumed to ride in `part.text` as a complete part (OpenCode-fork
+        // shape). Re-verify against a real keyed Kilo session.
+        const text = msg.part?.text;
+        if (text) this.emit({ type: 'model-output', fullText: text });
         break;
+      }
 
-      case 'tool_use':
-        if (msg.tool_name && msg.call_id) {
-          this.emit({
-            type: 'tool-call',
-            toolName: msg.tool_name,
-            args: msg.tool_input ?? {},
-            callId: msg.call_id,
-          });
-        }
-        break;
+      case 'step_finish': {
+        // SCHEMA UNVERIFIED — needs keyed session (#30): usage is assumed to
+        // ride on `part.cost` (USD) + `part.tokens.{input,output,cache.{read,write}}`
+        // (OpenCode-fork shape). Kilo is BYOK so billingModel is 'api-key'.
+        const part = msg.part;
+        if (!part) break;
+        const t = part.tokens ?? {};
+        // WHY set (not accumulate): mirrors the verified OpenCode single-step
+        // semantics — the turn totals land on one step_finish. Multi-step
+        // aggregation is a tracked follow-up (#30).
+        this.inputTokens = t.input ?? this.inputTokens;
+        this.outputTokens = t.output ?? this.outputTokens;
+        const cacheRead = t.cache?.read ?? 0;
+        const cacheWrite = t.cache?.write ?? 0;
+        if (typeof part.cost === 'number') this.totalCost = part.cost;
 
-      case 'tool_result':
-        if (msg.call_id && msg.tool_name) {
-          this.emit({
-            type: 'tool-result',
-            toolName: msg.tool_name,
-            result: msg.tool_result,
-            callId: msg.call_id,
-          });
-
-          // Detect file edits and emit fs-edit event
-          if (isKiloFileEditTool(msg.tool_name)) {
-            const filePath = extractKiloFilePath(msg.tool_input);
-            if (filePath) {
-              this.emit({
-                type: 'fs-edit',
-                description: `${msg.tool_name}: ${filePath}`,
-                path: filePath,
-              });
-            }
-          }
-        }
-        break;
-
-      case 'memory_bank_read':
-        // WHY: Memory Bank reads happen when Kilo loads project context at session
-        // start or before a complex task. We track which files were read so the
-        // mobile app can display "Recalled: projectbrief.md, activeContext.md".
-        // This makes the Memory Bank feature tangible to users who don't read logs.
-        if (msg.memory_file) {
-          this.memoryBankReads.push(msg.memory_file);
-          this.emit({
-            type: 'event',
-            name: 'memory-bank-read',
-            payload: {
-              file: msg.memory_file,
-              contentPreview: msg.memory_content
-                ? msg.memory_content.slice(0, 200)
-                : undefined,
-              totalReads: this.memoryBankReads.length,
-              allFiles: [...this.memoryBankReads],
-            },
-          });
-        }
-        break;
-
-      case 'memory_bank_write':
-        // WHY: Memory Bank writes happen when Kilo discovers new architectural
-        // decisions, patterns, or progress updates worth persisting. We notify
-        // users so they know their context is growing — this is the core value prop
-        // of Kilo. Without visibility, users don't know the feature is working.
-        if (msg.memory_file) {
-          this.memoryBankWrites.push(msg.memory_file);
-          this.emit({
-            type: 'event',
-            name: 'memory-bank-write',
-            payload: {
-              file: msg.memory_file,
-              section: msg.memory_section,
-              contentPreview: msg.memory_content
-                ? msg.memory_content.slice(0, 200)
-                : undefined,
-              totalWrites: this.memoryBankWrites.length,
-              allFiles: [...new Set(this.memoryBankWrites)], // deduplicate
-            },
-          });
-        }
-        break;
-
-      case 'tokens':
-        // WHY: Kilo emits token counts after each model request. We accumulate
-        // across the session so the mobile app shows a running cost total.
-        if (msg.usage) {
-          const incrInput = msg.usage.input_tokens ?? 0;
-          const incrOutput = msg.usage.output_tokens ?? 0;
-          const incrCacheRead = msg.usage.cache_read_tokens ?? 0;
-          const incrCacheWrite = msg.usage.cache_write_tokens ?? 0;
-
-          // WHY: Local/free models (Ollama, LM Studio) have zero marginal cost.
-          // We detect local usage by model name or apiBaseUrl and set costUsd=0.
-          const isLocal = isKiloLocalModel(this.options.model, this.options.apiBaseUrl);
-          const incrCost = isLocal ? 0 : (msg.usage.cost_usd ?? 0);
-
-          this.inputTokens += incrInput;
-          this.outputTokens += incrOutput;
-          this.cacheReadTokens += incrCacheRead;
-          this.cacheWriteTokens += incrCacheWrite;
-          this.totalCostUsd += incrCost;
-
-          // Emit legacy token-count (keep for existing consumers)
-          this.emit({
-            type: 'token-count',
-            inputTokens: this.inputTokens,
-            outputTokens: this.outputTokens,
-            cacheReadTokens: this.cacheReadTokens,
-            cacheWriteTokens: this.cacheWriteTokens,
-            costUsd: this.totalCostUsd,
-          });
-
-          // WHY: Emit unified CostReport. Kilo local models use billingModel='free'
-          // with costUsd=0; remote models use 'api-key'. source='agent-reported'
-          // when Kilo reports cost_usd; 'styrby-estimate' otherwise.
-          const billingModel: BillingModel = isLocal ? 'free' : 'api-key';
-          const hasAgentCost = !isLocal && msg.usage.cost_usd !== undefined;
-          const costReport: CostReport = {
-            sessionId: this.sessionId ?? '',
-            messageId: null,
-            agentType: 'kilo',
-            model: this.options.model ?? 'unknown',
-            timestamp: new Date().toISOString(),
-            source: hasAgentCost ? 'agent-reported' : 'styrby-estimate',
-            billingModel,
-            costUsd: incrCost,
-            inputTokens: incrInput,
-            outputTokens: incrOutput,
-            cacheReadTokens: incrCacheRead,
-            cacheWriteTokens: incrCacheWrite,
-            rawAgentPayload: hasAgentCost ? (msg.usage as unknown as Record<string, unknown>) : null,
-          };
-          this.emit({ type: 'cost-report', report: costReport });
-        }
-        break;
-
-      case 'error':
+        // Legacy token-count (kept for existing consumers).
         this.emit({
-          type: 'status',
-          status: 'error',
-          detail: msg.error ?? 'Kilo encountered an error',
+          type: 'token-count',
+          inputTokens: this.inputTokens,
+          outputTokens: this.outputTokens,
+          totalTokens: this.inputTokens + this.outputTokens,
+          costUsd: this.totalCost,
         });
+
+        // Unified CostReport — source='agent-reported' (Kilo reports real USD).
+        const costReport: CostReport = {
+          sessionId: this.sessionId ?? '',
+          messageId: null,
+          agentType: 'kilo',
+          model: this.options.model ?? 'unknown',
+          timestamp: new Date().toISOString(),
+          source: 'agent-reported',
+          billingModel: 'api-key',
+          costUsd: this.totalCost,
+          inputTokens: this.inputTokens,
+          outputTokens: this.outputTokens,
+          cacheReadTokens: cacheRead,
+          cacheWriteTokens: cacheWrite,
+          rawAgentPayload: msg as unknown as Record<string, unknown>,
+        };
+        this.emit({ type: 'cost-report', report: costReport });
+        break;
+      }
+
+      case 'step_start':
+        // Turn boundary — no payload to surface.
         break;
 
-      case 'complete':
-        // WHY: Kilo emits 'complete' when the response is fully done, including
-        // any Memory Bank writes that happen at the end of a task.
-        this.emit({ type: 'status', status: 'idle' });
+      case 'error': {
+        // VERIFIED shape: error events carry a nested `error.data.message`
+        // (falling back to error.name). Captured directly from the real binary.
+        const detail =
+          msg.error?.data?.message ?? msg.error?.name ?? 'Kilo encountered an error';
+        this.emit({ type: 'status', status: 'error', detail });
         break;
+      }
 
       default:
-        logger.debug('[KiloBackend] Unknown message type:', msg);
+        // WHY no tool-call / tool-result / fs-edit mapping: the real Kilo
+        // tool-event schema has NOT been captured yet (a keyed, tool-triggering
+        // session is required — #30). The prior adapter mapped an INVENTED
+        // tool_use/tool_result/memory_bank_* schema Kilo never emits. Rather
+        // than re-invent, we surface nothing until the real shape is verified.
+        logger.debug('[KiloBackend] Unhandled kilo event type:', msg.type);
     }
   }
 
@@ -511,9 +306,9 @@ class KiloBackend extends StreamingAgentBackendBase {
     this.lineBuffer = lines.pop() ?? '';
 
     for (const line of lines) {
-      const msg = parseKiloJsonLine(line);
+      const msg = parseKiloJson(line);
       if (msg) {
-        this.handleKiloMessage(msg);
+        this.handleJsonMessage(msg);
       } else if (line.trim()) {
         logger.debug('[KiloBackend] Non-JSON stdout:', line);
       }
@@ -522,9 +317,6 @@ class KiloBackend extends StreamingAgentBackendBase {
 
   /**
    * Start a new Kilo session.
-   *
-   * Resets all token/cost accumulators and Memory Bank tracking.
-   * Optionally sends an initial prompt to begin work immediately.
    *
    * @param initialPrompt - Optional prompt to send immediately after session start
    * @returns Promise resolving to the new session information
@@ -538,12 +330,9 @@ class KiloBackend extends StreamingAgentBackendBase {
     this.sessionId = randomUUID();
     this.inputTokens = 0;
     this.outputTokens = 0;
-    this.cacheReadTokens = 0;
-    this.cacheWriteTokens = 0;
-    this.totalCostUsd = 0;
+    this.totalCost = 0;
     this.lineBuffer = '';
-    this.memoryBankReads = [];
-    this.memoryBankWrites = [];
+    this.kiloSessionId = this.options.resumeSessionId ?? null;
 
     this.emit({ type: 'status', status: 'starting' });
 
@@ -562,9 +351,8 @@ class KiloBackend extends StreamingAgentBackendBase {
   /**
    * Send a prompt to Kilo.
    *
-   * Spawns a Kilo subprocess with JSON output mode. Memory Bank is enabled
-   * or disabled based on the memoryBankEnabled option. Kilo writes structured
-   * JSON messages to stdout including Memory Bank events.
+   * Spawns `kilo run <prompt> --format json` (verified CLI surface). The
+   * prompt is a POSITIONAL argument — there is no `--prompt` flag.
    *
    * @param sessionId - The active session ID (must match startSession result)
    * @param prompt - The user's prompt text
@@ -586,55 +374,25 @@ class KiloBackend extends StreamingAgentBackendBase {
     this.lineBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
-    // Build Kilo command arguments
-    const args: string[] = [
-      'run',          // Kilo subcommand for non-interactive one-shot execution
-      '--prompt',
-      prompt,
-      '--output',
-      'json',         // Request JSON output for structured parsing
-      '--no-interactive', // Prevent blocking on stdin
-    ];
+    // Build Kilo command arguments.
+    //
+    // WHY this exact shape (VERIFIED against `kilo run --help`, kilo v7.3.41,
+    // 2026-06-11): headless runs use the `run` SUBCOMMAND with a POSITIONAL
+    // message (no `--prompt`, no `--output`, no `--no-interactive`, no
+    // `--memory-bank` — the prior adapter invented all four). `--format json`
+    // emits raw JSON events; `-m/--model` and `-s/--session` are real. `--auto`
+    // auto-approves permissions so the non-interactive pipeline never blocks on
+    // a permission prompt (replaces the invented stdin y/n protocol).
+    const args: string[] = ['run', prompt, '--format', 'json', '--auto'];
 
     // Model override
     if (this.options.model) {
       args.push('--model', this.options.model);
     }
 
-    // Custom API base URL for non-OpenAI providers (Ollama, etc.)
-    // SECURITY: Validate the URL scheme to prevent SSRF via non-HTTP schemes.
-    if (this.options.apiBaseUrl) {
-      try {
-        const parsed = new URL(this.options.apiBaseUrl);
-        if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-          throw new Error(`Invalid API base URL scheme: ${parsed.protocol}. Only http:// and https:// are allowed.`);
-        }
-        args.push('--api-base', this.options.apiBaseUrl);
-      } catch (e) {
-        if (e instanceof Error && e.message.includes('Invalid API base URL scheme')) {
-          throw e;
-        }
-        throw new Error(`Invalid API base URL: "${this.options.apiBaseUrl}". Must be a valid http:// or https:// URL.`);
-      }
-    }
-
-    // Memory Bank configuration
-    // WHY: Memory Bank is enabled by default because it's Kilo's primary value prop.
-    // Users who don't want it can set memoryBankEnabled: false. We explicitly pass
-    // the flag so behavior is predictable regardless of Kilo's config file default.
-    const memoryBankEnabled = this.options.memoryBankEnabled !== false;
-    if (memoryBankEnabled) {
-      args.push('--memory-bank');
-      if (this.options.memoryBankPath) {
-        args.push('--memory-bank-path', this.options.memoryBankPath);
-      }
-    } else {
-      args.push('--no-memory-bank');
-    }
-
-    // Resume existing session for context continuity
-    if (this.options.resumeSessionId) {
-      args.push('--resume', this.options.resumeSessionId);
+    // Resume a prior Kilo session for context continuity (real `-s/--session`).
+    if (this.kiloSessionId) {
+      args.push('--session', this.kiloSessionId);
     }
 
     // Extra args (validated for shell safety — SEC-ARGS-001)
@@ -670,7 +428,7 @@ class KiloBackend extends StreamingAgentBackendBase {
           throw new Error('Failed to create stdio pipes');
         }
 
-        // Handle stdout — Kilo JSON messages including Memory Bank events
+        // Handle stdout — Kilo JSON events
         this.process.stdout.on('data', (data: Buffer) => {
           this.processStdout(data);
         });
@@ -700,9 +458,9 @@ class KiloBackend extends StreamingAgentBackendBase {
 
           // Flush remaining buffer
           if (this.lineBuffer.trim()) {
-            const msg = parseKiloJsonLine(this.lineBuffer);
+            const msg = parseKiloJson(this.lineBuffer);
             if (msg) {
-              this.handleKiloMessage(msg);
+              this.handleJsonMessage(msg);
             }
             this.lineBuffer = '';
           }
@@ -758,10 +516,6 @@ class KiloBackend extends StreamingAgentBackendBase {
   /**
    * Cancel the current Kilo operation.
    *
-   * WHY: When cancelling, we give Kilo 3 seconds to flush Memory Bank writes
-   * before force-killing. This prevents partial Memory Bank updates that could
-   * leave the project context in an inconsistent state.
-   *
    * @param sessionId - The active session ID to cancel
    * @throws {Error} When session ID does not match the active session
    */
@@ -776,58 +530,18 @@ class KiloBackend extends StreamingAgentBackendBase {
       // non-zero exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
       this.markCancelled();
       this.process.kill('SIGTERM');
-      // WHY: Give Kilo 3 seconds to flush any pending Memory Bank writes to disk
-      // before SIGKILL. A partial write could corrupt the project context on next
-      // session start. The escalation timer is tracked by the base class so it is
-      // cancelled on clean exit / dispose / double-cancel (SOC2 CC7.2).
+      // WHY: Track escalation timer via the base class so it is cleared on
+      // clean exit / dispose / double-cancel. SOC2 CC7.2.
       this.scheduleForceKill();
     }
 
     this.emit({ type: 'status', status: 'idle' });
   }
 
-  /**
-   * Respond to a Kilo permission request.
-   *
-   * Kilo may request permission for shell execution, file operations, or
-   * Memory Bank writes to sensitive sections. We relay the user's decision
-   * via stdin.
-   *
-   * @param requestId - The ID of the permission request from Kilo
-   * @param approved - Whether the user approved the request
-   */
-  async respondToPermission(requestId: string, approved: boolean): Promise<void> {
-    this.emit({
-      type: 'permission-response',
-      id: requestId,
-      approved,
-    });
-
-    if (this.process?.stdin && !this.process.killed) {
-      const response = approved ? 'y\n' : 'n\n';
-      try {
-        this.process.stdin.write(response);
-      } catch {
-        // Stdin may be closed — safe to ignore
-      }
-    }
-  }
-
-  // waitForResponseComplete inherited from StreamingAgentBackendBase.
-
-  /**
-   * Clean up Kilo-specific state and defer the rest to the base class.
-   *
-   * WHY: Memory Bank read/write tracking is reset on dispose since it is
-   * session-scoped state. A new backend instance starts with a clean slate.
-   * Base dispose() handles the listener array, the cancel timer, and process
-   * termination (SOC2 CC7.2 event-loop hygiene).
-   */
-  async dispose(): Promise<void> {
-    this.memoryBankReads = [];
-    this.memoryBankWrites = [];
-    await super.dispose();
-  }
+  // respondToPermission, waitForResponseComplete, and dispose are inherited
+  // from StreamingAgentBackendBase. Kilo runs headless with `--auto`, so the
+  // base default (emit-only) is exactly right for permission handling — there
+  // is no interactive y/n stdin protocol to relay (the prior adapter invented one).
 }
 
 // ============================================================================
@@ -837,15 +551,9 @@ class KiloBackend extends StreamingAgentBackendBase {
 /**
  * Create a Kilo backend.
  *
- * Kilo is a community-driven AI coding agent with Memory Bank (persistent
- * project context) and support for 500+ models via OpenAI-compatible APIs.
- *
- * The kilo binary must be installed and available in PATH.
- * Install via: `npm install -g @kilocode/cli` (provides both `kilo` and
- * `kilocode` binaries; we invoke `kilo`).
- *
- * Memory Bank is enabled by default. Kilo stores memory files in
- * <cwd>/.kilo/memory/ (tracked in git, shared with the team).
+ * Kilo is an OpenCode fork with support for 500+ models. The kilo binary must
+ * be installed and available in PATH (install per the Kilo project docs; we
+ * invoke `kilo`).
  *
  * @param options - Configuration options for the backend
  * @returns KiloBackendResult with backend instance and resolved model
@@ -854,19 +562,9 @@ class KiloBackend extends StreamingAgentBackendBase {
  *
  * @example
  * ```ts
- * // Standard usage with Memory Bank enabled
  * const { backend } = createKiloBackend({
  *   cwd: '/path/to/project',
- *   model: 'gpt-4o',
- *   memoryBankEnabled: true,
- * });
- *
- * // With Ollama (local model, no API key needed)
- * const { backend } = createKiloBackend({
- *   cwd: '/path/to/project',
- *   model: 'ollama/llama3',
- *   apiBaseUrl: 'http://localhost:11434/v1',
- *   memoryBankEnabled: true,
+ *   model: 'anthropic/claude-sonnet-4',
  * });
  *
  * const { sessionId } = await backend.startSession();
@@ -878,9 +576,6 @@ export function createKiloBackend(options: KiloBackendOptions): KiloBackendResul
     cwd: options.cwd,
     model: options.model,
     hasApiKey: !!options.apiKey,
-    apiBaseUrl: options.apiBaseUrl,
-    memoryBankEnabled: options.memoryBankEnabled !== false,
-    memoryBankPath: options.memoryBankPath,
     resumeSessionId: options.resumeSessionId,
   });
 

--- a/packages/styrby-cli/src/agent/factories/opencode.ts
+++ b/packages/styrby-cli/src/agent/factories/opencode.ts
@@ -99,31 +99,44 @@ export interface OpenCodeBackendResult {
 }
 
 /**
- * OpenCode JSON output message types.
+ * OpenCode `--format json` event — VERIFIED against the real opencode binary
+ * (v1.17.x, captured 2026-06-10). opencode emits newline-delimited events of the
+ * shape `{ type, sessionID, part }`:
+ *   - `step_start`  : turn boundary (no payload to surface)
+ *   - `text`        : assistant output, carried in `part.text` (a complete part,
+ *                     not a delta)
+ *   - `step_finish` : authoritative usage event — `part.cost` (USD) +
+ *                     `part.tokens.{input,output,reasoning,cache.{read,write}}`
+ * `sessionID` is present on EVERY event and is captured for `--session` resume.
  *
- * These match the output format when using `--format json`.
+ * WHY this replaced the prior interface: the old shape (`type:'session'` with
+ * `Cost`/`PromptTokens`/`CompletionTokens`) does not exist in opencode's output —
+ * it was an invented schema, so the parser emitted nothing against the real CLI.
  */
-interface OpenCodeJsonMessage {
-  type: 'assistant' | 'tool_use' | 'tool_result' | 'status' | 'error' | 'session';
-  content?: string;
-  tool_name?: string;
-  tool_input?: Record<string, unknown>;
-  tool_result?: unknown;
-  call_id?: string;
-  status?: string;
-  error?: string;
-  session?: OpenCodeSessionInfo;
+interface OpenCodeTokens {
+  input?: number;
+  output?: number;
+  reasoning?: number;
+  cache?: { read?: number; write?: number };
 }
-
-/**
- * OpenCode session info from JSON output.
- */
-interface OpenCodeSessionInfo {
-  id?: string;
-  Cost?: number;
-  PromptTokens?: number;
-  CompletionTokens?: number;
-  TotalTokens?: number;
+interface OpenCodePart {
+  /** Part discriminator: 'step-start' | 'text' | 'step-finish' | tool parts. */
+  type?: string;
+  /** Assistant text (present on `text` events). */
+  text?: string;
+  /** Step cost in USD (present on `step-finish`). */
+  cost?: number;
+  /** Token usage for the step (present on `step-finish`). */
+  tokens?: OpenCodeTokens;
+  /** Stop reason (present on `step-finish`). */
+  reason?: string;
+}
+interface OpenCodeJsonMessage {
+  /** Event type: 'step_start' | 'text' | 'step_finish' | …. */
+  type: string;
+  /** Session id, present on every event (used for `--session` resume). */
+  sessionID?: string;
+  part?: OpenCodePart;
 }
 
 /**
@@ -171,131 +184,78 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
    * @param msg - The parsed OpenCode message
    */
   private handleJsonMessage(msg: OpenCodeJsonMessage): void {
+    // sessionID rides on EVERY event; capture it so follow-up prompts resume the
+    // same opencode session via `--session`.
+    if (msg.sessionID) this.openCodeSessionId = msg.sessionID;
+
     switch (msg.type) {
-      case 'assistant':
-        if (msg.content) {
-          this.emit({ type: 'model-output', textDelta: msg.content });
-        }
+      case 'text': {
+        // Assistant output. opencode delivers complete text parts (not deltas),
+        // so emit fullText rather than a delta.
+        const text = msg.part?.text;
+        if (text) this.emit({ type: 'model-output', fullText: text });
         break;
+      }
 
-      case 'tool_use':
-        if (msg.tool_name && msg.call_id) {
-          this.emit({
-            type: 'tool-call',
-            toolName: msg.tool_name,
-            args: msg.tool_input ?? {},
-            callId: msg.call_id,
-          });
-        }
-        break;
+      case 'step_finish': {
+        // Authoritative usage event: part.cost (USD) + part.tokens.{input,output,
+        // cache.{read,write}}. opencode is BYOK so billingModel is 'api-key'.
+        const part = msg.part;
+        if (!part) break;
+        const t = part.tokens ?? {};
+        // WHY set (not accumulate): the verified single-step session reports the
+        // turn totals on its one step_finish. Multi-step (tool-using) sessions
+        // emit multiple step_finish events whose aggregation semantics are not yet
+        // captured — taking the latest avoids double-counting the resent context
+        // window (part.tokens.input includes full context each step). Multi-step
+        // aggregation is a tracked follow-up (real tool-session capture needed).
+        this.inputTokens = t.input ?? this.inputTokens;
+        this.outputTokens = t.output ?? this.outputTokens;
+        const cacheRead = t.cache?.read ?? 0;
+        const cacheWrite = t.cache?.write ?? 0;
+        if (typeof part.cost === 'number') this.totalCost = part.cost;
 
-      case 'tool_result':
-        if (msg.call_id && msg.tool_name) {
-          this.emit({
-            type: 'tool-result',
-            toolName: msg.tool_name,
-            result: msg.tool_result,
-            callId: msg.call_id,
-          });
-
-          // Check for file edits in tool results
-          if (
-            msg.tool_name === 'write_file' ||
-            msg.tool_name === 'edit_file' ||
-            msg.tool_name === 'str_replace_editor'
-          ) {
-            const input = msg.tool_input ?? {};
-            const path = (input.path as string) ?? (input.file_path as string);
-            if (path) {
-              this.emit({
-                type: 'fs-edit',
-                description: `${msg.tool_name}: ${path}`,
-                path,
-              });
-            }
-          }
-        }
-        break;
-
-      case 'status':
-        if (msg.status) {
-          const statusMap: Record<string, 'starting' | 'running' | 'idle' | 'stopped' | 'error'> =
-            {
-              starting: 'starting',
-              running: 'running',
-              idle: 'idle',
-              complete: 'idle',
-              stopped: 'stopped',
-              error: 'error',
-            };
-          const status = statusMap[msg.status] ?? 'running';
-          this.emit({ type: 'status', status });
-        }
-        break;
-
-      case 'error':
+        // Legacy token-count (kept for existing consumers).
         this.emit({
-          type: 'status',
-          status: 'error',
-          detail: msg.error ?? 'Unknown error',
+          type: 'token-count',
+          inputTokens: this.inputTokens,
+          outputTokens: this.outputTokens,
+          totalTokens: this.inputTokens + this.outputTokens,
+          costUsd: this.totalCost,
         });
+
+        // Unified CostReport — source='agent-reported' (opencode reports real USD).
+        const costReport: CostReport = {
+          sessionId: this.sessionId ?? '',
+          messageId: null,
+          agentType: 'opencode',
+          model: this.options.model ?? 'unknown',
+          timestamp: new Date().toISOString(),
+          source: 'agent-reported',
+          billingModel: 'api-key',
+          costUsd: this.totalCost,
+          inputTokens: this.inputTokens,
+          outputTokens: this.outputTokens,
+          cacheReadTokens: cacheRead,
+          cacheWriteTokens: cacheWrite,
+          rawAgentPayload: msg as unknown as Record<string, unknown>,
+        };
+        this.emit({ type: 'cost-report', report: costReport });
         break;
+      }
 
-      case 'session':
-        if (msg.session) {
-          const session = msg.session;
-          if (session.id) {
-            this.openCodeSessionId = session.id;
-          }
-          // Update cost tracking from session data
-          if (session.Cost !== undefined) {
-            this.totalCost = session.Cost;
-          }
-          if (session.PromptTokens !== undefined) {
-            this.inputTokens = session.PromptTokens;
-          }
-          if (session.CompletionTokens !== undefined) {
-            this.outputTokens = session.CompletionTokens;
-          }
-
-          // Emit legacy token-count (keep for existing consumers)
-          this.emit({
-            type: 'token-count',
-            inputTokens: this.inputTokens,
-            outputTokens: this.outputTokens,
-            totalTokens: session.TotalTokens ?? this.inputTokens + this.outputTokens,
-            costUsd: this.totalCost,
-          });
-
-          // WHY: Emit unified CostReport alongside token-count so cost-reporter
-          // can persist the full source-of-truth shape to cost_records (migration 022).
-          // source='agent-reported' because OpenCode's session event carries Cost
-          // directly from the agent. rawAgentPayload preserves the session JSON for
-          // SOC2 CC7.2 audit trail.
-          if (session.Cost !== undefined) {
-            const costReport: CostReport = {
-              sessionId: this.sessionId ?? '',
-              messageId: null,
-              agentType: 'opencode',
-              model: this.options.model ?? 'unknown',
-              timestamp: new Date().toISOString(),
-              source: 'agent-reported',
-              billingModel: 'api-key',
-              costUsd: this.totalCost,
-              inputTokens: this.inputTokens,
-              outputTokens: this.outputTokens,
-              cacheReadTokens: 0,
-              cacheWriteTokens: 0,
-              rawAgentPayload: session as unknown as Record<string, unknown>,
-            };
-            this.emit({ type: 'cost-report', report: costReport });
-          }
-        }
+      case 'step_start':
+        // Turn boundary — no payload to surface.
         break;
 
       default:
-        // Log unknown message types for debugging
-        logger.debug('[OpenCodeBackend] Unknown message type:', msg);
+        // WHY no tool-call / tool-result / fs-edit mapping: the real opencode
+        // tool-event schema has NOT been captured yet (a tool-triggering session
+        // is required). The prior code mapped an INVENTED `tool_use`/`tool_result`
+        // schema opencode never emits — rather than re-invent, we surface nothing
+        // until the real shape is verified. Tracked in the per-agent protocol
+        // verification task.
+        logger.debug('[OpenCodeBackend] Unhandled opencode event type:', msg.type);
     }
   }
 
@@ -380,21 +340,22 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
 
     this.emit({ type: 'status', status: 'running' });
 
-    // Build OpenCode command arguments
-    const args: string[] = [
-      '--format',
-      'json', // Use JSON output format
-      '--message',
-      prompt,
-      '--non-interactive', // Run in non-interactive mode
-    ];
+    // Build OpenCode command arguments.
+    //
+    // WHY this exact shape (verified against `opencode run --help`, opencode
+    // v1.17.x, 2026-06-10): headless runs use the `run` SUBCOMMAND with a
+    // POSITIONAL message — there is no `--message` flag and no `--non-interactive`
+    // flag (the prior args invented both, which would have launched the TUI or
+    // errored instead of running headless). `--format json` emits raw JSON events;
+    // `-m/--model` and `-s/--session` are real. `run` is inherently non-interactive.
+    const args: string[] = ['run', prompt, '--format', 'json'];
 
     // Add model if specified
     if (this.options.model) {
       args.push('--model', this.options.model);
     }
 
-    // Add session ID for persistence
+    // Add session ID for persistence (continue a prior session)
     if (this.openCodeSessionId) {
       args.push('--session', this.openCodeSessionId);
     }

--- a/packages/styrby-cli/src/cli/handlers/start.ts
+++ b/packages/styrby-cli/src/cli/handlers/start.ts
@@ -18,6 +18,7 @@
  */
 
 import { logger } from '@/ui/logger';
+import { AGENT_TYPES } from 'styrby-shared';
 
 /**
  * Handle the `styrby start` command.
@@ -39,7 +40,13 @@ export async function handleStart(args: string[]): Promise<void> {
   // WHY: Validate agent type early to prevent unvalidated strings from
   // reaching the logger and Supabase session records. Without this gate,
   // `styrby start --agent "$(malicious)"` would pass through to DB insert.
-  const VALID_AGENTS = ['claude', 'codex', 'gemini', 'opencode', 'aider'];
+  //
+  // WHY AGENT_TYPES (not a local list): the canonical 11-agent set lives in
+  // @styrby/shared as the single source of truth. A previous local 5-element
+  // allowlist drifted out of sync with the registered factories, silently making
+  // goose/amp/crush/kilo/kiro/droid unreachable via `styrby start` even though
+  // their backends worked. Deriving the gate from AGENT_TYPES closes that drift.
+  const VALID_AGENTS: readonly string[] = AGENT_TYPES;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--agent' || args[i] === '-a') {

--- a/packages/styrby-cli/src/commands/__tests__/versionDrift.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/versionDrift.test.ts
@@ -199,7 +199,9 @@ describe('checkVersionCompatibility', () => {
     { agentId: 'goose', within: '1.1.0', below: '0.9.9', above: '3.0.0' },
     { agentId: 'amp', within: '0.8.0', below: '0.4.9', above: '2.0.0' },
     { agentId: 'crush', within: '0.5.0', below: '0.0.9', above: '2.0.0' },
-    { agentId: 'kilo', within: '1.2.0', below: '0.9.9', above: '3.0.0' },
+    // kilo maxTestedVersion was bumped to 7.x (real binary is v7.3.41), so the
+    // "within" and "above max-tested" probes must track that.
+    { agentId: 'kilo', within: '7.0.0', below: '0.9.9', above: '8.0.0' },
     { agentId: 'kiro', within: '0.5.0', below: '0.0.9', above: '2.0.0' },
     { agentId: 'droid', within: '0.5.0', below: '0.0.9', above: '2.0.0' },
   ];

--- a/packages/styrby-cli/src/commands/agentProbe.ts
+++ b/packages/styrby-cli/src/commands/agentProbe.ts
@@ -411,16 +411,21 @@ const AGENT_PROBE_REGISTRY: Record<AllAgentType, AgentProbeConfig> = {
     command: 'kilo',
     versionFlag: '--version',
     versionPattern: /(\d+\.\d+\.\d+)/,
+    // Kilo is an OpenCode fork: `--format json` emits `{ type, sessionID, part }`
+    // events (envelope VERIFIED vs real binary v7.3.41, 2026-06-11). text →
+    // part.text; step_finish → part.cost + part.tokens. Tool-event shape is
+    // unverified (needs a keyed, tool-triggering session — #30).
     expectedStreamFormat: {
-      type: '"text" | "tool_use" | "tool_result" | "memory_bank_read" | "memory_bank_write" | "tokens" | "error" | "complete"',
-      'tokens.usage.input_tokens': 'number',
-      'tokens.usage.output_tokens': 'number',
-      'tokens.usage.cost_usd': 'number',
+      type: '"text" | "step_start" | "step_finish" | "error"',
+      'part.text': 'string (text events)',
+      'part.cost': 'number USD (step_finish)',
+      'part.tokens.input': 'number',
+      'part.tokens.output': 'number',
     },
-    parserFile: 'agent/factories/kilo.ts (handleKiloMessage)',
+    parserFile: 'agent/factories/kilo.ts (handleJsonMessage)',
     installHint: 'npm install -g @kilocode/cli',
     minSupportedVersion: '1.0.0',
-    maxTestedVersion: '2.99.99',
+    maxTestedVersion: '7.99.99',
     startupVersionPatterns: [/kilo v?(\d+\.\d+\.\d+)/i, /kilocode@(\d+\.\d+\.\d+)/i],
   },
 

--- a/packages/styrby-shared/src/relay/types.ts
+++ b/packages/styrby-shared/src/relay/types.ts
@@ -36,6 +36,7 @@ export type RelayChannelName = `relay:${string}`;
 export type DeviceType = 'cli' | 'mobile' | 'web';
 
 // AgentType and code review types are imported from main types
+import { AGENT_TYPES } from '../types.js';
 import type { AgentType, CodeReviewStatus, ReviewFile, ReviewComment } from '../types.js';
 export type { AgentType };
 
@@ -486,11 +487,8 @@ const BaseRelayMessageSchema = z.object({
   sender_type: z.enum(['cli', 'mobile', 'web']),
 });
 
-/** Zod schema for AgentType */
-const AgentTypeSchema = z.enum([
-  'claude', 'codex', 'gemini', 'opencode', 'aider', 'goose',
-  'amp', 'crush', 'kilo', 'kiro', 'droid',
-]);
+/** Zod schema for AgentType — derived from the canonical AGENT_TYPES list. */
+const AgentTypeSchema = z.enum(AGENT_TYPES);
 
 /** Zod schema for ChatMessage */
 export const ChatMessageSchema = BaseRelayMessageSchema.extend({

--- a/packages/styrby-shared/src/types.ts
+++ b/packages/styrby-shared/src/types.ts
@@ -2,8 +2,24 @@
  * Shared type definitions for Styrby
  */
 
-/** Agent identifiers supported by Styrby */
-export type AgentType = 'claude' | 'codex' | 'gemini' | 'opencode' | 'aider' | 'goose' | 'amp' | 'crush' | 'kilo' | 'kiro' | 'droid';
+/**
+ * Canonical list of agent identifiers Styrby supports — the SINGLE SOURCE OF
+ * TRUTH. The {@link AgentType} union, the relay Zod enum, and the CLI's
+ * `styrby start --agent` allowlist all derive from this so they can never drift.
+ *
+ * WHY this exists: the CLI's `start` handler previously hardcoded its own
+ * 5-element allowlist that fell out of sync with the 11 registered agent
+ * factories, silently making goose/amp/crush/kilo/kiro/droid unreachable via
+ * `styrby start` even though their backends worked. Deriving every consumer from
+ * one array closes that drift class.
+ */
+export const AGENT_TYPES = [
+  'claude', 'codex', 'gemini', 'opencode', 'aider', 'goose',
+  'amp', 'crush', 'kilo', 'kiro', 'droid',
+] as const;
+
+/** Agent identifiers supported by Styrby (derived from {@link AGENT_TYPES}). */
+export type AgentType = (typeof AGENT_TYPES)[number];
 
 /** Session status */
 export type SessionStatus = 'starting' | 'running' | 'idle' | 'stopped' | 'error';


### PR DESCRIPTION
## Summary
The agent layer was largely written against **imagined CLI protocols**. This verifies all 11 agents against the **real installed binary** (`--help` + live runs) and fixes the integrations to match reality. **Net -2k LOC** (deleting fiction). Answers "do the other agents actually fire off?" — the honest answer was *no* for most.

## Reachability fix
- **AGENT_TYPES single source of truth** (`@styrby/shared`). The CLI's `styrby start` allowlist had drifted to 5 agents, so **goose/amp/crush/kilo/kiro/droid were UNREACHABLE** despite registered factories. The type, the relay Zod enum, and the CLI gate now derive from one const — drift impossible.

## Real-binary protocol fixes
| Agent | Was (fiction) | Real (verified) |
|---|---|---|
| opencode | `--message` / `{type:'session',Cost}` | `run <p> --format json` / `{step_start\|text\|step_finish, part:{cost,tokens}}` (captured live) |
| amp | `chat --message --format json` | `amp -x <p> --stream-json` (claude-compatible stream-json) + **fixed dual-key disclosure regression** |
| droid | `chat --message --format json --backend` | `droid exec <p> --output-format stream-json` (claude-shaped; no cost field) |
| kilo | `run --prompt --output json --memory-bank` (fabricated) | opencode-fork `run <p> --format json`; maxTestedVersion 2.x→7.x |
| crush | JSON/ACP parser | **CRITICAL: no machine-readable output** (TUI) → plain-text passthrough |
| goose | `--format jsonl --no-interactive` (neither exists) | `run -t <p> --output-format stream-json` |

**Verified already-correct (no change):** claude, codex (`mcp-server`), gemini (`--experimental-acp`), aider (`--show-tokens`).

## Install hints (registry-verified)
amp→`@ampcode/cli` (deprecated alias), crush→`charmbracelet/tap/crush`, + added claude/codex/gemini. `droid` confirmed Factory-owned (not a name-squat).

## Known gap (not blind-fixed)
- ⚠️ **kiro** left UNCHANGED — couldn't install locally (`cli.kiro.dev/install` dead); real binary is likely `kiro-cli` (we spawn `kiro`). Flagged as top unverified risk rather than guessed-at.
- **49 tests skipped-with-reason** ("schema unverified — needs keyed session #30") — honest placeholders for success-path tool/cost events not capturable without API keys.

## Test Plan
- [x] CLI typecheck 0 + full suite **2603 pass / 49 skip / 0 fail**
- [x] web + mobile + shared typecheck 0
- [ ] CI passes
- [ ] (follow-up) keyed sessions to un-skip success-path tool/cost tests + verify kiro

🤖 Shipped via /gh-ship