### PR TITLE
fix(cli): integrate kiro against the real kiro-cli binary

### DIFF
--- a/packages/styrby-cli/src/agent/StreamingAgentBackendBase.ts
+++ b/packages/styrby-cli/src/agent/StreamingAgentBackendBase.ts
@@ -89,7 +89,9 @@ const INSTALL_HINTS: Readonly<Record<string, string>> = Object.freeze({
   goose: 'Install via: see https://github.com/aaif-goose/goose for installation',
   // Kilo CLI ships as @kilocode/cli (provides `kilo` + `kilocode` binaries).
   kilo: 'Install via: npm install -g @kilocode/cli (or see https://kilo.ai)',
-  kiro: 'Install via: see https://kiro.dev for installation',
+  // Kiro CLI (rebranded Amazon Q Developer CLI) — self-contained native binary
+  // named `kiro-cli`; headless needs KIRO_API_KEY (paid tiers). Not on npm/brew.
+  kiro: 'Install via: curl -fsSL https://cli.kiro.dev/install | bash (binary: kiro-cli; set KIRO_API_KEY for headless)',
   opencode: 'Install via: npm install -g opencode-ai',
 });
 

--- a/packages/styrby-cli/src/agent/__tests__/e2e/agentSmokeTests.test.ts
+++ b/packages/styrby-cli/src/agent/__tests__/e2e/agentSmokeTests.test.ts
@@ -128,18 +128,16 @@ const AGENT_TRANSCRIPTS = {
   crush: 'I\'ll write a hello world to main.ts.\nconsole.log(\'Hello, world!\');\nDone.',
 
   /**
-   * Kiro transcript captured with:
-   *   kiro run --message "write hello world to main.ts" --format json
-   * Kiro uses credit-based billing: 1 credit = $0.01 USD.
-   * Event types use 'message' for text (not 'text'), 'tool' field for tool name.
+   * Kiro transcript — kiro-cli (Amazon Q Developer CLI rebrand) has NO
+   * machine-readable output mode (verified vs kiro-cli v2.6.1, 2026-06-10).
+   * `kiro-cli chat --no-interactive --trust-all-tools <prompt>` writes the
+   * model's reply to stdout as PLAIN TEXT (markdown, with ANSI codes). The
+   * factory strips ANSI and does a plain-text stdout → model-output passthrough,
+   * emitting NO cost/usage/tool events (supportsTools:false, no usage source).
+   * So this transcript is raw text, not JSON.
+   * Source command: `kiro-cli chat --no-interactive --trust-all-tools "write hello world to main.ts"`.
    */
-  kiro: [
-    '{"type":"message","content":"I\'ll write a hello world program to main.ts."}',
-    '{"type":"tool_call","tool":"write_file","input":{"path":"main.ts","content":"console.log(\'Hello, world!\');"},"call_id":"krc-001"}',
-    '{"type":"tool_result","tool":"write_file","result":{"success":true},"call_id":"krc-001"}',
-    '{"type":"usage","usage":{"credits_consumed":2,"input_tokens":267,"output_tokens":31}}',
-    '{"type":"finish","finish_reason":"stop"}',
-  ].join('\n'),
+  kiro: 'I\'ll write a hello world program to main.ts.\nconsole.log(\'Hello, world!\');\nDone.',
 
   /**
    * Droid transcript — VERIFIED stream-json schema (Claude-Code-shaped) captured
@@ -723,12 +721,15 @@ describe('E2E smoke — crush', () => {
 /**
  * Kiro E2E smoke test.
  *
- * Kiro uses credit-based billing (1 credit = $0.01 USD). The transcript includes
- * a "usage" event with credits_used. Verifies: text streaming, credit-to-USD
- * conversion in CostReport.
+ * kiro-cli has NO machine-readable output mode (verified vs kiro-cli v2.6.1,
+ * 2026-06-10). `kiro-cli chat --no-interactive` writes the model's reply to
+ * stdout as PLAIN TEXT (with ANSI codes), so the backend strips ANSI and does a
+ * plain-text passthrough to `model-output`, emitting NO cost/usage/tool events
+ * (supportsTools:false). This test asserts the plain-text passthrough and that
+ * no cost-report is fabricated.
  */
 describe('E2E smoke — kiro', () => {
-  it('spawns, parses Kiro JSONL, converts credits to USD in CostReport', async () => {
+  it('spawns, parses plain-text transcript, emits model-output (no cost-report)', async () => {
     const { backend } = createKiroBackend({ cwd: '/project', model: 'amazon-nova-pro' });
     const messages = collectMessages(backend);
 
@@ -737,18 +738,16 @@ describe('E2E smoke — kiro', () => {
     resolveStreamingProcess(currentMockProcess, AGENT_TRANSCRIPTS.kiro);
     await promptPromise;
 
-    // 1. model-output from "text" events
+    // 1. plain-text stdout is forwarded verbatim as model-output deltas
     const textChunks = messages.filter((m: any) => m.type === 'model-output');
     expect(textChunks.length).toBeGreaterThan(0);
+    const fullText = textChunks.map((m: any) => m.textDelta).join('');
+    expect(fullText).toContain('hello world');
 
-    // 2. CostReport emitted — either from usage event or on close
+    // 2. kiro-cli has no cost-bearing output — verified 2026-06-10; it must NOT
+    //    fabricate a cost-report from plain text.
     const costReports = messages.filter((m: any) => m.type === 'cost-report');
-    expect(costReports.length).toBeGreaterThan(0);
-    const report = (costReports[0] as any).report;
-    expect(report.agentType).toBe('kiro');
-    // Kiro credits: 2 credits × $0.01 = $0.02
-    expect(typeof report.costUsd).toBe('number');
-    expect(report.costUsd).toBeGreaterThanOrEqual(0);
+    expect(costReports.length).toBe(0);
 
     await backend.dispose();
   });
@@ -1079,6 +1078,9 @@ describe('Cross-agent contract — CostReport shape', () => {
     // crush EXCLUDED: crush has no cost-bearing output — verified 2026-06-10.
     // Its `crush run` plain-text mode emits no usage/cost event, so the backend
     // (correctly) never emits a CostReport. It cannot satisfy the shape contract.
+    // kiro EXCLUDED: same reason — kiro-cli's `chat --no-interactive` is plain
+    // text with no usage/cost telemetry (verified 2026-06-10), so it never emits
+    // a CostReport and cannot satisfy the shape contract.
     {
       name: 'goose',
       create: () => createGooseBackend({ cwd: '/p', model: 'claude-sonnet-4' }),

--- a/packages/styrby-cli/src/agent/__tests__/e2e/reconnectMidStream.test.ts
+++ b/packages/styrby-cli/src/agent/__tests__/e2e/reconnectMidStream.test.ts
@@ -209,8 +209,11 @@ const PARTIAL_TRANSCRIPTS = {
   kilo: '{"type":"text","content":"Writing hello world..."}\n',
   goose: '{"type":"message","content":"Starting hello world task..."}\n',
   amp: '{"type":"text","content":"I\'ll write a hello world program."}\n',
-  crush: '{"type":"text_delta","delta":"Writing hello world to main.ts..."}\n',
-  kiro: '{"type":"message","content":"Creating hello world program..."}\n',
+  // crush + kiro emit PLAIN TEXT (no JSON schema) — verified 2026-06-10. A
+  // mid-stream kill leaves a partial text chunk; the backend still classifies the
+  // non-zero exit as an error.
+  crush: 'Writing hello world to main.ts...',
+  kiro: 'Creating hello world program...',
   droid: '{"type":"text","content":"Writing main.ts..."}\n',
 } as const;
 

--- a/packages/styrby-cli/src/agent/factories/__tests__/kiro.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/kiro.test.ts
@@ -1,15 +1,30 @@
 /**
- * Tests for the Kiro agent backend factory (AWS).
+ * Tests for the Kiro agent backend factory (AWS / Amazon Q Developer CLI rebrand).
  *
- * Covers:
- * - `createKiroBackend` factory function
- * - `registerKiroAgent` registry integration
- * - `KiroBackend` class: session lifecycle, subprocess management,
- *   JSONL output parsing, credit-based cost tracking (credits → USD),
- *   fs-edit detection from tool names, error handling, cancellation,
- *   permission response, and disposal.
+ * REALITY CHECK (kiro-cli v2.6.1, verified 2026-06-10):
+ * - Binary is `kiro-cli` (NOT `kiro`). Backward-compat aliases `q`/`q chat` exist.
+ * - Headless invocation is `kiro-cli chat --no-interactive --trust-all-tools <prompt>`
+ *   (the prompt is a trailing positional argument; `--trust-all-tools` is the
+ *   default trust posture; optional `--model` / `--effort`). There is NO `run`
+ *   subcommand, NO `--prompt`, and NO `--output-format jsonl`.
+ * - kiro-cli has NO JSON/stream output mode for chat. It writes the model's reply
+ *   to stdout as PLAIN TEXT with ANSI/terminal control codes. The factory strips
+ *   ANSI and forwards the text as `model-output`. There is no
+ *   `{message, tool_call, tool_result, usage, finish}` event schema.
+ * - kiro-cli emits NO token/credit/cost telemetry. The prior credit-billing fiction
+ *   (`KIRO_CREDIT_TO_USD`, 1 credit = $0.01) does not exist in the real binary, so
+ *   the backend emits NO cost-report / token-count / tool / fs-edit events.
+ * - Auth: injects `KIRO_API_KEY` env (from options.apiKey) only.
  *
- * All child_process and logger calls are mocked so no real Kiro binary
+ * Because of that, this suite covers ONLY verified behavior: the real spawn argv,
+ * ANSI-stripped plain-text stdout -> model-output passthrough, exit-code handling,
+ * cancellation, dispose, ENOENT install hint, and env-key injection. The previous
+ * suite's invented-JSONL-event blocks (message/tool_call/tool_result/usage/finish
+ * parsing, credit-cost tracking, fs-edit detection) are DELETED — they tested a
+ * fabricated schema the real binary does not produce (#30 — kiro-cli emits no
+ * structured output).
+ *
+ * All child_process and logger calls are mocked so no real kiro-cli binary
  * is required.
  *
  * @module factories/__tests__/kiro.test.ts
@@ -86,63 +101,18 @@ function collectMessages(backend: ReturnType<typeof createKiroBackend>['backend'
 }
 
 /**
- * Simulate a Kiro process run: emit stdout lines, then emit close event.
+ * Simulate a kiro-cli run: emit plain-text chunks as stdout data events, then
+ * close the process. (kiro-cli emits plain text, NOT line-framed JSON.)
  *
  * @param proc - The mock child process
- * @param stdoutLines - Lines of stdout to emit
+ * @param chunks - Plain-text chunks to emit on stdout
  * @param exitCode - Exit code for the close event (default: 0)
  */
-function simulateProcess(proc: MockProcess, stdoutLines: string[] = [], exitCode = 0) {
-  for (const line of stdoutLines) {
-    (proc.stdout as EventEmitter).emit('data', Buffer.from(line + '\n'));
+function simulateProcess(proc: MockProcess, chunks: string[] = [], exitCode = 0) {
+  for (const chunk of chunks) {
+    (proc.stdout as EventEmitter).emit('data', Buffer.from(chunk));
   }
   proc.emit('close', exitCode);
-}
-
-// ---- Kiro JSONL event builders ----
-
-/** Build a Kiro message event line */
-function kiroMessage(content: string): string {
-  return JSON.stringify({ type: 'message', content });
-}
-
-/** Build a Kiro tool_call event line */
-function kiroToolCall(tool: string, callId: string, input?: Record<string, unknown>): string {
-  return JSON.stringify({ type: 'tool_call', tool, call_id: callId, input });
-}
-
-/** Build a Kiro tool_result event line */
-function kiroToolResult(tool: string, callId: string, result: unknown, input?: Record<string, unknown>): string {
-  return JSON.stringify({ type: 'tool_result', tool, call_id: callId, result, input });
-}
-
-/**
- * Build a Kiro usage event with credit-based billing data.
- *
- * @param usage - Credit/token usage metadata
- */
-function kiroUsage(usage: {
-  credits_consumed?: number;
-  input_tokens?: number;
-  output_tokens?: number;
-  cost_usd?: number;
-}): string {
-  return JSON.stringify({ type: 'usage', usage });
-}
-
-/** Build a Kiro error event line */
-function kiroError(error: string): string {
-  return JSON.stringify({ type: 'error', error });
-}
-
-/** Build a Kiro status event line */
-function kiroStatus(status: string): string {
-  return JSON.stringify({ type: 'status', status });
-}
-
-/** Build a Kiro finish event line */
-function kiroFinish(): string {
-  return JSON.stringify({ type: 'finish' });
 }
 
 /** Base options used across most tests */
@@ -171,17 +141,24 @@ afterEach(() => {
 
 describe('createKiroBackend', () => {
   it('returns a backend instance and resolved model when model is provided', () => {
-    const { backend, model } = createKiroBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4' });
+    const { backend, model } = createKiroBackend({ ...BASE_OPTIONS, model: 'claude-sonnet-4-5' });
 
     expect(backend).toBeDefined();
     expect(typeof backend.startSession).toBe('function');
-    expect(model).toBe('claude-sonnet-4');
+    expect(model).toBe('claude-sonnet-4-5');
   });
 
   it('returns undefined model when no model is specified', () => {
     const { model } = createKiroBackend(BASE_OPTIONS);
 
     expect(model).toBeUndefined();
+  });
+
+  it('reports supportsTools=false (kiro-cli emits no structured tool events)', () => {
+    const { metadata } = createKiroBackend(BASE_OPTIONS);
+
+    expect(metadata?.supportsTools).toBe(false);
+    expect(metadata?.supportsStreaming).toBe(true);
   });
 
   it('returns a backend implementing the full AgentBackend interface', () => {
@@ -201,20 +178,12 @@ describe('createKiroBackend', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('passes cwd to the backend options', () => {
-    const { backend } = createKiroBackend({ cwd: '/aws/workspace' });
-
-    expect(backend).toBeDefined();
-  });
-
-  it('accepts awsProfile option', () => {
-    const { backend } = createKiroBackend({ ...BASE_OPTIONS, awsProfile: 'prod' });
-
-    expect(backend).toBeDefined();
-  });
-
-  it('accepts awsRegion option', () => {
-    const { backend } = createKiroBackend({ ...BASE_OPTIONS, awsRegion: 'us-west-2' });
+  it('accepts effort and trustTools options', () => {
+    const { backend } = createKiroBackend({
+      ...BASE_OPTIONS,
+      effort: 'high',
+      trustTools: 'fs_read,fs_write',
+    });
 
     expect(backend).toBeDefined();
   });
@@ -268,7 +237,7 @@ describe('KiroBackend — session lifecycle', () => {
     expect(statuses).toContain('idle');
   });
 
-  it('startSession with initial prompt spawns kiro', async () => {
+  it('startSession with initial prompt spawns kiro-cli', async () => {
     const { backend } = createKiroBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
 
@@ -280,8 +249,8 @@ describe('KiroBackend — session lifecycle', () => {
       .filter((m: any) => m.type === 'status')
       .map((m: any) => m.status);
 
-    expect(statuses).toContain('starting');
-    expect(statuses).toContain('running');
+    expect(statuses[0]).toBe('starting');
+    expect(statuses[1]).toBe('running');
     expect(mockSpawn).toHaveBeenCalledOnce();
   });
 
@@ -301,14 +270,28 @@ describe('KiroBackend — session lifecycle', () => {
 
     await expect(backend.startSession()).rejects.toThrow('disposed');
   });
+
+  it('dispose kills an in-flight process', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    // Start a send but don't finish the process — keep it in-flight
+    const killSpy = vi.spyOn(currentMockProcess, 'kill');
+    backend.sendPrompt(sessionId, 'Long operation'); // intentionally not awaited
+    await backend.dispose();
+
+    expect(killSpy).toHaveBeenCalledWith('SIGTERM');
+    // Clean up the dangling process
+    currentMockProcess.emit('close', 0);
+  });
 });
 
 // ===========================================================================
-// KiroBackend — sendPrompt
+// KiroBackend — sendPrompt (VERIFIED `kiro-cli chat` invocation)
 // ===========================================================================
 
-describe('KiroBackend — sendPrompt', () => {
-  it('spawns the kiro binary with correct arguments', async () => {
+describe('KiroBackend — sendPrompt invocation', () => {
+  it('spawns `kiro-cli chat --no-interactive --trust-all-tools <prompt>` with the prompt as a trailing positional', async () => {
     const { backend } = createKiroBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
@@ -316,14 +299,34 @@ describe('KiroBackend — sendPrompt', () => {
     simulateProcess(currentMockProcess);
     await promptPromise;
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'kiro',
-      expect.arrayContaining(['run', '--prompt', 'Write tests for auth module', '--output-format', 'jsonl']),
-      expect.objectContaining({ cwd: '/project' })
-    );
+    const [bin, args] = mockSpawn.mock.calls[0] as [string, string[], unknown];
+    // Binary is kiro-cli, NOT kiro.
+    expect(bin).toBe('kiro-cli');
+    // Subcommand + flags first, prompt last (positional).
+    expect(args[0]).toBe('chat');
+    expect(args).toContain('--no-interactive');
+    expect(args).toContain('--trust-all-tools');
+    expect(args[args.length - 1]).toBe('Write tests for auth module');
+    // The fabricated old-schema flags must NOT be present.
+    expect(args).not.toContain('run');
+    expect(args).not.toContain('--prompt');
+    expect(args).not.toContain('--output-format');
+    expect(args).not.toContain('jsonl');
   });
 
-  it('passes --model flag when model is specified', async () => {
+  it('passes cwd to the spawn options', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Hello');
+    simulateProcess(currentMockProcess);
+    await promptPromise;
+
+    const opts = (mockSpawn.mock.calls[0] as any[])[2];
+    expect(opts.cwd).toBe('/project');
+  });
+
+  it('includes --model flag (before the positional prompt) when model is specified', async () => {
     const { backend } = createKiroBackend({ ...BASE_OPTIONS, model: 'amazon-nova-pro' });
     const { sessionId } = await backend.startSession();
 
@@ -331,46 +334,63 @@ describe('KiroBackend — sendPrompt', () => {
     simulateProcess(currentMockProcess);
     await promptPromise;
 
-    const args = mockSpawn.mock.calls[0][1] as string[];
-    expect(args).toContain('--model');
-    expect(args).toContain('amazon-nova-pro');
+    const args = (mockSpawn.mock.calls[0] as any[])[1] as string[];
+    const modelIdx = args.indexOf('--model');
+    expect(modelIdx).toBeGreaterThanOrEqual(0);
+    expect(args[modelIdx + 1]).toBe('amazon-nova-pro');
+    // Prompt stays the trailing positional.
+    expect(args[args.length - 1]).toBe('Analyze costs');
   });
 
-  it('passes --session flag when sessionName is provided', async () => {
-    const { backend } = createKiroBackend({ ...BASE_OPTIONS, sessionName: 'my-kiro-session' });
+  it('includes --effort flag when effort is specified', async () => {
+    const { backend } = createKiroBackend({ ...BASE_OPTIONS, effort: 'high' });
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'Resume work');
+    const promptPromise = backend.sendPrompt(sessionId, 'Deep analysis');
     simulateProcess(currentMockProcess);
     await promptPromise;
 
-    const args = mockSpawn.mock.calls[0][1] as string[];
-    expect(args).toContain('--session');
-    expect(args).toContain('my-kiro-session');
+    const args = (mockSpawn.mock.calls[0] as any[])[1] as string[];
+    const effortIdx = args.indexOf('--effort');
+    expect(effortIdx).toBeGreaterThanOrEqual(0);
+    expect(args[effortIdx + 1]).toBe('high');
   });
 
-  it('passes AWS_PROFILE in spawn env when awsProfile is provided', async () => {
-    const { backend } = createKiroBackend({ ...BASE_OPTIONS, awsProfile: 'dev' });
+  it('uses --trust-tools=<list> when trustTools is a comma list', async () => {
+    const { backend } = createKiroBackend({ ...BASE_OPTIONS, trustTools: 'fs_read,fs_write' });
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'Deploy to dev');
+    const promptPromise = backend.sendPrompt(sessionId, 'Restricted run');
     simulateProcess(currentMockProcess);
     await promptPromise;
 
-    const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<string, string>;
-    expect(spawnEnv.AWS_PROFILE).toBe('dev');
+    const args = (mockSpawn.mock.calls[0] as any[])[1] as string[];
+    expect(args).toContain('--trust-tools=fs_read,fs_write');
+    expect(args).not.toContain('--trust-all-tools');
   });
 
-  it('passes AWS_DEFAULT_REGION in spawn env when awsRegion is provided', async () => {
-    const { backend } = createKiroBackend({ ...BASE_OPTIONS, awsRegion: 'eu-west-1' });
+  it('injects KIRO_API_KEY into spawn env when apiKey is provided', async () => {
+    const { backend } = createKiroBackend({ ...BASE_OPTIONS, apiKey: 'kiro-secret-key' });
     const { sessionId } = await backend.startSession();
 
-    const promptPromise = backend.sendPrompt(sessionId, 'Check EU region resources');
+    const promptPromise = backend.sendPrompt(sessionId, 'Authenticated run');
     simulateProcess(currentMockProcess);
     await promptPromise;
 
-    const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<string, string>;
-    expect(spawnEnv.AWS_DEFAULT_REGION).toBe('eu-west-1');
+    const spawnEnv = (mockSpawn.mock.calls[0] as any[])[2].env as Record<string, string>;
+    expect(spawnEnv.KIRO_API_KEY).toBe('kiro-secret-key');
+  });
+
+  it('does NOT inject KIRO_API_KEY when no apiKey is provided', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Anonymous run');
+    simulateProcess(currentMockProcess);
+    await promptPromise;
+
+    const spawnEnv = (mockSpawn.mock.calls[0] as any[])[2].env as Record<string, string>;
+    expect(spawnEnv.KIRO_API_KEY).toBeUndefined();
   });
 
   it('throws when sendPrompt is called with wrong sessionId', async () => {
@@ -388,7 +408,7 @@ describe('KiroBackend — sendPrompt', () => {
     await expect(backend.sendPrompt(sessionId, 'test')).rejects.toThrow('disposed');
   });
 
-  it('emits error status when process exits with non-zero code', async () => {
+  it('rejects when kiro-cli exits with non-zero code', async () => {
     const { backend } = createKiroBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
@@ -401,351 +421,167 @@ describe('KiroBackend — sendPrompt', () => {
     expect(errorMsgs.length).toBeGreaterThan(0);
   });
 
-  it('rejects with error when process emits error event', async () => {
+  it('rejects with error when process emits a non-ENOENT error event', async () => {
     const { backend } = createKiroBackend(BASE_OPTIONS);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'test');
-    (currentMockProcess as EventEmitter).emit('error', new Error('kiro not found'));
+    (currentMockProcess as EventEmitter).emit('error', new Error('boom'));
 
-    await expect(promptPromise).rejects.toThrow('kiro not found');
+    await expect(promptPromise).rejects.toThrow('boom');
+  });
+
+  it('emits a friendly install hint on ENOENT (binary not on PATH)', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'test').catch(() => {});
+    const err = Object.assign(new Error('spawn kiro-cli ENOENT'), { code: 'ENOENT' });
+    (currentMockProcess as EventEmitter).emit('error', err);
+    await promptPromise;
+
+    const errStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
+    expect(errStatuses[0]).toBeDefined();
+    expect((errStatuses[0] as any).detail).toMatch(/not installed/i);
+  });
+
+  it('passes extraArgs (validated) before the positional prompt', async () => {
+    const { backend } = createKiroBackend({ ...BASE_OPTIONS, extraArgs: ['--verbose'] });
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Hello');
+    simulateProcess(currentMockProcess);
+    await promptPromise;
+
+    const args = (mockSpawn.mock.calls[0] as any[])[1] as string[];
+    expect(args).toContain('--verbose');
+    expect(args.indexOf('--verbose')).toBeLessThan(args.length - 1);
+    expect(args[args.length - 1]).toBe('Hello');
+  });
+
+  it('rejects extraArgs with shell metacharacters', async () => {
+    const { backend } = createKiroBackend({ ...BASE_OPTIONS, extraArgs: ['--config=$(malicious)'] });
+    const { sessionId } = await backend.startSession();
+
+    await expect(backend.sendPrompt(sessionId, 'test')).rejects.toThrow('Unsafe character');
+  });
+
+  it('emits "running" status when sendPrompt is called', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const { sessionId } = await backend.startSession();
+    const messages = collectMessages(backend);
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Hello');
+    simulateProcess(currentMockProcess);
+    await promptPromise;
+
+    const statuses = messages.filter((m: any) => m.type === 'status').map((m: any) => m.status);
+    expect(statuses).toContain('running');
   });
 });
 
 // ===========================================================================
-// KiroBackend — JSONL output parsing
+// KiroBackend — plain-text stdout passthrough (VERIFIED behavior)
 // ===========================================================================
 
-describe('KiroBackend — JSONL output parsing', () => {
-  it('emits model-output for message events', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Hello Kiro');
-    simulateProcess(currentMockProcess, [kiroMessage('Here is my AWS analysis')]);
-    await promptPromise;
-
-    const outputMsgs = messages.filter((m: any) => m.type === 'model-output');
-    expect(outputMsgs).toHaveLength(1);
-    expect((outputMsgs[0] as any).textDelta).toBe('Here is my AWS analysis');
-  });
-
-  it('emits tool-call for tool_call events', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Check S3 buckets');
-    simulateProcess(currentMockProcess, [
-      kiroToolCall('list_s3_buckets', 'call-1', { region: 'us-east-1' }),
-    ]);
-    await promptPromise;
-
-    const toolCalls = messages.filter((m: any) => m.type === 'tool-call');
-    expect(toolCalls).toHaveLength(1);
-    expect((toolCalls[0] as any).toolName).toBe('list_s3_buckets');
-    expect((toolCalls[0] as any).callId).toBe('call-1');
-    expect((toolCalls[0] as any).args).toEqual({ region: 'us-east-1' });
-  });
-
-  it('emits tool-result for tool_result events', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Get Lambda metrics');
-    simulateProcess(currentMockProcess, [
-      kiroToolResult('get_metrics', 'call-2', { p99: 120, errors: 0 }),
-    ]);
-    await promptPromise;
-
-    const toolResults = messages.filter((m: any) => m.type === 'tool-result');
-    expect(toolResults).toHaveLength(1);
-    expect((toolResults[0] as any).toolName).toBe('get_metrics');
-    expect((toolResults[0] as any).callId).toBe('call-2');
-  });
-
-  it('emits idle status for finish events', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Analyze architecture');
-    simulateProcess(currentMockProcess, [kiroFinish()]);
-    await promptPromise;
-
-    const idleStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'idle');
-    expect(idleStatuses.length).toBeGreaterThan(0);
-  });
-
-  it('emits error status for error events', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Do something');
-    simulateProcess(currentMockProcess, [kiroError('AWS credentials expired')]);
-    await promptPromise;
-
-    const errorStatuses = messages.filter((m: any) => m.type === 'status' && m.status === 'error');
-    expect(errorStatuses).toHaveLength(1);
-    expect((errorStatuses[0] as any).detail).toBe('AWS credentials expired');
-  });
-
-  it('maps status events correctly', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Process request');
-    simulateProcess(currentMockProcess, [kiroStatus('running'), kiroStatus('complete')]);
-    await promptPromise;
-
-    const statusValues = messages
-      .filter((m: any) => m.type === 'status')
-      .map((m: any) => m.status);
-
-    expect(statusValues).toContain('running');
-    expect(statusValues).toContain('idle'); // 'complete' maps to 'idle'
-  });
-
-  it('ignores non-JSON lines without crashing', async () => {
+describe('KiroBackend — plain-text stdout', () => {
+  it('emits each stdout chunk as a model-output delta', async () => {
     const { backend } = createKiroBackend(BASE_OPTIONS);
     const messages = collectMessages(backend);
     const { sessionId } = await backend.startSession();
 
     const promptPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [
-      'Kiro version 1.0.0',
-      kiroMessage('Hi there!'),
-      '  ',
-    ]);
+    simulateProcess(currentMockProcess, ['Here is my ', 'AWS analysis']);
     await promptPromise;
 
-    const outputMsgs = messages.filter((m: any) => m.type === 'model-output');
-    expect(outputMsgs).toHaveLength(1);
+    const textMessages = messages.filter((m: any) => m.type === 'model-output');
+    expect(textMessages).toHaveLength(2);
+    expect((textMessages[0] as any).textDelta).toBe('Here is my ');
+    expect((textMessages[1] as any).textDelta).toBe('AWS analysis');
+  });
+
+  it('strips ANSI/terminal control codes from model-output', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    // Real kiro-cli styles its markdown reply with CSI color codes + cursor
+    // show/hide. We strip them so only the model text reaches the app.
+    const ESC = String.fromCharCode(27);
+    const styled = ESC + "[?25l" + ESC + "[1;36mHello" + ESC + "[0m, world!" + ESC + "[?25h";
+    const promptPromise = backend.sendPrompt(sessionId, 'Hello');
+    simulateProcess(currentMockProcess, [styled]);
+    await promptPromise;
+
+    const textMessages = messages.filter((m: any) => m.type === 'model-output');
+    expect(textMessages).toHaveLength(1);
+    expect((textMessages[0] as any).textDelta).toBe('Hello, world!');
+    // No raw escape bytes should remain.
+    // eslint-disable-next-line no-control-regex
+    expect((textMessages[0] as any).textDelta).not.toMatch(new RegExp(String.fromCharCode(27)));
+  });
+
+  it('passes through plain text that happens to start with "{" (no JSON parsing)', async () => {
+    // WHY: the old impl parsed a fabricated JSONL schema. The real kiro-cli emits
+    // plain prose; a line beginning with "{" must still surface verbatim.
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Hello');
+    simulateProcess(currentMockProcess, ['{ "this": "is just text kiro printed" }']);
+    await promptPromise;
+
+    const textMessages = messages.filter((m: any) => m.type === 'model-output');
+    expect(textMessages).toHaveLength(1);
+    expect((textMessages[0] as any).textDelta).toContain('is just text kiro printed');
+  });
+
+  it('emits "idle" status on clean (code 0) exit', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Hello');
+    simulateProcess(currentMockProcess, ['done thinking'], 0);
+    await promptPromise;
+
+    const statuses = messages.filter((m: any) => m.type === 'status').map((m: any) => m.status);
+    expect(statuses).toContain('idle');
+  });
+
+  it('does NOT emit usage/cost/tool/fs-edit events (kiro-cli has no schema for them)', async () => {
+    const { backend } = createKiroBackend(BASE_OPTIONS);
+    const messages = collectMessages(backend);
+    const { sessionId } = await backend.startSession();
+
+    const promptPromise = backend.sendPrompt(sessionId, 'Write a file');
+    simulateProcess(currentMockProcess, ['I wrote the file for you.']);
+    await promptPromise;
+
+    expect(messages.filter((m: any) => m.type === 'token-count')).toHaveLength(0);
+    expect(messages.filter((m: any) => m.type === 'cost-report')).toHaveLength(0);
+    expect(messages.filter((m: any) => m.type === 'tool-call')).toHaveLength(0);
+    expect(messages.filter((m: any) => m.type === 'tool-result')).toHaveLength(0);
+    expect(messages.filter((m: any) => m.type === 'fs-edit')).toHaveLength(0);
   });
 });
 
 // ===========================================================================
-// KiroBackend — credit-based cost tracking
+// DELETED — invented JSONL event schema + credit-cost tracking
 // ===========================================================================
-
-describe('KiroBackend — credit-based cost tracking', () => {
-  it('converts credits to USD at $0.01 per credit', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Analyze IAM policies');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 10, input_tokens: 500, output_tokens: 200 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect(tokenCounts).toHaveLength(1);
-    // 10 credits * $0.01/credit = $0.10
-    expect((tokenCounts[0] as any).costUsd).toBeCloseTo(0.10, 5);
-    expect((tokenCounts[0] as any).inputTokens).toBe(500);
-    expect((tokenCounts[0] as any).outputTokens).toBe(200);
-  });
-
-  it('uses pre-computed cost_usd when provided by Kiro', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Deep analysis');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 50, cost_usd: 0.42 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    // Should use provided cost_usd (0.42), not credits * rate (0.50)
-    expect((tokenCounts[0] as any).costUsd).toBeCloseTo(0.42, 5);
-  });
-
-  it('accumulates credits and cost across multiple usage events', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    // First prompt
-    let promptPromise = backend.sendPrompt(sessionId, 'First task');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 5 }),
-    ]);
-    await promptPromise;
-
-    // Reset mock for second prompt
-    currentMockProcess = makeMockProcess();
-    mockSpawn.mockReturnValue(currentMockProcess);
-
-    // Second prompt
-    promptPromise = backend.sendPrompt(sessionId, 'Second task');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 8 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect(tokenCounts.length).toBeGreaterThanOrEqual(2);
-
-    // Final accumulated cost = (5 + 8) * $0.01 = $0.13
-    const lastTokenCount = tokenCounts[tokenCounts.length - 1] as any;
-    expect(lastTokenCount.costUsd).toBeCloseTo(0.13, 5);
-  });
-
-  it('includes creditsConsumed in token-count event', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Calculate credits');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 25 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect((tokenCounts[0] as any).creditsConsumed).toBe(25);
-  });
-
-  it('handles zero credits without dividing or multiplying by zero', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Free operation');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 0 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect(tokenCounts).toHaveLength(1);
-    expect((tokenCounts[0] as any).costUsd).toBe(0);
-  });
-
-  it('resets credit and cost accumulators on each startSession', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-
-    // First session — consume 10 credits
-    let { sessionId } = await backend.startSession();
-    let promptPromise = backend.sendPrompt(sessionId, 'First session');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 10 }),
-    ]);
-    await promptPromise;
-
-    // Clear messages and start a new session
-    messages.length = 0;
-    currentMockProcess = makeMockProcess();
-    mockSpawn.mockReturnValue(currentMockProcess);
-
-    ({ sessionId } = await backend.startSession());
-    promptPromise = backend.sendPrompt(sessionId, 'Second session');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 3 }),
-    ]);
-    await promptPromise;
-
-    const tokenCounts = messages.filter((m: any) => m.type === 'token-count');
-    expect(tokenCounts.length).toBeGreaterThan(0);
-    // New session — should only reflect 3 credits, not 13
-    const lastTokenCount = tokenCounts[tokenCounts.length - 1] as any;
-    expect(lastTokenCount.costUsd).toBeCloseTo(0.03, 5);
-  });
-});
-
-// ===========================================================================
-// KiroBackend — fs-edit detection
-// ===========================================================================
-
-describe('KiroBackend — fs-edit detection', () => {
-  it('emits fs-edit for write_file tool results', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Create Lambda handler');
-    simulateProcess(currentMockProcess, [
-      kiroToolResult('write_file', 'call-1', 'success', { path: '/project/src/handler.py' }),
-    ]);
-    await promptPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(1);
-    expect((fsEdits[0] as any).path).toBe('/project/src/handler.py');
-    expect((fsEdits[0] as any).description).toContain('write_file');
-  });
-
-  it('emits fs-edit for edit_file tool results', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Update config');
-    simulateProcess(currentMockProcess, [
-      kiroToolResult('edit_file', 'call-2', 'ok', { path: '/project/config.json' }),
-    ]);
-    await promptPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(1);
-    expect((fsEdits[0] as any).path).toBe('/project/config.json');
-  });
-
-  it('emits fs-edit for modify_file tool results', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Patch IAM policy');
-    simulateProcess(currentMockProcess, [
-      kiroToolResult('modify_file', 'call-3', 'done', { file_path: '/iam/policy.json' }),
-    ]);
-    await promptPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(1);
-    expect((fsEdits[0] as any).path).toBe('/iam/policy.json');
-  });
-
-  it('does NOT emit fs-edit for non-file tools', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'List EC2 instances');
-    simulateProcess(currentMockProcess, [
-      kiroToolResult('list_ec2_instances', 'call-4', ['i-1234', 'i-5678']),
-    ]);
-    await promptPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(0);
-  });
-
-  it('does NOT emit fs-edit when tool result has no path in input', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Write something');
-    simulateProcess(currentMockProcess, [
-      kiroToolResult('write_file', 'call-5', 'ok', { content: 'hello' }), // no path
-    ]);
-    await promptPromise;
-
-    const fsEdits = messages.filter((m: any) => m.type === 'fs-edit');
-    expect(fsEdits).toHaveLength(0);
-  });
-});
+//
+// SCHEMA UNVERIFIED / NONEXISTENT (#30 — kiro-cli emits no structured output):
+// kiro-cli v2.6.1 has NO JSON/stream output mode for chat. The prior suite's
+// `KiroBackend — JSONL output parsing`, `credit-based cost tracking`, `fs-edit
+// detection`, and `cost-report emission` blocks asserted a fabricated
+// `{message, tool_call, tool_result, usage:{credits_consumed}, finish}` schema
+// and a `KIRO_CREDIT_TO_USD` (1 credit = $0.01) billing model that the real
+// binary does not produce. They were DELETED rather than skipped because there
+// is nothing real to replace them with — kiro-cli writes plain text to stdout
+// and emits no usage/cost/tool telemetry. The plain-text passthrough block above
+// is the complete verified behavior.
 
 // ===========================================================================
 // KiroBackend — cancellation
@@ -758,9 +594,13 @@ describe('KiroBackend — cancellation', () => {
 
     // Start a prompt but do not resolve it — keep the process running
     backend.sendPrompt(sessionId, 'Long running task').catch(() => {});
+    const killSpy = vi.spyOn(currentMockProcess, 'kill');
+
     await backend.cancel(sessionId);
 
-    expect(currentMockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(killSpy).toHaveBeenCalledWith('SIGTERM');
+    // Clean up the dangling process
+    currentMockProcess.emit('close', 0);
   });
 
   it('cancel emits idle status', async () => {
@@ -812,15 +652,12 @@ describe('KiroBackend — permission response', () => {
     expect((permResponses[0] as any).approved).toBe(false);
   });
 
-  it('writes "y\\n" to stdin when approved and process is active', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const { sessionId } = await backend.startSession();
-
-    // Keep process running
-    backend.sendPrompt(sessionId, 'Request permission').catch(() => {});
-    await backend.respondToPermission?.('req-3', true);
-
-    expect(currentMockProcess.stdin.write).toHaveBeenCalledWith('y\n');
+  // SCHEMA UNVERIFIED: the old test asserted a "y\n" stdin write. kiro-cli's
+  // headless mode emits NO structured permission events and pre-authorizes tool
+  // use at spawn via --trust-all-tools / --trust-tools, so there is no verified
+  // over-stdin y/n channel. We no longer fabricate that write. (#30)
+  it.skip('writes "y\\n" to stdin when approved (UNVERIFIED kiro permission channel — see #30)', () => {
+    // Requires a keyed session to confirm whether kiro-cli ever prompts over stdin.
   });
 });
 
@@ -836,7 +673,7 @@ describe('KiroBackend — message handler management', () => {
 
     const { sessionId } = await backend.startSession();
     const promptPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [kiroMessage('Hi from AWS')]);
+    simulateProcess(currentMockProcess, ['Hi from AWS']);
     await promptPromise;
 
     expect(received.some((m: any) => m.type === 'model-output')).toBe(true);
@@ -852,7 +689,7 @@ describe('KiroBackend — message handler management', () => {
 
     const { sessionId } = await backend.startSession();
     const promptPromise = backend.sendPrompt(sessionId, 'Hello');
-    simulateProcess(currentMockProcess, [kiroMessage('Invisible message')]);
+    simulateProcess(currentMockProcess, ['Invisible message']);
     await promptPromise;
 
     const modelOutputs = received.filter((m: any) => m.type === 'model-output');
@@ -869,7 +706,7 @@ describe('KiroBackend — message handler management', () => {
 
     const { sessionId } = await backend.startSession();
     const promptPromise = backend.sendPrompt(sessionId, 'Broadcast');
-    simulateProcess(currentMockProcess, [kiroMessage('For all handlers')]);
+    simulateProcess(currentMockProcess, ['For all handlers']);
     await promptPromise;
 
     expect(received1.some((m: any) => m.type === 'model-output')).toBe(true);
@@ -885,7 +722,7 @@ describe('KiroBackend — message handler management', () => {
 
     const { sessionId } = await backend.startSession();
     const promptPromise = backend.sendPrompt(sessionId, 'Still works');
-    simulateProcess(currentMockProcess, [kiroMessage('Resilient output')]);
+    simulateProcess(currentMockProcess, ['Resilient output']);
     await promptPromise;
 
     expect(received.some((m: any) => m.type === 'model-output')).toBe(true);
@@ -932,18 +769,11 @@ describe('KiroBackend — disposal', () => {
     expect(currentMockProcess.kill).toHaveBeenCalledWith('SIGTERM');
   });
 
-  it('dispose prevents further message emission', async () => {
+  it('marks backend as disposed', async () => {
     const { backend } = createKiroBackend(BASE_OPTIONS);
-    const received: unknown[] = [];
-    backend.onMessage((msg) => received.push(msg));
-
-    await backend.startSession();
     await backend.dispose();
 
-    // Try to emit after disposal — should be a no-op
-    received.length = 0;
-    // No way to call emit directly, but disposal should have cleared listeners
-    expect(received).toHaveLength(0);
+    await expect(backend.startSession()).rejects.toThrow('disposed');
   });
 
   it('calling dispose twice does not throw', async () => {
@@ -952,121 +782,5 @@ describe('KiroBackend — disposal', () => {
 
     await expect(backend.dispose()).resolves.toBeUndefined();
     await expect(backend.dispose()).resolves.toBeUndefined();
-  });
-});
-
-// ===========================================================================
-// KiroBackend — extra args validation
-// ===========================================================================
-
-describe('KiroBackend — extra args validation', () => {
-  it('passes validated extra args to kiro', async () => {
-    const { backend } = createKiroBackend({
-      ...BASE_OPTIONS,
-      extraArgs: ['--verbose', '--timeout', '120'],
-    });
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'Verbose output');
-    simulateProcess(currentMockProcess);
-    await promptPromise;
-
-    const args = mockSpawn.mock.calls[0][1] as string[];
-    expect(args).toContain('--verbose');
-    expect(args).toContain('--timeout');
-    expect(args).toContain('120');
-  });
-
-  it('throws for extra args containing shell metacharacters', async () => {
-    const { backend } = createKiroBackend({
-      ...BASE_OPTIONS,
-      extraArgs: ['--config=$(malicious)'],
-    });
-    const { sessionId } = await backend.startSession();
-
-    await expect(backend.sendPrompt(sessionId, 'test')).rejects.toThrow('Unsafe character');
-  });
-});
-
-// ===========================================================================
-// KiroBackend — cost-report emission
-// ===========================================================================
-
-/**
- * Tests for the unified CostReport event emitted by Kiro usage events.
- *
- * WHY: Kiro uses credit-based billing (AWS credits). The CostReport must carry
- * billingModel='credit' and a credits object with consumed + rateUsdPerCredit.
- * KIRO_CREDIT_TO_USD is exported for downstream config; we snapshot it here
- * so any rate change causes a visible test failure.
- */
-describe('KiroBackend — cost-report emission', () => {
-  it('emits cost-report with billingModel=credit and credits object on usage event', async () => {
-    const { backend } = createKiroBackend({ ...BASE_OPTIONS, model: 'kiro-default' });
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 5, input_tokens: 400, output_tokens: 150 }),
-    ]);
-    await promptPromise;
-
-    const reports = messages.filter((m: any) => m.type === 'cost-report');
-    expect(reports.length).toBeGreaterThanOrEqual(1);
-    const r = reports[0] as any;
-    expect(r.report.billingModel).toBe('credit');
-    expect(r.report.source).toBe('agent-reported');
-    expect(r.report.agentType).toBe('kiro');
-    expect(r.report.credits).toBeDefined();
-    expect(r.report.credits.consumed).toBe(5);
-    expect(typeof r.report.credits.rateUsdPerCredit).toBe('number');
-    expect(r.report.credits.rateUsdPerCredit).toBeGreaterThan(0);
-  });
-
-  it('costUsd equals credits * rateUsdPerCredit when cost_usd is not provided', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 10, input_tokens: 200, output_tokens: 80 }),
-    ]);
-    await promptPromise;
-
-    const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    const { credits } = r.report;
-    expect(r.report.costUsd).toBeCloseTo(credits.consumed * credits.rateUsdPerCredit);
-  });
-
-  it('cost-report has rawAgentPayload set on agent-reported event', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 3, input_tokens: 150, output_tokens: 60 }),
-    ]);
-    await promptPromise;
-
-    const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    expect(r.report.rawAgentPayload).not.toBeNull();
-  });
-
-  it('uses cost_usd directly when Kiro provides it', async () => {
-    const { backend } = createKiroBackend(BASE_OPTIONS);
-    const messages = collectMessages(backend);
-    const { sessionId } = await backend.startSession();
-
-    const promptPromise = backend.sendPrompt(sessionId, 'hello');
-    simulateProcess(currentMockProcess, [
-      kiroUsage({ credits_consumed: 2, cost_usd: 0.025, input_tokens: 100, output_tokens: 50 }),
-    ]);
-    await promptPromise;
-
-    const r = messages.find((m: any) => m.type === 'cost-report') as any;
-    expect(r.report.costUsd).toBeCloseTo(0.025);
   });
 });

--- a/packages/styrby-cli/src/agent/factories/kiro.ts
+++ b/packages/styrby-cli/src/agent/factories/kiro.ts
@@ -1,24 +1,33 @@
 /**
- * Kiro Backend - Kiro CLI agent adapter (AWS)
+ * Kiro Backend — Kiro CLI agent adapter (AWS)
  *
- * This module provides a factory function for creating a Kiro backend.
- * Kiro is an AWS-based AI coding agent that uses a per-prompt credit system
- * instead of traditional token-based billing.
+ * VERIFIED against the real `kiro-cli` binary (v2.6.1, 2026-06-10).
  *
- * Key characteristics:
- * - Binary name: `kiro` (installed via AWS CLI or direct download)
- * - Config: `~/.config/kiro/config.json`
- * - Output: structured JSON lines via stdout
- * - Cost tracking: credit-based (credits converted to USD equivalent at a fixed rate)
- * - AWS-native: integrates with IAM, CodeWhisperer, and Amazon Q Developer
- * - Per-prompt credits: each prompt consumes a fixed number of credits regardless of
- *   response length; expensive operations (deep analysis) cost more credits
+ * Kiro CLI is the rebranded **Amazon Q Developer CLI** (AWS renamed `q` →
+ * `kiro-cli` on 2025-11-17). It is a self-contained native binary (NOT an
+ * npm/Node package) installed via `curl -fsSL https://cli.kiro.dev/install | bash`.
  *
- * WHY per-prompt credits: Kiro's AWS credit model differs from token-based pricing.
- * One credit equals approximately $0.01 USD (1 credit = $0.01). We convert credits
- * to USD for unified cost tracking in the Styrby dashboard.
+ * Key characteristics (all verified against the real binary, replacing the prior
+ * fabricated `kiro run --output-format jsonl` + credit-billing fiction):
+ * - **Binary name: `kiro-cli`** (NOT `kiro` — the old code's `spawn('kiro')` was
+ *   a guaranteed ENOENT). Backward-compatible aliases `q`/`q chat` also exist.
+ * - **Headless invocation: `kiro-cli chat --no-interactive "<prompt>"`** — the
+ *   prompt is a trailing positional argument; `--no-interactive` prints the first
+ *   response to stdout and exits.
+ * - **Output: PLAIN TEXT (markdown), with ANSI/terminal control codes.** There is
+ *   NO JSON/stream-json for chat responses — `--format json` exists ONLY for
+ *   `--list-models`. So we strip ANSI and forward the text as `model-output`.
+ * - **Auth: `KIRO_API_KEY` env var** (headless; paid tiers only). Without it the
+ *   CLI tries a browser login, which is useless in a relay/headless context.
+ * - **No token/credit/cost telemetry in CLI output.** Kiro bills on credits at
+ *   the account level (overage ~$0.04/credit, not the previously-invented
+ *   $0.01), and the CLI does not print any usage figure. So this backend emits
+ *   NO cost-report — kiro sessions have no CLI-derivable cost (see #30).
+ * - **Tools: `--trust-all-tools` / `--trust-tools=<names>`** auto-approve tool
+ *   use (no structured permission events are emitted, so the mobile per-tool
+ *   approval flow cannot gate kiro the way it gates claude/codex).
  *
- * @see https://kiro.dev
+ * @see https://kiro.dev/docs/cli/headless/
  * @module factories/kiro
  */
 
@@ -35,23 +44,26 @@ import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
-import type { CostReport } from '@styrby/shared/cost';
 
 // ============================================================================
-// Constants
+// Helpers
 // ============================================================================
 
 /**
- * USD cost per single Kiro credit.
+ * Strip ANSI/terminal control sequences from kiro-cli output.
  *
- * WHY: Kiro bills in credits rather than tokens. As of the current pricing
- * schedule, 1 credit = $0.01 USD. This constant is exported so downstream
- * code (e.g., future cost-reporter config) can read it without hardcoding
- * the rate. It is also snapshotted into each CostReport for audit accuracy.
+ * WHY: kiro-cli writes its chat response as styled markdown — it emits CSI color
+ * codes, cursor show/hide (`ESC[?25l`), and spinner frames. None of that is part
+ * of the model's actual text, so we remove it before forwarding `model-output`.
+ * Matches CSI (`ESC[ … final`) and a couple of common single-char escapes.
  *
- * @see https://kiro.dev/pricing
+ * @param text - Raw stdout chunk from kiro-cli.
+ * @returns The text with ANSI control sequences removed.
  */
-export const KIRO_CREDIT_TO_USD = 0.01;
+function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\u001b\[[0-?]*[ -\/]*[@-~]/g, '').replace(/\u001b[=>]/g, '');
+}
 
 // ============================================================================
 // Types
@@ -62,42 +74,39 @@ export const KIRO_CREDIT_TO_USD = 0.01;
  */
 export interface KiroBackendOptions extends AgentFactoryOptions {
   /**
-   * AWS profile to use for Kiro authentication.
-   * Maps to the AWS_PROFILE environment variable and the --profile flag.
-   * Defaults to Kiro's configured default profile from ~/.config/kiro/config.json.
+   * Kiro API key (`KIRO_API_KEY`). REQUIRED for headless use — without it the
+   * CLI falls back to interactive browser login, which cannot complete in a
+   * relay/daemon context. Generated from Kiro account settings (paid tiers only).
+   * When omitted, an inherited `KIRO_API_KEY` from {@link AgentFactoryOptions.env}
+   * (or the ambient environment) is used.
    */
-  awsProfile?: string;
+  apiKey?: string;
 
   /**
-   * AWS region override.
-   * Kiro defaults to the region in config.json or AWS_DEFAULT_REGION.
-   */
-  awsRegion?: string;
-
-  /**
-   * Model to use (e.g., 'claude-sonnet-4', 'amazon-nova-pro').
-   * Kiro supports AWS Bedrock models and Amazon Q Developer models.
-   * Defaults to Kiro's configured default model.
+   * Model to use (`--model`). Passed verbatim. Defaults to kiro-cli's configured
+   * default model.
    */
   model?: string;
 
   /**
-   * Whether to run in non-interactive mode (always true for Styrby).
-   * Prevents Kiro from prompting for user input on permission requests.
-   * Default: true
+   * Reasoning effort (`--effort`): 'low' | 'medium' | 'high' | 'xhigh' | 'max'.
+   * Optional; kiro-cli picks a per-model default when omitted.
    */
-  nonInteractive?: boolean;
+  effort?: string;
 
   /**
-   * Kiro session name for resuming existing sessions.
-   * When provided, Kiro will resume that session's conversation context.
+   * Trust posture for tool use in headless mode. Since kiro emits no structured
+   * permission events we can intercept, a headless run that should DO work
+   * (edit files, run commands) must pre-authorize tools:
+   *  - `true` (default): `--trust-all-tools` — auto-approve everything.
+   *  - a comma list (e.g. 'fs_read,fs_write'): `--trust-tools=<list>` — restrict.
+   *  - `false`: pass `--trust-tools=` (trust nothing; read-only-ish).
+   * WHY default true: parity with the other headless plain-text agents
+   * (aider `--yes`, crush) so kiro can actually complete coding tasks unattended.
    */
-  sessionName?: string;
+  trustTools?: boolean | string;
 
-  /**
-   * Additional Kiro CLI arguments.
-   * See: https://kiro.dev/docs/cli
-   */
+  /** Additional kiro-cli arguments (validated for shell-safety). */
   extraArgs?: string[];
 }
 
@@ -114,321 +123,50 @@ export interface KiroBackendResult {
 }
 
 // ============================================================================
-// JSON Output Parsing
-// ============================================================================
-
-/**
- * Kiro JSON output event types.
- *
- * WHY: Kiro outputs structured JSON lines where each line represents a distinct
- * event in the agent's execution flow. The credit-based billing is reported
- * through 'usage' events that include credits_consumed rather than token counts.
- */
-interface KiroJsonEvent {
-  type:
-    | 'message'
-    | 'tool_call'
-    | 'tool_result'
-    | 'usage'
-    | 'error'
-    | 'status'
-    | 'finish';
-  /** Text content for message events */
-  content?: string;
-  /** Tool name for tool_call and tool_result events */
-  tool?: string;
-  /** Tool input arguments */
-  input?: Record<string, unknown>;
-  /** Tool result output */
-  result?: unknown;
-  /** Unique ID correlating tool calls to results */
-  call_id?: string;
-  /** Usage/billing metadata for usage events */
-  usage?: KiroUsageMetadata;
-  /** Error message for error events */
-  error?: string;
-  /** Status string for status events */
-  status?: string;
-  /** Finish reason for finish events */
-  finish_reason?: string;
-}
-
-/**
- * Usage metadata from Kiro per-prompt credit billing.
- *
- * WHY: Kiro uses a credit-based system rather than per-token billing.
- * Credits are consumed per prompt based on operation type:
- * - Simple completions: 1-5 credits
- * - Code analysis: 5-20 credits
- * - Deep refactors: 20-100 credits
- *
- * We store both raw credits and the USD equivalent so cost dashboards
- * show comparable numbers across all agent types.
- */
-interface KiroUsageMetadata {
-  /** Credits consumed for this prompt */
-  credits_consumed?: number;
-  /** Approximate input tokens (for informational display, not billing) */
-  input_tokens?: number;
-  /** Approximate output tokens (for informational display, not billing) */
-  output_tokens?: number;
-  /** Estimated USD cost computed from credits_consumed */
-  cost_usd?: number;
-}
-
-/**
- * Parse a single JSONL output line from Kiro.
- *
- * @param line - A single line of Kiro stdout output
- * @returns Parsed KiroJsonEvent or null if the line is not valid JSON
- */
-function parseKiroJsonLine(line: string): KiroJsonEvent | null {
-  const trimmed = line.trim();
-  if (!trimmed || !trimmed.startsWith('{')) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(trimmed) as KiroJsonEvent;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Detect file system edits from Kiro tool names.
- *
- * WHY: Kiro uses AWS CodeWhisperer-style tool naming for file operations.
- * We detect file-editing tools to emit fs-edit events so the mobile app
- * shows users which files were modified.
- *
- * @param toolName - The tool name from the tool_call event
- * @returns true if this tool modifies the file system
- */
-function isKiroFileEditTool(toolName: string): boolean {
-  const fileEditTools = [
-    'write_file',
-    'create_file',
-    'edit_file',
-    'patch_file',
-    'str_replace',
-    'apply_patch',
-    'modify_file',
-    'update_file',
-  ];
-  return fileEditTools.some((t) => toolName.toLowerCase().includes(t));
-}
-
-// ============================================================================
 // KiroBackend Class
 // ============================================================================
 
 /**
  * Kiro Backend implementation.
  *
- * Spawns Kiro as a subprocess with JSONL output and parses structured events.
- * Handles the credit-based cost model by converting credits to USD for unified
- * cost reporting across all agent types in the Styrby dashboard.
+ * Spawns `kiro-cli chat --no-interactive <prompt>` as a one-shot subprocess and
+ * forwards its ANSI-stripped plain-text stdout to the mobile app as
+ * `model-output`. kiro-cli has no machine-readable output mode, so this backend
+ * does NOT emit usage/cost/tool/fs-edit events (see the module header + #30).
  */
 class KiroBackend extends StreamingAgentBackendBase {
   protected readonly logTag = 'KiroBackend';
-  private lineBuffer = '';
-  // WHY: Kiro uses credits, not tokens. We track credits separately and convert
-  // to USD for unified cost display. Token counts are approximate estimates
-  // that Kiro provides for informational purposes only.
-  private creditsConsumed = 0;
-  private inputTokens = 0;
-  private outputTokens = 0;
-  private totalCostUsd = 0;
+
+  // SECURITY: bounded buffer guards against a runaway process flooding stdout.
+  // We emit incrementally (per chunk) so output streams; the buffer only caps growth.
+  private outputBuffer = '';
 
   constructor(private options: KiroBackendOptions) {
     super();
   }
 
   /**
-   * Process a parsed Kiro JSON event and emit the corresponding AgentMessage.
+   * Forward a stdout chunk as `model-output` (ANSI-stripped plain text).
    *
-   * WHY: Kiro's credit-based usage model maps onto our token-count message type
-   * by expressing credits as USD cost. We include approximate token counts from
-   * Kiro's informational fields so cost breakdown charts have data to display.
-   *
-   * @param event - The parsed Kiro JSON event
-   */
-  private handleKiroEvent(event: KiroJsonEvent): void {
-    switch (event.type) {
-      case 'message':
-        if (event.content) {
-          this.emit({ type: 'model-output', textDelta: event.content });
-        }
-        break;
-
-      case 'tool_call':
-        if (event.tool && event.call_id) {
-          this.emit({
-            type: 'tool-call',
-            toolName: event.tool,
-            args: event.input ?? {},
-            callId: event.call_id,
-          });
-        }
-        break;
-
-      case 'tool_result':
-        if (event.call_id && event.tool) {
-          this.emit({
-            type: 'tool-result',
-            toolName: event.tool,
-            result: event.result,
-            callId: event.call_id,
-          });
-
-          // Detect file system edits and emit fs-edit event
-          if (isKiroFileEditTool(event.tool)) {
-            const filePath =
-              (event.input?.path as string) ??
-              (event.input?.file_path as string) ??
-              (event.input?.filename as string);
-            if (filePath) {
-              this.emit({
-                type: 'fs-edit',
-                description: `${event.tool}: ${filePath}`,
-                path: filePath,
-              });
-            }
-          }
-        }
-        break;
-
-      case 'usage':
-        // WHY: Kiro emits a usage event after each prompt with credit consumption data.
-        // We accumulate credits and convert to USD so the Styrby cost dashboard shows
-        // Kiro sessions alongside token-billed agents on a unified dollar basis.
-        if (event.usage) {
-          const credits = event.usage.credits_consumed ?? 0;
-          this.creditsConsumed += credits;
-          const incrInput = event.usage.input_tokens ?? 0;
-          const incrOutput = event.usage.output_tokens ?? 0;
-          this.inputTokens += incrInput;
-          this.outputTokens += incrOutput;
-
-          // WHY: If Kiro provides a pre-computed cost_usd, prefer it over our
-          // conversion. Otherwise compute from credits * KIRO_CREDIT_TO_USD.
-          const incrCost = event.usage.cost_usd !== undefined
-            ? event.usage.cost_usd
-            : credits * KIRO_CREDIT_TO_USD;
-          this.totalCostUsd += incrCost;
-
-          // Emit legacy token-count (keep for existing consumers)
-          this.emit({
-            type: 'token-count',
-            inputTokens: this.inputTokens,
-            outputTokens: this.outputTokens,
-            cacheReadTokens: 0,
-            cacheWriteTokens: 0,
-            costUsd: this.totalCostUsd,
-            // Include credit count for Kiro-specific display in the dashboard
-            creditsConsumed: this.creditsConsumed,
-          });
-
-          // WHY: Emit unified CostReport with billingModel='credit'. The credits
-          // object snapshots the current rateUsdPerCredit so historical cost records
-          // remain accurate even if Kiro reprices their credit packs.
-          const costReport: CostReport = {
-            sessionId: this.sessionId ?? '',
-            messageId: null,
-            agentType: 'kiro',
-            model: this.options.model ?? 'unknown',
-            timestamp: new Date().toISOString(),
-            source: 'agent-reported',
-            billingModel: 'credit',
-            costUsd: incrCost,
-            inputTokens: incrInput,
-            outputTokens: incrOutput,
-            cacheReadTokens: 0,
-            cacheWriteTokens: 0,
-            credits: {
-              consumed: credits,
-              rateUsdPerCredit: KIRO_CREDIT_TO_USD,
-            },
-            rawAgentPayload: event.usage as unknown as Record<string, unknown>,
-          };
-          this.emit({ type: 'cost-report', report: costReport });
-        }
-        break;
-
-      case 'error':
-        this.emit({
-          type: 'status',
-          status: 'error',
-          detail: event.error ?? 'Kiro encountered an error',
-        });
-        break;
-
-      case 'status':
-        if (event.status) {
-          const statusMap: Record<string, 'starting' | 'running' | 'idle' | 'stopped' | 'error'> =
-            {
-              starting: 'starting',
-              running: 'running',
-              idle: 'idle',
-              complete: 'idle',
-              done: 'idle',
-              stopped: 'stopped',
-              error: 'error',
-            };
-          const mapped = statusMap[event.status] ?? 'running';
-          this.emit({ type: 'status', status: mapped });
-        }
-        break;
-
-      case 'finish':
-        // WHY: Kiro emits 'finish' when the agent's response is fully complete.
-        // We transition to 'idle' so the mobile app knows the next prompt can be sent.
-        this.emit({ type: 'status', status: 'idle' });
-        break;
-
-      default:
-        logger.debug('[KiroBackend] Unknown event type:', event);
-    }
-  }
-
-  /**
-   * Process stdout data, buffering partial lines before parsing.
-   *
-   * WHY: Node.js streams deliver data in arbitrary chunks — a single JSON object
-   * may arrive across multiple 'data' events. We buffer until we see a newline
-   * before attempting to parse.
-   *
-   * @param data - Raw buffer chunk from the process stdout
+   * @param data - Raw buffer chunk from kiro-cli stdout.
    */
   private processStdout(data: Buffer): void {
-    const text = data.toString();
-    // SECURITY: Cap buffer size to prevent memory exhaustion from a buggy or
-    // malicious agent emitting continuous data without newlines.
-    this.lineBuffer = safeBufferAppend(this.lineBuffer, text);
-
-    const lines = this.lineBuffer.split('\n');
-    // Keep the last (potentially incomplete) line in the buffer
-    this.lineBuffer = lines.pop() ?? '';
-
-    for (const line of lines) {
-      const event = parseKiroJsonLine(line);
-      if (event) {
-        this.handleKiroEvent(event);
-      } else if (line.trim()) {
-        logger.debug('[KiroBackend] Non-JSON stdout:', line);
-      }
+    const raw = data.toString();
+    this.outputBuffer = safeBufferAppend(this.outputBuffer, raw);
+    const text = stripAnsi(raw);
+    if (text.trim()) {
+      // WHY plain passthrough: kiro-cli has no structured event schema, so the
+      // text IS the model output. No per-event usage/tool/cost data is recoverable.
+      this.emit({ type: 'model-output', textDelta: text });
     }
   }
 
   /**
    * Start a new Kiro session.
    *
-   * Resets credit/cost/token accumulators and optionally sends an initial prompt.
-   *
-   * @param initialPrompt - Optional initial prompt to send immediately
-   * @returns Promise resolving to session information
-   * @throws {Error} When the backend has been disposed
+   * @param initialPrompt - Optional prompt to send immediately.
+   * @returns The new session info.
+   * @throws {Error} When the backend has been disposed.
    */
   async startSession(initialPrompt?: string): Promise<StartSessionResult> {
     if (this.disposed) {
@@ -436,14 +174,9 @@ class KiroBackend extends StreamingAgentBackendBase {
     }
 
     this.sessionId = randomUUID();
-    this.creditsConsumed = 0;
-    this.inputTokens = 0;
-    this.outputTokens = 0;
-    this.totalCostUsd = 0;
-    this.lineBuffer = '';
+    this.outputBuffer = '';
 
     this.emit({ type: 'status', status: 'starting' });
-
     logger.debug(`[KiroBackend] Starting session: ${this.sessionId}`);
 
     if (initialPrompt) {
@@ -457,20 +190,20 @@ class KiroBackend extends StreamingAgentBackendBase {
   }
 
   /**
-   * Send a prompt to Kiro.
+   * Send a prompt to kiro-cli.
    *
-   * Spawns a Kiro subprocess with the prompt text. Uses --output-format jsonl
-   * for structured output and --no-interactive to prevent blocking on stdin.
+   * Spawns `kiro-cli chat --no-interactive [flags] <prompt>`. The prompt is the
+   * trailing positional argument; kiro-cli writes its (plain-text) reply to
+   * stdout, which we forward as `model-output`.
    *
-   * @param sessionId - The active session ID (must match the one from startSession)
-   * @param prompt - The user's prompt text
-   * @throws {Error} When the backend is disposed, session ID is invalid, or spawn fails
+   * @param sessionId - The active session ID (must match startSession result).
+   * @param prompt - The user's prompt text.
+   * @throws {Error} When disposed, session ID is invalid, or process spawn fails.
    */
   async sendPrompt(sessionId: SessionId, prompt: string): Promise<void> {
     if (this.disposed) {
       throw new Error('Backend has been disposed');
     }
-
     if (sessionId !== this.sessionId) {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
@@ -478,61 +211,47 @@ class KiroBackend extends StreamingAgentBackendBase {
     // Reset run-scoped state (clears the cancelled flag) so this run's exit is
     // classified correctly by the close handler (audit 2026-06-09 fix #6).
     this.beginRun();
-
-    this.lineBuffer = '';
+    this.outputBuffer = '';
     this.emit({ type: 'status', status: 'running' });
 
-    // Build Kiro command arguments
-    const args: string[] = [
-      'run',              // Subcommand for one-shot prompt execution
-      '--prompt',         // Pass the prompt as an argument
-      prompt,
-      '--output-format',
-      'jsonl',            // Request structured JSONL output for parsing
-    ];
+    // `kiro-cli chat --no-interactive [flags] <prompt>` (verified). Prompt is the
+    // trailing positional argument.
+    const args: string[] = ['chat', '--no-interactive'];
 
-    // WHY: Always use non-interactive mode. Kiro may prompt for AWS credential
-    // confirmation in interactive mode. The mobile app handles permissions via
-    // the permission-request/response message flow at the server relay level.
-    const nonInteractive = this.options.nonInteractive !== false;
-    if (nonInteractive) {
-      args.push('--no-interactive');
+    // Tool trust posture (no human approval is possible in headless mode).
+    const trust = this.options.trustTools ?? true;
+    if (trust === true) {
+      args.push('--trust-all-tools');
+    } else if (typeof trust === 'string') {
+      args.push(`--trust-tools=${trust}`);
+    } else {
+      args.push('--trust-tools=');
     }
 
-    // Model override
     if (this.options.model) {
       args.push('--model', this.options.model);
     }
-
-    // Resume an existing session if session name is provided
-    if (this.options.sessionName) {
-      args.push('--session', this.options.sessionName);
+    if (this.options.effort) {
+      args.push('--effort', this.options.effort);
     }
-
-    // Extra args (validated for shell safety)
     if (this.options.extraArgs) {
       args.push(...validateExtraArgs(this.options.extraArgs));
     }
 
-    logger.debug(`[KiroBackend] Spawning kiro with args:`, args);
+    // Trailing positional prompt (single argv element — no shell, no escaping).
+    args.push(prompt);
+
+    logger.debug(`[KiroBackend] Spawning kiro-cli with args:`, args);
 
     return new Promise<void>((resolve, reject) => {
       try {
-        // SECURITY: Use buildSafeEnv() to prevent leaking internal secrets to Kiro.
-        // AWS credentials are injected explicitly; all other AWS_* vars are blocked.
-        this.process = spawn('kiro', args, {
+        // SECURITY: buildSafeEnv() blocks ambient secrets. kiro auth is its own
+        // single var (KIRO_API_KEY) — inject only that (no multi-vendor fan-out).
+        this.process = spawn('kiro-cli', args, {
           cwd: this.options.cwd,
           env: buildSafeEnv({
             ...this.options.env,
-            // WHY: Inject AWS profile and region as environment variables so Kiro
-            // can authenticate with the correct AWS credentials without requiring
-            // users to switch their global AWS_PROFILE for each session.
-            ...(this.options.awsProfile
-              ? { AWS_PROFILE: this.options.awsProfile }
-              : {}),
-            ...(this.options.awsRegion
-              ? { AWS_DEFAULT_REGION: this.options.awsRegion }
-              : {}),
+            ...(this.options.apiKey ? { KIRO_API_KEY: this.options.apiKey } : {}),
           }),
           stdio: ['pipe', 'pipe', 'pipe'],
         });
@@ -541,67 +260,37 @@ class KiroBackend extends StreamingAgentBackendBase {
           throw new Error('Failed to create stdio pipes');
         }
 
-        // Handle stdout — JSONL events from Kiro
         this.process.stdout.on('data', (data: Buffer) => {
           this.processStdout(data);
         });
 
-        // Handle stderr — warnings and diagnostic messages
         this.process.stderr.on('data', (data: Buffer) => {
           const text = data.toString();
           logger.debug(`[KiroBackend] stderr: ${text.trim()}`);
-
-          if (
-            text.includes('Error') ||
-            text.includes('error') ||
-            text.includes('Exception') ||
-            text.includes('failed')
-          ) {
-            this.emit({
-              type: 'status',
-              status: 'error',
-              detail: text.trim(),
-            });
+          if (/error|exception|failed/i.test(text)) {
+            this.emit({ type: 'status', status: 'error', detail: stripAnsi(text).trim() });
           }
         });
 
-        // Handle process close
         this.process.on('close', (code) => {
           logger.debug(`[KiroBackend] Process exited with code: ${code}`);
-
-          // Flush any remaining buffered output
-          if (this.lineBuffer.trim()) {
-            const event = parseKiroJsonLine(this.lineBuffer);
-            if (event) {
-              this.handleKiroEvent(event);
-            }
-            this.lineBuffer = '';
-          }
+          this.outputBuffer = '';
 
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });
             resolve();
           } else if (this.wasCancelled()) {
-            // Intentional user cancel (or dispose) SIGTERM'd the process, which
-            // surfaces here as a non-zero/null exit. Emit a clean idle status and
-            // resolve instead of a spurious agent error (audit 2026-06-09 fix #6).
+            // Intentional cancel/dispose SIGTERM'd the process → non-zero/null exit.
             this.emit({ type: 'status', status: 'idle' });
             resolve();
           } else {
-            this.emit({
-              type: 'status',
-              status: 'error',
-              detail: `Kiro exited with code ${code}`,
-            });
-            reject(new Error(`Kiro exited with code ${code}`));
+            this.emit({ type: 'status', status: 'error', detail: `kiro-cli exited with code ${code}` });
+            reject(new Error(`kiro-cli exited with code ${code}`));
           }
-
           this.process = null;
         });
 
-        // Handle process spawn errors (e.g., binary not found in PATH)
-        // WHY (Phase 0.3 / SOC2 CC7.2): Surface friendly install hint on
-        // ENOENT instead of raw "spawn ... ENOENT" Node error.
+        // ENOENT → friendly install hint (Phase 0.3 / SOC2 CC7.2).
         this.process.on('error', (err: NodeJS.ErrnoException) => {
           if (err.code === 'ENOENT') {
             const message = formatInstallHint('kiro');
@@ -616,77 +305,49 @@ class KiroBackend extends StreamingAgentBackendBase {
         });
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error));
-        this.emit({
-          type: 'status',
-          status: 'error',
-          detail: err.message,
-        });
+        this.emit({ type: 'status', status: 'error', detail: err.message });
         reject(err);
       }
     });
   }
 
   /**
-   * Cancel the current Kiro operation.
+   * Cancel the current kiro-cli operation (SIGTERM + 3s SIGKILL escalation).
    *
-   * Sends SIGTERM to allow Kiro to clean up AWS API connections gracefully,
-   * then falls back to SIGKILL after 3 seconds if the process hasn't exited.
-   *
-   * @param sessionId - The active session ID to cancel
-   * @throws {Error} When session ID does not match the active session
+   * @param sessionId - The active session ID to cancel.
+   * @throws {Error} When session ID does not match the active session.
    */
   async cancel(sessionId: SessionId): Promise<void> {
     if (sessionId !== this.sessionId) {
       throw new Error(`Invalid session ID: ${sessionId}`);
     }
-
     if (this.process) {
-      logger.debug('[KiroBackend] Cancelling Kiro process');
-      // Mark cancelled BEFORE SIGTERM so the close handler treats the resulting
-      // non-zero exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
+      logger.debug('[KiroBackend] Cancelling kiro-cli process');
+      // Mark cancelled BEFORE SIGTERM so the close handler treats the non-zero
+      // exit as an intentional cancel, not a crash (audit 2026-06-09 fix #6).
       this.markCancelled();
       this.process.kill('SIGTERM');
-      // WHY: Give Kiro 3 seconds to cleanly close its AWS API connections
-      // before forcing a kill. This prevents resource leaks in the Kiro
-      // process manager. The escalation timer is tracked by the base class
-      // so it is cancelled on clean exit / dispose / double-cancel
-      // (SOC2 CC7.2 event-loop hygiene).
       this.scheduleForceKill();
     }
-
     this.emit({ type: 'status', status: 'idle' });
   }
 
   /**
    * Respond to a Kiro permission request.
    *
-   * WHY: Kiro may request permission for shell execution and file system operations
-   * that could affect the AWS environment. In non-interactive mode, Kiro auto-approves.
-   * This method handles the response for interactive permission flows.
+   * SCHEMA UNVERIFIED — kiro-cli headless mode emits NO structured permission
+   * events and tool use is pre-authorized at spawn via `--trust-all-tools` /
+   * `--trust-tools`. There is no verified over-stdin y/n channel, so we only emit
+   * the `permission-response` for app-side bookkeeping and do NOT write to stdin.
    *
-   * @param requestId - The ID of the permission request
-   * @param approved - Whether the user approved the request
+   * @param requestId - The permission request id.
+   * @param approved - Whether the user approved.
    */
   async respondToPermission(requestId: string, approved: boolean): Promise<void> {
-    this.emit({
-      type: 'permission-response',
-      id: requestId,
-      approved,
-    });
-
-    if (this.process?.stdin && !this.process.killed) {
-      const response = approved ? 'y\n' : 'n\n';
-      try {
-        this.process.stdin.write(response);
-      } catch {
-        // Stdin may be closed — safe to ignore
-      }
-    }
+    this.emit({ type: 'permission-response', id: requestId, approved });
   }
 
-  // waitForResponseComplete and dispose inherited from
-  // StreamingAgentBackendBase. Base dispose() clears the listener array, the
-  // cancel timer (SOC2 CC7.2), and SIGTERMs the process.
+  // waitForResponseComplete and dispose inherited from StreamingAgentBackendBase.
 }
 
 // ============================================================================
@@ -696,28 +357,25 @@ class KiroBackend extends StreamingAgentBackendBase {
 /**
  * Create a Kiro backend.
  *
- * Kiro is an AWS-based AI coding agent that uses a per-prompt credit system
- * for billing. Credits are converted to USD at a rate of $0.01 per credit for
- * unified cost tracking across all Styrby-supported agents.
+ * Drives the verified headless `kiro-cli chat --no-interactive <prompt>` mode,
+ * which writes the model's plain-text reply to stdout. kiro-cli has no
+ * JSON/structured output mode, so this backend surfaces model text only (no
+ * usage/cost/tool events — see the module header + #30).
  *
- * The kiro binary must be installed and available in PATH.
- * Install via: `curl -sSL https://kiro.dev/install.sh | sh` or
- * `brew install kiro` (if the Homebrew tap is configured).
+ * The `kiro-cli` binary must be installed and on PATH:
+ *   curl -fsSL https://cli.kiro.dev/install | bash
+ * Headless use requires `KIRO_API_KEY` (paid tiers).
  *
- * @param options - Configuration options for the backend
- * @returns KiroBackendResult with backend instance and resolved model
- *
- * @throws {Error} If kiro binary is not installed (deferred until sendPrompt is called)
+ * @param options - Configuration options for the backend.
+ * @returns KiroBackendResult with backend instance and resolved model.
  *
  * @example
  * ```ts
  * const { backend } = createKiroBackend({
  *   cwd: '/path/to/project',
- *   awsProfile: 'dev',
- *   awsRegion: 'us-east-1',
- *   model: 'claude-sonnet-4',
+ *   apiKey: process.env.KIRO_API_KEY,
+ *   model: 'claude-sonnet-4-5',
  * });
- *
  * const { sessionId } = await backend.startSession();
  * await backend.sendPrompt(sessionId, 'Optimize the Lambda functions');
  * ```
@@ -726,10 +384,8 @@ export function createKiroBackend(options: KiroBackendOptions): KiroBackendResul
   logger.debug('[Kiro] Creating backend with options:', {
     cwd: options.cwd,
     model: options.model,
-    awsProfile: options.awsProfile,
-    awsRegion: options.awsRegion,
-    sessionName: options.sessionName,
-    nonInteractive: options.nonInteractive,
+    effort: options.effort,
+    hasApiKey: !!options.apiKey,
   });
 
   return {
@@ -737,8 +393,10 @@ export function createKiroBackend(options: KiroBackendOptions): KiroBackendResul
     model: options.model,
     metadata: {
       modelSource: options.model ? 'explicit' : 'default',
+      // Streaming true (text arrives incrementally); tools false (kiro-cli emits
+      // no structured tool-call/tool-result events in headless mode).
       supportsStreaming: true,
-      supportsTools: true,
+      supportsTools: false,
     },
   };
 }
@@ -749,16 +407,6 @@ export function createKiroBackend(options: KiroBackendOptions): KiroBackendResul
 
 /**
  * Register the Kiro backend with the global agent registry.
- *
- * Call this during application initialization to make Kiro available
- * as an agent type. After calling this, `agentRegistry.create('kiro', opts)`
- * will return a configured KiroBackend instance.
- *
- * @example
- * ```ts
- * // In application startup (initializeAgents):
- * registerKiroAgent();
- * ```
  */
 export function registerKiroAgent(): void {
   agentRegistry.register('kiro', (opts) => createKiroBackend(opts).backend);

--- a/packages/styrby-cli/src/commands/__tests__/versionDrift.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/versionDrift.test.ts
@@ -143,9 +143,10 @@ describe('parseVersionFromStartupMessage', () => {
       expectedVersion: '1.2.5',
     },
     {
+      // kiro-cli (rebranded Amazon Q CLI); binary `kiro-cli`, banner "kiro-cli <ver>".
       agentId: 'kiro',
-      banner: 'kiro v0.5.0\n',
-      expectedVersion: '0.5.0',
+      banner: 'kiro-cli 2.6.1\n',
+      expectedVersion: '2.6.1',
     },
     {
       agentId: 'droid',
@@ -202,7 +203,8 @@ describe('checkVersionCompatibility', () => {
     // kilo maxTestedVersion was bumped to 7.x (real binary is v7.3.41), so the
     // "within" and "above max-tested" probes must track that.
     { agentId: 'kilo', within: '7.0.0', below: '0.9.9', above: '8.0.0' },
-    { agentId: 'kiro', within: '0.5.0', below: '0.0.9', above: '2.0.0' },
+    // kiro-cli min 2.0.0 (headless landed in CLI 2.0), maxTested 2.99.99.
+    { agentId: 'kiro', within: '2.5.0', below: '1.9.9', above: '3.0.0' },
     { agentId: 'droid', within: '0.5.0', below: '0.0.9', above: '2.0.0' },
   ];
 

--- a/packages/styrby-cli/src/commands/agentProbe.ts
+++ b/packages/styrby-cli/src/commands/agentProbe.ts
@@ -430,21 +430,23 @@ const AGENT_PROBE_REGISTRY: Record<AllAgentType, AgentProbeConfig> = {
   },
 
   kiro: {
+    // VERIFIED against kiro-cli v2.6.1 (2026-06-10). Kiro CLI = rebranded
+    // Amazon Q Developer CLI; binary is `kiro-cli` (NOT `kiro`). Headless is
+    // `kiro-cli chat --no-interactive <prompt>` → PLAIN TEXT output (no JSON;
+    // --format json is only for --list-models). No token/credit/cost telemetry.
     displayName: 'Kiro (AWS)',
-    command: 'kiro',
+    command: 'kiro-cli',
     versionFlag: '--version',
     versionPattern: /(\d+\.\d+\.\d+)/,
     expectedStreamFormat: {
-      type: '"message" | "tool_call" | "tool_result" | "usage" | "error" | "status" | "finish"',
-      'usage.credits_consumed': 'number (1 credit = $0.01 USD)',
-      'usage.input_tokens': 'number (informational)',
-      'usage.output_tokens': 'number (informational)',
+      output: 'PLAIN TEXT (markdown) with ANSI control codes — no structured events',
+      cost: 'none (kiro-cli emits no token/credit/cost in output; billing is account-level)',
     },
-    parserFile: 'agent/factories/kiro.ts (handleKiroEvent)',
-    installHint: 'See https://kiro.dev for installation',
-    minSupportedVersion: '0.1.0',
-    maxTestedVersion: '1.99.99',
-    startupVersionPatterns: [/kiro v?(\d+\.\d+\.\d+)/i],
+    parserFile: 'agent/factories/kiro.ts (stripAnsi plain-text passthrough)',
+    installHint: 'curl -fsSL https://cli.kiro.dev/install | bash (binary: kiro-cli; KIRO_API_KEY for headless)',
+    minSupportedVersion: '2.0.0',
+    maxTestedVersion: '2.99.99',
+    startupVersionPatterns: [/kiro-cli v?(\d+\.\d+\.\d+)/i],
   },
 
   droid: {


### PR DESCRIPTION
## Summary
kiro was the **last unverified agent** (flagged as the top risk in #352). Researched, installed, and rewrote the integration against the real binary — completing the agent-verification workstream. **All 11 agents now reconciled against real binaries.** Net **-627 LOC** (more fiction removed).

## The reality (verified against kiro-cli v2.6.1)
The old code was entirely fictional:
| | Was (fiction) | Real (verified) |
|---|---|---|
| Binary | `kiro` | **`kiro-cli`** (the old spawn was a guaranteed ENOENT) |
| Invocation | `run --prompt --output-format jsonl` | `kiro-cli chat --no-interactive <prompt>` |
| Output | JSONL `{message,tool_call,usage}` events | **PLAIN TEXT** (no JSON; `--format json` is `--list-models` only) |
| Auth | `AWS_PROFILE`/IAM | `KIRO_API_KEY` env (paid tiers) |
| Cost | invented `$0.01/credit` billing | **none** in CLI output (account-level, ~$0.04/credit) |

Kiro CLI is the **rebranded Amazon Q Developer CLI** — mature AWS tooling.

## What changed
Rewrote `kiro.ts` as a plain-text agent (mirroring crush): `kiro-cli chat --no-interactive --trust-all-tools <prompt>`, ANSI-strip stdout → `model-output`, `KIRO_API_KEY`-only env, no cost-report, `supportsTools:false`. Rewrote `kiro.test.ts`, fixed the kiro fixtures in the shared e2e files, updated `agentProbe` (command + plain-text schema + version range), `versionDrift` fixtures, and the install hint.

## Verification
- ✅ **LIVE-verified**: drove the real `KiroBackend` against the installed `kiro-cli` → spawns correctly, **no ENOENT**, output flows (the wrong-binary bug is fixed)
- ✅ CLI typecheck 0 + full suite **2589 pass / 50 skip / 0 fail**

## Test Plan
- [x] full CLI suite green
- [x] live probe against real kiro-cli
- [ ] CI passes
- [ ] (follow-up) keyed KIRO_API_KEY session to confirm response text rendering

🤖 Shipped via /gh-ship