### PR TITLE
fix(cli,mobile): OSI/version/concurrency + OTEL hardening (#26/#27 + SEC-MOB-003)

### DIFF
--- a/packages/styrby-cli/CHANGELOG.md
+++ b/packages/styrby-cli/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 2026-06-11 - Version-compat + concurrency fixes
+
+#### Fixed
+
+- **amp no longer falsely reports a version warning.** The version-compat check
+  assumed semver `major.minor`, but amp ships a `0.0.<build-number>` scheme
+  (real binary reports e.g. `0.0.1781143784`). Against the old `0.5.0` floor,
+  every real amp install sorted "below minimum supported." Set amp's floor to
+  the absolute `0.0.0`. Also corrected amp's `installHint` from the deprecated
+  `@sourcegraph/amp` alias to canonical `@ampcode/cli`.
+- **Concurrent prompts no longer orphan an agent process.** The relay dispatches
+  `sendPrompt` fire-and-forget, so two chat messages in quick succession both
+  reached the backend, and each spawn-per-prompt agent (opencode/amp/droid/
+  kilo/crush/goose/kiro/aider/claude — all 9 streaming backends) does
+  `this.process = spawn(...)` — the second
+  spawn overwrote `this.process` and left the first child running detached with
+  interleaved output. Added a busy guard in `beginRun()`: an overlapping prompt
+  is now rejected ("agent is busy") so the caller can retry after the current
+  run finishes or is cancelled. One agent process per backend at a time.
+
+### 2026-06-11 - OSI-layer resilience hardening
+
+#### Fixed
+
+- **kiro output is cleaner on mobile.** The kiro-cli ANSI stripper only removed
+  CSI color codes and two ESC characters, so OSC sequences (window-title /
+  hyperlink), charset designators, and stray control bytes (carriage returns,
+  BEL, DEL) passed through into the relayed `model-output` and rendered as
+  garbage glyphs on the mobile app. Centralized into a hardened `utils/ansi.ts`
+  (OSC + CSI + 3-byte charset + C0-control handling; preserves tab and newline)
+  and pointed kiro at it.
+
+#### Changed
+
+- Added malformed-frame regression tests for the codex MCP event handler and
+  shared ANSI stripping, locking in the existing null/non-object guards so a
+  buggy or truncated protocol frame can never throw out of the parse path
+  (test-only; no behavior change).
+
 ### 2026-06-11 - Managed agent sessions + real-binary reconciliation + relay hardening
 
 The CLI now drives **all 11 agents through a uniform managed-spawn path** and every

--- a/packages/styrby-cli/src/agent/StreamingAgentBackendBase.ts
+++ b/packages/styrby-cli/src/agent/StreamingAgentBackendBase.ts
@@ -208,14 +208,35 @@ export abstract class StreamingAgentBackendBase implements AgentBackend {
   protected cancelled = false;
 
   /**
-   * Reset run-scoped state at the start of a new prompt.
+   * Reset run-scoped state at the start of a new prompt, and reject the prompt
+   * if a previous run is still in flight.
    *
-   * Currently clears the `cancelled` flag so a fresh run is not mistaken for a
+   * Clears the `cancelled` flag so a fresh run is not mistaken for a
    * previously-cancelled one. Subclasses MUST call this at the top of
    * `sendPrompt()` (before spawning) so the cancel-vs-crash discrimination in
    * the close handler is correct per run.
+   *
+   * WHY the busy guard (#27 concurrency fix): the relay dispatcher invokes
+   * `agent.sendPrompt(...)` fire-and-forget (no await — see apiSession relay
+   * handler). Two chat messages arriving in quick succession would therefore
+   * both reach `sendPrompt`, and each spawn-per-prompt backend does
+   * `this.process = spawn(...)`. Without a guard the second spawn overwrites
+   * `this.process`, ORPHANING the first child (it keeps running detached, its
+   * stdout interleaves with the second run, and its close handler nulls the
+   * second run's process reference). One agent process per backend at a time is
+   * the invariant; reject the overlapping prompt so the caller can retry after
+   * the current run finishes or is cancelled. The mobile UI normally disables
+   * input while a run is active, so this only fires on resends / double-taps /
+   * a misbehaving controller — exactly the edge case this guard exists for.
+   *
+   * @throws {Error} If a run is already in flight (`this.process` is live).
    */
   protected beginRun(): void {
+    if (this.process && !this.process.killed) {
+      throw new Error(
+        'Agent is busy: a prompt is already running. Wait for it to finish or cancel it first.',
+      );
+    }
     this.cancelled = false;
   }
 

--- a/packages/styrby-cli/src/agent/factories/__tests__/codex.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/codex.test.ts
@@ -233,6 +233,28 @@ describe('codex event -> AgentMessage mapping', () => {
     expect(out).toContainEqual(expect.objectContaining({ type: 'event', name: 'some_future_event' }));
   });
 
+  // #26 L7 resilience: the codex MCP event stream is semi-trusted. A buggy
+  // server, a truncated frame, or a protocol drift can deliver a null,
+  // primitive, or array where an event object is expected. handleCodexEvent
+  // guards with `if (!raw || typeof raw !== 'object') return` — these tests
+  // lock that guard in so a malformed frame can never throw out of the handler.
+  it('ignores null/undefined/primitive frames without throwing or emitting', () => {
+    const { messages } = makeBackend();
+    for (const bad of [null, undefined, 0, 42, '', 'a string', true, NaN]) {
+      expect(() => captured.handler!(bad as never)).not.toThrow();
+    }
+    expect(messages).toHaveLength(0);
+  });
+
+  it('does not throw on an object frame with a missing or non-string type', () => {
+    const { messages } = makeBackend();
+    for (const bad of [{}, { type: 123 }, { type: null }, { notType: 'x' }, { type: {} }]) {
+      expect(() => captured.handler!(bad as never)).not.toThrow();
+    }
+    // Coercion-heavy fields must not crash even when present with wrong types.
+    expect(() => captured.handler!({ type: 'exec_command_begin', call_id: {}, command: 5 } as never)).not.toThrow();
+  });
+
   it('non-object event is ignored', () => {
     const { messages } = makeBackend();
     captured.handler!('not an object');

--- a/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
@@ -871,6 +871,36 @@ describe('OpenCodeBackend — cancel', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #27 concurrency guard — beginRun() rejects an overlapping prompt
+// ---------------------------------------------------------------------------
+
+describe('OpenCodeBackend — concurrent prompt guard (#27)', () => {
+  it('rejects a second prompt while the first run is still in flight', async () => {
+    const { backend } = createOpenCodeBackend({ cwd: '/tmp/project' });
+    const { sessionId } = await backend.startSession();
+
+    // First prompt spawns a process and stays running (no close emitted).
+    const first = backend.sendPrompt(sessionId, 'one');
+
+    // The relay dispatches fire-and-forget, so a second prompt can arrive
+    // mid-run. It must be rejected (busy), NOT silently spawn a second process
+    // that orphans the first.
+    await expect(backend.sendPrompt(sessionId, 'two')).rejects.toThrow(/busy/i);
+
+    // Finish the first run; this.process is nulled by the close handler.
+    lastFakeProcess.emit('close', 0);
+    await first;
+
+    // A subsequent prompt is accepted again (the guard only blocks overlap).
+    const third = backend.sendPrompt(sessionId, 'three');
+    lastFakeProcess.emit('close', 0); // close the new run so it resolves
+    await expect(third).resolves.toBeUndefined();
+
+    await backend.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
 
 describe('OpenCodeBackend — respondToPermission', () => {
   it('emits permission-response with approved=true', async () => {

--- a/packages/styrby-cli/src/agent/factories/kiro.ts
+++ b/packages/styrby-cli/src/agent/factories/kiro.ts
@@ -43,27 +43,14 @@ import type {
 import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
+// WHY shared util (#26): kiro-cli writes styled markdown (CSI color codes,
+// OSC sequences, cursor show/hide, spinner frames, stray control bytes) that is
+// not part of the model's text. stripAnsi removes it at the L6 encoding boundary
+// before forwarding model-output. Centralised in utils/ansi (the prior inline
+// copy only handled CSI + two ESC chars).
+import { stripAnsi } from '@/utils/ansi';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
 
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/**
- * Strip ANSI/terminal control sequences from kiro-cli output.
- *
- * WHY: kiro-cli writes its chat response as styled markdown — it emits CSI color
- * codes, cursor show/hide (`ESC[?25l`), and spinner frames. None of that is part
- * of the model's actual text, so we remove it before forwarding `model-output`.
- * Matches CSI (`ESC[ … final`) and a couple of common single-char escapes.
- *
- * @param text - Raw stdout chunk from kiro-cli.
- * @returns The text with ANSI control sequences removed.
- */
-function stripAnsi(text: string): string {
-  // eslint-disable-next-line no-control-regex
-  return text.replace(/\u001b\[[0-?]*[ -\/]*[@-~]/g, '').replace(/\u001b[=>]/g, '');
-}
 
 // ============================================================================
 // Types

--- a/packages/styrby-cli/src/commands/__tests__/versionDrift.test.ts
+++ b/packages/styrby-cli/src/commands/__tests__/versionDrift.test.ts
@@ -189,7 +189,10 @@ describe('checkVersionCompatibility', () => {
   const cases: Array<{
     agentId: AllAgentType;
     within: string;
-    below: string;
+    // null = this agent has no below-min state (its floor is the absolute
+    // 0.0.0). amp is the case: it ships a `0.0.<build-number>` calver scheme,
+    // so minSupported is 0.0.0 and nothing can sort below it (#27).
+    below: string | null;
     above: string;
   }> = [
     { agentId: 'claude', within: '1.2.0', below: '0.9.0', above: '3.0.0' },
@@ -198,7 +201,8 @@ describe('checkVersionCompatibility', () => {
     { agentId: 'opencode', within: '0.5.0', below: '0.0.9', above: '2.0.0' },
     { agentId: 'aider', within: '0.65.0', below: '0.59.9', above: '1.0.0' },
     { agentId: 'goose', within: '1.1.0', below: '0.9.9', above: '3.0.0' },
-    { agentId: 'amp', within: '0.8.0', below: '0.4.9', above: '2.0.0' },
+    // amp: 0.0.<build-number> scheme; within = a real build version, no below-min.
+    { agentId: 'amp', within: '0.0.1781143784', below: null, above: '2.0.0' },
     { agentId: 'crush', within: '0.5.0', below: '0.0.9', above: '2.0.0' },
     // kilo maxTestedVersion was bumped to 7.x (real binary is v7.3.41), so the
     // "within" and "above max-tested" probes must track that.
@@ -218,8 +222,9 @@ describe('checkVersionCompatibility', () => {
         expect(result.maxTested).toBeTruthy();
       });
 
-      it(`v${below} (below minimum) → below-min`, () => {
-        const result = checkVersionCompatibility(agentId, below);
+      // Skipped for agents whose floor is 0.0.0 (no version sorts below min).
+      it.skipIf(below === null)(`v${below} (below minimum) → below-min`, () => {
+        const result = checkVersionCompatibility(agentId, below as string);
         expect(result.compatibility).toBe('below-min');
         expect(result.detectedVersion).toBe(below);
       });

--- a/packages/styrby-cli/src/commands/agentProbe.ts
+++ b/packages/styrby-cli/src/commands/agentProbe.ts
@@ -382,8 +382,15 @@ const AGENT_PROBE_REGISTRY: Record<AllAgentType, AgentProbeConfig> = {
       'usage.cost_usd': 'number',
     },
     parserFile: 'agent/factories/amp.ts (handleAmpMessage)',
-    installHint: 'npm install -g @sourcegraph/amp',
-    minSupportedVersion: '0.5.0',
+    // @sourcegraph/amp is a deprecated alias re-exporting @ampcode/cli (see
+    // INSTALL_HINTS in StreamingAgentBackendBase.ts) — point users at canonical.
+    installHint: 'npm install -g @ampcode/cli',
+    // WHY 0.0.0 (#27 fix): amp does NOT use semver major.minor — it ships a
+    // `0.0.<build-number>` calver scheme (real binary reports e.g.
+    // 0.0.1781143784). The prior 0.5.0 floor flagged EVERY real amp install as
+    // "below minimum supported" (minor 0 < 5). 0.0.0 makes the build-number
+    // patch the only meaningful component; maxTested 1.99.99 still covers it.
+    minSupportedVersion: '0.0.0',
     maxTestedVersion: '1.99.99',
     startupVersionPatterns: [/amp v?(\d+\.\d+\.\d+)/i, /amp@(\d+\.\d+\.\d+)/i],
   },

--- a/packages/styrby-cli/src/utils/__tests__/ansi.test.ts
+++ b/packages/styrby-cli/src/utils/__tests__/ansi.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for `utils/ansi` stripAnsi (#26 L6 encoding resilience).
+ *
+ * Control bytes are built with String.fromCharCode so the test source stays
+ * pure ASCII (no raw escape bytes embedded in the file).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stripAnsi } from '../ansi';
+
+const ESC = String.fromCharCode(0x1b); // 
+const BEL = String.fromCharCode(0x07); // 
+const CR = String.fromCharCode(0x0d); // \r
+const NUL = String.fromCharCode(0x00);
+const DEL = String.fromCharCode(0x7f);
+
+describe('stripAnsi', () => {
+  it('strips CSI colour sequences', () => {
+    expect(stripAnsi(`${ESC}[31mred${ESC}[0m`)).toBe('red');
+    expect(stripAnsi(`${ESC}[1;32mbold green${ESC}[0m`)).toBe('bold green');
+  });
+
+  it('strips CSI cursor show/hide (kiro spinner frames)', () => {
+    expect(stripAnsi(`${ESC}[?25lloading${ESC}[?25h`)).toBe('loading');
+  });
+
+  it('strips OSC title/hyperlink sequences (BEL-terminated)', () => {
+    expect(stripAnsi(`${ESC}]0;window title${BEL}hello`)).toBe('hello');
+  });
+
+  it('strips OSC sequences terminated by ST (ESC backslash)', () => {
+    expect(stripAnsi(`${ESC}]8;;https://x.com${ESC}\\link${ESC}]8;;${ESC}\\`)).toBe('link');
+  });
+
+  it('strips other two-char ESC sequences (keypad/charset)', () => {
+    expect(stripAnsi(`${ESC}=app${ESC}>${ESC}(Btext`)).toBe('apptext');
+  });
+
+  it('strips stray C0 control bytes and DEL', () => {
+    expect(stripAnsi(`a${NUL}b${DEL}c`)).toBe('abc');
+  });
+
+  it('strips carriage returns (line-redraw artifacts)', () => {
+    expect(stripAnsi(`overwritten${CR}final`)).toBe('overwrittenfinal');
+  });
+
+  it('preserves tab and newline (meaningful whitespace)', () => {
+    expect(stripAnsi('line1\nline2\tindented')).toBe('line1\nline2\tindented');
+  });
+
+  it('leaves plain text untouched (incl. unicode/emoji)', () => {
+    expect(stripAnsi('hello world 🚀 café')).toBe('hello world 🚀 café');
+  });
+
+  it('is idempotent (stripping twice equals once)', () => {
+    const input = `${ESC}[31m${ESC}]0;t${BEL}x${CR}y`;
+    expect(stripAnsi(stripAnsi(input))).toBe(stripAnsi(input));
+  });
+
+  it('handles an empty string', () => {
+    expect(stripAnsi('')).toBe('');
+  });
+});

--- a/packages/styrby-cli/src/utils/ansi.ts
+++ b/packages/styrby-cli/src/utils/ansi.ts
@@ -1,0 +1,51 @@
+/**
+ * Terminal-control-sequence stripping for plain-text agent output.
+ *
+ * Plain-text agents (kiro-cli, and the version probes) emit markdown styled
+ * with terminal escape sequences: CSI color codes, OSC title/hyperlink
+ * sequences, charset designators, cursor show/hide, spinner frames, and stray
+ * C0 control bytes. None of that is part of the model's actual text. Because
+ * the stripped output is relayed to the mobile app and rendered as a plain
+ * string, residual control bytes show up as garbage glyphs. This strips them
+ * at the L6 encoding boundary so what reaches the relay is clean UTF-8 text.
+ *
+ * @module utils/ansi
+ */
+
+/* eslint-disable no-control-regex */
+
+// Regexes use \u escapes (not raw bytes) so the source stays readable ASCII.
+// Applied in order; earlier rules consume multi-byte sequences before the
+// final catch-all strips any remaining lone control bytes.
+const OSC = /\u001b\][^]*?(?:\u0007|\u001b\\)/g; // ESC ] ... (BEL | ESC backslash)
+const CSI = /\u001b\[[0-?]*[ -\/]*[@-~]/g;          // ESC [ ... final byte
+const CHARSET = /\u001b[()*+][@-~]/g;                 // ESC ( B  charset designation (3-byte)
+const ESC2 = /\u001b[@-_=>#%]/g;                      // other 2-byte Fe/Fs escapes (keypad, reset)
+const C0 = /[\u0000-\u0008\u000b-\u001f\u007f]/g; // C0 + DEL, keep \t(09) \n(0A)
+
+/**
+ * Strip terminal escape / control sequences from a stdout chunk, preserving
+ * human-readable text plus tab and newline.
+ *
+ * Handles, in order: OSC (title/hyperlink), CSI (color/cursor/erase), charset
+ * designators (ESC ( B), other two-byte ESC sequences (keypad/reset), then
+ * stray C0 control bytes + DEL, EXCEPT tab and newline.
+ *
+ * WHY keep \t and \n: meaningful whitespace in the rendered text.
+ * WHY strip \r (in the C0 range): kiro-cli redraws lines with carriage
+ * returns; a lone \r in relayed text causes overwrite artifacts on mobile.
+ *
+ * @param text - Raw stdout chunk from a plain-text agent.
+ * @returns The chunk with control sequences removed.
+ *
+ * @example
+ * stripAnsi(escSeq + '[31mred' + escSeq + '[0m') // 'red'
+ */
+export function stripAnsi(text: string): string {
+  return text
+    .replace(OSC, '')
+    .replace(CSI, '')
+    .replace(CHARSET, '')
+    .replace(ESC2, '')
+    .replace(C0, '');
+}

--- a/packages/styrby-mobile/app/settings/__tests__/metrics.test.tsx
+++ b/packages/styrby-mobile/app/settings/__tests__/metrics.test.tsx
@@ -208,7 +208,7 @@ describe('MetricsScreen', () => {
     expect(result.errors['endpoint']).toBeDefined();
   });
 
-  it('validateOtelConfig: endpoint must start with http(s)://', () => {
+  it('validateOtelConfig: endpoint must be a URL (rejects non-http schemes)', () => {
     const result = validateOtelConfig({
       enabled: true,
       endpoint: 'ftp://invalid.example.com/v1/metrics',
@@ -217,7 +217,32 @@ describe('MetricsScreen', () => {
       timeoutMs: 5000,
     });
     expect(result.isValid).toBe(false);
-    expect(result.errors['endpoint']).toContain('http');
+    expect(result.errors['endpoint']).toContain('https');
+  });
+
+  // SEC-MOB-003: OTEL spans carry session + cost metadata, so a cleartext
+  // http:// collector would leak them to a passive observer. https-only.
+  it('validateOtelConfig: rejects cleartext http:// endpoint', () => {
+    const result = validateOtelConfig({
+      enabled: true,
+      endpoint: 'http://collector.example.com/v1/metrics',
+      headers: {},
+      serviceName: 'styrby-cli',
+      timeoutMs: 5000,
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors['endpoint']).toContain('https');
+  });
+
+  it('validateOtelConfig: accepts https:// endpoint', () => {
+    const result = validateOtelConfig({
+      enabled: true,
+      endpoint: 'https://collector.example.com/v1/metrics',
+      headers: {},
+      serviceName: 'styrby-cli',
+      timeoutMs: 5000,
+    });
+    expect(result.isValid).toBe(true);
   });
 
   it('validateOtelConfig: service name cannot be empty', () => {

--- a/packages/styrby-mobile/src/lib/otel-config.ts
+++ b/packages/styrby-mobile/src/lib/otel-config.ts
@@ -134,8 +134,12 @@ export function validateOtelConfig(config: Partial<OtelUserConfig>): OtelConfigV
       errors['endpoint'] = 'Endpoint URL is required when OTEL export is enabled';
     } else {
       const trimmed = config.endpoint.trim();
-      if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
-        errors['endpoint'] = 'Endpoint must start with http:// or https://';
+      // WHY https-only (SEC-MOB-003): OTEL spans carry session + cost metadata.
+      // Permitting http:// would export that telemetry in cleartext to a
+      // user-configured collector — a passive network observer could read it.
+      // This matches the documented contract in this function's @example.
+      if (!trimmed.startsWith('https://')) {
+        errors['endpoint'] = 'Endpoint must start with https:// (cleartext http:// is not allowed)';
       } else {
         try {
           new URL(trimmed);


### PR DESCRIPTION
## Summary
Tail of the multi-lens verification arc. Three CLI fixes + one mobile fix, each found by exercising the real codebase (real binaries, real parse paths, a real mobile audit) — not imagined implementation.

- **CLI #26 (OSI resilience):** `stripAnsi` leaked OSC/charset/control bytes into mobile output → hardened + centralized into `utils/ansi.ts`; kiro repointed. + codex malformed-frame regression tests.
- **CLI #27 (version + concurrency):** amp falsely flagged "below min" (it uses a `0.0.<build>` scheme, floor was `0.5.0`) → fixed + install hint corrected. Concurrent fire-and-forget prompts orphaned an agent process → busy guard in `beginRun()` (all 9 streaming backends).
- **Mobile SEC-MOB-003:** `validateOtelConfig` allowed a cleartext `http://` collector (leaking session/cost telemetry) → https-only, matching its documented contract.

## Changes
- `styrby-cli`: `utils/ansi.ts` (new) + test, `kiro.ts` (repoint), `StreamingAgentBackendBase.ts` (busy guard), `agentProbe.ts` (amp floor + hint), `versionDrift.test.ts`, codex/opencode tests, CHANGELOG.
- `styrby-mobile`: `lib/otel-config.ts` (https-only) + `metrics.test.tsx` (+3 tests).

## Test Plan
- [x] Full CLI suite 2616 pass / 122 files (incl. new ansi/codex/concurrency tests)
- [x] Mobile OTEL 13/13 (incl. http-reject / https-accept)
- [x] typecheck 0 across all 4 packages; CLI build green
- [ ] CI passes (CLI + mobile jobs; web/shared path-skipped)

🤖 Shipped via /gh-ship