### PR TITLE
fix(cli): recover opencode cost from session storage (issue #26855)

### DIFF
--- a/packages/styrby-cli/CHANGELOG.md
+++ b/packages/styrby-cli/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 2026-06-11 - Multi-step cost accounting verified + clarified
+
+#### Changed
+
+- **opencode/kilo cost reporting is now provably correct for multi-step
+  (tool-using) turns.** Verified the real billing path end-to-end: each
+  `step_finish` is one API call, the backend emits one `cost-report` per event,
+  the cost-reporter writes one `cost_records` row per event (unique idempotency
+  key), and budget-monitor SUMS the rows — so per-step values already sum to the
+  true turn total. The step handlers now emit explicit per-step deltas (never
+  carry a prior step's value forward) and the misleading "take latest" comment
+  is corrected to document the insert-per-event-summed contract. Added a
+  multi-step regression test asserting deltas, not running totals (a running
+  total would have caused the downstream sum to over-count). Single-step cost
+  was already verified correct against real stored opencode session data.
+
+#### Fixed
+
+- **opencode cost is no longer lost when the final step is dropped from stdout
+  (root-cause fix for opencode issue #26855).** opencode's `run --format json`
+  can exit on `session.status=idle` before flushing the final `step_finish` to
+  stdout — but it persists every step to session storage. The backend now
+  reconciles against that authoritative storage on process close
+  (`opencodeStorage.ts`): it reads the turn's step-finish parts and recovers any
+  the stream dropped (deduped by part id / count, so it never double-counts and
+  is a no-op when the stream was complete). Version-independent — works whether
+  or not the user's opencode has the upstream fix. +14 tests (storage reader +
+  recovery integration).
+
+#### Known issue (upstream, remaining)
+
+- kilo (an opencode fork) shares the #26855 stdout-truncation risk, but its
+  on-disk storage layout was not confirmed (no keyed kilo session captured), so
+  it is not yet wired. The reconciliation module is parameterized and ready;
+  tracked as a follow-up (`COST-OPENCODE-26855` in exclusions.json).
+
 ### 2026-06-11 - Version-compat + concurrency fixes
 
 #### Fixed

--- a/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/opencode.test.ts
@@ -59,6 +59,21 @@ vi.mock('@/ui/logger', () => ({
   },
 }));
 
+// Controllable mock of the #26855 storage reader. Defaults to "no stored parts"
+// so every existing test sees the recovery as a no-op; the cost-recovery test
+// sets `storageMock.parts` to simulate steps opencode persisted but dropped from
+// stdout. selectMissedStepFinishes is kept REAL (pure dedupe logic).
+const storageMock = vi.hoisted(() => ({ parts: [] as Array<Record<string, number | string>> }));
+vi.mock('../opencodeStorage', async (importActual) => {
+  const actual = await importActual<typeof import('../opencodeStorage')>();
+  return {
+    ...actual,
+    resolveOpencodeStorageDir: () => '/fake/storage',
+    findLatestAssistantMessageId: () => 'msg_test',
+    readStepFinishParts: () => storageMock.parts,
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Import SUT (after mocks are in place)
 // ---------------------------------------------------------------------------
@@ -478,6 +493,92 @@ describe('OpenCodeBackend — JSON-line parsing', () => {
     expect(cost?.report).toMatchObject({
       agentType: 'opencode', source: 'agent-reported', billingModel: 'api-key',
       costUsd: 0.0123, inputTokens: 11346, outputTokens: 17, cacheReadTokens: 5, cacheWriteTokens: 0,
+    });
+  });
+
+  // Multi-step billing contract (verified 2026-06-11): a tool-using turn emits
+  // one step_finish PER API call; we emit one cost-report per event; the
+  // cost-reporter writes one summed cost_records row per event. So each
+  // cost-report must carry THAT step's values (a delta), NOT a running total —
+  // otherwise the downstream SUM over-counts. This guards against a regression
+  // back to accumulation.
+  it('emits one PER-STEP cost-report per step_finish (deltas, not a running total)', async () => {
+    const { messages, promptPromise } = await setupWithRunningPrompt();
+    const steps = [
+      { cost: 0.01, tokens: { input: 1000, output: 10, cache: { read: 0, write: 0 } } },
+      { cost: 0.02, tokens: { input: 1500, output: 20, cache: { read: 0, write: 0 } } },
+      { cost: 0.03, tokens: { input: 2000, output: 30, cache: { read: 0, write: 0 } } },
+    ];
+    for (const s of steps) {
+      emitStdout(JSON.stringify({ type: 'step_finish', sessionID: 'ses_1', part: { type: 'step-finish', reason: 'stop', ...s } }));
+    }
+    setImmediate(() => closeProcess(0));
+    await promptPromise;
+
+    const costs = messages.filter((m: any) => m.type === 'cost-report').map((m: any) => m.report);
+    expect(costs).toHaveLength(3);
+    // Each row carries its OWN step's values (delta semantics) ...
+    expect(costs.map((r: any) => r.costUsd)).toEqual([0.01, 0.02, 0.03]);
+    expect(costs.map((r: any) => r.inputTokens)).toEqual([1000, 1500, 2000]);
+    expect(costs.map((r: any) => r.outputTokens)).toEqual([10, 20, 30]);
+    // ... so the downstream SUM is the true turn total (the regression guard:
+    // if any row carried a running total, these sums would be inflated).
+    const sum = (k: string) => costs.reduce((a: number, r: any) => a + r[k], 0);
+    expect(sum('costUsd')).toBeCloseTo(0.06, 10);
+    expect(sum('inputTokens')).toBe(4500);
+    expect(sum('outputTokens')).toBe(60);
+  });
+
+  // Root-cause fix for opencode #26855: `run --format json` can exit before
+  // flushing the final step-finish to stdout, but it persists to session
+  // storage. On close we reconcile against storage and recover the missed cost.
+  describe('#26855 cost recovery from session storage', () => {
+    afterEach(() => {
+      storageMock.parts = []; // restore the default "no stored parts" for other tests
+    });
+
+    const stored = [
+      { id: 'prt_1', cost: 0.01, inputTokens: 1000, outputTokens: 10, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      { id: 'prt_2', cost: 0.02, inputTokens: 1500, outputTokens: 20, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      { id: 'prt_3', cost: 0.03, inputTokens: 2000, outputTokens: 30, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    ];
+
+    /** Emit `n` step-finish events on stdout (the first n of `stored`). */
+    function emitFirstN(n: number) {
+      for (let i = 0; i < n; i++) {
+        const s = stored[i];
+        emitStdout(JSON.stringify({
+          type: 'step_finish', sessionID: 'ses_1',
+          part: { type: 'step-finish', id: s.id, messageID: 'msg_test', cost: s.cost, tokens: { input: s.inputTokens, output: s.outputTokens } },
+        }));
+      }
+    }
+
+    it('recovers the final step-finish that stdout dropped', async () => {
+      storageMock.parts = stored; // storage has all 3
+      const { messages, promptPromise } = await setupWithRunningPrompt();
+      emitFirstN(2); // stdout only delivered 2 (the 3rd is the #26855 drop)
+      setImmediate(() => closeProcess(0));
+      await promptPromise;
+
+      const costs = messages.filter((m: any) => m.type === 'cost-report').map((m: any) => m.report);
+      expect(costs).toHaveLength(3); // 2 live + 1 recovered
+      expect(costs[2]).toMatchObject({ costUsd: 0.03, inputTokens: 2000, outputTokens: 30 });
+      expect(costs[2].rawAgentPayload).toMatchObject({ recovered: true, source: 'session-storage', partId: 'prt_3' });
+      // Downstream sum is now the true turn total (0.01 + 0.02 + 0.03).
+      expect(costs.reduce((a: number, r: any) => a + r.costUsd, 0)).toBeCloseTo(0.06, 10);
+    });
+
+    it('does NOT double-count when stdout was already complete', async () => {
+      storageMock.parts = stored;
+      const { messages, promptPromise } = await setupWithRunningPrompt();
+      emitFirstN(3); // stdout delivered all 3
+      setImmediate(() => closeProcess(0));
+      await promptPromise;
+
+      const costs = messages.filter((m: any) => m.type === 'cost-report').map((m: any) => m.report);
+      expect(costs).toHaveLength(3); // no recovery row added
+      expect(costs.some((r: any) => r.rawAgentPayload?.recovered)).toBe(false);
     });
   });
 });

--- a/packages/styrby-cli/src/agent/factories/__tests__/opencodeStorage.test.ts
+++ b/packages/styrby-cli/src/agent/factories/__tests__/opencodeStorage.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for `opencodeStorage` — the authoritative cost-recovery reader
+ * that closes opencode issue #26855 (final step-finish dropped from stdout).
+ *
+ * The fs-reading functions are exercised against a temp dir populated with the
+ * REAL opencode storage JSON shapes (captured from a live install 2026-06-11):
+ *   storage/message/<sessionID>/<msgID>.json   role=assistant
+ *   storage/part/<msgID>/<partID>.json         type=step-finish {cost,tokens}
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  resolveOpencodeStorageDir,
+  readStepFinishParts,
+  findLatestAssistantMessageId,
+  selectMissedStepFinishes,
+  type OpencodeStepFinish,
+} from '../opencodeStorage';
+
+// ---------------------------------------------------------------------------
+// resolveOpencodeStorageDir — XDG handling
+// ---------------------------------------------------------------------------
+
+describe('resolveOpencodeStorageDir', () => {
+  it('honors XDG_DATA_HOME when set', () => {
+    expect(resolveOpencodeStorageDir({ XDG_DATA_HOME: '/data' } as NodeJS.ProcessEnv)).toBe(
+      join('/data', 'opencode', 'storage'),
+    );
+  });
+
+  it('falls back to ~/.local/share when XDG_DATA_HOME is unset/blank', () => {
+    const got = resolveOpencodeStorageDir({ XDG_DATA_HOME: '  ' } as NodeJS.ProcessEnv);
+    expect(got.endsWith(join('.local', 'share', 'opencode', 'storage'))).toBe(true);
+  });
+
+  it('supports a fork product dir name', () => {
+    expect(resolveOpencodeStorageDir({ XDG_DATA_HOME: '/d' } as NodeJS.ProcessEnv, 'kilo')).toBe(
+      join('/d', 'kilo', 'storage'),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fs-reading functions — against a temp storage tree with real shapes
+// ---------------------------------------------------------------------------
+
+describe('readStepFinishParts + findLatestAssistantMessageId', () => {
+  let storageDir: string;
+  const SES = 'ses_test1';
+  const MSG = 'msg_test1';
+
+  beforeEach(() => {
+    storageDir = join(mkdtempSync(join(tmpdir(), 'oc-store-')), 'storage');
+    // message
+    const msgDir = join(storageDir, 'message', SES);
+    mkdirSync(msgDir, { recursive: true });
+    writeFileSync(join(msgDir, `${MSG}.json`), JSON.stringify({ id: MSG, role: 'assistant', sessionID: SES }));
+    writeFileSync(join(msgDir, 'msg_user.json'), JSON.stringify({ id: 'msg_user', role: 'user', sessionID: SES }));
+    // parts: 2 step-finishes + a step-start + a text (must be filtered out)
+    const partDir = join(storageDir, 'part', MSG);
+    mkdirSync(partDir, { recursive: true });
+    writeFileSync(join(partDir, 'prt_a.json'), JSON.stringify({ id: 'prt_a', type: 'step-start' }));
+    writeFileSync(join(partDir, 'prt_b.json'), JSON.stringify({ id: 'prt_b', type: 'text', text: 'hi' }));
+    writeFileSync(join(partDir, 'prt_c.json'), JSON.stringify({
+      id: 'prt_c', type: 'step-finish', cost: 0.01, tokens: { input: 1000, output: 10, cache: { read: 1, write: 2 } },
+    }));
+    writeFileSync(join(partDir, 'prt_d.json'), JSON.stringify({
+      id: 'prt_d', type: 'step-finish', cost: 0.02, tokens: { input: 1500, output: 20 },
+    }));
+  });
+
+  afterEach(() => {
+    rmSync(join(storageDir, '..'), { recursive: true, force: true });
+  });
+
+  it('reads only step-finish parts, coerced + sorted by id', () => {
+    const parts = readStepFinishParts(storageDir, MSG);
+    expect(parts.map((p) => p.id)).toEqual(['prt_c', 'prt_d']); // step-start/text filtered out, sorted
+    expect(parts[0]).toEqual({ id: 'prt_c', cost: 0.01, inputTokens: 1000, outputTokens: 10, cacheReadTokens: 1, cacheWriteTokens: 2 });
+    expect(parts[1]).toMatchObject({ cost: 0.02, inputTokens: 1500, outputTokens: 20, cacheReadTokens: 0, cacheWriteTokens: 0 });
+  });
+
+  it('returns [] for a message with no stored parts', () => {
+    expect(readStepFinishParts(storageDir, 'msg_missing')).toEqual([]);
+  });
+
+  it('finds the latest assistant message id (ignores user messages)', () => {
+    expect(findLatestAssistantMessageId(storageDir, SES)).toBe(MSG);
+  });
+
+  it('returns null when the session has no stored messages', () => {
+    expect(findLatestAssistantMessageId(storageDir, 'ses_missing')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectMissedStepFinishes — the dedupe / recovery decision (pure)
+// ---------------------------------------------------------------------------
+
+describe('selectMissedStepFinishes', () => {
+  const parts: OpencodeStepFinish[] = [
+    { id: 'p1', cost: 0.01, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    { id: 'p2', cost: 0.02, inputTokens: 2, outputTokens: 2, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    { id: 'p3', cost: 0.03, inputTokens: 3, outputTokens: 3, cacheReadTokens: 0, cacheWriteTokens: 0 },
+  ];
+
+  it('id regime: recovers exactly the step(s) whose id was not seen on stdout', () => {
+    const missed = selectMissedStepFinishes(parts, new Set(['p1', 'p2']), 2);
+    expect(missed.map((p) => p.id)).toEqual(['p3']); // the #26855 dropped-final case
+  });
+
+  it('complete stream: id regime recovers nothing (no double-count)', () => {
+    expect(selectMissedStepFinishes(parts, new Set(['p1', 'p2', 'p3']), 3)).toEqual([]);
+  });
+
+  it('count regime (no ids on stdout): recovers the trailing missed step(s)', () => {
+    const missed = selectMissedStepFinishes(parts, new Set(), 2);
+    expect(missed.map((p) => p.id)).toEqual(['p3']);
+  });
+
+  it('total truncation (stdoutCount 0): recovers all stored steps', () => {
+    expect(selectMissedStepFinishes(parts, new Set(), 0).map((p) => p.id)).toEqual(['p1', 'p2', 'p3']);
+  });
+
+  it('count regime never recovers when stdout already saw all (no double-count)', () => {
+    expect(selectMissedStepFinishes(parts, new Set(), 3)).toEqual([]);
+  });
+});

--- a/packages/styrby-cli/src/agent/factories/kilo.ts
+++ b/packages/styrby-cli/src/agent/factories/kilo.ts
@@ -232,26 +232,37 @@ class KiloBackend extends StreamingAgentBackendBase {
         const part = msg.part;
         if (!part) break;
         const t = part.tokens ?? {};
-        // WHY set (not accumulate): mirrors the verified OpenCode single-step
-        // semantics — the turn totals land on one step_finish. Multi-step
-        // aggregation is a tracked follow-up (#30).
+        // WHY emit PER-STEP values (NOT a running total) — multi-step billing
+        // correctness (mirrors opencode.ts; verified 2026-06-11 via the real
+        // cost_records contract): each step_finish is one API call, we emit one
+        // cost-report per event, the cost-reporter writes one summed cost_records
+        // row per event, so summing per-step rows = the true turn total.
+        // Accumulating into a running total here would make each row cumulative
+        // and the downstream SUM would over-count. (Corrects the prior "take
+        // latest" comment.) RESIDUAL RISK (kilo only): issue #26855 — the final
+        // step_finish may not reach stdout. opencode.ts now reconciles against
+        // session storage on close to recover it (opencodeStorage.ts); kilo can
+        // adopt the same once its storage dir is confirmed (COST-OPENCODE-26855).
         //
-        // WHY toNonNegativeNumber (#24 DAST fix): these come from untrusted
-        // stdout; a string/negative would propagate a non-number into the
-        // `number`-typed CostReport and token arithmetic. Coerce at the boundary.
-        this.inputTokens = t.input === undefined ? this.inputTokens : toNonNegativeNumber(t.input);
-        this.outputTokens = t.output === undefined ? this.outputTokens : toNonNegativeNumber(t.output);
+        // WHY toNonNegativeNumber (#24): untrusted stdout; coerce per-step
+        // (default 0 if absent) — never carry a prior step's value forward, which
+        // would re-count it when rows are summed.
+        const stepInput = toNonNegativeNumber(t.input);
+        const stepOutput = toNonNegativeNumber(t.output);
         const cacheRead = toNonNegativeNumber(t.cache?.read);
         const cacheWrite = toNonNegativeNumber(t.cache?.write);
-        if (part.cost !== undefined) this.totalCost = toNonNegativeNumber(part.cost, this.totalCost);
+        const stepCost = toNonNegativeNumber(part.cost);
+        this.inputTokens = stepInput;
+        this.outputTokens = stepOutput;
+        this.totalCost = stepCost;
 
-        // Legacy token-count (kept for existing consumers).
+        // Legacy token-count (kept for existing consumers) — this step's tokens.
         this.emit({
           type: 'token-count',
-          inputTokens: this.inputTokens,
-          outputTokens: this.outputTokens,
-          totalTokens: this.inputTokens + this.outputTokens,
-          costUsd: this.totalCost,
+          inputTokens: stepInput,
+          outputTokens: stepOutput,
+          totalTokens: stepInput + stepOutput,
+          costUsd: stepCost,
         });
 
         // Unified CostReport — source='agent-reported' (Kilo reports real USD).
@@ -263,9 +274,9 @@ class KiloBackend extends StreamingAgentBackendBase {
           timestamp: new Date().toISOString(),
           source: 'agent-reported',
           billingModel: 'api-key',
-          costUsd: this.totalCost,
-          inputTokens: this.inputTokens,
-          outputTokens: this.outputTokens,
+          costUsd: stepCost,
+          inputTokens: stepInput,
+          outputTokens: stepOutput,
           cacheReadTokens: cacheRead,
           cacheWriteTokens: cacheWrite,
           rawAgentPayload: msg as unknown as Record<string, unknown>,

--- a/packages/styrby-cli/src/agent/factories/opencode.ts
+++ b/packages/styrby-cli/src/agent/factories/opencode.ts
@@ -26,6 +26,12 @@ import { agentRegistry } from '../core';
 import { logger } from '@/ui/logger';
 import { buildSafeEnv, safeBufferAppend, validateExtraArgs } from '@/utils/safeEnv';
 import { toNonNegativeNumber } from '@/utils/coerce';
+import {
+  resolveOpencodeStorageDir,
+  readStepFinishParts,
+  findLatestAssistantMessageId,
+  selectMissedStepFinishes,
+} from './opencodeStorage';
 import { resolveApiKeyEnv, type ApiKeyProvider } from '@/utils/apiKeyProvider';
 import { StreamingAgentBackendBase, formatInstallHint } from '../StreamingAgentBackendBase';
 import type { CostReport } from '@styrby/shared/cost';
@@ -123,6 +129,10 @@ interface OpenCodeTokens {
 interface OpenCodePart {
   /** Part discriminator: 'step-start' | 'text' | 'step-finish' | tool parts. */
   type?: string;
+  /** Stable part id (`prt_...`); used to dedupe stdout vs storage recovery. */
+  id?: string;
+  /** Owning assistant message id (`msg_...`); locates the turn in storage. */
+  messageID?: string;
   /** Assistant text (present on `text` events). */
   text?: string;
   /** Step cost in USD (present on `step-finish`). */
@@ -171,6 +181,13 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
   private inputTokens = 0;
   private outputTokens = 0;
   private totalCost = 0;
+  // #26855 cost-recovery state, reset per turn (see resetTurnCostTracking):
+  /** Part ids of step-finish events we emitted from stdout this turn. */
+  private seenStepFinishIds = new Set<string>();
+  /** Count of step-finish events seen on stdout this turn. */
+  private stdoutStepFinishCount = 0;
+  /** The current turn's assistant message id, learned from stdout step-finish events. */
+  private currentTurnMessageId: string | null = null;
   private lineBuffer = '';
 
   constructor(private options: OpenCodeBackendOptions) {
@@ -204,50 +221,61 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
         const part = msg.part;
         if (!part) break;
         const t = part.tokens ?? {};
-        // WHY set (not accumulate): the verified single-step session reports the
-        // turn totals on its one step_finish. Multi-step (tool-using) sessions
-        // emit multiple step_finish events whose aggregation semantics are not yet
-        // captured — taking the latest avoids double-counting the resent context
-        // window (part.tokens.input includes full context each step). Multi-step
-        // aggregation is a tracked follow-up (real tool-session capture needed).
+        // Track this stdout step-finish so the on-close storage reconciliation
+        // (opencode #26855) can tell which steps already reached us and recover
+        // only the ones the stream dropped. id/messageID may be absent on older
+        // opencode; the reconciler degrades to count-based recovery if so.
+        this.stdoutStepFinishCount += 1;
+        if (part.id) this.seenStepFinishIds.add(part.id);
+        if (part.messageID) this.currentTurnMessageId = part.messageID;
+        // WHY emit PER-STEP values (NOT a running total) — multi-step billing
+        // correctness, verified 2026-06-11 by tracing the real cost_records
+        // contract (not inferred):
+        //   • opencode emits one step_finish PER API call. A tool-using turn
+        //     emits several; each carries THAT call's input/output/cost (you are
+        //     billed for the full input context on every call — that is real
+        //     spend, not double-counting).
+        //   • We emit one cost-report per step_finish. The cost-reporter writes
+        //     ONE cost_records row per event (unique idempotency key,
+        //     `cost-${Date.now()}-${uuid}`), and budget-monitor SUMS the rows.
+        //   • Therefore summing the per-step rows already yields the true turn
+        //     total. DO NOT accumulate into a running total here: that would make
+        //     each emitted row cumulative, and the downstream sum would
+        //     quadratically OVER-count. (This corrects the prior "take latest"
+        //     comment, which misdescribed the behavior.)
+        //   • Known residual risk — opencode issue #26855: `run --format json`
+        //     can exit before emitting the FINAL step_finish on stdout (it is in
+        //     session storage but not the stream), so we may miss the last call's
+        //     cost. Tracked; a storage-read fallback is the eventual fix.
         //
-        // WHY toNonNegativeNumber (#24 DAST fix): the raw values are typed
-        // `number?` but come from untrusted stdout. A buggy/old binary that sends
-        // a string or negative would otherwise propagate a non-number into the
-        // `number`-typed CostReport and into `input + output` arithmetic (string
-        // concat). Coercing at the parse boundary keeps the declared type honest.
-        this.inputTokens = t.input === undefined ? this.inputTokens : toNonNegativeNumber(t.input);
-        this.outputTokens = t.output === undefined ? this.outputTokens : toNonNegativeNumber(t.output);
+        // WHY toNonNegativeNumber (#24): raw values are untrusted stdout; coerce
+        // a string/negative/NaN to a finite number at the parse boundary so the
+        // `number`-typed CostReport stays honest. Per-step (default 0 if a field
+        // is absent) — never carry a prior step's value forward, which would
+        // re-count it when the rows are summed.
+        const stepInput = toNonNegativeNumber(t.input);
+        const stepOutput = toNonNegativeNumber(t.output);
         const cacheRead = toNonNegativeNumber(t.cache?.read);
         const cacheWrite = toNonNegativeNumber(t.cache?.write);
-        if (part.cost !== undefined) this.totalCost = toNonNegativeNumber(part.cost, this.totalCost);
+        const stepCost = toNonNegativeNumber(part.cost);
+        this.inputTokens = stepInput;
+        this.outputTokens = stepOutput;
+        this.totalCost = stepCost;
 
-        // Legacy token-count (kept for existing consumers).
+        // Legacy token-count (kept for existing consumers) — this step's tokens.
         this.emit({
           type: 'token-count',
-          inputTokens: this.inputTokens,
-          outputTokens: this.outputTokens,
-          totalTokens: this.inputTokens + this.outputTokens,
-          costUsd: this.totalCost,
+          inputTokens: stepInput,
+          outputTokens: stepOutput,
+          totalTokens: stepInput + stepOutput,
+          costUsd: stepCost,
         });
 
         // Unified CostReport — source='agent-reported' (opencode reports real USD).
-        const costReport: CostReport = {
-          sessionId: this.sessionId ?? '',
-          messageId: null,
-          agentType: 'opencode',
-          model: this.options.model ?? 'unknown',
-          timestamp: new Date().toISOString(),
-          source: 'agent-reported',
-          billingModel: 'api-key',
-          costUsd: this.totalCost,
-          inputTokens: this.inputTokens,
-          outputTokens: this.outputTokens,
-          cacheReadTokens: cacheRead,
-          cacheWriteTokens: cacheWrite,
-          rawAgentPayload: msg as unknown as Record<string, unknown>,
-        };
-        this.emit({ type: 'cost-report', report: costReport });
+        this.emitCostReport(
+          { input: stepInput, output: stepOutput, cacheRead, cacheWrite, cost: stepCost },
+          msg as unknown as Record<string, unknown>,
+        );
         break;
       }
 
@@ -263,6 +291,87 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
         // until the real shape is verified. Tracked in the per-agent protocol
         // verification task.
         logger.debug('[OpenCodeBackend] Unhandled opencode event type:', msg.type);
+    }
+  }
+
+  /**
+   * Build + emit a unified CostReport for one opencode API call (one step).
+   *
+   * Shared by the live stdout path and the on-close storage reconciliation so
+   * both produce byte-identical cost-report shapes (the cost-reporter writes one
+   * summed cost_records row per event).
+   *
+   * @param v - This step's usage (already coerced to finite non-negative numbers).
+   * @param raw - Raw payload for audit (the stdout event, or a storage marker).
+   */
+  private emitCostReport(
+    v: { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number },
+    raw: Record<string, unknown>,
+  ): void {
+    const report: CostReport = {
+      sessionId: this.sessionId ?? '',
+      messageId: null,
+      agentType: 'opencode',
+      model: this.options.model ?? 'unknown',
+      timestamp: new Date().toISOString(),
+      source: 'agent-reported',
+      billingModel: 'api-key',
+      costUsd: v.cost,
+      inputTokens: v.input,
+      outputTokens: v.output,
+      cacheReadTokens: v.cacheRead,
+      cacheWriteTokens: v.cacheWrite,
+      rawAgentPayload: raw,
+    };
+    this.emit({ type: 'cost-report', report });
+  }
+
+  /** Reset the per-turn #26855 cost-recovery tracking at the start of a prompt. */
+  private resetTurnCostTracking(): void {
+    this.seenStepFinishIds.clear();
+    this.stdoutStepFinishCount = 0;
+    this.currentTurnMessageId = null;
+  }
+
+  /**
+   * Recover any step-finish costs that opencode persisted to session storage but
+   * never emitted on stdout (opencode issue #26855: `run --format json` can exit
+   * on `session.status=idle` before flushing the final step-finish event).
+   *
+   * Reads the turn's step-finish parts from opencode's on-disk storage, selects
+   * the ones the stdout stream missed (id-dedupe when available, else count-based
+   * trailing recovery), and emits a recovered cost-report for each — so the
+   * billed total is complete regardless of the user's opencode version. Wholly
+   * best-effort: any failure (no storage, fork without this layout, malformed
+   * files) leaves the live-streamed costs untouched and never throws.
+   */
+  private reconcileCostFromStorage(): void {
+    try {
+      const sessionId = this.openCodeSessionId;
+      if (!sessionId) return;
+      const storageDir = resolveOpencodeStorageDir();
+      const messageId =
+        this.currentTurnMessageId ?? findLatestAssistantMessageId(storageDir, sessionId);
+      if (!messageId) return;
+      const parts = readStepFinishParts(storageDir, messageId);
+      if (parts.length === 0) return;
+      const missed = selectMissedStepFinishes(
+        parts,
+        this.seenStepFinishIds,
+        this.stdoutStepFinishCount,
+      );
+      for (const p of missed) {
+        logger.debug(
+          `[OpenCodeBackend] Recovered step-finish ${p.id} from storage (opencode #26855); cost=${p.cost}`,
+        );
+        this.emitCostReport(
+          { input: p.inputTokens, output: p.outputTokens, cacheRead: p.cacheReadTokens, cacheWrite: p.cacheWriteTokens, cost: p.cost },
+          { recovered: true, source: 'session-storage', partId: p.id, messageId },
+        );
+      }
+    } catch (err) {
+      // Recovery must never break the run; the live-streamed costs still stand.
+      logger.debug('[OpenCodeBackend] storage cost reconciliation skipped:', err);
     }
   }
 
@@ -307,6 +416,7 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
     this.outputTokens = 0;
     this.totalCost = 0;
     this.lineBuffer = '';
+    this.resetTurnCostTracking();
     this.openCodeSessionId = this.options.resumeSessionId ?? null;
 
     this.emit({ type: 'status', status: 'starting' });
@@ -344,6 +454,9 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
     // Reset run-scoped state (clears the cancelled flag) so this run's exit is
     // classified correctly by the close handler (audit 2026-06-09 fix #6).
     this.beginRun();
+    // Reset per-turn cost-recovery tracking so the on-close storage
+    // reconciliation only considers THIS turn's step-finishes (#26855).
+    this.resetTurnCostTracking();
 
     this.emit({ type: 'status', status: 'running' });
 
@@ -439,6 +552,11 @@ class OpenCodeBackend extends StreamingAgentBackendBase {
             }
             this.lineBuffer = '';
           }
+
+          // Recover any step-finish costs opencode persisted to storage but
+          // never flushed to stdout (#26855). Best-effort + deduped against the
+          // stdout-seen steps, so it is a no-op when the stream was complete.
+          this.reconcileCostFromStorage();
 
           if (code === 0) {
             this.emit({ type: 'status', status: 'idle' });

--- a/packages/styrby-cli/src/agent/factories/opencodeStorage.ts
+++ b/packages/styrby-cli/src/agent/factories/opencodeStorage.ts
@@ -1,0 +1,157 @@
+/**
+ * Authoritative cost recovery from opencode's persisted session storage.
+ *
+ * WHY (root-cause fix for opencode issue #26855): opencode's `run --format json`
+ * JSON loop can exit when it observes `session.status=idle` BEFORE it emits the
+ * final `step-finish` event on stdout. The event is generated and persisted to
+ * opencode's on-disk session storage, but never reaches our stdout parser — so
+ * the last API call's cost would be silently lost. The issue is fixed in newer
+ * opencode, but we cannot control which opencode version a user has installed,
+ * and the maintainer's own guidance is that "the session database contains
+ * complete usage data." So rather than depend on the best-effort stream, we
+ * reconcile against that authoritative storage on process close. This module is
+ * the pure, side-effect-free storage reader; the backend wires it into close.
+ *
+ * Storage layout (verified against a real opencode install, 2026-06-11):
+ *   <root>/opencode/storage/message/<sessionID>/<msgID>.json   (assistant msgs)
+ *   <root>/opencode/storage/part/<msgID>/<partID>.json         (step-finish etc.)
+ * where <root> = $XDG_DATA_HOME or ~/.local/share. Part IDs (`prt_...`) are
+ * monotonic/sortable, so filename sort == chronological order.
+ *
+ * @module agent/factories/opencodeStorage
+ */
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { toNonNegativeNumber } from '@/utils/coerce';
+
+/** A step-finish usage record recovered from storage (one API call). */
+export interface OpencodeStepFinish {
+  /** Stable part id (`prt_...`), used to dedupe against stdout-seen events. */
+  id: string;
+  /** USD cost of this single API call. */
+  cost: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+/**
+ * Resolve the opencode (or fork) storage directory, honoring XDG.
+ *
+ * @param env - Environment to read XDG_DATA_HOME from. Default `process.env`.
+ * @param product - Storage product dir name (default 'opencode'; forks differ).
+ * @returns Absolute path to the `storage` dir.
+ */
+export function resolveOpencodeStorageDir(
+  env: NodeJS.ProcessEnv = process.env,
+  product = 'opencode',
+): string {
+  const base = env.XDG_DATA_HOME && env.XDG_DATA_HOME.trim() !== ''
+    ? env.XDG_DATA_HOME
+    : join(homedir(), '.local', 'share');
+  return join(base, product, 'storage');
+}
+
+/**
+ * Read all `step-finish` parts for a given message, in chronological order.
+ *
+ * Best-effort and defensive: a missing dir, unreadable file, or malformed JSON
+ * yields fewer/zero records rather than throwing — cost recovery must never
+ * break the agent run.
+ *
+ * @param storageDir - The resolved storage dir (see resolveOpencodeStorageDir).
+ * @param messageId - The assistant message id whose steps to read.
+ * @returns Step-finish usage records, sorted by part id (chronological).
+ */
+export function readStepFinishParts(storageDir: string, messageId: string): OpencodeStepFinish[] {
+  const dir = join(storageDir, 'part', messageId);
+  if (!existsSync(dir)) return [];
+  const out: OpencodeStepFinish[] = [];
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith('.json')).sort();
+  } catch {
+    return [];
+  }
+  for (const f of files) {
+    try {
+      const p = JSON.parse(readFileSync(join(dir, f), 'utf8')) as Record<string, any>;
+      if (p?.type !== 'step-finish') continue;
+      const t = p.tokens ?? {};
+      out.push({
+        id: typeof p.id === 'string' ? p.id : f.replace(/\.json$/, ''),
+        cost: toNonNegativeNumber(p.cost),
+        inputTokens: toNonNegativeNumber(t.input),
+        outputTokens: toNonNegativeNumber(t.output),
+        cacheReadTokens: toNonNegativeNumber(t.cache?.read),
+        cacheWriteTokens: toNonNegativeNumber(t.cache?.write),
+      });
+    } catch {
+      // skip unreadable/malformed part
+    }
+  }
+  return out;
+}
+
+/**
+ * Find the most recent assistant message id for a session — the fallback used
+ * to locate the just-finished turn when stdout gave us no `messageID` (e.g. a
+ * total truncation where not even the first step-finish reached the stream).
+ *
+ * @param storageDir - The resolved storage dir.
+ * @param sessionId - The opencode session id.
+ * @returns The latest assistant message id, or null if none found.
+ */
+export function findLatestAssistantMessageId(storageDir: string, sessionId: string): string | null {
+  const dir = join(storageDir, 'message', sessionId);
+  if (!existsSync(dir)) return null;
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith('.json')).sort();
+  } catch {
+    return null;
+  }
+  // Sortable ids → the latest assistant message is the last by filename.
+  for (let i = files.length - 1; i >= 0; i--) {
+    try {
+      const m = JSON.parse(readFileSync(join(dir, files[i]), 'utf8')) as Record<string, any>;
+      if (m?.role === 'assistant') return typeof m.id === 'string' ? m.id : files[i].replace(/\.json$/, '');
+    } catch {
+      // skip
+    }
+  }
+  return null;
+}
+
+/**
+ * Decide which step-finish records were MISSED by the stdout stream and must be
+ * recovered from storage, avoiding any double-count.
+ *
+ * Two regimes, chosen safely:
+ *  - If stdout provided a part id for every step-finish it emitted
+ *    (`seenIds.size === stdoutCount` and `stdoutCount > 0`), dedupe by id: emit
+ *    exactly the storage parts whose id we did not already see.
+ *  - Otherwise (ids unavailable/partial, or total truncation with stdoutCount=0),
+ *    fall back to count-based trailing recovery: emit the storage parts after the
+ *    first `stdoutCount` (the #26855 failure mode drops the TRAILING step(s)).
+ *
+ * @param storageParts - All step-finish parts for the turn's message (chronological).
+ * @param seenIds - Part ids observed on stdout this turn (may be empty).
+ * @param stdoutCount - Count of step-finish events observed on stdout this turn.
+ * @returns The subset of storageParts to emit as recovered cost-reports.
+ */
+export function selectMissedStepFinishes(
+  storageParts: OpencodeStepFinish[],
+  seenIds: ReadonlySet<string>,
+  stdoutCount: number,
+): OpencodeStepFinish[] {
+  const haveAllIds = stdoutCount > 0 && seenIds.size === stdoutCount;
+  if (haveAllIds) {
+    return storageParts.filter((p) => !seenIds.has(p.id));
+  }
+  // Count-based trailing recovery (also covers stdoutCount === 0 → recover all).
+  return storageParts.slice(stdoutCount);
+}


### PR DESCRIPTION
## Summary
Root-cause fix for opencode issue #26855: `run --format json` can exit before flushing the final `step_finish` to stdout, so the last API call's cost was silently lost (under-counting tool-heavy turns). Since we can't control the user's opencode version, this fixes it **client-side and version-independently** by reconciling against opencode's authoritative on-disk session storage on process close.

## Changes
- **New `opencodeStorage.ts`** — pure reader of opencode's real storage layout + the recovery-selection logic (dedupe by part id / count).
- **`opencode.ts`** — tracks step-finish ids/count seen on stdout per turn; on close, recovers the missed step(s) from storage. Deduped so it never double-counts and is a no-op when the stream was complete; best-effort (never throws).
- **`opencode.ts` + `kilo.ts`** — clarified the per-step cost-report contract (each step = one summed `cost_records` row; never accumulate into a running total).
- kilo shares the risk but its storage dir is unconfirmed without a keyed session — tracked as a follow-up (module is parameterized + ready).

## Test Plan
- [x] +14 tests: storage reader vs real-shape fixtures, dedupe logic across all regimes, recovery + no-double-count integration tests
- [x] Full CLI suite 2631 pass / 123 files; typecheck 0; build green
- [ ] CI passes (CLI jobs; web/mobile/shared path-skipped)

🤖 Shipped via /gh-ship