### PR TITLE
feat(mcp): add get_team_policy tool + GET /api/v1/team-policies

### DIFF
--- a/packages/styrby-cli/src/api/styrbyApiClient.ts
+++ b/packages/styrby-cli/src/api/styrbyApiClient.ts
@@ -324,6 +324,30 @@ export interface AuditSearchResponse {
   count: number;
 }
 
+/** Query params for {@link StyrbyApiClient.getTeamPolicies}. */
+export interface TeamPoliciesQuery {
+  /** Advisory agent type; the endpoint may use it to narrow results. */
+  agentType?: string;
+}
+
+/** A single governance policy as returned by GET /api/v1/team-policies. */
+export interface TeamPolicyRow {
+  name: string;
+  description: string | null;
+  ruleType: 'cost_threshold' | 'agent_filter' | 'tool_allowlist' | 'time_window';
+  action: 'block' | 'require_approval' | 'allow_with_audit';
+  threshold: number | null;
+  agentFilter: string[];
+  priority: number;
+}
+
+/** Response shape of GET /api/v1/team-policies. */
+export interface TeamPoliciesResponse {
+  policies: TeamPolicyRow[];
+  /** False when the user belongs to no team (solo Free/Pro). */
+  hasTeam: boolean;
+}
+
 export type SessionStatus = 'starting' | 'running' | 'idle' | 'paused' | 'stopped' | 'error' | 'expired';
 
 export interface SessionListQuery {
@@ -941,6 +965,25 @@ export class StyrbyApiClient {
         limit: query.limit,
         since: query.since,
       },
+      retryable: true,
+    });
+  }
+
+  /**
+   * Fetch the calling user's active team governance policies.
+   *
+   * The team is resolved server-side from the API key (never passed in), so an
+   * agent cannot probe another team's policies. Returns `hasTeam:false` + an
+   * empty list for solo accounts. Backs the MCP `get_team_policy` tool.
+   *
+   * @param query - Optional advisory agentType.
+   * @returns The team's enabled policies (priority-ordered) + hasTeam flag.
+   */
+  getTeamPolicies(query: TeamPoliciesQuery = {}): Promise<TeamPoliciesResponse> {
+    return this.request<TeamPoliciesResponse>({
+      method: 'GET',
+      path: '/api/v1/team-policies',
+      query: { agent_type: query.agentType },
       retryable: true,
     });
   }

--- a/packages/styrby-cli/src/commands/mcpServe.ts
+++ b/packages/styrby-cli/src/commands/mcpServe.ts
@@ -37,6 +37,7 @@ import { loadPersistedData } from '@/persistence';
 import { logger } from '@/ui/logger';
 import { runStdioServer } from '@/mcp/server';
 import { createSupabaseApprovalHandler } from '@/mcp/approvalHandler';
+import { createApiTeamPolicyHandler } from '@/mcp/teamPolicyHandler';
 
 /**
  * Top-level entry for `styrby mcp <subcommand>`.
@@ -110,13 +111,14 @@ async function handleMcpServe(): Promise<void> {
   }
 
   const handler = createSupabaseApprovalHandler(apiClient, data.userId, data.machineId);
+  const teamPolicyHandler = createApiTeamPolicyHandler(apiClient);
 
   // Banner goes to stderr — invisible to the JSON-RPC protocol on stdout.
   logger.info(chalk.bold.cyan('Styrby MCP server starting on stdio…'));
-  logger.info(chalk.gray('  Tools exposed: request_approval'));
+  logger.info(chalk.gray('  Tools exposed: request_approval, get_team_policy'));
   logger.info(chalk.gray('  Awaiting client handshake'));
 
-  await runStdioServer(handler);
+  await runStdioServer(handler, teamPolicyHandler);
 
   logger.info(chalk.gray('MCP transport closed; exiting.'));
 }

--- a/packages/styrby-cli/src/mcp/__tests__/server.test.ts
+++ b/packages/styrby-cli/src/mcp/__tests__/server.test.ts
@@ -15,8 +15,30 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createStyrbyMcpServer, type ApprovalHandler } from '../server';
-import type { RequestApprovalInput, RequestApprovalOutput } from '../tools';
+import { createStyrbyMcpServer, type ApprovalHandler, type TeamPolicyHandler } from '../server';
+import type {
+  RequestApprovalInput,
+  RequestApprovalOutput,
+  GetTeamPolicyInput,
+  GetTeamPolicyOutput,
+} from '../tools';
+
+/**
+ * Stub TeamPolicyHandler that records calls and returns canned output.
+ * Defaults to a solo user (no team) unless overridden.
+ */
+function teamPolicyStub(
+  canned: GetTeamPolicyOutput = { policies: [], hasTeam: false },
+): TeamPolicyHandler & { calls: GetTeamPolicyInput[] } {
+  const calls: GetTeamPolicyInput[] = [];
+  return {
+    calls,
+    async getPolicies(input) {
+      calls.push(input);
+      return canned;
+    },
+  };
+}
 
 // ============================================================================
 // Stub handler
@@ -95,11 +117,19 @@ describe('createStyrbyMcpServer', () => {
       expect(Object.keys(registered)).toContain('request_approval');
     });
 
-    it('does not register any other tools in the Phase 1 wedge', () => {
+    it('registers ONLY request_approval when no team-policy handler is injected', () => {
       const server = createStyrbyMcpServer(handler);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const registered = (server as any)._registeredTools;
       expect(Object.keys(registered)).toEqual(['request_approval']);
+    });
+
+    it('registers get_team_policy only when a team-policy handler IS injected', () => {
+      const server = createStyrbyMcpServer(handler, teamPolicyStub());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const registered = (server as any)._registeredTools;
+      expect(Object.keys(registered)).toContain('get_team_policy');
+      expect(Object.keys(registered)).toContain('request_approval');
     });
   });
 
@@ -212,6 +242,76 @@ describe('createStyrbyMcpServer', () => {
           risk: 'low',
         }),
       ).rejects.toThrow('Supabase unreachable');
+    });
+  });
+
+  // ==========================================================================
+  // get_team_policy handler (Cluster B2)
+  // ==========================================================================
+
+  describe('get_team_policy handler', () => {
+    it('forwards the optional agentType to the team-policy handler', async () => {
+      const policyStub = teamPolicyStub();
+      const server = createStyrbyMcpServer(handler, policyStub);
+
+      await callTool(server, 'get_team_policy', { agentType: 'claude' });
+
+      expect(policyStub.calls).toHaveLength(1);
+      expect(policyStub.calls[0]).toEqual({ agentType: 'claude' });
+    });
+
+    it('returns hasTeam=false summary for a solo user', async () => {
+      const server = createStyrbyMcpServer(handler, teamPolicyStub({ policies: [], hasTeam: false }));
+
+      const res = await callTool(server, 'get_team_policy', {});
+
+      expect(res.structuredContent).toEqual({ policies: [], hasTeam: false });
+      expect(res.content[0].text).toMatch(/solo account/i);
+    });
+
+    it('summarizes each policy as "[priority] name (ruleType) -> action"', async () => {
+      const server = createStyrbyMcpServer(
+        handler,
+        teamPolicyStub({
+          hasTeam: true,
+          policies: [
+            {
+              name: 'Prod cost cap',
+              description: null,
+              ruleType: 'cost_threshold',
+              action: 'require_approval',
+              threshold: 50,
+              agentFilter: [],
+              priority: 10,
+            },
+          ],
+        }),
+      );
+
+      const res = await callTool(server, 'get_team_policy', {});
+
+      expect(res.structuredContent.hasTeam).toBe(true);
+      expect(res.structuredContent.policies).toHaveLength(1);
+      expect(res.content[0].text).toContain('[10] Prod cost cap (cost_threshold) → require_approval');
+    });
+
+    it('reports a team with zero active policies distinctly from no team', async () => {
+      const server = createStyrbyMcpServer(handler, teamPolicyStub({ policies: [], hasTeam: true }));
+
+      const res = await callTool(server, 'get_team_policy', {});
+
+      expect(res.content[0].text).toMatch(/no active governance policies/i);
+    });
+
+    it('propagates handler errors as a tool error', async () => {
+      const failing: TeamPolicyHandler = {
+        async getPolicies() {
+          throw new Error('policy API unreachable');
+        },
+      };
+      const server = createStyrbyMcpServer(handler, failing);
+
+      await expect(callTool(server, 'get_team_policy', {})).rejects.toThrow('policy API unreachable');
     });
   });
 });

--- a/packages/styrby-cli/src/mcp/server.ts
+++ b/packages/styrby-cli/src/mcp/server.ts
@@ -46,8 +46,12 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   RequestApprovalInputSchema,
   RequestApprovalOutputSchema,
+  GetTeamPolicyInputSchema,
+  GetTeamPolicyOutputSchema,
   type RequestApprovalInput,
   type RequestApprovalOutput,
+  type GetTeamPolicyInput,
+  type GetTeamPolicyOutput,
 } from './tools.js';
 
 // ============================================================================
@@ -97,6 +101,23 @@ export interface ApprovalHandler {
   request(input: RequestApprovalInput, timeoutMs: number): Promise<RequestApprovalOutput>;
 }
 
+/**
+ * Reads the calling user's team governance policies. Injected (like
+ * {@link ApprovalHandler}) so tests can stub it and the real implementation
+ * (`./teamPolicyHandler.ts`, backed by `GET /api/v1/team-policies`) stays out
+ * of the server factory's import graph.
+ */
+export interface TeamPolicyHandler {
+  /**
+   * Fetches enabled governance policies for the user's active team.
+   *
+   * @param input - Validated tool input (optional advisory agentType).
+   * @returns The team's policies (empty + hasTeam:false for solo users).
+   * @throws {Error} On API failures — converted to a tool error response by the MCP layer.
+   */
+  getPolicies(input: GetTeamPolicyInput): Promise<GetTeamPolicyOutput>;
+}
+
 // ============================================================================
 // Server factory
 // ============================================================================
@@ -109,16 +130,22 @@ export interface ApprovalHandler {
  * exercise the tool handlers directly without a transport.
  *
  * @param approvalHandler - The dependency that delivers approval requests to mobile
+ * @param teamPolicyHandler - Optional. When provided, registers the
+ *   `get_team_policy` tool. Omitted in contexts that only need approvals (and
+ *   to keep existing single-arg callers/tests working unchanged).
  * @returns The configured McpServer instance
  *
  * @example
  * ```ts
  * const handler = await createSupabaseApprovalHandler(supabase);
- * const server = createStyrbyMcpServer(handler);
+ * const server = createStyrbyMcpServer(handler, teamPolicyHandler);
  * await server.connect(new StdioServerTransport());
  * ```
  */
-export function createStyrbyMcpServer(approvalHandler: ApprovalHandler): McpServer {
+export function createStyrbyMcpServer(
+  approvalHandler: ApprovalHandler,
+  teamPolicyHandler?: TeamPolicyHandler,
+): McpServer {
   const server = new McpServer(SERVER_INFO);
 
   // ── request_approval tool ────────────────────────────────────────────────
@@ -164,6 +191,48 @@ export function createStyrbyMcpServer(approvalHandler: ApprovalHandler): McpServ
     },
   );
 
+  // ── get_team_policy tool (optional) ──────────────────────────────────────
+  // Only registered when a team-policy handler is injected. This is the
+  // orchestration primitive: an agent fetches its team's governance rules so
+  // it can self-check (and call request_approval) BEFORE a risky action,
+  // rather than acting blind and being blocked after the fact.
+  if (teamPolicyHandler) {
+    server.registerTool(
+      'get_team_policy',
+      {
+        title: 'Get team governance policies',
+        description:
+          "Return the calling user's active team governance policies (cost thresholds, agent/tool filters, time windows) and what each does on match (block / require_approval / allow_with_audit). Call this BEFORE a risky or costly action to decide whether to proceed or request approval. Returns an empty list for solo users with no team.",
+        inputSchema: GetTeamPolicyInputSchema,
+        outputSchema: GetTeamPolicyOutputSchema,
+        annotations: {
+          // WHY readOnlyHint=true: this is a pure read of governance config; it
+          // never mutates state, so MCP clients may call it freely.
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+      },
+      async (input): Promise<{ content: Array<{ type: 'text'; text: string }>; structuredContent: GetTeamPolicyOutput }> => {
+        const result = await teamPolicyHandler.getPolicies(input as GetTeamPolicyInput);
+
+        const summary = !result.hasTeam
+          ? 'No team — no governance policies apply (solo account).'
+          : result.policies.length === 0
+            ? 'Team has no active governance policies.'
+            : result.policies
+                .map((p) => `[${p.priority}] ${p.name} (${p.ruleType}) → ${p.action}`)
+                .join('\n');
+
+        return {
+          content: [{ type: 'text', text: summary }],
+          structuredContent: result,
+        };
+      },
+    );
+  }
+
   return server;
 }
 
@@ -178,9 +247,13 @@ export function createStyrbyMcpServer(approvalHandler: ApprovalHandler): McpServ
  * shutdown signal — we never want the server outliving its consumer).
  *
  * @param approvalHandler - Real or test approval handler
+ * @param teamPolicyHandler - Optional team-policy handler; enables `get_team_policy`.
  */
-export async function runStdioServer(approvalHandler: ApprovalHandler): Promise<void> {
-  const server = createStyrbyMcpServer(approvalHandler);
+export async function runStdioServer(
+  approvalHandler: ApprovalHandler,
+  teamPolicyHandler?: TeamPolicyHandler,
+): Promise<void> {
+  const server = createStyrbyMcpServer(approvalHandler, teamPolicyHandler);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // The transport keeps process.stdin alive; resolution happens when the

--- a/packages/styrby-cli/src/mcp/teamPolicyHandler.ts
+++ b/packages/styrby-cli/src/mcp/teamPolicyHandler.ts
@@ -1,0 +1,37 @@
+/**
+ * apiClient-backed team-policy handler for the MCP server.
+ *
+ * Implements the {@link TeamPolicyHandler} contract from `./server.ts` by
+ * reading the calling user's active team governance policies through
+ * `GET /api/v1/team-policies` (key-authenticated). The endpoint resolves the
+ * user's team server-side from the API key, so no team id is passed from the
+ * agent — an agent cannot probe another team's policies.
+ *
+ * @module mcp/teamPolicyHandler
+ */
+
+import type { TeamPolicyHandler } from './server.js';
+import type { GetTeamPolicyInput, GetTeamPolicyOutput } from './tools.js';
+import type { StyrbyApiClient } from '@/api/styrbyApiClient';
+
+/**
+ * Creates an apiClient-backed TeamPolicyHandler.
+ *
+ * @param apiClient - Authenticated StyrbyApiClient with the user's styrby_* key.
+ * @returns A handler the MCP server uses to back the `get_team_policy` tool.
+ */
+export function createApiTeamPolicyHandler(apiClient: StyrbyApiClient): TeamPolicyHandler {
+  return {
+    async getPolicies(input: GetTeamPolicyInput): Promise<GetTeamPolicyOutput> {
+      try {
+        // agentType is advisory (server may use it to narrow in future); pass
+        // it through so the contract is honoured even though the current
+        // endpoint returns all enabled policies for the agent to reason over.
+        return await apiClient.getTeamPolicies({ agentType: input.agentType });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'unknown';
+        throw new Error(`Failed to fetch team policies: ${msg}`);
+      }
+    },
+  };
+}

--- a/packages/styrby-cli/src/mcp/tools.ts
+++ b/packages/styrby-cli/src/mcp/tools.ts
@@ -98,6 +98,76 @@ export type RequestApprovalOutput = {
 };
 
 // ============================================================================
+// get_team_policy
+// ============================================================================
+
+/**
+ * Input schema for the `get_team_policy` tool.
+ *
+ * The tool returns the calling user's active team governance policies so an
+ * agent can self-check BEFORE acting (e.g. "is there a cost threshold or a
+ * tool allowlist I should respect?"). Input is intentionally minimal — the
+ * agent reasons over the returned rules rather than the server pre-filtering.
+ *
+ * @property agentType - Optional. The agent's own type (e.g. `claude`, `codex`).
+ *                       Advisory only — included so future server-side filtering
+ *                       can narrow to policies whose `agentFilter` matches.
+ */
+export const GetTeamPolicyInputSchema = {
+  agentType: z.string().min(1).max(50).optional(),
+};
+
+/**
+ * A single team governance policy as exposed to an agent.
+ *
+ * Mirrors the agent-relevant columns of the `team_policies` table
+ * (migration 021). Internal columns (ids, approver_user_id, timestamps) are
+ * deliberately omitted — an agent only needs to know WHAT the rule is and what
+ * happens when it matches, not who authored it.
+ *
+ * @property name - Human-readable policy name.
+ * @property description - Optional longer explanation.
+ * @property ruleType - 'cost_threshold' | 'agent_filter' | 'tool_allowlist' | 'time_window'.
+ * @property action - What happens on match: 'block' | 'require_approval' | 'allow_with_audit'.
+ * @property threshold - Numeric threshold (e.g. USD for cost_threshold); null when N/A.
+ * @property agentFilter - Agent types / tool names the rule applies to ([] = all).
+ * @property priority - Lower = evaluated first.
+ */
+export const TeamPolicySchema = z.object({
+  name: z.string(),
+  description: z.string().nullable(),
+  ruleType: z.enum(['cost_threshold', 'agent_filter', 'tool_allowlist', 'time_window']),
+  action: z.enum(['block', 'require_approval', 'allow_with_audit']),
+  threshold: z.number().nullable(),
+  agentFilter: z.array(z.string()),
+  priority: z.number(),
+});
+export type TeamPolicy = z.infer<typeof TeamPolicySchema>;
+
+/**
+ * Output of the `get_team_policy` tool.
+ *
+ * @property policies - Enabled governance policies for the user's team, ordered
+ *                      by priority (ascending). Empty for solo users (no team).
+ * @property hasTeam - False when the user belongs to no team (solo Free/Pro).
+ *                     Lets the agent distinguish "no team" from "team with zero
+ *                     policies" without inspecting array length semantics.
+ */
+export const GetTeamPolicyOutputSchema = {
+  policies: z.array(TeamPolicySchema),
+  hasTeam: z.boolean(),
+};
+
+export type GetTeamPolicyInput = {
+  agentType?: string;
+};
+
+export type GetTeamPolicyOutput = {
+  policies: TeamPolicy[];
+  hasTeam: boolean;
+};
+
+// ============================================================================
 // Tool catalog metadata
 // ============================================================================
 

--- a/packages/styrby-shared/src/mcp/catalog.ts
+++ b/packages/styrby-shared/src/mcp/catalog.ts
@@ -65,10 +65,10 @@ export const STYRBY_MCP_TOOLS: readonly MCPToolDescriptor[] = [
     name: 'get_team_policy',
     title: 'Look up team policy',
     description:
-      'Returns the effective approval/budget/blocked-tool policy for the agent\'s session. Lets agents check before attempting an action whether it would auto-block or require approval. Phase 4.',
+      "Returns the calling user's active team governance policies (cost thresholds, agent/tool filters, time windows) and what each does on match. Lets agents self-check before an action whether it would block or require approval. Empty for solo users.",
     category: 'policy',
-    status: 'planned',
-    introducedIn: '0.4.0',
+    status: 'ga',
+    introducedIn: '0.2.0',
   },
   {
     name: 'log_to_audit',

--- a/packages/styrby-web/openapi.yaml
+++ b/packages/styrby-web/openapi.yaml
@@ -337,6 +337,100 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/team-policies:
+    get:
+      summary: Get the authenticated user's active team governance policies
+      tags:
+        - teams
+      security:
+        - apiKeyBearer: []
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 50
+          required: false
+          name: agent_type
+          in: query
+      responses:
+        "200":
+          description: The user's enabled team governance policies (priority-ordered). Empty + hasTeam:false for solo users.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  policies:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        description:
+                          type:
+                            - string
+                            - "null"
+                        ruleType:
+                          type: string
+                          enum:
+                            - cost_threshold
+                            - agent_filter
+                            - tool_allowlist
+                            - time_window
+                        action:
+                          type: string
+                          enum:
+                            - block
+                            - require_approval
+                            - allow_with_audit
+                        threshold:
+                          type:
+                            - number
+                            - "null"
+                        agentFilter:
+                          type: array
+                          items:
+                            type: string
+                        priority:
+                          type: integer
+                      required:
+                        - name
+                        - description
+                        - ruleType
+                        - action
+                        - threshold
+                        - agentFilter
+                        - priority
+                  hasTeam:
+                    type: boolean
+                required:
+                  - policies
+                  - hasTeam
+        "400":
+          description: Bad Request — validation failed or malformed body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized — missing or invalid API key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Too Many Requests — rate limit exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/v1/auth/exchange:
     post:
       summary: Exchange a session cookie for a short-lived API token

--- a/packages/styrby-web/src/app/api/v1/team-policies/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/team-policies/__tests__/route.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for GET /api/v1/team-policies (Cluster B2 — MCP get_team_policy backend).
+ *
+ * Verifies:
+ *  - team resolved from auth context, not the request (OWASP A01)
+ *  - solo user (no membership) → { policies: [], hasTeam: false }
+ *  - team user → enabled policies mapped to the camelCase contract
+ *  - NUMERIC threshold coerced from string → number (or null)
+ *  - DB errors are sanitized to 500 + Sentry
+ *
+ * @module api/v1/team-policies/__tests__/route
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+// ── auth bypass: invoke handler with a fixed auth context ───────────────────
+const mockAuthContext = { userId: 'user-1', keyId: 'key-1', scopes: ['read'] };
+
+vi.mock('@/middleware/api-auth', () => ({
+  withApiAuthAndRateLimit: vi.fn((handler: Function) => {
+    return async (request: NextRequest) => handler(request, mockAuthContext);
+  }),
+  addRateLimitHeaders: vi.fn((response: NextResponse) => response),
+  ApiAuthContext: {},
+}));
+
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }));
+
+// ── supabase admin mock: result per table ───────────────────────────────────
+let tableResults: Record<string, { data?: unknown; error?: unknown }> = {};
+
+function chainFor(table: string) {
+  const result = tableResults[table] ?? { data: [], error: null };
+  const chain: Record<string, unknown> = {};
+  for (const m of ['select', 'eq', 'in', 'order']) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  // Thenable: awaiting the chain at any point resolves to the table result.
+  chain['then'] = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn((table: string) => chainFor(table)),
+  })),
+}));
+
+import { GET } from '../route';
+
+function makeReq(): NextRequest {
+  return new NextRequest('https://x.test/api/v1/team-policies');
+}
+
+describe('GET /api/v1/team-policies', () => {
+  beforeEach(() => {
+    tableResults = {};
+    vi.clearAllMocks();
+  });
+
+  it('returns hasTeam=false + empty list for a solo user (no membership)', async () => {
+    tableResults['team_members'] = { data: [], error: null };
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ policies: [], hasTeam: false });
+  });
+
+  it('returns enabled policies mapped to the camelCase contract for a team user', async () => {
+    tableResults['team_members'] = { data: [{ team_id: 'team-1' }], error: null };
+    tableResults['team_policies'] = {
+      data: [
+        {
+          name: 'Prod cost cap',
+          description: 'Require approval over $50',
+          rule_type: 'cost_threshold',
+          action: 'require_approval',
+          threshold: '50.000000', // NUMERIC comes back as string
+          agent_filter: ['claude'],
+          priority: 10,
+        },
+        {
+          name: 'No deletes',
+          description: null,
+          rule_type: 'tool_allowlist',
+          action: 'block',
+          threshold: null,
+          agent_filter: null, // null → []
+          priority: 20,
+        },
+      ],
+      error: null,
+    };
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.hasTeam).toBe(true);
+    expect(body.policies).toHaveLength(2);
+    expect(body.policies[0]).toEqual({
+      name: 'Prod cost cap',
+      description: 'Require approval over $50',
+      ruleType: 'cost_threshold',
+      action: 'require_approval',
+      threshold: 50, // coerced string → number
+      agentFilter: ['claude'],
+      priority: 10,
+    });
+    // null threshold stays null; null agent_filter becomes []
+    expect(body.policies[1].threshold).toBeNull();
+    expect(body.policies[1].agentFilter).toEqual([]);
+  });
+
+  it('returns 500 (sanitized) when the membership lookup fails', async () => {
+    tableResults['team_members'] = { data: null, error: { message: 'db down' } };
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).not.toContain('db down'); // sanitized
+  });
+
+  it('returns 500 when the policy read fails', async () => {
+    tableResults['team_members'] = { data: [{ team_id: 'team-1' }], error: null };
+    tableResults['team_policies'] = { data: null, error: { message: 'policy boom' } };
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/styrby-web/src/app/api/v1/team-policies/route.ts
+++ b/packages/styrby-web/src/app/api/v1/team-policies/route.ts
@@ -1,0 +1,123 @@
+/**
+ * GET /api/v1/team-policies
+ *
+ * Returns the calling user's active team governance policies. Backs the CLI's
+ * MCP `get_team_policy` tool so an agent can self-check a team's rules (cost
+ * thresholds, agent/tool filters, time windows) BEFORE acting.
+ *
+ * The team is resolved server-side from the API key's user_id (never supplied
+ * by the caller), so an agent cannot read another team's policies. Solo users
+ * (no team membership) get `{ policies: [], hasTeam: false }`.
+ *
+ * @auth Required - Bearer `styrby_*` API key via withApiAuthAndRateLimit
+ * @rateLimit default per-key (governance config is low-volume; no override)
+ *
+ * @returns 200 { policies: TeamPolicy[], hasTeam: boolean }
+ *
+ * @error 401 { error }  - Missing or invalid API key
+ * @error 429 { error }  - Rate limit exceeded
+ * @error 500 { error }  - Unexpected database error (sanitized)
+ *
+ * @security OWASP A01:2021 - team resolved from auth context, not the request.
+ * @security OWASP A07:2021 - auth enforced by withApiAuthAndRateLimit.
+ * @security SOC 2 CC6.1 - 'read' scope sufficient (no mutation).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+
+import {
+  withApiAuthAndRateLimit,
+  type ApiAuthContext,
+} from '@/middleware/api-auth';
+import { createAdminClient } from '@/lib/supabase/server';
+
+const ROUTE_ID = '/api/v1/team-policies';
+
+/** Raw row shape from the team_policies table (snake_case, NUMERIC as string). */
+interface TeamPolicyDbRow {
+  name: string;
+  description: string | null;
+  rule_type: 'cost_threshold' | 'agent_filter' | 'tool_allowlist' | 'time_window';
+  action: 'block' | 'require_approval' | 'allow_with_audit';
+  threshold: number | string | null;
+  agent_filter: string[] | null;
+  priority: number;
+}
+
+/**
+ * GET handler — wrapped by withApiAuthAndRateLimit (never called directly).
+ *
+ * @param _request - Authenticated NextRequest (no query params consumed yet;
+ *   `agent_type` is accepted by the client for forward-compat but the endpoint
+ *   intentionally returns ALL enabled policies for the agent to reason over).
+ * @param authContext - Auth context (userId from the API key).
+ * @returns 200 with { policies, hasTeam }, or a sanitized error.
+ */
+async function handleGet(_request: NextRequest, authContext: ApiAuthContext): Promise<NextResponse> {
+  const { userId } = authContext;
+  const supabase = createAdminClient();
+
+  // 1. Resolve the user's team memberships. A user may belong to 0..N teams;
+  //    we return the union of enabled policies across all their teams.
+  const { data: memberships, error: memberErr } = await supabase
+    .from('team_members')
+    .select('team_id')
+    .eq('user_id', userId);
+
+  if (memberErr) {
+    Sentry.captureException(new Error(`team_members lookup error: ${memberErr.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to resolve team membership' }, { status: 500 });
+  }
+
+  const teamIds = (memberships ?? []).map((m) => (m as { team_id: string }).team_id);
+
+  // 2. Solo user (no team): return empty + hasTeam=false. Distinguishing this
+  //    from "team with zero policies" lets the agent reason correctly.
+  if (teamIds.length === 0) {
+    return NextResponse.json(
+      { policies: [], hasTeam: false },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  // 3. Read enabled policies for the user's teams, priority-ordered.
+  const { data: rows, error: policyErr } = await supabase
+    .from('team_policies')
+    .select('name, description, rule_type, action, threshold, agent_filter, priority')
+    .in('team_id', teamIds)
+    .eq('enabled', true)
+    .order('priority', { ascending: true });
+
+  if (policyErr) {
+    Sentry.captureException(new Error(`team_policies read error: ${policyErr.message}`), {
+      extra: { route: ROUTE_ID },
+    });
+    return NextResponse.json({ error: 'Failed to read team policies' }, { status: 500 });
+  }
+
+  // 4. Map snake_case DB columns to the camelCase API contract. threshold is a
+  //    Postgres NUMERIC which the driver may return as a string — coerce to a
+  //    number (or null) so the client gets a stable numeric type.
+  const policies = ((rows ?? []) as TeamPolicyDbRow[]).map((r) => ({
+    name: r.name,
+    description: r.description,
+    ruleType: r.rule_type,
+    action: r.action,
+    threshold: r.threshold === null ? null : Number(r.threshold),
+    agentFilter: r.agent_filter ?? [],
+    priority: r.priority,
+  }));
+
+  return NextResponse.json(
+    { policies, hasTeam: true },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}
+
+/**
+ * GET /api/v1/team-policies — required scope: ['read'].
+ */
+export const GET = withApiAuthAndRateLimit(handleGet, ['read']);

--- a/packages/styrby-web/src/lib/api/openapi/v1-registry.ts
+++ b/packages/styrby-web/src/lib/api/openapi/v1-registry.ts
@@ -216,6 +216,45 @@ registry.registerPath({
   },
 });
 
+// GET /api/v1/team-policies
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/team-policies',
+  summary: "Get the authenticated user's active team governance policies",
+  tags: ['teams'],
+  security: [{ [apiKeyAuth.name]: [] }],
+  request: {
+    query: z.object({
+      agent_type: z.string().min(1).max(50).optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description:
+        "The user's enabled team governance policies (priority-ordered). Empty + hasTeam:false for solo users.",
+      content: {
+        'application/json': {
+          schema: z.object({
+            policies: z.array(
+              z.object({
+                name: z.string(),
+                description: z.string().nullable(),
+                ruleType: z.enum(['cost_threshold', 'agent_filter', 'tool_allowlist', 'time_window']),
+                action: z.enum(['block', 'require_approval', 'allow_with_audit']),
+                threshold: z.number().nullable(),
+                agentFilter: z.array(z.string()),
+                priority: z.number().int(),
+              }),
+            ),
+            hasTeam: z.boolean(),
+          }),
+        },
+      },
+    },
+    ...standardErrorResponses,
+  },
+});
+
 // POST /api/v1/auth/exchange
 registry.registerPath({
   method: 'post',


### PR DESCRIPTION
## Summary
The orchestration wedge: agents can now fetch their team's governance policies and **self-check before a risky action** (rather than acting blind + being blocked). Completes one of the three B2 pieces (`get_team_policy`); `log_to_audit` + the web install flow remain tracked follow-ups.

## Changes
- **NEW** `GET /api/v1/team-policies` — key-authed (`read` scope). Team resolved **server-side from the API key** (never passed by caller), so an agent cannot probe another team. Solo users → `{ policies: [], hasTeam: false }`. Reads governance `team_policies` (migration 021); NUMERIC threshold coerced; snake_case→camelCase.
- **NEW** `apiClient.getTeamPolicies()`, **NEW** `mcp/teamPolicyHandler.ts`.
- `mcp/server.ts`: `TeamPolicyHandler` + `get_team_policy` registration as an **optional second handler** — `createStyrbyMcpServer`/`runStdioServer` stay backward-compatible (no churn to existing callers/tests). Read-only/idempotent tool. Wired in `mcpServe.ts`.
- shared catalog: `get_team_policy` status `planned → ga`.

## Notes
- **No DB migration** (reads an existing table) — so no Postgres apply job needed.
- Cross-team isolation is enforced at the endpoint, not the agent.

## Test Plan
- [ ] CI passes (cli + web + shared chains)
- [x] +9 tests (5 MCP server, 4 web route)
- [x] 3-pkg gate local: shared/cli/web typecheck+build, cli 2663 tests, web route, lint

🤖 Shipped via /gh-ship