### PR TITLE
feat(mcp): add log_to_audit tool + mcp_agent_log audit action

### DIFF
--- a/packages/styrby-cli/src/commands/mcpServe.ts
+++ b/packages/styrby-cli/src/commands/mcpServe.ts
@@ -38,6 +38,7 @@ import { logger } from '@/ui/logger';
 import { runStdioServer } from '@/mcp/server';
 import { createSupabaseApprovalHandler } from '@/mcp/approvalHandler';
 import { createApiTeamPolicyHandler } from '@/mcp/teamPolicyHandler';
+import { createApiAuditLogHandler } from '@/mcp/auditLogHandler';
 
 /**
  * Top-level entry for `styrby mcp <subcommand>`.
@@ -112,13 +113,14 @@ async function handleMcpServe(): Promise<void> {
 
   const handler = createSupabaseApprovalHandler(apiClient, data.userId, data.machineId);
   const teamPolicyHandler = createApiTeamPolicyHandler(apiClient);
+  const auditLogHandler = createApiAuditLogHandler(apiClient);
 
   // Banner goes to stderr — invisible to the JSON-RPC protocol on stdout.
   logger.info(chalk.bold.cyan('Styrby MCP server starting on stdio…'));
-  logger.info(chalk.gray('  Tools exposed: request_approval, get_team_policy'));
+  logger.info(chalk.gray('  Tools exposed: request_approval, get_team_policy, log_to_audit'));
   logger.info(chalk.gray('  Awaiting client handshake'));
 
-  await runStdioServer(handler, teamPolicyHandler);
+  await runStdioServer(handler, teamPolicyHandler, auditLogHandler);
 
   logger.info(chalk.gray('MCP transport closed; exiting.'));
 }

--- a/packages/styrby-cli/src/mcp/__tests__/auditLogHandler.test.ts
+++ b/packages/styrby-cli/src/mcp/__tests__/auditLogHandler.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for createApiAuditLogHandler (mcp/auditLogHandler.ts).
+ *
+ * Verifies the handler maps the log_to_audit tool input onto a writeAuditEvent
+ * call with the fixed `mcp_agent_log` action, folds note+level+context into
+ * metadata, and surfaces API errors.
+ *
+ * @module mcp/__tests__/auditLogHandler
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createApiAuditLogHandler } from '../auditLogHandler';
+import type { StyrbyApiClient } from '@/api/styrbyApiClient';
+
+/** Minimal apiClient stub exposing only writeAuditEvent. */
+function clientStub(impl: StyrbyApiClient['writeAuditEvent']): StyrbyApiClient {
+  return { writeAuditEvent: impl } as unknown as StyrbyApiClient;
+}
+
+describe('createApiAuditLogHandler', () => {
+  it('writes the mcp_agent_log action with note+level+context in metadata', async () => {
+    const writeAuditEvent = vi.fn(async () => ({ id: 'audit-1', created_at: '2026-06-12T00:00:00Z' }));
+    const handler = createApiAuditLogHandler(clientStub(writeAuditEvent as never));
+
+    const out = await handler.log({
+      message: 'ran migration 014',
+      level: 'warning',
+      resourceType: 'migration',
+      resourceId: '014',
+      context: { files: 3 },
+    });
+
+    expect(writeAuditEvent).toHaveBeenCalledWith({
+      action: 'mcp_agent_log',
+      resource_type: 'migration',
+      resource_id: '014',
+      metadata: { message: 'ran migration 014', level: 'warning', files: 3 },
+    });
+    expect(out).toEqual({ id: 'audit-1', recordedAt: '2026-06-12T00:00:00Z' });
+  });
+
+  it('defaults level to info when omitted', async () => {
+    const writeAuditEvent = vi.fn(async () => ({ id: 'a', created_at: 't' }));
+    const handler = createApiAuditLogHandler(clientStub(writeAuditEvent as never));
+
+    await handler.log({ message: 'did a thing' });
+
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { message: 'did a thing', level: 'info' } }),
+    );
+  });
+
+  it('wraps API errors with a clear message', async () => {
+    const handler = createApiAuditLogHandler(
+      clientStub((async () => {
+        throw new Error('429 rate limited');
+      }) as never),
+    );
+
+    await expect(handler.log({ message: 'x' })).rejects.toThrow(/Failed to record audit event: 429 rate limited/);
+  });
+});

--- a/packages/styrby-cli/src/mcp/__tests__/server.test.ts
+++ b/packages/styrby-cli/src/mcp/__tests__/server.test.ts
@@ -15,13 +15,34 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createStyrbyMcpServer, type ApprovalHandler, type TeamPolicyHandler } from '../server';
+import {
+  createStyrbyMcpServer,
+  type ApprovalHandler,
+  type TeamPolicyHandler,
+  type AuditLogHandler,
+} from '../server';
 import type {
   RequestApprovalInput,
   RequestApprovalOutput,
   GetTeamPolicyInput,
   GetTeamPolicyOutput,
+  LogToAuditInput,
+  LogToAuditOutput,
 } from '../tools';
+
+/** Stub AuditLogHandler that records calls and returns a canned row. */
+function auditLogStub(
+  canned: LogToAuditOutput = { id: 'audit-1', recordedAt: '2026-06-12T00:00:00.000Z' },
+): AuditLogHandler & { calls: LogToAuditInput[] } {
+  const calls: LogToAuditInput[] = [];
+  return {
+    calls,
+    async log(input) {
+      calls.push(input);
+      return canned;
+    },
+  };
+}
 
 /**
  * Stub TeamPolicyHandler that records calls and returns canned output.
@@ -130,6 +151,19 @@ describe('createStyrbyMcpServer', () => {
       const registered = (server as any)._registeredTools;
       expect(Object.keys(registered)).toContain('get_team_policy');
       expect(Object.keys(registered)).toContain('request_approval');
+    });
+
+    it('registers log_to_audit only when an audit-log handler IS injected', () => {
+      const without = createStyrbyMcpServer(handler, teamPolicyStub());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(Object.keys((without as any)._registeredTools)).not.toContain('log_to_audit');
+
+      const withAll = createStyrbyMcpServer(handler, teamPolicyStub(), auditLogStub());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const registered = Object.keys((withAll as any)._registeredTools);
+      expect(registered).toContain('log_to_audit');
+      expect(registered).toContain('get_team_policy');
+      expect(registered).toContain('request_approval');
     });
   });
 
@@ -312,6 +346,56 @@ describe('createStyrbyMcpServer', () => {
       const server = createStyrbyMcpServer(handler, failing);
 
       await expect(callTool(server, 'get_team_policy', {})).rejects.toThrow('policy API unreachable');
+    });
+  });
+
+  // ==========================================================================
+  // log_to_audit handler (Cluster B2)
+  // ==========================================================================
+
+  describe('log_to_audit handler', () => {
+    it('forwards the note + optional fields to the audit-log handler', async () => {
+      const stub = auditLogStub();
+      const server = createStyrbyMcpServer(handler, teamPolicyStub(), stub);
+
+      await callTool(server, 'log_to_audit', {
+        message: 'ran migration 014',
+        level: 'warning',
+        resourceType: 'migration',
+        resourceId: '014',
+      });
+
+      expect(stub.calls).toHaveLength(1);
+      expect(stub.calls[0]).toMatchObject({
+        message: 'ran migration 014',
+        level: 'warning',
+        resourceType: 'migration',
+        resourceId: '014',
+      });
+    });
+
+    it('returns the created audit row id in both content and structuredContent', async () => {
+      const server = createStyrbyMcpServer(
+        handler,
+        teamPolicyStub(),
+        auditLogStub({ id: 'audit-xyz', recordedAt: '2026-06-12T01:02:03.000Z' }),
+      );
+
+      const res = await callTool(server, 'log_to_audit', { message: 'did a thing' });
+
+      expect(res.structuredContent).toEqual({ id: 'audit-xyz', recordedAt: '2026-06-12T01:02:03.000Z' });
+      expect(res.content[0].text).toContain('audit-xyz');
+    });
+
+    it('propagates handler errors as a tool error', async () => {
+      const failing: AuditLogHandler = {
+        async log() {
+          throw new Error('audit API unreachable');
+        },
+      };
+      const server = createStyrbyMcpServer(handler, teamPolicyStub(), failing);
+
+      await expect(callTool(server, 'log_to_audit', { message: 'x' })).rejects.toThrow('audit API unreachable');
     });
   });
 });

--- a/packages/styrby-cli/src/mcp/auditLogHandler.ts
+++ b/packages/styrby-cli/src/mcp/auditLogHandler.ts
@@ -1,0 +1,51 @@
+/**
+ * apiClient-backed audit-log handler for the MCP server.
+ *
+ * Implements the {@link AuditLogHandler} contract from `./server.ts` by writing
+ * the agent's note to `POST /api/v1/audit` with the fixed `mcp_agent_log`
+ * action (migration 102). The note + advisory level + any structured context
+ * are carried in `metadata`; the action itself is non-authority-bearing so a
+ * write-scoped key cannot abuse it to forge a privileged event.
+ *
+ * @module mcp/auditLogHandler
+ */
+
+import type { AuditLogHandler } from './server.js';
+import type { LogToAuditInput, LogToAuditOutput } from './tools.js';
+import type { StyrbyApiClient } from '@/api/styrbyApiClient';
+
+/** The single allowlisted audit_action this tool may write (migration 102). */
+const MCP_AGENT_LOG_ACTION = 'mcp_agent_log';
+
+/**
+ * Creates an apiClient-backed AuditLogHandler.
+ *
+ * @param apiClient - Authenticated StyrbyApiClient with the user's styrby_* key.
+ * @returns A handler the MCP server uses to back the `log_to_audit` tool.
+ */
+export function createApiAuditLogHandler(apiClient: StyrbyApiClient): AuditLogHandler {
+  return {
+    async log(input: LogToAuditInput): Promise<LogToAuditOutput> {
+      // The agent's note + advisory level + context all live in metadata. The
+      // top-level `action` is the fixed informational identifier.
+      const metadata: Record<string, unknown> = {
+        message: input.message,
+        level: input.level ?? 'info',
+        ...(input.context ?? {}),
+      };
+
+      try {
+        const res = await apiClient.writeAuditEvent({
+          action: MCP_AGENT_LOG_ACTION,
+          resource_type: input.resourceType,
+          resource_id: input.resourceId,
+          metadata,
+        });
+        return { id: res.id, recordedAt: res.created_at };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'unknown';
+        throw new Error(`Failed to record audit event: ${msg}`);
+      }
+    },
+  };
+}

--- a/packages/styrby-cli/src/mcp/server.ts
+++ b/packages/styrby-cli/src/mcp/server.ts
@@ -48,10 +48,14 @@ import {
   RequestApprovalOutputSchema,
   GetTeamPolicyInputSchema,
   GetTeamPolicyOutputSchema,
+  LogToAuditInputSchema,
+  LogToAuditOutputSchema,
   type RequestApprovalInput,
   type RequestApprovalOutput,
   type GetTeamPolicyInput,
   type GetTeamPolicyOutput,
+  type LogToAuditInput,
+  type LogToAuditOutput,
 } from './tools.js';
 
 // ============================================================================
@@ -118,6 +122,23 @@ export interface TeamPolicyHandler {
   getPolicies(input: GetTeamPolicyInput): Promise<GetTeamPolicyOutput>;
 }
 
+/**
+ * Records an agent-authored audit-log event. Injected (like the other
+ * handlers); the real implementation (`./auditLogHandler.ts`, backed by
+ * `POST /api/v1/audit` with the `mcp_agent_log` action) stays out of the
+ * server factory's import graph.
+ */
+export interface AuditLogHandler {
+  /**
+   * Writes the agent's note to the audit trail.
+   *
+   * @param input - Validated tool input (message + optional level/resource/context).
+   * @returns The created audit row id + timestamp.
+   * @throws {Error} On API failures — converted to a tool error response by the MCP layer.
+   */
+  log(input: LogToAuditInput): Promise<LogToAuditOutput>;
+}
+
 // ============================================================================
 // Server factory
 // ============================================================================
@@ -133,18 +154,21 @@ export interface TeamPolicyHandler {
  * @param teamPolicyHandler - Optional. When provided, registers the
  *   `get_team_policy` tool. Omitted in contexts that only need approvals (and
  *   to keep existing single-arg callers/tests working unchanged).
+ * @param auditLogHandler - Optional. When provided, registers the
+ *   `log_to_audit` tool.
  * @returns The configured McpServer instance
  *
  * @example
  * ```ts
  * const handler = await createSupabaseApprovalHandler(supabase);
- * const server = createStyrbyMcpServer(handler, teamPolicyHandler);
+ * const server = createStyrbyMcpServer(handler, teamPolicyHandler, auditLogHandler);
  * await server.connect(new StdioServerTransport());
  * ```
  */
 export function createStyrbyMcpServer(
   approvalHandler: ApprovalHandler,
   teamPolicyHandler?: TeamPolicyHandler,
+  auditLogHandler?: AuditLogHandler,
 ): McpServer {
   const server = new McpServer(SERVER_INFO);
 
@@ -233,6 +257,40 @@ export function createStyrbyMcpServer(
     );
   }
 
+  // ── log_to_audit tool (optional) ─────────────────────────────────────────
+  // The compliance leg of the wedge: an agent records what it did to the
+  // user's audit trail. Writes the fixed, non-authority-bearing mcp_agent_log
+  // action (the note lives in metadata), so a write-scoped key cannot use this
+  // to forge an authority-bearing event.
+  if (auditLogHandler) {
+    server.registerTool(
+      'log_to_audit',
+      {
+        title: 'Record an event to the audit log',
+        description:
+          "Record a note in the user's audit trail describing what you did (e.g. 'ran migration 014', 'deleted 3 stale branches'). Use after a significant or irreversible action so there is a durable, user-visible record. Returns the audit row id.",
+        inputSchema: LogToAuditInputSchema,
+        outputSchema: LogToAuditOutputSchema,
+        annotations: {
+          // WHY readOnlyHint=false: it appends a row. But it is append-only and
+          // non-destructive, so destructiveHint stays false.
+          readOnlyHint: false,
+          destructiveHint: false,
+          // Not idempotent: each call appends a distinct audit row.
+          idempotentHint: false,
+          openWorldHint: true,
+        },
+      },
+      async (input): Promise<{ content: Array<{ type: 'text'; text: string }>; structuredContent: LogToAuditOutput }> => {
+        const result = await auditLogHandler.log(input as LogToAuditInput);
+        return {
+          content: [{ type: 'text', text: `Recorded audit event ${result.id} at ${result.recordedAt}.` }],
+          structuredContent: result,
+        };
+      },
+    );
+  }
+
   return server;
 }
 
@@ -248,12 +306,14 @@ export function createStyrbyMcpServer(
  *
  * @param approvalHandler - Real or test approval handler
  * @param teamPolicyHandler - Optional team-policy handler; enables `get_team_policy`.
+ * @param auditLogHandler - Optional audit-log handler; enables `log_to_audit`.
  */
 export async function runStdioServer(
   approvalHandler: ApprovalHandler,
   teamPolicyHandler?: TeamPolicyHandler,
+  auditLogHandler?: AuditLogHandler,
 ): Promise<void> {
-  const server = createStyrbyMcpServer(approvalHandler, teamPolicyHandler);
+  const server = createStyrbyMcpServer(approvalHandler, teamPolicyHandler, auditLogHandler);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // The transport keeps process.stdin alive; resolution happens when the

--- a/packages/styrby-cli/src/mcp/tools.ts
+++ b/packages/styrby-cli/src/mcp/tools.ts
@@ -168,6 +168,63 @@ export type GetTeamPolicyOutput = {
 };
 
 // ============================================================================
+// log_to_audit
+// ============================================================================
+
+/**
+ * Advisory severity for an agent-logged audit event. Informational only — it
+ * has no authority-bearing meaning; it just helps a human scanning the trail.
+ */
+export const AuditLogLevelSchema = z.enum(['info', 'warning', 'error']);
+export type AuditLogLevel = z.infer<typeof AuditLogLevelSchema>;
+
+/**
+ * Input schema for the `log_to_audit` tool.
+ *
+ * Lets an agent record what it did to the user's audit trail (e.g. "ran
+ * database migration 014", "deleted 3 stale branches"). Writes the fixed,
+ * non-authority-bearing `mcp_agent_log` action; the note + context live in
+ * metadata. This is the compliance leg of the orchestration wedge.
+ *
+ * @property message - Human-readable note describing what the agent did.
+ * @property level - Optional advisory severity (default 'info').
+ * @property resourceType - Optional entity type the event relates to (e.g. 'session').
+ * @property resourceId - Optional entity id.
+ * @property context - Optional structured detail (files touched, command, etc.).
+ */
+export const LogToAuditInputSchema = {
+  message: z.string().min(1).max(2000),
+  level: AuditLogLevelSchema.optional(),
+  resourceType: z.string().min(1).max(100).optional(),
+  resourceId: z.string().min(1).max(255).optional(),
+  context: z.record(z.unknown()).optional(),
+};
+
+/**
+ * Output of the `log_to_audit` tool.
+ *
+ * @property id - The audit_log row id created.
+ * @property recordedAt - ISO 8601 timestamp the event was recorded.
+ */
+export const LogToAuditOutputSchema = {
+  id: z.string(),
+  recordedAt: z.string(),
+};
+
+export type LogToAuditInput = {
+  message: string;
+  level?: AuditLogLevel;
+  resourceType?: string;
+  resourceId?: string;
+  context?: Record<string, unknown>;
+};
+
+export type LogToAuditOutput = {
+  id: string;
+  recordedAt: string;
+};
+
+// ============================================================================
 // Tool catalog metadata
 // ============================================================================
 

--- a/packages/styrby-shared/src/mcp/__tests__/catalog.test.ts
+++ b/packages/styrby-shared/src/mcp/__tests__/catalog.test.ts
@@ -99,14 +99,20 @@ describe('request_approval tool', () => {
   });
 });
 
-describe('planned tools', () => {
+describe('roadmap vs shipped tools', () => {
   const planned = STYRBY_MCP_TOOLS.filter((t) => t.status === 'planned');
+  const ga = STYRBY_MCP_TOOLS.filter((t) => t.status === 'ga');
 
-  it('there are at least 2 planned tools on the roadmap', () => {
-    expect(planned.length).toBeGreaterThanOrEqual(2);
+  // WHY ga-presence (not a planned-count floor): the previous assertion required
+  // >= 2 'planned' tools, which our own progress invalidates — shipping a tool
+  // moves it planned -> ga and shrinks the roadmap toward zero. A count floor on
+  // unshipped work makes completing work fail CI. Instead assert the catalog
+  // reflects REAL shipped capability (>= 1 ga tool), which only grows.
+  it('has at least one shipped (ga) tool — the catalog reflects real capability', () => {
+    expect(ga.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('planned tools are all scheduled for 0.4.0 or later', () => {
+  it('planned tools (if any remain) are scheduled for 0.4.0 or later', () => {
     for (const tool of planned) {
       const [, minor] = tool.introducedIn.split('.').map(Number);
       // 0.4.0+ => minor >= 4

--- a/packages/styrby-shared/src/mcp/catalog.ts
+++ b/packages/styrby-shared/src/mcp/catalog.ts
@@ -74,10 +74,10 @@ export const STYRBY_MCP_TOOLS: readonly MCPToolDescriptor[] = [
     name: 'log_to_audit',
     title: 'Write to audit log',
     description:
-      'Appends a structured event to the user\'s audit log table. Useful for compliance trails (SOC2 CC7.2) when agents take significant actions. Phase 4.',
+      "Appends a structured event to the user's audit log table. Useful for compliance trails (SOC2 CC7.2) when agents take significant actions. Writes the non-authority-bearing mcp_agent_log action.",
     category: 'audit',
-    status: 'planned',
-    introducedIn: '0.4.0',
+    status: 'ga',
+    introducedIn: '0.2.0',
   },
   {
     name: 'query_session_history',

--- a/packages/styrby-web/src/__tests__/migration-102.test.ts
+++ b/packages/styrby-web/src/__tests__/migration-102.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Migration 102 structural test — mcp_agent_log audit_action enum value.
+ *
+ * Validates that migration 102 adds the `mcp_agent_log` value to the
+ * `audit_action` enum using the safe, idempotent, non-transactional-friendly
+ * pattern (`ALTER TYPE ... ADD VALUE IF NOT EXISTS`) the codebase uses for all
+ * enum extensions. This value backs the MCP `log_to_audit` tool and is the only
+ * new action the /api/v1/audit forgery allowlist gained.
+ *
+ * WHY a structural test: a future edit that drops the IF NOT EXISTS guard would
+ * make the migration fail on re-run; one that renames the value would silently
+ * break the log_to_audit write path (the allowlist + handler hard-code the
+ * string). Live apply is additionally proven by the Postgres migrations-apply CI.
+ *
+ * @module __tests__/migration-102
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const MIGRATIONS_DIR = resolve(__dirname, '../../../..', 'supabase/migrations');
+
+function readMigration(filename: string): string {
+  return readFileSync(resolve(MIGRATIONS_DIR, filename), 'utf-8');
+}
+
+describe('Migration 102: mcp_agent_log audit_action', () => {
+  const sql = readMigration('102_mcp_agent_log_audit_action.sql');
+
+  it('adds mcp_agent_log via ALTER TYPE ... ADD VALUE IF NOT EXISTS', () => {
+    expect(sql).toMatch(
+      /ALTER TYPE\s+audit_action\s+ADD VALUE\s+IF NOT EXISTS\s+'mcp_agent_log'/,
+    );
+  });
+
+  it('does NOT use the new value in the same migration (PG same-tx restriction)', () => {
+    // The value must not appear in any INSERT/comparison in this file — only the
+    // ADD VALUE statement. Guard against a future edit adding a DO/assert that
+    // would break apply.
+    expect(sql).not.toMatch(/INSERT\s+INTO/i);
+    expect(sql).not.toMatch(/=\s*'mcp_agent_log'/);
+  });
+});

--- a/packages/styrby-web/src/app/api/v1/audit/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/v1/audit/__tests__/route.test.ts
@@ -297,6 +297,22 @@ describe('POST /api/v1/audit', () => {
       expect(response.status).toBe(201);
     });
 
+    it('accepts mcp_agent_log (log_to_audit tool — informational, non-authority-bearing)', async () => {
+      // The MCP log_to_audit tool writes this action; it carries the agent's
+      // note in metadata and has no authority on the receiving side (migration 102).
+      insertCallQueue.push({
+        data: { id: 'log-001', created_at: '2026-06-12T00:00:00Z' },
+        error: null,
+      });
+      const response = await POST(
+        createRequest({
+          action: 'mcp_agent_log',
+          metadata: { message: 'ran migration 014', level: 'info' },
+        }),
+      );
+      expect(response.status).toBe(201);
+    });
+
     it('accepts mcp_approval_timeout (CLI-only writer)', async () => {
       insertCallQueue.push({
         data: { id: 'tmo-001', created_at: '2026-05-05T00:00:00Z' },

--- a/packages/styrby-web/src/app/api/v1/audit/route.ts
+++ b/packages/styrby-web/src/app/api/v1/audit/route.ts
@@ -117,6 +117,11 @@ const ALLOWED_AUDIT_ACTIONS = [
   // The CLI is the only writer; the decision row is gated separately.
   'mcp_approval_requested',
   'mcp_approval_timeout',
+  // MCP `log_to_audit` tool: an agent records what it did. Purely
+  // informational — the agent's note lives in metadata and this action has NO
+  // authority-bearing semantics on the receiving side (unlike the deliberately
+  // EXCLUDED mcp_approval_decided). Added by migration 102. SOC2 CC6.1.
+  'mcp_agent_log',
   // Budget alert side-effect: CLI writes when a budget action mutated settings
   'settings_updated',
 ] as const;

--- a/supabase/migrations/102_mcp_agent_log_audit_action.sql
+++ b/supabase/migrations/102_mcp_agent_log_audit_action.sql
@@ -1,0 +1,34 @@
+-- Migration 102: mcp_agent_log audit_action enum value (Cluster B2 — log_to_audit)
+--
+-- WHY: the MCP server exposes a `log_to_audit` tool (styrby-cli/src/mcp) that
+-- lets an agent record what it did to the user's audit trail (the
+-- audit/compliance leg of the orchestration wedge). All such writes flow
+-- through POST /api/v1/audit, whose action column is the `audit_action` ENUM.
+--
+-- WHY a single, dedicated, NON-authority-bearing value: /api/v1/audit
+-- allowlists which actions an API-key holder may write, specifically to stop a
+-- leaked write-scoped key from forging authority-bearing actions like
+-- `mcp_approval_decided` (which the CLI treats as "the user approved this
+-- command" — forging it is RCE). `mcp_agent_log` is purely informational: it
+-- carries the agent's free-text note in metadata and has zero authority on the
+-- receiving side. Giving log_to_audit its OWN value (rather than letting the
+-- tool write arbitrary actions) preserves the forgery guard — the web
+-- allowlist adds exactly this one value, nothing else.
+--
+-- WHY no data migration: forward-only enum addition; no existing rows use it.
+--
+-- WHY no rollback: PostgreSQL enum values cannot be dropped without recreating
+-- the type and rewriting every dependent column. An unused value is harmless;
+-- if the CLI/web side rolls back, the value simply goes unwritten.
+--
+-- Technical note: ALTER TYPE ... ADD VALUE IF NOT EXISTS is safe on Supabase
+-- (PG 15+) and idempotent on re-run. The new value is NOT used in this same
+-- migration (Postgres forbids using a freshly-added enum value in the
+-- transaction that added it), so there is no DO/assert block here — the
+-- migrations-apply CI job validates the statement applies, and the web
+-- allowlist test (api/v1/audit) validates the value is accepted end to end.
+--
+-- @security SOC 2 CC6.1 (least privilege — scoped allowlist), OWASP A04:2021
+--   (insecure design — forgery-resistant audit action surface).
+
+ALTER TYPE audit_action ADD VALUE IF NOT EXISTS 'mcp_agent_log';


### PR DESCRIPTION
## Summary
Completes the MCP orchestration trio — **request_approval + get_team_policy + log_to_audit**. Agents can now record what they did to the user's audit trail after significant/irreversible actions (the compliance leg of the wedge). Closes the `log_to_audit` part of B2; only the web install flow (B2b) remains.

## Changes
- **migration 102** — `ALTER TYPE audit_action ADD VALUE 'mcp_agent_log'` (forward-only, `IF NOT EXISTS`, same pattern as 069). No assert block (PG forbids using a freshly-added enum value in the adding transaction); the Postgres migrations-apply job + the web allowlist test verify it end to end.
- **`/api/v1/audit` allowlist** gains exactly `mcp_agent_log` — non-authority-bearing, informational. **Forgery guard intact**: `mcp_approval_decided` + `team_command_*` stay excluded, so a leaked write-scoped key still can't forge a privileged event.
- **MCP tool** — `LogToAudit` schema + `AuditLogHandler` + registration as an optional 3rd handler (backward-compatible factory/runner); `mcp/auditLogHandler.ts` writes via `apiClient.writeAuditEvent` (note/level/context → metadata). Wired in `mcpServe.ts`.
- shared catalog: `log_to_audit` status `planned → ga`.

## Test Plan
- [ ] CI passes (cli + web + shared chains + **Postgres migrations-apply** validates migration 102)
- [x] +9 tests (3 MCP server, 3 handler unit, 1 web allowlist-accept, 2 migration-102)
- [x] 3-pkg gate local: typecheck+build, cli 2670 tests, web 29 tests, lint

🤖 Shipped via /gh-ship