### PR TITLE
feat(mobile): label raw touchables for screen readers + a11y guard

### DIFF
--- a/packages/styrby-mobile/app/(tabs)/costs.tsx
+++ b/packages/styrby-mobile/app/(tabs)/costs.tsx
@@ -205,6 +205,9 @@ export default function CostsScreen() {
         <Text className="text-zinc-500 text-center mt-2">{error}</Text>
         <Pressable
           onPress={refresh}
+          accessibilityRole="button"
+          accessibilityLabel="Try again"
+          accessibilityHint="Reloads your cost data"
           className="bg-brand px-6 py-3 rounded-xl mt-6 active:opacity-80"
         >
           <Text className="text-white font-semibold">Try Again</Text>

--- a/packages/styrby-mobile/src/__tests__/a11y-touchables.test.ts
+++ b/packages/styrby-mobile/src/__tests__/a11y-touchables.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Accessibility regression guard (Cluster C3).
+ *
+ * Screen readers (VoiceOver / TalkBack) announce an interactive element using
+ * its accessibility props. A raw `<Pressable>` / `<TouchableOpacity>` with no
+ * `accessibilityRole` / `accessibilityLabel` is announced as an unlabeled
+ * "button" (or not at all), which is the single most common mobile-a11y defect.
+ *
+ * The app already routes most interactions through accessible UI primitives
+ * (e.g. SettingRow sets role+label once for every settings row). This test
+ * guards the REMAINDER: any file that drops to a RAW touchable must reference
+ * at least one accessibility prop, so a new screen can't ship a bare,
+ * unlabeled control. It is a file-level guard (not per-element) on purpose —
+ * raw layout-wrapper Pressables (e.g. tap-outside-to-dismiss backdrops) are
+ * legitimate, so we only require that a file using raw touchables engages with
+ * accessibility somewhere rather than ignoring it entirely.
+ *
+ * Caught real gaps when added (2026-06-12): costs, AgentSelector,
+ * SessionCarousel, NotificationStream all had raw Pressables with no a11y.
+ *
+ * @module __tests__/a11y-touchables
+ */
+
+// WHY no vitest import: styrby-mobile uses Jest (not vitest). Jest globals
+// (describe/it/expect) are available without import.
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const MOBILE_ROOT = resolve(__dirname, '../..');
+const SCAN_DIRS = ['app', 'src/components'];
+
+/** Files using a RAW touchable. */
+const RAW_TOUCHABLE = /<\s*(Pressable|TouchableOpacity|TouchableHighlight|TouchableWithoutFeedback)\b/;
+
+/** Any accessibility prop / RN a11y API. */
+const A11Y_REFERENCE =
+  /accessibilityRole|accessibilityLabel|accessibilityHint|accessibilityState|accessibilityValue|accessible\s*=|importantForAccessibility|accessibilityElementsHidden/;
+
+/** Recursively collect .tsx files under a directory, skipping tests. */
+function collectTsx(dir: string): string[] {
+  let out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      out = out.concat(collectTsx(full));
+    } else if (entry.endsWith('.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('mobile a11y — raw touchables carry accessibility props', () => {
+  const files = SCAN_DIRS.flatMap((d) => collectTsx(resolve(MOBILE_ROOT, d)));
+
+  it('scans a non-trivial number of component files (guard is actually running)', () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  it('every file using a raw Pressable/Touchable references an accessibility prop', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const src = readFileSync(file, 'utf-8');
+      if (RAW_TOUCHABLE.test(src) && !A11Y_REFERENCE.test(src)) {
+        offenders.push(file.replace(MOBILE_ROOT + '/', ''));
+      }
+    }
+    if (offenders.length > 0) {
+      // Surface the actionable guidance; the assertion below prints the list.
+      console.error(
+        'Files using a raw touchable with NO accessibility prop. Add ' +
+          'accessibilityRole + accessibilityLabel (or use an accessible primitive ' +
+          `like SettingRow):\n${offenders.join('\n')}`,
+      );
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/styrby-mobile/src/components/AgentSelector.tsx
+++ b/packages/styrby-mobile/src/components/AgentSelector.tsx
@@ -186,6 +186,9 @@ export function AgentSelector({
       <Pressable
         onPress={() => !disabled && setModalVisible(true)}
         disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={currentConfig ? `Selected agent: ${currentConfig.name}. Change agent` : 'Select agent'}
+        accessibilityState={{ disabled }}
         className={`flex-row items-center px-3 py-2 rounded-xl ${
           disabled ? 'opacity-50' : ''
         }`}
@@ -254,6 +257,8 @@ export function AgentSelector({
               </Text>
               <Pressable
                 onPress={() => setModalVisible(false)}
+                accessibilityRole="button"
+                accessibilityLabel="Close agent selector"
                 className="p-2"
                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
               >
@@ -271,6 +276,9 @@ export function AgentSelector({
                   <Pressable
                     key={agent}
                     onPress={() => handleSelect(agent)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${config.name}. ${config.description}`}
+                    accessibilityState={{ selected: isSelected }}
                     className={`flex-row items-center p-4 rounded-xl ${
                       isSelected ? '' : 'bg-zinc-800/50'
                     }`}

--- a/packages/styrby-mobile/src/components/NotificationStream.tsx
+++ b/packages/styrby-mobile/src/components/NotificationStream.tsx
@@ -98,6 +98,9 @@ function NotificationItem({
       className={`flex-row p-3 border-b border-zinc-800 ${
         !notification.read ? 'bg-zinc-900/50' : ''
       }`}
+      accessibilityRole="button"
+      accessibilityLabel={`${notification.read ? '' : 'Unread. '}${notification.title}. ${notification.message}`}
+      accessibilityHint={notification.actionable ? 'Action required. Opens this notification' : 'Opens this notification'}
     >
       {/* Icon */}
       <View

--- a/packages/styrby-mobile/src/components/SessionCarousel.tsx
+++ b/packages/styrby-mobile/src/components/SessionCarousel.tsx
@@ -106,6 +106,9 @@ export function SessionCarousel({ sessions, onSessionPress, onApprove, onDeny }:
                 onPress={() => onSessionPress(session)}
                 style={{ backgroundColor: config.bgColor }}
                 className="rounded-2xl p-4 h-full"
+                accessibilityRole="button"
+                accessibilityLabel={`${config.name} session: ${session.title || 'Active session'}, status ${session.status.replace('_', ' ')}`}
+                accessibilityHint="Opens this session's details"
               >
                 {/* Header */}
                 <View className="flex-row items-center justify-between">
@@ -152,12 +155,16 @@ export function SessionCarousel({ sessions, onSessionPress, onApprove, onDeny }:
                       <Pressable
                         onPress={() => onApprove?.(session)}
                         className="bg-green-500 px-4 py-1.5 rounded-lg mr-2"
+                        accessibilityRole="button"
+                        accessibilityLabel="Approve permission request"
                       >
                         <Text className="text-white font-medium text-sm">Approve</Text>
                       </Pressable>
                       <Pressable
                         onPress={() => onDeny?.(session)}
                         className="bg-zinc-700 px-4 py-1.5 rounded-lg"
+                        accessibilityRole="button"
+                        accessibilityLabel="Deny permission request"
                       >
                         <Text className="text-zinc-300 font-medium text-sm">Deny</Text>
                       </Pressable>


### PR DESCRIPTION
## Summary
Cluster C3 (mobile a11y). The app already routes most interactions through accessible primitives (e.g. `SettingRow` sets role+label for every settings row — 149/189 tsx files already had a11y props). This closes the real gaps: **4 files with raw `Pressable`s lacking labels**, which screen readers announce as unlabeled buttons.

## Changes
- **a11y props added** to raw touchables in: `costs` ("Try Again"), `AgentSelector` (trigger/close/option rows, with `accessibilityState` selected/disabled), `SessionCarousel` (card + approve/deny), `NotificationStream` (rows, unread-aware label).
- **NEW** `a11y-touchables.test.ts` — a durable regression guard: any file using a raw `Pressable`/`Touchable` must reference an accessibility prop (file-level, so legitimate layout-wrapper backdrops pass). A new unlabeled control now fails CI.

## Notes
- On-device VoiceOver/TalkBack verification is operator-gated (needs a real device); this PR delivers the labels + the static guard, both CI-verifiable.

## Test Plan
- [ ] CI passes (mobile chain)
- [x] +2 tests; mobile gate local: typecheck, lint, 1705 jest tests

🤖 Shipped via /gh-ship