### PR TITLE
feat(cli): wire native file watcher into session lifecycle

### DIFF
--- a/packages/styrby-cli/src/api/apiSession.ts
+++ b/packages/styrby-cli/src/api/apiSession.ts
@@ -20,6 +20,7 @@ import type { RelayMessage, AgentType as SharedAgentType } from 'styrby-shared';
 import { logger } from '@/ui/logger';
 import { classifyRelayMessage } from './relayMessageDispatch';
 import { safeRelaySend } from './safeRelaySend';
+import { createFileWatcher, type FileWatcherHandle } from '@/session/fileWatcher';
 
 /**
  * Callback type for session updates (status changes, errors, completion).
@@ -191,6 +192,39 @@ export class ApiSessionManager {
     // Update status to running
     await this.updateSessionStatus(supabase, sessionId, 'running');
 
+    // 4b. Optional project file watcher → fs-edit events to mobile.
+    //
+    // WHY opt-in (STYRBY_SESSION_FILE_EVENTS): watching the project dir lets
+    // mobile see which files the agent touches in real time, but it adds an
+    // OS watcher per session and emits relay traffic. Gating it keeps the
+    // default behavior unchanged; operators opt in (and can pair it with
+    // STYRBY_NATIVE_WATCHER for the SIMD-fast recursive native backend). The
+    // watcher already filters node_modules/.git/build noise. Each change is
+    // bridged as an `fs-edit` AgentMessage through the SAME path as real agent
+    // output, so it reaches mobile via the existing relay plumbing.
+    let fileWatcher: FileWatcherHandle | undefined;
+    if (process.env.STYRBY_SESSION_FILE_EVENTS === 'true' && projectPath) {
+      try {
+        fileWatcher = await createFileWatcher({
+          dir: projectPath,
+          onChange: (changes) => {
+            for (const change of changes) {
+              this.handleAgentMessage(
+                sessionId,
+                agentType,
+                { type: 'fs-edit', description: `${change.kind} ${change.path}`, path: change.path },
+                api,
+              );
+            }
+          },
+        });
+        logger.debug('Session file watcher started', { sessionId, backend: fileWatcher.backend });
+      } catch (error) {
+        // Non-fatal: a session must run even if the watcher can't start.
+        logger.debug('Session file watcher failed to start (non-fatal)', { sessionId, error });
+      }
+    }
+
     // 5. Build the ActiveSession handle
     let stopped = false;
     const activeSession: ActiveSession = {
@@ -214,6 +248,10 @@ export class ApiSessionManager {
 
         // Remove relay message handler first to stop accepting new mobile input
         api.offRelayMessage(relayMessageHandler);
+
+        // Stop the project file watcher (releases the OS watcher + its threads).
+        // Done before agent dispose so no fs-edit events fire mid-teardown.
+        fileWatcher?.stop();
 
         // Dispose the agent process
         try {

--- a/packages/styrby-cli/src/session/__tests__/fileWatcher.test.ts
+++ b/packages/styrby-cli/src/session/__tests__/fileWatcher.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the project file watcher (session/fileWatcher.ts).
+ *
+ * Exercises the fs.watch FALLBACK path (the native peer isn't compiled in CI)
+ * with a real temp directory, plus the noise filter, debounce batching, and
+ * idempotent stop. Top-level file changes are used because Linux fs.watch does
+ * not support recursive watching — the fallback degrades to top-level there,
+ * and these assertions hold on both recursive (macOS) and non-recursive (Linux)
+ * platforms. Recursive-on-Linux is the native backend's job.
+ *
+ * @module session/__tests__/fileWatcher
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createFileWatcher, DEFAULT_IGNORE, type FileChange, type FileWatcherHandle } from '../fileWatcher';
+
+const handles: FileWatcherHandle[] = [];
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const h of handles.splice(0)) h.stop();
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'styrby-fw-'));
+  dirs.push(d);
+  return d;
+}
+
+/** Wait until `predicate()` is true or the timeout elapses. */
+async function waitFor(predicate: () => boolean, timeoutMs = 4000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return predicate();
+}
+
+describe('DEFAULT_IGNORE', () => {
+  it('drops dependency / VCS / build / cache paths', () => {
+    for (const p of [
+      'node_modules/foo/index.js',
+      'pkg/node_modules/x.ts',
+      '.git/HEAD',
+      'dist/bundle.js',
+      '.next/cache/x',
+      'coverage/lcov.info',
+      '.DS_Store',
+    ]) {
+      expect(DEFAULT_IGNORE.test(p), p).toBe(true);
+    }
+  });
+
+  it('keeps real source paths', () => {
+    for (const p of ['src/index.ts', 'app/page.tsx', 'README.md', 'lib/util.js']) {
+      expect(DEFAULT_IGNORE.test(p), p).toBe(false);
+    }
+  });
+});
+
+describe('createFileWatcher — fs.watch fallback', () => {
+  it('reports a top-level file change with a dir-relative path', async () => {
+    const dir = tempDir();
+    const batches: FileChange[][] = [];
+    const handle = await createFileWatcher({ dir, onChange: (c) => batches.push(c), debounceMs: 40 });
+    handles.push(handle);
+    expect(handle.backend === 'fs.watch' || handle.backend === 'none').toBe(true);
+
+    if (handle.backend === 'none') return; // platform without fs.watch — nothing to assert
+    writeFileSync(join(dir, 'hello.ts'), 'export const x = 1;');
+
+    const seen = await waitFor(() => batches.flat().some((c) => c.path === 'hello.ts'));
+    expect(seen).toBe(true);
+    const change = batches.flat().find((c) => c.path === 'hello.ts')!;
+    expect(['create', 'modify', 'other']).toContain(change.kind);
+  });
+
+  it('debounces rapid changes into a single batch', async () => {
+    const dir = tempDir();
+    const batches: FileChange[][] = [];
+    const handle = await createFileWatcher({ dir, onChange: (c) => batches.push(c), debounceMs: 80 });
+    handles.push(handle);
+    if (handle.backend === 'none') return;
+
+    writeFileSync(join(dir, 'a.ts'), '1');
+    writeFileSync(join(dir, 'b.ts'), '2');
+
+    await waitFor(() => batches.flat().some((c) => c.path === 'a.ts'));
+    // Allow the debounce window to settle.
+    await new Promise((r) => setTimeout(r, 120));
+    const paths = new Set(batches.flat().map((c) => c.path));
+    expect(paths.has('a.ts') || paths.has('b.ts')).toBe(true);
+    // Both writes happened inside one debounce window → at most a couple batches,
+    // never one batch per raw fs event.
+    expect(batches.length).toBeLessThanOrEqual(3);
+  });
+
+  it('filters out ignored paths (node_modules)', async () => {
+    const dir = tempDir();
+    mkdirSync(join(dir, 'node_modules'), { recursive: true });
+    const batches: FileChange[][] = [];
+    const handle = await createFileWatcher({ dir, onChange: (c) => batches.push(c), debounceMs: 40 });
+    handles.push(handle);
+    if (handle.backend === 'none') return;
+
+    writeFileSync(join(dir, 'node_modules', 'junk.js'), 'noise');
+    writeFileSync(join(dir, 'real.ts'), 'source');
+
+    await waitFor(() => batches.flat().some((c) => c.path === 'real.ts'));
+    await new Promise((r) => setTimeout(r, 80));
+    const paths = batches.flat().map((c) => c.path);
+    expect(paths).not.toContain('node_modules/junk.js');
+    expect(paths.some((p) => p.startsWith('node_modules'))).toBe(false);
+  });
+
+  it('stop() is idempotent and halts delivery', async () => {
+    const dir = tempDir();
+    const batches: FileChange[][] = [];
+    const handle = await createFileWatcher({ dir, onChange: (c) => batches.push(c), debounceMs: 40 });
+    handles.push(handle);
+
+    handle.stop();
+    expect(() => handle.stop()).not.toThrow(); // idempotent
+
+    if (handle.backend === 'none') return;
+    const countAfterStop = batches.flat().length;
+    writeFileSync(join(dir, 'after-stop.ts'), 'x');
+    await new Promise((r) => setTimeout(r, 200));
+    expect(batches.flat().length).toBe(countAfterStop); // no new deliveries
+  });
+});

--- a/packages/styrby-cli/src/session/fileWatcher.ts
+++ b/packages/styrby-cli/src/session/fileWatcher.ts
@@ -1,0 +1,217 @@
+/**
+ * Project file watcher — surfaces file changes during an active session.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `@styrby/native` ships a SIMD-fast, debounced, recursive directory watcher
+ * (`watchDirectory` / `stopWatcher`, file_watcher.rs) but nothing in the CLI
+ * consumed it — the binding was built + tested in isolation. This service is
+ * the consumer: it watches a session's project directory and reports batched
+ * file changes, so mobile can see what the agent is touching in real time.
+ *
+ * NATIVE-WITH-FALLBACK (mirrors the jsonl-parser pattern)
+ * ------------------------------------------------------
+ * `@styrby/native` is an OPTIONAL peer — it may not be compiled for the current
+ * platform (e.g. CI without a Rust toolchain). So we try the native watcher
+ * first and transparently fall back to Node's `fs.watch`:
+ *   - Native: recursive on every platform, OS-debounced, batched.
+ *   - Fallback: `fs.watch({ recursive: true })` (macOS/Windows). Linux does NOT
+ *     support recursive fs.watch, so there we watch the top level only and note
+ *     the limitation — the native watcher is the recursive-on-Linux path.
+ * The fallback adds its own debounce so both backends deliver batched changes.
+ *
+ * NOISE FILTERING
+ * ---------------
+ * A recursive watch over a project dir would fire constantly on `node_modules`,
+ * `.git`, build output, etc. Those are filtered out before `onChange` so the
+ * relay (and the mobile UI / battery) only see meaningful source changes.
+ *
+ * @module session/fileWatcher
+ */
+
+import * as fs from 'node:fs';
+import { relative, sep } from 'node:path';
+import { logger } from '@/ui/logger';
+
+/** A single file change reported to the consumer. */
+export interface FileChange {
+  /** create | modify | remove (fallback maps fs.watch eventTypes onto these). */
+  kind: 'create' | 'modify' | 'remove' | 'other';
+  /** Path of the affected file, relative to the watched dir (posix-ish). */
+  path: string;
+}
+
+/** Options for {@link createFileWatcher}. */
+export interface FileWatcherOptions {
+  /** Absolute path of the directory to watch. */
+  dir: string;
+  /** Called with a non-empty batch of changes after debounce/filtering. */
+  onChange: (changes: FileChange[]) => void;
+  /**
+   * Paths matching this are dropped. Defaults to {@link DEFAULT_IGNORE}
+   * (node_modules / .git / build output / caches).
+   */
+  ignore?: RegExp;
+  /** Fallback debounce window in ms (native already debounces). Default 150. */
+  debounceMs?: number;
+}
+
+/** Handle returned by {@link createFileWatcher}. */
+export interface FileWatcherHandle {
+  /** Stop watching and release OS resources. Idempotent. */
+  stop: () => void;
+  /** Which backend is active — useful for diagnostics + tests. */
+  readonly backend: 'native' | 'fs.watch' | 'none';
+}
+
+/**
+ * Default ignore pattern: dependency/VCS/build/cache directories that produce
+ * high-frequency noise and never represent meaningful agent edits.
+ */
+export const DEFAULT_IGNORE =
+  /(^|[/\\])(node_modules|\.git|dist|build|\.next|\.expo|\.turbo|coverage|\.cache|\.DS_Store)([/\\]|$)/;
+
+/** Minimal shape we use from the optional `@styrby/native` module. */
+interface NativeWatchModule {
+  isNativeLoaded: boolean;
+  watchDirectory: (
+    dir: string,
+    cb: (events: Array<{ kind: string; paths: string[] }>) => void,
+  ) => unknown;
+  stopWatcher: (handle: unknown) => void;
+}
+
+/** Map a native WatchEvent.kind / fs.watch eventType onto our FileChange.kind. */
+function normalizeKind(raw: string): FileChange['kind'] {
+  if (raw === 'create' || raw === 'rename') return 'create';
+  if (raw === 'modify' || raw === 'change') return 'modify';
+  if (raw === 'remove') return 'remove';
+  return 'other';
+}
+
+/**
+ * Start watching `dir` for file changes, preferring the native watcher and
+ * falling back to `fs.watch`. Returns a handle whose `stop()` releases the
+ * watcher; safe to call once and exactly once per session.
+ *
+ * @param opts - Watch configuration (dir, onChange, optional ignore/debounce).
+ * @returns A handle with `stop()` and the active `backend`.
+ *
+ * @example
+ * const watcher = await createFileWatcher({
+ *   dir: session.projectPath,
+ *   onChange: (changes) => emitFsEdits(changes),
+ * });
+ * // ... later, on session end:
+ * watcher.stop();
+ */
+export async function createFileWatcher(opts: FileWatcherOptions): Promise<FileWatcherHandle> {
+  const ignore = opts.ignore ?? DEFAULT_IGNORE;
+  const debounceMs = opts.debounceMs ?? 150;
+
+  /** Convert an absolute path to a dir-relative, forward-slash path. */
+  const toRel = (abs: string): string => relative(opts.dir, abs).split(sep).join('/');
+
+  /** Drop ignored paths; emit only when something survives. */
+  const deliver = (changes: FileChange[]): void => {
+    const kept = changes.filter((c) => c.path !== '' && !ignore.test(c.path));
+    if (kept.length > 0) opts.onChange(kept);
+  };
+
+  // ── Native backend (optional peer) ────────────────────────────────────────
+  // WHY opt-in via STYRBY_NATIVE_WATCHER: the native module is an optional peer
+  // and the watcher spawns OS-level threads. Defaulting to the JS fallback keeps
+  // behavior identical on stock installs; operators who built @styrby/native can
+  // flip the flag for recursive-on-Linux + SIMD-debounced watching.
+  if (process.env.STYRBY_NATIVE_WATCHER === 'true') {
+    try {
+      // @ts-ignore — @styrby/native is an optional peer; TS2307 is expected.
+      const native = (await import('@styrby/native')) as NativeWatchModule;
+      if (native.isNativeLoaded && typeof native.watchDirectory === 'function') {
+        const handle = native.watchDirectory(opts.dir, (events) => {
+          const changes: FileChange[] = [];
+          for (const ev of events) {
+            for (const p of ev.paths) {
+              changes.push({ kind: normalizeKind(ev.kind), path: toRel(p) });
+            }
+          }
+          deliver(changes);
+        });
+        logger.debug('[FileWatcher] using native backend', { dir: opts.dir });
+        let stopped = false;
+        return {
+          backend: 'native',
+          stop: () => {
+            if (stopped) return;
+            stopped = true;
+            try {
+              native.stopWatcher(handle);
+            } catch (err) {
+              logger.debug('[FileWatcher] native stop error (ignored)', { err });
+            }
+          },
+        };
+      }
+    } catch (err) {
+      // Native unavailable — fall through to the JS watcher.
+      logger.debug('[FileWatcher] native unavailable, using fs.watch', { err });
+    }
+  }
+
+  // ── fs.watch fallback (debounced) ─────────────────────────────────────────
+  let pending = new Map<string, FileChange['kind']>();
+  let timer: NodeJS.Timeout | undefined;
+
+  const flush = (): void => {
+    timer = undefined;
+    if (pending.size === 0) return;
+    const batch: FileChange[] = Array.from(pending, ([path, kind]) => ({ path, kind }));
+    pending = new Map();
+    deliver(batch);
+  };
+
+  const onRaw = (eventType: string, filename: string | Buffer | null): void => {
+    if (!filename) return;
+    const path = (typeof filename === 'string' ? filename : filename.toString()).split(sep).join('/');
+    // fs.watch can't distinguish create vs modify reliably — 'rename' covers
+    // create/delete, 'change' covers modify. We record the latest kind per path.
+    pending.set(path, normalizeKind(eventType));
+    if (!timer) timer = setTimeout(flush, debounceMs);
+  };
+
+  let watcher: fs.FSWatcher;
+  try {
+    watcher = fs.watch(opts.dir, { persistent: false, recursive: true }, onRaw);
+  } catch {
+    // Linux: recursive fs.watch is unsupported (ERR_FEATURE_UNAVAILABLE_ON_PLATFORM).
+    // Watch the top level only; recursive coverage requires the native backend.
+    logger.debug('[FileWatcher] recursive fs.watch unsupported; watching top level only', {
+      dir: opts.dir,
+    });
+    try {
+      watcher = fs.watch(opts.dir, { persistent: false, recursive: false }, onRaw);
+    } catch (err) {
+      logger.debug('[FileWatcher] fs.watch failed; no watcher active', { dir: opts.dir, err });
+      return { backend: 'none', stop: () => {} };
+    }
+  }
+
+  logger.debug('[FileWatcher] using fs.watch backend', { dir: opts.dir });
+  let stopped = false;
+  return {
+    backend: 'fs.watch',
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      try {
+        watcher.close();
+      } catch {
+        // already closed
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Cluster A4 partial. `@styrby/native` shipped a SIMD-fast recursive directory watcher (`watchDirectory`/`stopWatcher`) but **nothing consumed it** — built + tested in isolation. This adds the consumer.

## Changes
- **NEW** `session/fileWatcher.ts` — optional `@styrby/native` load (behind `STYRBY_NATIVE_WATCHER`, mirrors the proven `jsonl-parser` pattern) with a Node `fs.watch` fallback. Fallback degrades to top-level on Linux (recursive `fs.watch` unsupported → native is the recursive-on-Linux path), filters `node_modules`/`.git`/build/cache noise, debounces into batches, idempotent `stop()`.
- **MOD** `apiSession.ts` — wired into the session lifecycle, opt-in via `STYRBY_SESSION_FILE_EVENTS`: watches `projectPath`, bridges each change as an `fs-edit` AgentMessage through the existing relay path (`handleAgentMessage` already had `case 'fs-edit'`), stops in cleanup before agent dispose.

## Notes
- **Both flags default off** — zero behavior change on stock installs.
- On-device "mobile shows file edits" UX is operator-verifiable; the CLI wiring + watcher are CI-verified here.

## Test Plan
- [ ] CI passes (CLI chain)
- [x] +6 fileWatcher tests (real temp-dir fs.watch, ignore filter, debounce, idempotent stop)
- [x] CLI gate local: typecheck, 2676 tests, build; apiSession tests still green (non-breaking wiring)

🤖 Shipped via /gh-ship