### PR TITLE
refactor(mobile): split ChatMessage.tsx 533->146 LOC (Cluster A2)

### DIFF
--- a/packages/styrby-mobile/src/components/ChatMessage.tsx
+++ b/packages/styrby-mobile/src/components/ChatMessage.tsx
@@ -1,58 +1,45 @@
 /**
  * Chat Message Component
  *
- * Renders a single message in the chat UI.
- * Supports different message types: user, agent, system, error.
+ * Renders a single message in the chat UI (user / assistant / system / error),
+ * with markdown code parsing (fenced blocks, inline code) for text content.
  *
- * Enhanced with markdown code parsing:
- * - Fenced code blocks (```lang ... ```) with language labels, copy button,
- *   and horizontal scrolling
- * - Inline code (`code`) with monospace font and distinct background
- * - Regular text renders normally (no regressions)
+ * Cluster A2 split: the sub-renderers and pure parser were moved into
+ * `./chat/*` to keep this file under the 400-LOC ceiling. The public API
+ * (types + `parseMessageContent`) is re-exported here so existing importers of
+ * `./ChatMessage` keep working unchanged.
  *
  * @module components/ChatMessage
  */
 
-import { View, Text, Pressable, ScrollView, Platform } from 'react-native';
-import { useState, useMemo, useRef, useEffect } from 'react';
-import * as Clipboard from 'expo-clipboard';
+import { View, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { AgentType } from 'styrby-shared';
+import type { ChatMessageData } from './chat/message-types';
+import { CodeBlock } from './chat/CodeBlock';
+import { ThinkingBlock } from './chat/ThinkingBlock';
+import { TextBlock } from './chat/TextBlock';
 
-/**
- * Message types
- */
-export type MessageRole = 'user' | 'assistant' | 'system' | 'error';
-
-/**
- * Message content block types
- */
-export type ContentBlockType = 'text' | 'code' | 'thinking';
-
-export interface ContentBlock {
-  type: ContentBlockType;
-  content: string;
-  language?: string; // For code blocks
-}
-
-/**
- * Chat message data
- */
-export interface ChatMessageData {
-  id: string;
-  role: MessageRole;
-  agentType?: AgentType;
-  content: ContentBlock[];
-  timestamp: string;
-  isStreaming?: boolean;
-  costUsd?: number;
-  durationMs?: number;
-}
+// Re-export the public surface so `import { ... } from './ChatMessage'` is
+// unchanged for every existing consumer (chat screen, SessionReplay, etc.).
+export type {
+  MessageRole,
+  ContentBlockType,
+  ContentBlock,
+  ChatMessageData,
+} from './chat/message-types';
+export {
+  parseMessageContent,
+  parseInlineCode,
+  type ParsedSegmentType,
+  type ParsedSegment,
+} from './chat/message-content';
 
 interface ChatMessageProps {
   message: ChatMessageData;
 }
 
+/** Per-agent display config (name + accent colors). */
 const AGENT_CONFIG: Record<AgentType, { name: string; color: string; bgColor: string }> = {
   claude: { name: 'Claude', color: '#f97316', bgColor: 'rgba(249, 115, 22, 0.1)' },
   codex: { name: 'Codex', color: '#22c55e', bgColor: 'rgba(34, 197, 94, 0.1)' },
@@ -67,375 +54,10 @@ const AGENT_CONFIG: Record<AgentType, { name: string; color: string; bgColor: st
   droid: { name: 'Droid', color: '#64748b', bgColor: 'rgba(100, 116, 139, 0.1)' },
 };
 
-function CodeBlock({ content, language }: { content: string; language?: string }) {
-  const [copied, setCopied] = useState(false);
-
-  /**
-   * Stores active timer IDs so they can be cleared if the component unmounts
-   * before they fire, preventing state updates on unmounted components.
-   */
-  const timerIdsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
-
-  // WHY: Clear all pending timers when the component unmounts. Without this,
-  // the setCopied(false) and Clipboard.setStringAsync('') callbacks fire on an
-  // already-unmounted component, causing React "Can't perform a state update on
-  // an unmounted component" warnings and potential clipboard side-effects.
-  useEffect(() => {
-    // WHY: Capture the ref value in a local variable so the cleanup function
-    // always operates on the same array instance even if timerIdsRef.current
-    // is reassigned before cleanup runs (React's ref timing guarantee).
-    const timers = timerIdsRef.current;
-    return () => {
-      timers.forEach(clearTimeout);
-    };
-  }, []);
-
-  const handleCopy = async () => {
-    await Clipboard.setStringAsync(content);
-    setCopied(true);
-    // Reset the "Copied!" indicator after 2 seconds
-    timerIdsRef.current.push(setTimeout(() => setCopied(false), 2000));
-    // SEC-MOB-001 FIX: Clear the clipboard after 30 seconds.
-    // WHY: Code blocks may contain secrets (API keys, tokens, passwords) that
-    // the developer copies during a session. If the user copies sensitive content
-    // and then switches apps, that data sits in the system clipboard indefinitely,
-    // accessible to any app that reads the clipboard (many do so on every focus).
-    // Clearing after 30 seconds limits the exposure window without disrupting
-    // normal paste workflows (users typically paste within a few seconds).
-    timerIdsRef.current.push(setTimeout(() => Clipboard.setStringAsync(''), 30000));
-  };
-
-  return (
-    <View className="bg-zinc-900 rounded-lg overflow-hidden my-2">
-      {/* Header */}
-      <View className="flex-row items-center justify-between px-3 py-2 bg-zinc-800/50 border-b border-zinc-700">
-        <Text className="text-zinc-400 text-xs font-mono">{language || 'code'}</Text>
-        <Pressable onPress={handleCopy} className="flex-row items-center">
-          <Ionicons
-            name={copied ? 'checkmark' : 'copy-outline'}
-            size={14}
-            color={copied ? '#22c55e' : '#71717a'}
-          />
-          <Text className="text-zinc-500 text-xs ml-1">{copied ? 'Copied!' : 'Copy'}</Text>
-        </Pressable>
-      </View>
-      {/* Code */}
-      <View className="p-3">
-        <Text className="text-zinc-300 font-mono text-sm" selectable>
-          {content}
-        </Text>
-      </View>
-    </View>
-  );
-}
-
-function ThinkingBlock({ content }: { content: string }) {
-  const [expanded, setExpanded] = useState(false);
-
-  return (
-    <Pressable
-      onPress={() => setExpanded(!expanded)}
-      className="bg-zinc-800/50 rounded-lg my-2 overflow-hidden"
-    >
-      <View className="flex-row items-center px-3 py-2">
-        <Ionicons name="bulb-outline" size={14} color="#71717a" />
-        <Text className="text-zinc-500 text-xs ml-2 flex-1">Thinking...</Text>
-        <Ionicons
-          name={expanded ? 'chevron-up' : 'chevron-down'}
-          size={14}
-          color="#71717a"
-        />
-      </View>
-      {expanded && (
-        <View className="px-3 pb-3 border-t border-zinc-700">
-          <Text className="text-zinc-500 text-sm mt-2">{content}</Text>
-        </View>
-      )}
-    </Pressable>
-  );
-}
-
-// ============================================================================
-// Markdown Content Parsing
-// ============================================================================
-
 /**
- * Segment types produced by parsing message content for markdown-style
- * code fences and inline code backticks.
+ * Renders one chat message bubble with its agent header, content blocks, and
+ * optional cost/duration footer.
  */
-export type ParsedSegmentType = 'text' | 'code_block' | 'inline_code';
-
-/**
- * A parsed segment of message content.
- * The parser splits raw text into these segments so each can be
- * rendered with the appropriate component.
- */
-export interface ParsedSegment {
-  /** What kind of content this segment represents */
-  type: ParsedSegmentType;
-  /** The text content of the segment (code or prose) */
-  content: string;
-  /** Language identifier for code blocks (e.g., "typescript") */
-  language?: string;
-}
-
-/**
- * Monospace font family selected per platform.
- * WHY: iOS and Android ship different built-in monospace fonts.
- * Using Platform.select avoids a runtime lookup and keeps the
- * bundle free of custom font files.
- */
-const MONO_FONT_FAMILY = Platform.select({
-  ios: 'Menlo',
-  android: 'monospace',
-  default: 'monospace',
-});
-
-/**
- * Parses message content into segments of text, code blocks, and inline code.
- *
- * Handles:
- * - Fenced code blocks (triple backtick with optional language)
- * - Inline code (single backtick)
- * - Regular text (everything else)
- * - Edge cases: empty code blocks, unclosed fences, nested backticks
- *
- * @param content - Raw message content string
- * @returns Array of parsed segments for rendering
- *
- * @example
- * parseMessageContent("Hello `world`")
- * // => [{ type: 'text', content: 'Hello ' }, { type: 'inline_code', content: 'world' }]
- */
-export function parseMessageContent(content: string): ParsedSegment[] {
-  const segments: ParsedSegment[] = [];
-  if (!content) return segments;
-
-  // WHY: We use a two-pass approach — first extract fenced code blocks,
-  // then parse the remaining text for inline code. This prevents backticks
-  // inside fenced blocks from being treated as inline code delimiters.
-  //
-  // KNOWN LIMITATION: Nested code fences (``` inside ```) are not supported by
-  // this regex-based parser. A message like:
-  //   ````md
-  //   ```js
-  //   code
-  //   ```
-  //   ````
-  // will be parsed incorrectly. This edge case is extremely rare in AI-generated
-  // output and not worth the complexity of a full CommonMark parser here.
-  const codeBlockRegex = /```(\w*)\n?([\s\S]*?)```/g;
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = codeBlockRegex.exec(content)) !== null) {
-    // Text before this code block
-    if (match.index > lastIndex) {
-      const textBefore = content.slice(lastIndex, match.index);
-      segments.push(...parseInlineCode(textBefore));
-    }
-
-    // The fenced code block itself
-    const language = match[1] || undefined;
-    const codeContent = match[2];
-    // WHY: Only add the segment if there's actual content. Empty fences
-    // (``` ```) are valid markdown but render as nothing useful.
-    if (codeContent.trim()) {
-      segments.push({ type: 'code_block', content: codeContent, language });
-    }
-
-    lastIndex = match.index + match[0].length;
-  }
-
-  // Remaining text after the last code block (or all text if no blocks found)
-  if (lastIndex < content.length) {
-    const remaining = content.slice(lastIndex);
-    segments.push(...parseInlineCode(remaining));
-  }
-
-  return segments;
-}
-
-/**
- * Parses a text string for inline code segments (single backtick delimited).
- *
- * @param text - Text that does not contain fenced code blocks
- * @returns Array of text and inline_code segments
- */
-function parseInlineCode(text: string): ParsedSegment[] {
-  const segments: ParsedSegment[] = [];
-  // WHY: Non-greedy match between single backticks. We avoid matching
-  // double/triple backticks by requiring non-backtick after opening.
-  const inlineRegex = /`([^`]+)`/g;
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = inlineRegex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      segments.push({ type: 'text', content: text.slice(lastIndex, match.index) });
-    }
-    segments.push({ type: 'inline_code', content: match[1] });
-    lastIndex = match.index + match[0].length;
-  }
-
-  if (lastIndex < text.length) {
-    segments.push({ type: 'text', content: text.slice(lastIndex) });
-  }
-
-  return segments;
-}
-
-// ============================================================================
-// Inline Code Block Component (for fenced code blocks found inside text)
-// ============================================================================
-
-/**
- * Renders a fenced code block found inside a text segment.
- * Provides a dark container with language label, horizontal scrolling,
- * and a copy button.
- *
- * @param props - code content and optional language identifier
- * @returns Styled code block with copy functionality
- */
-function InlineCodeBlock({ content: codeContent, language }: { content: string; language?: string }) {
-  const [copied, setCopied] = useState(false);
-
-  /**
-   * Stores active timer IDs so they can be cleared if the component unmounts
-   * before they fire. Same pattern as CodeBlock above.
-   */
-  const timerIdsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
-
-  useEffect(() => {
-    // WHY: Capture the ref value in a local variable so the cleanup function
-    // always operates on the same array instance even if timerIdsRef.current
-    // is reassigned before cleanup runs (React's ref timing guarantee).
-    const timers = timerIdsRef.current;
-    return () => {
-      timers.forEach(clearTimeout);
-    };
-  }, []);
-
-  /**
-   * Copies the code content to the clipboard with a timed clear.
-   */
-  const handleCopy = async () => {
-    await Clipboard.setStringAsync(codeContent);
-    setCopied(true);
-    timerIdsRef.current.push(setTimeout(() => setCopied(false), 2000));
-    // WHY: Same security pattern as the main CodeBlock — clear clipboard
-    // after 30s to limit exposure of potentially sensitive code.
-    timerIdsRef.current.push(setTimeout(() => Clipboard.setStringAsync(''), 30000));
-  };
-
-  return (
-    <View className="bg-zinc-900 rounded-lg border border-zinc-800 my-2 overflow-hidden">
-      {/* Header row: language label + copy button */}
-      <View className="flex-row items-center justify-between px-3 py-1.5 bg-zinc-800/50">
-        <Text className="text-zinc-500 text-xs" style={{ fontFamily: MONO_FONT_FAMILY }}>
-          {language || 'code'}
-        </Text>
-        <Pressable
-          onPress={handleCopy}
-          hitSlop={8}
-          className="flex-row items-center"
-          accessibilityRole="button"
-          accessibilityLabel={`Copy ${language || 'code'} block`}
-        >
-          <Ionicons
-            name={copied ? 'checkmark' : 'copy-outline'}
-            size={14}
-            color={copied ? '#22c55e' : '#71717a'}
-          />
-          <Text className="text-zinc-400 text-xs ml-1">
-            {copied ? 'Copied!' : 'Copy'}
-          </Text>
-        </Pressable>
-      </View>
-      {/* Code content with horizontal scroll for long lines */}
-      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-        <View className="p-3">
-          <Text
-            className="text-sm text-green-400"
-            style={{ fontFamily: MONO_FONT_FAMILY }}
-            selectable
-          >
-            {codeContent}
-          </Text>
-        </View>
-      </ScrollView>
-    </View>
-  );
-}
-
-// ============================================================================
-// Text Block Component (enhanced with inline code + code block parsing)
-// ============================================================================
-
-/**
- * Renders a text content block with markdown-style code parsing.
- *
- * Parses the raw text for:
- * - Fenced code blocks (```language ... ```) rendered as distinct containers
- * - Inline code (`code`) rendered with monospace font and background
- * - Regular text rendered normally
- *
- * @param props - The text content to render
- * @returns Parsed and styled text with code highlighting
- */
-function TextBlock({ content }: { content: string }) {
-  // WHY: Memoize parsing so we don't re-parse on every render.
-  // Message content is immutable once received, so this is safe.
-  const segments = useMemo(() => parseMessageContent(content), [content]);
-
-  // Fast path: if no code was found, render as plain text (most common case)
-  if (segments.length === 1 && segments[0].type === 'text') {
-    return (
-      <Text className="text-zinc-200 text-base leading-6" selectable>
-        {content}
-      </Text>
-    );
-  }
-
-  return (
-    <View>
-      {segments.map((segment, index) => {
-        switch (segment.type) {
-          case 'code_block':
-            return (
-              <InlineCodeBlock
-                key={index}
-                content={segment.content}
-                language={segment.language}
-              />
-            );
-          case 'inline_code':
-            return (
-              <Text key={index} className="text-zinc-200 text-base leading-6" selectable>
-                <Text
-                  className="text-sm text-orange-300 bg-zinc-800 rounded px-1.5 py-0.5"
-                  style={{ fontFamily: MONO_FONT_FAMILY }}
-                >
-                  {segment.content}
-                </Text>
-              </Text>
-            );
-          default:
-            return (
-              <Text
-                key={index}
-                className="text-zinc-200 text-base leading-6"
-                selectable
-              >
-                {segment.content}
-              </Text>
-            );
-        }
-      })}
-    </View>
-  );
-}
-
 export function ChatMessage({ message }: ChatMessageProps) {
   const isUser = message.role === 'user';
   const isError = message.role === 'error';
@@ -451,9 +73,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
             style={{ backgroundColor: agentConfig.color }}
             className="w-5 h-5 rounded-md items-center justify-center"
           >
-            <Text className="text-white text-xs font-bold">
-              {agentConfig.name[0]}
-            </Text>
+            <Text className="text-white text-xs font-bold">{agentConfig.name[0]}</Text>
           </View>
           <Text className="text-zinc-400 text-sm ml-2">{agentConfig.name}</Text>
           {message.isStreaming && (
@@ -504,17 +124,13 @@ export function ChatMessage({ message }: ChatMessageProps) {
             {message.costUsd !== undefined && (
               <View className="flex-row items-center mr-3">
                 <Ionicons name="wallet-outline" size={12} color="#71717a" />
-                <Text className="text-zinc-500 text-xs ml-1">
-                  ${message.costUsd.toFixed(4)}
-                </Text>
+                <Text className="text-zinc-500 text-xs ml-1">${message.costUsd.toFixed(4)}</Text>
               </View>
             )}
             {message.durationMs !== undefined && (
               <View className="flex-row items-center">
                 <Ionicons name="time-outline" size={12} color="#71717a" />
-                <Text className="text-zinc-500 text-xs ml-1">
-                  {(message.durationMs / 1000).toFixed(1)}s
-                </Text>
+                <Text className="text-zinc-500 text-xs ml-1">{(message.durationMs / 1000).toFixed(1)}s</Text>
               </View>
             )}
           </View>
@@ -523,10 +139,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
 
       {/* Timestamp */}
       <Text className="text-zinc-600 text-xs mt-1">
-        {new Date(message.timestamp).toLocaleTimeString([], {
-          hour: 'numeric',
-          minute: '2-digit',
-        })}
+        {new Date(message.timestamp).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
       </Text>
     </View>
   );

--- a/packages/styrby-mobile/src/components/chat/CodeBlock.tsx
+++ b/packages/styrby-mobile/src/components/chat/CodeBlock.tsx
@@ -1,0 +1,98 @@
+/**
+ * Code block renderers for chat messages.
+ *
+ * Extracted from ChatMessage.tsx (Cluster A2 split):
+ * - {@link CodeBlock} renders a structured `type: 'code'` content block.
+ * - {@link InlineCodeBlock} renders a fenced code block found inside prose
+ *   (via the markdown parser), with horizontal scroll for long lines.
+ *
+ * Both share the copy-with-timed-clear behavior via {@link useCopyWithClear}.
+ *
+ * @module components/chat/CodeBlock
+ */
+
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { MONO_FONT_FAMILY } from './message-content';
+import { useCopyWithClear } from './useCopyWithClear';
+
+/**
+ * Renders a structured code content block (dark container, language label,
+ * copy button).
+ *
+ * @param props - code content + optional language identifier.
+ */
+export function CodeBlock({ content, language }: { content: string; language?: string }) {
+  const { copied, handleCopy } = useCopyWithClear(content);
+
+  return (
+    <View className="bg-zinc-900 rounded-lg overflow-hidden my-2">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-3 py-2 bg-zinc-800/50 border-b border-zinc-700">
+        <Text className="text-zinc-400 text-xs font-mono">{language || 'code'}</Text>
+        <Pressable
+          onPress={handleCopy}
+          className="flex-row items-center"
+          accessibilityRole="button"
+          accessibilityLabel={`Copy ${language || 'code'} block`}
+        >
+          <Ionicons
+            name={copied ? 'checkmark' : 'copy-outline'}
+            size={14}
+            color={copied ? '#22c55e' : '#71717a'}
+          />
+          <Text className="text-zinc-500 text-xs ml-1">{copied ? 'Copied!' : 'Copy'}</Text>
+        </Pressable>
+      </View>
+      {/* Code */}
+      <View className="p-3">
+        <Text className="text-zinc-300 font-mono text-sm" selectable>
+          {content}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Renders a fenced code block found inside a text segment: dark container with
+ * language label, horizontal scrolling, and a copy button.
+ *
+ * @param props - code content + optional language identifier.
+ */
+export function InlineCodeBlock({ content: codeContent, language }: { content: string; language?: string }) {
+  const { copied, handleCopy } = useCopyWithClear(codeContent);
+
+  return (
+    <View className="bg-zinc-900 rounded-lg border border-zinc-800 my-2 overflow-hidden">
+      {/* Header row: language label + copy button */}
+      <View className="flex-row items-center justify-between px-3 py-1.5 bg-zinc-800/50">
+        <Text className="text-zinc-500 text-xs" style={{ fontFamily: MONO_FONT_FAMILY }}>
+          {language || 'code'}
+        </Text>
+        <Pressable
+          onPress={handleCopy}
+          hitSlop={8}
+          className="flex-row items-center"
+          accessibilityRole="button"
+          accessibilityLabel={`Copy ${language || 'code'} block`}
+        >
+          <Ionicons
+            name={copied ? 'checkmark' : 'copy-outline'}
+            size={14}
+            color={copied ? '#22c55e' : '#71717a'}
+          />
+          <Text className="text-zinc-400 text-xs ml-1">{copied ? 'Copied!' : 'Copy'}</Text>
+        </Pressable>
+      </View>
+      {/* Code content with horizontal scroll for long lines */}
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <View className="p-3">
+          <Text className="text-sm text-green-400" style={{ fontFamily: MONO_FONT_FAMILY }} selectable>
+            {codeContent}
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/components/chat/TextBlock.tsx
+++ b/packages/styrby-mobile/src/components/chat/TextBlock.tsx
@@ -1,0 +1,60 @@
+/**
+ * TextBlock — renders a text content block with markdown-style code parsing.
+ *
+ * Extracted from ChatMessage.tsx (Cluster A2 split). Parses the raw text for
+ * fenced code blocks (rendered via {@link InlineCodeBlock}), inline code, and
+ * regular prose.
+ *
+ * @module components/chat/TextBlock
+ */
+
+import { View, Text } from 'react-native';
+import { useMemo } from 'react';
+import { parseMessageContent, MONO_FONT_FAMILY } from './message-content';
+import { InlineCodeBlock } from './CodeBlock';
+
+/**
+ * @param props - the raw text content to render.
+ */
+export function TextBlock({ content }: { content: string }) {
+  // WHY memoize: message content is immutable once received, so we don't
+  // re-parse on every render.
+  const segments = useMemo(() => parseMessageContent(content), [content]);
+
+  // Fast path: no code found → render as plain text (the common case).
+  if (segments.length === 1 && segments[0].type === 'text') {
+    return (
+      <Text className="text-zinc-200 text-base leading-6" selectable>
+        {content}
+      </Text>
+    );
+  }
+
+  return (
+    <View>
+      {segments.map((segment, index) => {
+        switch (segment.type) {
+          case 'code_block':
+            return <InlineCodeBlock key={index} content={segment.content} language={segment.language} />;
+          case 'inline_code':
+            return (
+              <Text key={index} className="text-zinc-200 text-base leading-6" selectable>
+                <Text
+                  className="text-sm text-orange-300 bg-zinc-800 rounded px-1.5 py-0.5"
+                  style={{ fontFamily: MONO_FONT_FAMILY }}
+                >
+                  {segment.content}
+                </Text>
+              </Text>
+            );
+          default:
+            return (
+              <Text key={index} className="text-zinc-200 text-base leading-6" selectable>
+                {segment.content}
+              </Text>
+            );
+        }
+      })}
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/components/chat/ThinkingBlock.tsx
+++ b/packages/styrby-mobile/src/components/chat/ThinkingBlock.tsx
@@ -1,0 +1,40 @@
+/**
+ * ThinkingBlock — collapsible "thinking" trace for chat messages.
+ *
+ * Extracted from ChatMessage.tsx (Cluster A2 split). Renders a `type:
+ * 'thinking'` content block as a tappable, collapsed-by-default disclosure.
+ *
+ * @module components/chat/ThinkingBlock
+ */
+
+import { View, Text, Pressable } from 'react-native';
+import { useState } from 'react';
+import { Ionicons } from '@expo/vector-icons';
+
+/**
+ * @param props - the thinking-trace text to disclose.
+ */
+export function ThinkingBlock({ content }: { content: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Pressable
+      onPress={() => setExpanded(!expanded)}
+      className="bg-zinc-800/50 rounded-lg my-2 overflow-hidden"
+      accessibilityRole="button"
+      accessibilityLabel={expanded ? 'Collapse thinking trace' : 'Expand thinking trace'}
+      accessibilityState={{ expanded }}
+    >
+      <View className="flex-row items-center px-3 py-2">
+        <Ionicons name="bulb-outline" size={14} color="#71717a" />
+        <Text className="text-zinc-500 text-xs ml-2 flex-1">Thinking...</Text>
+        <Ionicons name={expanded ? 'chevron-up' : 'chevron-down'} size={14} color="#71717a" />
+      </View>
+      {expanded && (
+        <View className="px-3 pb-3 border-t border-zinc-700">
+          <Text className="text-zinc-500 text-sm mt-2">{content}</Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}

--- a/packages/styrby-mobile/src/components/chat/__tests__/message-content.test.ts
+++ b/packages/styrby-mobile/src/components/chat/__tests__/message-content.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the chat message content parser (chat/message-content.ts).
+ *
+ * This pure logic was untested while embedded in ChatMessage.tsx; the Cluster
+ * A2 split moved it out and these tests now pin its contract: fenced code
+ * blocks, inline code, plain text, and the documented edge cases.
+ *
+ * @module components/chat/__tests__/message-content
+ */
+
+import { parseMessageContent, parseInlineCode } from '../message-content';
+
+describe('parseInlineCode', () => {
+  it('returns a single text segment for plain prose', () => {
+    expect(parseInlineCode('just words')).toEqual([{ type: 'text', content: 'just words' }]);
+  });
+
+  it('splits inline code from surrounding text', () => {
+    expect(parseInlineCode('use `npm ci` here')).toEqual([
+      { type: 'text', content: 'use ' },
+      { type: 'inline_code', content: 'npm ci' },
+      { type: 'text', content: ' here' },
+    ]);
+  });
+
+  it('handles back-to-back inline code', () => {
+    expect(parseInlineCode('`a``b`')).toEqual([
+      { type: 'inline_code', content: 'a' },
+      { type: 'inline_code', content: 'b' },
+    ]);
+  });
+});
+
+describe('parseMessageContent', () => {
+  it('returns [] for empty input', () => {
+    expect(parseMessageContent('')).toEqual([]);
+  });
+
+  it('parses a plain text message as one text segment', () => {
+    expect(parseMessageContent('hello world')).toEqual([{ type: 'text', content: 'hello world' }]);
+  });
+
+  it('extracts a fenced code block with its language', () => {
+    const segments = parseMessageContent('before\n```ts\nconst x = 1;\n```\nafter');
+    const code = segments.find((s) => s.type === 'code_block')!;
+    expect(code).toBeDefined();
+    expect(code.language).toBe('ts');
+    expect(code.content).toContain('const x = 1;');
+    // Surrounding prose is preserved as text segments.
+    expect(segments.some((s) => s.type === 'text' && s.content.includes('before'))).toBe(true);
+    expect(segments.some((s) => s.type === 'text' && s.content.includes('after'))).toBe(true);
+  });
+
+  it('treats a fence with no language as undefined language', () => {
+    const code = parseMessageContent('```\nplain\n```').find((s) => s.type === 'code_block')!;
+    expect(code.language).toBeUndefined();
+    expect(code.content).toContain('plain');
+  });
+
+  it('drops an empty fenced block (renders as nothing useful)', () => {
+    expect(parseMessageContent('```\n\n```')).toEqual([]);
+  });
+
+  it('does NOT treat backticks inside a fenced block as inline code', () => {
+    const segments = parseMessageContent('```\nuse `x` inside\n```');
+    // The only segment is the code block; no inline_code segment leaks out.
+    expect(segments.filter((s) => s.type === 'inline_code')).toHaveLength(0);
+    expect(segments.find((s) => s.type === 'code_block')!.content).toContain('`x`');
+  });
+
+  it('parses inline code in the prose around a fenced block', () => {
+    const segments = parseMessageContent('run `ls`\n```sh\necho hi\n```');
+    expect(segments.some((s) => s.type === 'inline_code' && s.content === 'ls')).toBe(true);
+    expect(segments.some((s) => s.type === 'code_block' && s.content.includes('echo hi'))).toBe(true);
+  });
+});

--- a/packages/styrby-mobile/src/components/chat/message-content.ts
+++ b/packages/styrby-mobile/src/components/chat/message-content.ts
@@ -1,0 +1,124 @@
+/**
+ * Markdown-ish content parsing for chat messages.
+ *
+ * Pure logic extracted from ChatMessage.tsx (Cluster A2 split). Splitting raw
+ * message text into renderable segments has no React dependency, so it lives
+ * here where it can be unit-tested directly and reused.
+ *
+ * @module components/chat/message-content
+ */
+
+import { Platform } from 'react-native';
+
+/** What a {@link ParsedSegment} represents. */
+export type ParsedSegmentType = 'text' | 'code_block' | 'inline_code';
+
+/**
+ * A parsed segment of message content. The parser splits raw text into these
+ * so each can be rendered with the appropriate component.
+ */
+export interface ParsedSegment {
+  /** What kind of content this segment represents. */
+  type: ParsedSegmentType;
+  /** The text content of the segment (code or prose). */
+  content: string;
+  /** Language identifier for code blocks (e.g. "typescript"). */
+  language?: string;
+}
+
+/**
+ * Monospace font family selected per platform.
+ * WHY: iOS and Android ship different built-in monospace fonts. Platform.select
+ * avoids a runtime lookup and keeps the bundle free of custom font files.
+ */
+export const MONO_FONT_FAMILY = Platform.select({
+  ios: 'Menlo',
+  android: 'monospace',
+  default: 'monospace',
+});
+
+/**
+ * Parses message content into segments of text, code blocks, and inline code.
+ *
+ * Handles: fenced code blocks (triple backtick + optional language), inline
+ * code (single backtick), regular text, and edge cases (empty code blocks,
+ * unclosed fences, nested backticks).
+ *
+ * @param content - Raw message content string.
+ * @returns Array of parsed segments for rendering.
+ *
+ * @example
+ * parseMessageContent("Hello `world`")
+ * // => [{ type: 'text', content: 'Hello ' }, { type: 'inline_code', content: 'world' }]
+ */
+export function parseMessageContent(content: string): ParsedSegment[] {
+  const segments: ParsedSegment[] = [];
+  if (!content) return segments;
+
+  // WHY two-pass: first extract fenced code blocks, then parse the remaining
+  // text for inline code. This prevents backticks inside fenced blocks from
+  // being treated as inline-code delimiters.
+  //
+  // KNOWN LIMITATION: nested code fences (``` inside ```) are not supported by
+  // this regex-based parser — extremely rare in AI output and not worth a full
+  // CommonMark parser here.
+  const codeBlockRegex = /```(\w*)\n?([\s\S]*?)```/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = codeBlockRegex.exec(content)) !== null) {
+    // Text before this code block.
+    if (match.index > lastIndex) {
+      const textBefore = content.slice(lastIndex, match.index);
+      segments.push(...parseInlineCode(textBefore));
+    }
+
+    // The fenced code block itself.
+    const language = match[1] || undefined;
+    const codeContent = match[2];
+    // WHY: only add the segment if there's actual content. Empty fences render
+    // as nothing useful.
+    if (codeContent.trim()) {
+      segments.push({ type: 'code_block', content: codeContent, language });
+    }
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Remaining text after the last code block (or all text if no blocks found).
+  if (lastIndex < content.length) {
+    const remaining = content.slice(lastIndex);
+    segments.push(...parseInlineCode(remaining));
+  }
+
+  return segments;
+}
+
+/**
+ * Parses a text string (with no fenced code blocks) for inline code segments.
+ *
+ * @param text - Text that does not contain fenced code blocks.
+ * @returns Array of text and inline_code segments.
+ */
+export function parseInlineCode(text: string): ParsedSegment[] {
+  const segments: ParsedSegment[] = [];
+  // WHY: non-greedy match between single backticks; require non-backtick after
+  // the opening so we don't match double/triple backticks.
+  const inlineRegex = /`([^`]+)`/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = inlineRegex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', content: text.slice(lastIndex, match.index) });
+    }
+    segments.push({ type: 'inline_code', content: match[1] });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: 'text', content: text.slice(lastIndex) });
+  }
+
+  return segments;
+}

--- a/packages/styrby-mobile/src/components/chat/message-types.ts
+++ b/packages/styrby-mobile/src/components/chat/message-types.ts
@@ -1,0 +1,37 @@
+/**
+ * Chat message domain types.
+ *
+ * Extracted from ChatMessage.tsx (Cluster A2 split) so the types can be
+ * imported without pulling in the React component tree, and so the component
+ * file stays under the 400-LOC ceiling.
+ *
+ * @module components/chat/message-types
+ */
+
+import type { AgentType } from 'styrby-shared';
+
+/** Who authored a chat message. */
+export type MessageRole = 'user' | 'assistant' | 'system' | 'error';
+
+/** The kind of a single content block within a message. */
+export type ContentBlockType = 'text' | 'code' | 'thinking';
+
+/** One renderable block of a message (prose, a code block, or a thinking trace). */
+export interface ContentBlock {
+  type: ContentBlockType;
+  content: string;
+  /** Language identifier for code blocks. */
+  language?: string;
+}
+
+/** A full chat message as rendered by {@link ChatMessage}. */
+export interface ChatMessageData {
+  id: string;
+  role: MessageRole;
+  agentType?: AgentType;
+  content: ContentBlock[];
+  timestamp: string;
+  isStreaming?: boolean;
+  costUsd?: number;
+  durationMs?: number;
+}

--- a/packages/styrby-mobile/src/components/chat/useCopyWithClear.ts
+++ b/packages/styrby-mobile/src/components/chat/useCopyWithClear.ts
@@ -1,0 +1,53 @@
+/**
+ * useCopyWithClear — copy text to the clipboard with a timed auto-clear.
+ *
+ * Extracted from the duplicated logic in ChatMessage's CodeBlock and
+ * InlineCodeBlock (Cluster A2 split). Both showed a "Copied!" state for 2s and
+ * cleared the system clipboard after 30s.
+ *
+ * WHY the 30s clear (SEC-MOB-001): code blocks can contain secrets (API keys,
+ * tokens) a developer copies mid-session. Left in the clipboard, that data is
+ * readable by any app that inspects the clipboard on focus (many do). Clearing
+ * after 30s bounds the exposure window without disrupting normal paste flows.
+ *
+ * WHY tracked timers: the setCopied(false) + clipboard-clear callbacks must be
+ * cancelled if the component unmounts first, otherwise React warns about state
+ * updates on an unmounted component (and the clipboard clear fires spuriously).
+ *
+ * @module components/chat/useCopyWithClear
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import * as Clipboard from 'expo-clipboard';
+
+/** "Copied!" indicator duration. */
+const COPIED_INDICATOR_MS = 2000;
+/** Clipboard auto-clear delay (SEC-MOB-001). */
+const CLIPBOARD_CLEAR_MS = 30000;
+
+/**
+ * @param text - The text to copy when {@link CopyState.handleCopy} runs.
+ * @returns `copied` (true for ~2s after a copy) and `handleCopy`.
+ */
+export function useCopyWithClear(text: string): { copied: boolean; handleCopy: () => Promise<void> } {
+  const [copied, setCopied] = useState(false);
+  const timerIdsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  useEffect(() => {
+    // Capture the ref value so cleanup operates on the same array instance even
+    // if the ref is reassigned before cleanup runs (React ref-timing guarantee).
+    const timers = timerIdsRef.current;
+    return () => {
+      timers.forEach(clearTimeout);
+    };
+  }, []);
+
+  const handleCopy = async (): Promise<void> => {
+    await Clipboard.setStringAsync(text);
+    setCopied(true);
+    timerIdsRef.current.push(setTimeout(() => setCopied(false), COPIED_INDICATOR_MS));
+    timerIdsRef.current.push(setTimeout(() => Clipboard.setStringAsync(''), CLIPBOARD_CLEAR_MS));
+  };
+
+  return { copied, handleCopy };
+}


### PR DESCRIPTION
## Summary
Cluster A2 (first of the >400-LOC component splits). `ChatMessage.tsx` was 533 LOC; CLAUDE.md mandates <400. Behavior-preserving extraction into co-located `chat/` modules → **533 → 146 LOC**.

## Changes
- `chat/message-types.ts` — message domain types.
- `chat/message-content.ts` — the pure markdown parser (`parseMessageContent`/`parseInlineCode`), now unit-testable.
- `chat/useCopyWithClear.ts` — DRY'd the duplicated clipboard copy + 30s auto-clear (SEC-MOB-001) logic.
- `chat/CodeBlock.tsx` / `ThinkingBlock.tsx` / `TextBlock.tsx` — the three sub-renderers.
- `ChatMessage.tsx` keeps the main component + **re-exports the full public API** (types + `parseMessageContent`), so every importer of `./ChatMessage` is unchanged.

## Notes
- Extracted code blocks now live in their own files with raw `Pressable`s → got a11y labels (required + verified by the C3 a11y guard; the originals lacked them on copy/expand buttons).

## Test Plan
- [ ] CI passes (mobile chain)
- [x] +10 tests for the extracted pure parser (fences, inline code, backticks-inside-fence edge case)
- [x] Mobile gate local: typecheck, lint, **1715 jest tests** (full suite — every ChatMessage consumer green = behavior preserved)

🤖 Shipped via /gh-ship