### PR TITLE
refactor(mobile): split VoiceInput.tsx 767->256 LOC (Cluster A2)

### DIFF
--- a/packages/styrby-mobile/src/components/VoiceInput.tsx
+++ b/packages/styrby-mobile/src/components/VoiceInput.tsx
@@ -2,565 +2,75 @@
  * VoiceInput Component
  *
  * Microphone button that records audio and transcribes it via a configurable
- * Whisper-compatible endpoint. Supports two interaction modes:
+ * Whisper-compatible endpoint. Two interaction modes:
+ * - 'hold': press and hold to record, release to transcribe (push-to-talk)
+ * - 'toggle': tap to start, tap again to stop and transcribe
  *
- * - 'hold': Press and hold to record, release to transcribe (push-to-talk)
- * - 'toggle': Tap once to start recording, tap again to stop and transcribe
+ * The recording / transcription state machine lives in {@link useVoiceRecording}
+ * (Cluster A2 split); this file is the presentational shell (button, recording
+ * label, confirmation modal, error toast).
  *
- * Recording lifecycle:
- * 1. Request microphone permission on first use
- * 2. Start expo-audio AudioRecorder at high-quality mono settings
- * 3. On stop, read the recorded file and POST to the transcription endpoint
- * 4. Surface the transcript text for the user to review before sending
- * 5. User can confirm (fill input) or dismiss (discard)
+ * TIER GATE (mobile-side): Voice commands are a premium feature. Callers MUST
+ * check the user's subscription tier before rendering VoiceInput — the `config`
+ * prop being null is not sufficient.
  *
- * When no transcription endpoint is configured, the button shows a disabled
- * state with a tooltip directing the user to configure one in Settings.
- *
- * WHY expo-audio over a native STT library: expo-audio is Expo's official
- * audio recording package (replaces the deprecated expo-av) and avoids adding
- * a native module dependency. Whisper-compatible APIs are widely available
- * (OpenAI, self-hosted, enterprise) and the config-driven approach keeps
- * Styrby vendor-neutral.
- *
- * TIER GATE (mobile-side): Voice commands are a Power-only feature.
- * When integrating this component into the chat screen or settings screen,
- * the caller MUST check the user's subscription tier before rendering the
- * VoiceInput button. Free and Pro users should see a locked state or an
- * upgrade prompt instead. The `config` prop being null is not sufficient
- * — it must be explicitly blocked based on tier.
- *
- * Example (in the chat screen):
  *   {userTier === 'growth' ? (
  *     <VoiceInput config={voiceConfig} onTranscript={handleTranscript} />
  *   ) : (
  *     <UpgradePrompt feature="Voice commands" requiredTier="growth" />
  *   )}
  *
+ * WHY expo-audio: Expo's official audio package (replaces deprecated expo-av);
+ * Whisper-compatible endpoints are widely available and keep Styrby
+ * vendor-neutral.
+ *
  * @module components/VoiceInput
  */
 
-import React, { useState, useRef, useCallback, useEffect } from 'react';
-import {
-  View,
-  Text,
-  Pressable,
-  Modal,
-  TextInput,
-  ActivityIndicator,
-  Animated,
-  Platform,
-  Alert,
-} from 'react-native';
+import { View, Text, Pressable, Modal, TextInput, ActivityIndicator, Animated, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import type { VoiceInputConfig } from 'styrby-shared';
+import type { VoiceInputProps } from './voice/types';
+import { useVoiceRecording } from './voice/useVoiceRecording';
 
-// ============================================================================
-// Constants
-// ============================================================================
-
-/**
- * WHY: We sample at 16 kHz mono because Whisper was trained primarily on
- * speech at that sample rate. Higher rates waste bandwidth; lower rates
- * degrade accuracy.
- *
- * expo-audio RecordingOptions uses a flat structure (no android/ios nesting
- * at the top level). Platform-specific overrides are available via `ios`/`android`
- * sub-objects but the top-level fields apply cross-platform.
- */
-const RECORDING_OPTIONS = {
-  isMeteringEnabled: true,
-  extension: '.m4a',
-  sampleRate: 16000,
-  numberOfChannels: 1,
-  bitRate: 32000,
-  android: {
-    outputFormat: 'mpeg4' as const,
-    audioEncoder: 'aac' as const,
-  },
-  ios: {
-    outputFormat: 'aac' as const,
-    audioQuality: 96 as const,  // AudioQuality.MEDIUM
-    linearPCMBitDepth: 16 as const,
-    linearPCMIsBigEndian: false,
-    linearPCMIsFloat: false,
-  },
-  web: {
-    mimeType: 'audio/webm',
-    bitsPerSecond: 32000,
-  },
-};
-
-/**
- * Maximum recording duration before auto-stop (3 minutes).
- * WHY: Prevents accidental runaway recordings and keeps transcription costs manageable.
- */
-const MAX_RECORDING_MS = 3 * 60 * 1000;
-
-// ============================================================================
-// Types
-// ============================================================================
-
-/**
- * Props for the VoiceInput component.
- */
-export interface VoiceInputProps {
-  /**
-   * Voice input configuration (mode, endpoint, key).
-   * When null or disabled, the button renders in a disabled/hidden state.
-   */
-  config: VoiceInputConfig | null;
-
-  /**
-   * Called when the user confirms a transcript to send.
-   * The parent chat screen should call its handleSend with this text.
-   *
-   * @param transcript - The confirmed transcribed text
-   */
-  onTranscript: (transcript: string) => void;
-
-  /**
-   * Whether the parent input is disabled (e.g. no relay connection).
-   * Prevents voice recording when the chat cannot accept messages.
-   */
-  disabled?: boolean;
-}
-
-// ============================================================================
-// Recording state type
-// ============================================================================
-
-type RecordingState = 'idle' | 'recording' | 'transcribing' | 'confirming' | 'error';
-
-// ============================================================================
-// Component
-// ============================================================================
+// Re-export the public types so existing importers of './VoiceInput' are
+// unchanged.
+export type { VoiceInputProps, RecordingState } from './voice/types';
 
 /**
  * Voice-to-text input button for the chat screen.
  *
- * Renders a microphone icon button that records audio via expo-audio and
- * transcribes it via a configurable Whisper-compatible endpoint.
- *
- * @param props - VoiceInputProps
- * @returns React element or null when voice is disabled
- *
- * @example
- * <VoiceInput
- *   config={voiceConfig}
- *   onTranscript={(text) => setInputText(text)}
- *   disabled={!isConnected}
- * />
+ * @param props - VoiceInputProps.
+ * @returns React element, or null when voice is disabled.
  */
 export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInputProps) {
-  const [state, setState] = useState<RecordingState>('idle');
-  // WHY only editedTranscript: the raw transcript is rendered into the
-  // editable TextInput via setEditedTranscript; we never read the unedited
-  // value back, so storing it separately would just trigger extra renders.
-  const [editedTranscript, setEditedTranscript] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
-  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const {
+    editedTranscript,
+    setEditedTranscript,
+    errorMessage,
+    showConfirmModal,
+    pulseAnim,
+    isRecording,
+    isTranscribing,
+    hasError,
+    isDisabled,
+    handleTogglePress,
+    handleHoldPressIn,
+    handleHoldPressOut,
+    handleConfirm,
+    handleDiscard,
+    handleDismissError,
+  } = useVoiceRecording({ config, onTranscript, disabled });
 
-  // WHY: Store AudioRecorder ref so we can stop it from event handlers
-  // that don't have access to closure state. Typed as unknown to avoid
-  // importing the class at module level (dynamic import keeps bundle lean).
-  const recordingRef = useRef<unknown>(null);
-  const autoStopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // WHY this ref (M1.1, 2026-04-30): the auto-stop setTimeout in
-  // startRecording needs to call the latest stopRecording, but stopRecording
-  // is declared further down (so it can't be in startRecording's deps array
-  // without a TDZ error). We assign this ref's .current at the bottom of the
-  // hook chain (after both startRecording + stopRecording exist) so the
-  // timer always sees the freshest implementation.
-  const stopRecordingRef = useRef<(() => Promise<void>) | null>(null);
-  // Same TDZ avoidance for transcribeAudio (declared after stopRecording).
-  // stopRecording calls transcribeAudio inside its async body; the ref lets
-  // each invocation reach the latest version without a circular dep.
-  const transcribeAudioRef = useRef<((uri: string) => Promise<void>) | null>(null);
-
-  // WHY: Use a ref initializer function instead of inline `new Animated.Value(1)`
-  // to avoid crashing in test environments where Animated.Value may not be
-  // fully implemented by the jest setup. The function form is only called once.
-  const pulseAnimRef = useRef<Animated.Value | null>(null);
-  if (!pulseAnimRef.current) {
-    try {
-      pulseAnimRef.current = new Animated.Value(1);
-    } catch {
-      // Animated.Value not available (test environment) — animations disabled
-    }
-  }
-  const pulseAnim = pulseAnimRef.current;
-
-  // --------------------------------------------------------------------------
-  // Pulse Animation
-  // --------------------------------------------------------------------------
-
-  /**
-   * Starts a repeating pulse animation to indicate active recording.
-   * WHY: Guards pulseAnim null check — in test environments Animated.Value
-   * creation may fail silently; we skip animations rather than crashing.
-   */
-  const startPulse = useCallback(() => {
-    if (!pulseAnim) return;
-    Animated.loop(
-      Animated.sequence([
-        Animated.timing(pulseAnim, { toValue: 1.3, duration: 500, useNativeDriver: true }),
-        Animated.timing(pulseAnim, { toValue: 1.0, duration: 500, useNativeDriver: true }),
-      ])
-    ).start();
-  }, [pulseAnim]);
-
-  /**
-   * Stops the pulse animation and resets scale to 1.
-   */
-  const stopPulse = useCallback(() => {
-    if (!pulseAnim) return;
-    pulseAnim.stopAnimation();
-    Animated.timing(pulseAnim, { toValue: 1, duration: 150, useNativeDriver: true }).start();
-  }, [pulseAnim]);
-
-  // --------------------------------------------------------------------------
-  // Recording
-  // --------------------------------------------------------------------------
-
-  /**
-   * Requests microphone permission and starts audio recording.
-   * Sets state to 'recording' and begins the pulse animation.
-   *
-   * @throws Shows Alert and sets error state if permissions are denied
-   */
-  const startRecording = useCallback(async () => {
-    if (disabled || !config?.enabled) return;
-
-    if (!config.transcriptionEndpoint) {
-      Alert.alert(
-        'No Transcription Endpoint',
-        'Configure a Whisper-compatible transcription URL in Settings > Voice Input.',
-        [{ text: 'OK' }]
-      );
-      return;
-    }
-
-    // SECURITY: Only allow HTTPS endpoints (or localhost for development).
-    // Audio data contains sensitive voice recordings — sending over plain HTTP
-    // exposes it to network-level eavesdropping. Block file://, ftp://, etc.
-    const endpoint = config.transcriptionEndpoint;
-    const isSecure = endpoint.startsWith('https://');
-    const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1|::1)(:\d+)?\//.test(endpoint);
-    if (!isSecure && !isLocalhost) {
-      Alert.alert(
-        'Insecure Endpoint',
-        'The transcription endpoint must use HTTPS to protect your voice data. '
-          + 'HTTP is only allowed for localhost development.',
-        [{ text: 'OK' }]
-      );
-      return;
-    }
-
-    try {
-      // WHY: We dynamically import expo-audio here to avoid a hard crash if the
-      // module is unavailable (e.g. Expo Go environments that don't include it).
-      // The component degrades to a disabled state instead.
-      const { requestRecordingPermissionsAsync, setAudioModeAsync, AudioRecorder } = await import('expo-audio');
-
-      const permission = await requestRecordingPermissionsAsync();
-      if (!permission.granted) {
-        Alert.alert(
-          'Microphone Permission',
-          'Styrby needs microphone access for voice commands. Enable it in Settings.',
-          [{ text: 'OK' }]
-        );
-        return;
-      }
-
-      // WHY: allowsRecording (not allowsRecordingIOS) is the expo-audio API.
-      // playsInSilentMode ensures recording works even when iOS silent switch is on.
-      await setAudioModeAsync({
-        allowsRecording: true,
-        playsInSilentMode: true,
-      });
-
-      // WHY: expo-audio uses an imperative AudioRecorder class.
-      // We prepareToRecordAsync first (allocates native resources), then record().
-      const recorder = new AudioRecorder(RECORDING_OPTIONS);
-      await recorder.prepareToRecordAsync();
-      recorder.record();
-      recordingRef.current = recorder;
-
-      setState('recording');
-      startPulse();
-
-      // WHY: Auto-stop after MAX_RECORDING_MS to prevent runaway recordings.
-      // Uses stopRecordingRef so the timer always invokes the latest
-      // stopRecording (see ref initialisation below the stopRecording decl).
-      autoStopTimerRef.current = setTimeout(() => {
-        void stopRecordingRef.current?.();
-      }, MAX_RECORDING_MS);
-    } catch (err) {
-      setState('error');
-      setErrorMessage('Could not start recording. Check microphone permissions.');
-      if (__DEV__) console.error('[VoiceInput] startRecording error:', err);
-    }
-    // WHY stopRecordingRef.current() (M1.1 fix, 2026-04-30): we need to
-    // invoke the latest stopRecording from inside this auto-stop timer,
-    // but stopRecording is declared further down the file and adding it
-    // to this deps array would be a TDZ reference error. The ref pattern
-    // (initialised below where stopRecording exists) lets the timer always
-    // hit the most recent stopRecording without a circular dep.
-  }, [disabled, config, startPulse]);
-
-  /**
-   * Stops the current recording, clears the auto-stop timer, and begins
-   * transcription.
-   *
-   * @returns void
-   */
-  const stopRecording = useCallback(async () => {
-    if (!recordingRef.current) return;
-
-    if (autoStopTimerRef.current) {
-      clearTimeout(autoStopTimerRef.current);
-      autoStopTimerRef.current = null;
-    }
-
-    stopPulse();
-    setState('transcribing');
-
-    try {
-      // WHY: AudioRecorder.stop() is the expo-audio replacement for
-      // expo-av's stopAndUnloadAsync(). The uri property replaces getURI().
-      // We import the class type from expo-audio (no runtime import needed —
-      // the recorder instance was already created in startRecording).
-      type AudioRecorderInstance = import('expo-audio').AudioRecorder;
-      const recorder = recordingRef.current as AudioRecorderInstance;
-      await recorder.stop();
-      const uri = recorder.uri;
-      recordingRef.current = null;
-
-      if (!uri) {
-        setState('error');
-        setErrorMessage('Recording failed — no audio captured.');
-        return;
-      }
-
-      // WHY transcribeAudioRef.current (M1.1, 2026-04-30): transcribeAudio
-      // is declared further down the file; adding it to deps directly would
-      // be a TDZ reference error. The ref pattern keeps the call always
-      // pointing at the freshest implementation without a circular dep.
-      await transcribeAudioRef.current?.(uri);
-    } catch (err) {
-      setState('error');
-      setErrorMessage('Recording stopped unexpectedly.');
-      if (__DEV__) console.error('[VoiceInput] stopRecording error:', err);
-    }
-  }, [stopPulse]);
-
-  // --------------------------------------------------------------------------
-  // Transcription
-  // --------------------------------------------------------------------------
-
-  /**
-   * POSTs the recorded audio file to the configured transcription endpoint
-   * and surfaces the resulting text for user confirmation.
-   *
-   * @param audioUri - Local file:// URI of the recorded audio
-   * @returns void
-   * @throws Sets error state on network or API failure
-   */
-  const transcribeAudio = useCallback(async (audioUri: string) => {
-    if (!config?.transcriptionEndpoint) return;
-
-    try {
-      const formData = new FormData();
-      // WHY: The Whisper API requires the file as multipart/form-data with
-      // the field name 'file' and a MIME type for the audio format.
-      formData.append('file', {
-        uri: audioUri,
-        name: 'audio.m4a',
-        type: 'audio/m4a',
-      } as unknown as Blob);
-      formData.append('model', 'whisper-1');
-      formData.append('response_format', 'text');
-
-      const headers: Record<string, string> = {
-        'Accept': 'application/json',
-      };
-
-      if (config.transcriptionApiKey) {
-        headers['Authorization'] = `Bearer ${config.transcriptionApiKey}`;
-      }
-
-      const response = await fetch(config.transcriptionEndpoint, {
-        method: 'POST',
-        headers,
-        body: formData,
-      });
-
-      if (!response.ok) {
-        const errText = await response.text().catch(() => response.statusText);
-        throw new Error(`Transcription failed (${response.status}): ${errText}`);
-      }
-
-      const text = await response.text();
-      const trimmed = text.trim();
-
-      if (!trimmed) {
-        setState('error');
-        setErrorMessage('No speech detected. Try again in a quieter environment.');
-        return;
-      }
-
-      setEditedTranscript(trimmed);
-      setState('confirming');
-      setShowConfirmModal(true);
-    } catch (err) {
-      setState('error');
-      const msg = err instanceof Error ? err.message : 'Transcription service unavailable.';
-      setErrorMessage(msg);
-      if (__DEV__) console.error('[VoiceInput] transcribeAudio error:', err);
-    }
-  }, [config]);
-
-  // Keep the forward-reference refs in sync with the latest function values.
-  // WHY (M1.1, 2026-04-30): startRecording's auto-stop timer and
-  // stopRecording's transcribe call need to invoke the freshest copies of
-  // stopRecording / transcribeAudio respectively, but those callbacks are
-  // declared after their callers in the file (and across-callback deps would
-  // be TDZ errors). This effect runs every render so the .current always
-  // points at the latest memoised value.
-  useEffect(() => {
-    stopRecordingRef.current = stopRecording;
-    transcribeAudioRef.current = transcribeAudio;
-  });
-
-  // WHY (unmount safety): if the user navigates away mid-recording, neither the
-  // auto-stop timer nor the AudioRecorder were ever torn down — the mic stayed
-  // engaged after the screen left. This unmount-only effect (empty deps, so the
-  // cleanup runs exactly once on teardown) clears the pending auto-stop timer
-  // and stops the recorder if one is still live. We read the refs at cleanup
-  // time so we always act on the latest instances.
-  useEffect(() => {
-    return () => {
-      if (autoStopTimerRef.current) {
-        clearTimeout(autoStopTimerRef.current);
-        autoStopTimerRef.current = null;
-      }
-      const recorder = recordingRef.current as { stop?: () => unknown } | null;
-      // Best-effort stop; ignore errors during teardown (instance may already
-      // be stopped/unloaded). Optional-chaining the method guards against
-      // expo-audio shape differences across versions.
-      try {
-        recorder?.stop?.();
-      } catch {
-        // Swallow: teardown must never throw.
-      }
-      recordingRef.current = null;
-    };
-  }, []);
-
-  // --------------------------------------------------------------------------
-  // Confirmation Modal Actions
-  // --------------------------------------------------------------------------
-
-  /**
-   * Confirms the (optionally edited) transcript and passes it to the parent.
-   * Resets local state so the component is ready for the next recording.
-   */
-  const handleConfirm = useCallback(() => {
-    const text = editedTranscript.trim();
-    if (text) {
-      onTranscript(text);
-    }
-    setShowConfirmModal(false);
-    setState('idle');
-    setEditedTranscript('');
-  }, [editedTranscript, onTranscript]);
-
-  /**
-   * Discards the transcript and resets to idle without calling onTranscript.
-   */
-  const handleDiscard = useCallback(() => {
-    setShowConfirmModal(false);
-    setState('idle');
-    setEditedTranscript('');
-  }, []);
-
-  /**
-   * Clears an error state and returns to idle.
-   */
-  const handleDismissError = useCallback(() => {
-    setState('idle');
-    setErrorMessage('');
-  }, []);
-
-  // --------------------------------------------------------------------------
-  // Button Press Handlers
-  // --------------------------------------------------------------------------
-
-  /**
-   * Handles tap events for toggle mode.
-   * First tap starts recording; second tap stops it.
-   */
-  const handleTogglePress = useCallback(() => {
-    if (state === 'recording') {
-      void stopRecording();
-    } else if (state === 'idle') {
-      void startRecording();
-    } else if (state === 'error') {
-      handleDismissError();
-    }
-  }, [state, startRecording, stopRecording, handleDismissError]);
-
-  /**
-   * Handles press-in for hold mode — starts recording.
-   */
-  const handleHoldPressIn = useCallback(() => {
-    if (state === 'idle') {
-      void startRecording();
-    }
-  }, [state, startRecording]);
-
-  /**
-   * Handles press-out for hold mode — stops recording.
-   */
-  const handleHoldPressOut = useCallback(() => {
-    if (state === 'recording') {
-      void stopRecording();
-    }
-  }, [state, stopRecording]);
-
-  // --------------------------------------------------------------------------
-  // Derived State
-  // --------------------------------------------------------------------------
-
-  const isRecording = state === 'recording';
-  const isTranscribing = state === 'transcribing';
-  const hasError = state === 'error';
-  const isDisabled = disabled || !config?.enabled || isTranscribing || state === 'confirming';
-
-  /**
-   * WHY: Button color changes to communicate state:
-   * - Brand orange: active recording
-   * - Red: error
-   * - Zinc: idle / disabled
-   */
-  const buttonColor = isRecording
-    ? '#f97316'
-    : hasError
-    ? '#ef4444'
-    : '#3f3f46';
+  // WHY: button color communicates state — orange recording, red error, zinc idle.
+  const buttonColor = isRecording ? '#f97316' : hasError ? '#ef4444' : '#3f3f46';
 
   const iconName: keyof typeof Ionicons.glyphMap = isRecording
     ? 'stop-circle'
     : hasError
-    ? 'alert-circle'
-    : isTranscribing
-    ? 'hourglass'
-    : 'mic';
-
-  // --------------------------------------------------------------------------
-  // Render
-  // --------------------------------------------------------------------------
+      ? 'alert-circle'
+      : isTranscribing
+        ? 'hourglass'
+        : 'mic';
 
   if (!config?.enabled) {
     return null;
@@ -579,10 +89,10 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
           isRecording
             ? 'Stop recording'
             : isTranscribing
-            ? 'Transcribing...'
-            : config.mode === 'hold'
-            ? 'Hold to record voice command'
-            : 'Tap to record voice command'
+              ? 'Transcribing...'
+              : config.mode === 'hold'
+                ? 'Hold to record voice command'
+                : 'Tap to record voice command'
         }
         accessibilityState={{ disabled: isDisabled }}
         style={{ marginLeft: 6 }}
@@ -609,13 +119,7 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
       {/* Recording indicator label */}
       {isRecording && (
         <View
-          style={{
-            position: 'absolute',
-            bottom: 72,
-            left: 0,
-            right: 0,
-            alignItems: 'center',
-          }}
+          style={{ position: 'absolute', bottom: 72, left: 0, right: 0, alignItems: 'center' }}
           pointerEvents="none"
         >
           <View
@@ -644,13 +148,7 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
         onRequestClose={handleDiscard}
         accessibilityViewIsModal
       >
-        <View
-          style={{
-            flex: 1,
-            backgroundColor: 'rgba(0,0,0,0.6)',
-            justifyContent: 'flex-end',
-          }}
-        >
+        <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'flex-end' }}>
           <View
             style={{
               backgroundColor: '#18181b',
@@ -723,9 +221,7 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
                 accessibilityLabel="Send transcript as message"
                 accessibilityState={{ disabled: !editedTranscript.trim() }}
               >
-                <Text style={{ color: 'white', fontWeight: '700', fontSize: 15 }}>
-                  Send Message
-                </Text>
+                <Text style={{ color: 'white', fontWeight: '700', fontSize: 15 }}>Send Message</Text>
               </Pressable>
             </View>
           </View>
@@ -736,12 +232,7 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
       {hasError && (
         <Pressable
           onPress={handleDismissError}
-          style={{
-            position: 'absolute',
-            bottom: 72,
-            left: 16,
-            right: 16,
-          }}
+          style={{ position: 'absolute', bottom: 72, left: 16, right: 16 }}
           accessibilityRole="button"
           accessibilityLabel={`Voice input error: ${errorMessage}. Tap to dismiss.`}
         >
@@ -755,9 +246,7 @@ export function VoiceInput({ config, onTranscript, disabled = false }: VoiceInpu
             }}
           >
             <Ionicons name="alert-circle" size={16} color="white" />
-            <Text style={{ color: 'white', fontSize: 13, marginLeft: 8, flex: 1 }}>
-              {errorMessage}
-            </Text>
+            <Text style={{ color: 'white', fontSize: 13, marginLeft: 8, flex: 1 }}>{errorMessage}</Text>
             <Ionicons name="close" size={16} color="white" />
           </View>
         </Pressable>

--- a/packages/styrby-mobile/src/components/voice/recording-options.ts
+++ b/packages/styrby-mobile/src/components/voice/recording-options.ts
@@ -1,0 +1,44 @@
+/**
+ * Audio recording configuration for VoiceInput.
+ *
+ * Extracted from VoiceInput.tsx (Cluster A2 split).
+ *
+ * @module components/voice/recording-options
+ */
+
+/**
+ * expo-audio RecordingOptions.
+ *
+ * WHY 16 kHz mono: Whisper was trained primarily on speech at that rate.
+ * Higher rates waste bandwidth; lower rates degrade accuracy. expo-audio uses
+ * a flat structure with optional ios/android/web sub-objects for overrides.
+ */
+export const RECORDING_OPTIONS = {
+  isMeteringEnabled: true,
+  extension: '.m4a',
+  sampleRate: 16000,
+  numberOfChannels: 1,
+  bitRate: 32000,
+  android: {
+    outputFormat: 'mpeg4' as const,
+    audioEncoder: 'aac' as const,
+  },
+  ios: {
+    outputFormat: 'aac' as const,
+    audioQuality: 96 as const, // AudioQuality.MEDIUM
+    linearPCMBitDepth: 16 as const,
+    linearPCMIsBigEndian: false,
+    linearPCMIsFloat: false,
+  },
+  web: {
+    mimeType: 'audio/webm',
+    bitsPerSecond: 32000,
+  },
+};
+
+/**
+ * Maximum recording duration before auto-stop (3 minutes).
+ * WHY: prevents accidental runaway recordings and keeps transcription costs
+ * manageable.
+ */
+export const MAX_RECORDING_MS = 3 * 60 * 1000;

--- a/packages/styrby-mobile/src/components/voice/types.ts
+++ b/packages/styrby-mobile/src/components/voice/types.ts
@@ -1,0 +1,35 @@
+/**
+ * VoiceInput types.
+ *
+ * Extracted from VoiceInput.tsx (Cluster A2 split).
+ *
+ * @module components/voice/types
+ */
+
+import type { VoiceInputConfig } from 'styrby-shared';
+
+/** Props for the VoiceInput component. */
+export interface VoiceInputProps {
+  /**
+   * Voice input configuration (mode, endpoint, key). When null or disabled, the
+   * button renders in a disabled/hidden state.
+   */
+  config: VoiceInputConfig | null;
+
+  /**
+   * Called when the user confirms a transcript to send. The parent chat screen
+   * should call its handleSend with this text.
+   *
+   * @param transcript - The confirmed transcribed text.
+   */
+  onTranscript: (transcript: string) => void;
+
+  /**
+   * Whether the parent input is disabled (e.g. no relay connection). Prevents
+   * voice recording when the chat cannot accept messages.
+   */
+  disabled?: boolean;
+}
+
+/** Recording lifecycle state. */
+export type RecordingState = 'idle' | 'recording' | 'transcribing' | 'confirming' | 'error';

--- a/packages/styrby-mobile/src/components/voice/useVoiceRecording.ts
+++ b/packages/styrby-mobile/src/components/voice/useVoiceRecording.ts
@@ -1,0 +1,356 @@
+/**
+ * useVoiceRecording — the recording / transcription state machine for VoiceInput.
+ *
+ * Extracted verbatim from VoiceInput.tsx (Cluster A2 split) so the component
+ * stays under the 400-LOC ceiling. Owns the recording lifecycle (permission →
+ * record → stop → transcribe → confirm), the pulse animation, the auto-stop
+ * timer, unmount teardown, and the press handlers. The component consumes the
+ * returned state + handlers and only renders.
+ *
+ * The forward-reference refs (stopRecordingRef / transcribeAudioRef) preserve
+ * the original TDZ-avoidance pattern: a callback declared earlier needs to call
+ * one declared later without a circular dep, so it goes through a ref kept in
+ * sync every render.
+ *
+ * @module components/voice/useVoiceRecording
+ */
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { Animated, Alert } from 'react-native';
+import type { VoiceInputProps, RecordingState } from './types';
+import { RECORDING_OPTIONS, MAX_RECORDING_MS } from './recording-options';
+
+/** Everything VoiceInput needs to render the button + confirmation modal. */
+export interface UseVoiceRecording {
+  editedTranscript: string;
+  setEditedTranscript: (text: string) => void;
+  errorMessage: string;
+  showConfirmModal: boolean;
+  pulseAnim: Animated.Value | null;
+  isRecording: boolean;
+  isTranscribing: boolean;
+  hasError: boolean;
+  isDisabled: boolean;
+  handleTogglePress: () => void;
+  handleHoldPressIn: () => void;
+  handleHoldPressOut: () => void;
+  handleConfirm: () => void;
+  handleDiscard: () => void;
+  handleDismissError: () => void;
+}
+
+/**
+ * @param params - The VoiceInput props (config, onTranscript, disabled).
+ * @returns Recording state + handlers for the presentational component.
+ */
+export function useVoiceRecording({
+  config,
+  onTranscript,
+  disabled = false,
+}: VoiceInputProps): UseVoiceRecording {
+  const [state, setState] = useState<RecordingState>('idle');
+  // WHY only editedTranscript: the raw transcript is rendered into the editable
+  // TextInput via setEditedTranscript; we never read the unedited value back.
+  const [editedTranscript, setEditedTranscript] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+
+  // WHY: store AudioRecorder ref so we can stop it from event handlers without
+  // access to closure state. Typed unknown to avoid a module-level import.
+  const recordingRef = useRef<unknown>(null);
+  const autoStopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // WHY this ref (M1.1): startRecording's auto-stop timer must call the latest
+  // stopRecording, declared further down — adding it to deps would be a TDZ
+  // error. The ref (synced below) always sees the freshest implementation.
+  const stopRecordingRef = useRef<(() => Promise<void>) | null>(null);
+  // Same TDZ avoidance for transcribeAudio (declared after stopRecording).
+  const transcribeAudioRef = useRef<((uri: string) => Promise<void>) | null>(null);
+
+  // WHY: ref-initializer (not inline `new Animated.Value(1)`) to avoid crashing
+  // in test environments where Animated.Value may be unimplemented.
+  const pulseAnimRef = useRef<Animated.Value | null>(null);
+  if (!pulseAnimRef.current) {
+    try {
+      pulseAnimRef.current = new Animated.Value(1);
+    } catch {
+      // Animated.Value not available (test environment) — animations disabled
+    }
+  }
+  const pulseAnim = pulseAnimRef.current;
+
+  // --- Pulse Animation ------------------------------------------------------
+
+  const startPulse = useCallback(() => {
+    if (!pulseAnim) return;
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulseAnim, { toValue: 1.3, duration: 500, useNativeDriver: true }),
+        Animated.timing(pulseAnim, { toValue: 1.0, duration: 500, useNativeDriver: true }),
+      ]),
+    ).start();
+  }, [pulseAnim]);
+
+  const stopPulse = useCallback(() => {
+    if (!pulseAnim) return;
+    pulseAnim.stopAnimation();
+    Animated.timing(pulseAnim, { toValue: 1, duration: 150, useNativeDriver: true }).start();
+  }, [pulseAnim]);
+
+  // --- Recording ------------------------------------------------------------
+
+  const startRecording = useCallback(async () => {
+    if (disabled || !config?.enabled) return;
+
+    if (!config.transcriptionEndpoint) {
+      Alert.alert(
+        'No Transcription Endpoint',
+        'Configure a Whisper-compatible transcription URL in Settings > Voice Input.',
+        [{ text: 'OK' }],
+      );
+      return;
+    }
+
+    // SECURITY: only HTTPS endpoints (or localhost for dev). Audio contains
+    // sensitive voice recordings — plain HTTP exposes it to eavesdropping.
+    const endpoint = config.transcriptionEndpoint;
+    const isSecure = endpoint.startsWith('https://');
+    const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1|::1)(:\d+)?\//.test(endpoint);
+    if (!isSecure && !isLocalhost) {
+      Alert.alert(
+        'Insecure Endpoint',
+        'The transcription endpoint must use HTTPS to protect your voice data. ' +
+          'HTTP is only allowed for localhost development.',
+        [{ text: 'OK' }],
+      );
+      return;
+    }
+
+    try {
+      // WHY dynamic import: avoid a hard crash if expo-audio is unavailable
+      // (e.g. Expo Go); the component degrades to a disabled state instead.
+      const { requestRecordingPermissionsAsync, setAudioModeAsync, AudioRecorder } = await import('expo-audio');
+
+      const permission = await requestRecordingPermissionsAsync();
+      if (!permission.granted) {
+        Alert.alert(
+          'Microphone Permission',
+          'Styrby needs microphone access for voice commands. Enable it in Settings.',
+          [{ text: 'OK' }],
+        );
+        return;
+      }
+
+      // WHY allowsRecording (not allowsRecordingIOS): the expo-audio API.
+      // playsInSilentMode ensures recording works with the iOS silent switch on.
+      await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
+
+      // expo-audio uses an imperative AudioRecorder: prepare then record.
+      const recorder = new AudioRecorder(RECORDING_OPTIONS);
+      await recorder.prepareToRecordAsync();
+      recorder.record();
+      recordingRef.current = recorder;
+
+      setState('recording');
+      startPulse();
+
+      // Auto-stop after MAX_RECORDING_MS via stopRecordingRef (latest impl).
+      autoStopTimerRef.current = setTimeout(() => {
+        void stopRecordingRef.current?.();
+      }, MAX_RECORDING_MS);
+    } catch (err) {
+      setState('error');
+      setErrorMessage('Could not start recording. Check microphone permissions.');
+      if (__DEV__) console.error('[VoiceInput] startRecording error:', err);
+    }
+  }, [disabled, config, startPulse]);
+
+  const stopRecording = useCallback(async () => {
+    if (!recordingRef.current) return;
+
+    if (autoStopTimerRef.current) {
+      clearTimeout(autoStopTimerRef.current);
+      autoStopTimerRef.current = null;
+    }
+
+    stopPulse();
+    setState('transcribing');
+
+    try {
+      // AudioRecorder.stop() replaces expo-av's stopAndUnloadAsync(); .uri
+      // replaces getURI(). The instance was created in startRecording.
+      type AudioRecorderInstance = import('expo-audio').AudioRecorder;
+      const recorder = recordingRef.current as AudioRecorderInstance;
+      await recorder.stop();
+      const uri = recorder.uri;
+      recordingRef.current = null;
+
+      if (!uri) {
+        setState('error');
+        setErrorMessage('Recording failed — no audio captured.');
+        return;
+      }
+
+      // transcribeAudioRef (M1.1): reach the freshest transcribeAudio without a
+      // TDZ/circular dep.
+      await transcribeAudioRef.current?.(uri);
+    } catch (err) {
+      setState('error');
+      setErrorMessage('Recording stopped unexpectedly.');
+      if (__DEV__) console.error('[VoiceInput] stopRecording error:', err);
+    }
+  }, [stopPulse]);
+
+  // --- Transcription --------------------------------------------------------
+
+  const transcribeAudio = useCallback(
+    async (audioUri: string) => {
+      if (!config?.transcriptionEndpoint) return;
+
+      try {
+        const formData = new FormData();
+        // Whisper requires the file as multipart/form-data, field name 'file'.
+        formData.append('file', {
+          uri: audioUri,
+          name: 'audio.m4a',
+          type: 'audio/m4a',
+        } as unknown as Blob);
+        formData.append('model', 'whisper-1');
+        formData.append('response_format', 'text');
+
+        const headers: Record<string, string> = { Accept: 'application/json' };
+        if (config.transcriptionApiKey) {
+          headers['Authorization'] = `Bearer ${config.transcriptionApiKey}`;
+        }
+
+        const response = await fetch(config.transcriptionEndpoint, {
+          method: 'POST',
+          headers,
+          body: formData,
+        });
+
+        if (!response.ok) {
+          const errText = await response.text().catch(() => response.statusText);
+          throw new Error(`Transcription failed (${response.status}): ${errText}`);
+        }
+
+        const text = await response.text();
+        const trimmed = text.trim();
+
+        if (!trimmed) {
+          setState('error');
+          setErrorMessage('No speech detected. Try again in a quieter environment.');
+          return;
+        }
+
+        setEditedTranscript(trimmed);
+        setState('confirming');
+        setShowConfirmModal(true);
+      } catch (err) {
+        setState('error');
+        const msg = err instanceof Error ? err.message : 'Transcription service unavailable.';
+        setErrorMessage(msg);
+        if (__DEV__) console.error('[VoiceInput] transcribeAudio error:', err);
+      }
+    },
+    [config],
+  );
+
+  // Keep the forward-reference refs in sync with the latest function values
+  // (M1.1): runs every render so .current always points at the latest memoised
+  // value, letting earlier callbacks invoke later ones without a TDZ error.
+  useEffect(() => {
+    stopRecordingRef.current = stopRecording;
+    transcribeAudioRef.current = transcribeAudio;
+  });
+
+  // Unmount safety: if the user navigates away mid-recording, tear down the
+  // auto-stop timer + recorder so the mic doesn't stay engaged. Empty deps so
+  // cleanup runs exactly once on teardown; refs read at cleanup time.
+  useEffect(() => {
+    return () => {
+      if (autoStopTimerRef.current) {
+        clearTimeout(autoStopTimerRef.current);
+        autoStopTimerRef.current = null;
+      }
+      const recorder = recordingRef.current as { stop?: () => unknown } | null;
+      try {
+        recorder?.stop?.();
+      } catch {
+        // Swallow: teardown must never throw.
+      }
+      recordingRef.current = null;
+    };
+  }, []);
+
+  // --- Confirmation Modal Actions -------------------------------------------
+
+  const handleConfirm = useCallback(() => {
+    const text = editedTranscript.trim();
+    if (text) {
+      onTranscript(text);
+    }
+    setShowConfirmModal(false);
+    setState('idle');
+    setEditedTranscript('');
+  }, [editedTranscript, onTranscript]);
+
+  const handleDiscard = useCallback(() => {
+    setShowConfirmModal(false);
+    setState('idle');
+    setEditedTranscript('');
+  }, []);
+
+  const handleDismissError = useCallback(() => {
+    setState('idle');
+    setErrorMessage('');
+  }, []);
+
+  // --- Button Press Handlers ------------------------------------------------
+
+  const handleTogglePress = useCallback(() => {
+    if (state === 'recording') {
+      void stopRecording();
+    } else if (state === 'idle') {
+      void startRecording();
+    } else if (state === 'error') {
+      handleDismissError();
+    }
+  }, [state, startRecording, stopRecording, handleDismissError]);
+
+  const handleHoldPressIn = useCallback(() => {
+    if (state === 'idle') {
+      void startRecording();
+    }
+  }, [state, startRecording]);
+
+  const handleHoldPressOut = useCallback(() => {
+    if (state === 'recording') {
+      void stopRecording();
+    }
+  }, [state, stopRecording]);
+
+  // --- Derived State --------------------------------------------------------
+
+  const isRecording = state === 'recording';
+  const isTranscribing = state === 'transcribing';
+  const hasError = state === 'error';
+  const isDisabled = disabled || !config?.enabled || isTranscribing || state === 'confirming';
+
+  return {
+    editedTranscript,
+    setEditedTranscript,
+    errorMessage,
+    showConfirmModal,
+    pulseAnim,
+    isRecording,
+    isTranscribing,
+    hasError,
+    isDisabled,
+    handleTogglePress,
+    handleHoldPressIn,
+    handleHoldPressOut,
+    handleConfirm,
+    handleDiscard,
+    handleDismissError,
+  };
+}


### PR DESCRIPTION
## Summary
Cluster A2 (2nd split). `VoiceInput.tsx` was 767 LOC (CLAUDE.md mandates <400). Behavior-preserving extraction of the recording/transcription state machine into a hook → **767 → 256 LOC**.

## Changes
- `voice/recording-options.ts` — `RECORDING_OPTIONS` + `MAX_RECORDING_MS`.
- `voice/types.ts` — `VoiceInputProps` + `RecordingState`.
- `voice/useVoiceRecording.ts` (356) — the full state machine (permission → record → stop → transcribe → confirm), pulse animation, auto-stop timer, unmount teardown, press handlers. The forward-reference refs (`stopRecordingRef`/`transcribeAudioRef`) preserve the original TDZ-avoidance pattern **exactly**.
- `VoiceInput.tsx` (256) — presentational shell consuming the hook; re-exports public types so importers of `./VoiceInput` are unchanged.

## Test Plan
- [ ] CI passes (mobile chain)
- [x] Existing `voice.test.tsx` + `chat-screen.test.tsx` still pass; full mobile suite **1715 green** = behavior preserved
- [x] typecheck + lint clean; a11y guard passes

🤖 Shipped via /gh-ship