### PR TITLE
refactor(mobile): split SessionReplay.tsx 617→226 LOC (Cluster A2)

### DIFF
--- a/packages/styrby-mobile/src/components/SessionReplay.tsx
+++ b/packages/styrby-mobile/src/components/SessionReplay.tsx
@@ -11,448 +11,64 @@
  * - Play/pause with speed control
  * - Auto-scroll to current message
  *
+ * Orchestrator only (Cluster A2 split): the rAF playback engine lives in
+ * `useReplayPlayback`, timing math in `replay-timing`, and the free-tier gate +
+ * speed dropdown in their own sub-components. This file wires them together.
+ *
  * @tier Pro+ only - Free users see an upgrade prompt
  */
 
-import {
-  View,
-  Text,
-  ScrollView,
-  Pressable,
-  Animated,
-  Dimensions,
-  Linking,
-} from 'react-native';
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { View, Text, ScrollView, Pressable, Animated } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { ChatMessage, type ChatMessageData, type ContentBlock } from './ChatMessage';
-import type { AgentType } from 'styrby-shared';
-import {
-  getUpgradeMessage,
-  getUpgradeButtonLabel,
-  getIosManageNote,
-  POLAR_CUSTOMER_PORTAL_URL,
-} from '../lib/platform-billing';
+import { ChatMessage } from './ChatMessage';
+import { formatTime, toChatMessageData } from './session-replay/replay-timing';
+import { useReplayPlayback } from './session-replay/useReplayPlayback';
+import { UpgradePrompt } from './session-replay/UpgradePrompt';
+import { SpeedSelector } from './session-replay/SpeedSelector';
+import type { SessionReplayProps } from './session-replay/types';
 
-// ============================================================================
-// Types
-// ============================================================================
-
-/**
- * Message data from the session_messages table.
- */
-export interface ReplayMessageData {
-  /** Unique message identifier */
-  id: string;
-  /** Message role */
-  role: 'user' | 'assistant' | 'system' | 'error';
-  /** Agent type for assistant messages */
-  agentType?: AgentType;
-  /** Message content (decrypted) */
-  content: string;
-  /** Message timestamp */
-  createdAt: string;
-  /** Cost in USD */
-  costUsd?: number;
-  /** Duration in milliseconds */
-  durationMs?: number;
-}
-
-/**
- * Props for the SessionReplay component.
- */
-interface SessionReplayProps {
-  /** All messages in the session, sorted by createdAt */
-  messages: ReplayMessageData[];
-  /** User's subscription tier */
-  userTier: 'free' | 'pro' | 'growth';
-  /** Callback when replay completes */
-  onComplete?: () => void;
-  /** Callback when user exits replay */
-  onExit?: () => void;
-}
-
-/**
- * Playback speed options.
- */
-type PlaybackSpeed = 0.5 | 1 | 2 | 4;
-
-/**
- * Playback state.
- */
-type PlaybackState = 'playing' | 'paused' | 'stopped';
-
-// ============================================================================
-// Constants
-// ============================================================================
-
-const SPEED_OPTIONS: PlaybackSpeed[] = [0.5, 1, 2, 4];
-
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/**
- * Formats milliseconds to MM:SS or HH:MM:SS.
- */
-function formatTime(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-
-  if (hours > 0) {
-    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
-  }
-
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
-}
-
-/**
- * Converts ReplayMessageData to ChatMessageData for rendering.
- */
-function toChatMessageData(message: ReplayMessageData): ChatMessageData {
-  const contentBlock: ContentBlock = { type: 'text', content: message.content };
-
-  return {
-    id: message.id,
-    role: message.role,
-    agentType: message.agentType,
-    content: [contentBlock],
-    timestamp: message.createdAt,
-    costUsd: message.costUsd,
-    durationMs: message.durationMs,
-  };
-}
-
-// ============================================================================
-// Upgrade Prompt Component
-// ============================================================================
-
-/**
- * Shown to free users who don't have access to replay.
- *
- * WHY platform-conditional rendering:
- * Apple App Store §3.1.3(a) classifies Styrby as a Reader App and prohibits
- * showing upgrade buttons, pricing, or links to external payment flows on iOS.
- * Android has no such restriction, so the full upgrade CTA is shown there.
- *
- * @param props.onExit - Optional callback when user presses "Go Back"
- */
-function UpgradePrompt({ onExit }: { onExit?: () => void }) {
-  const upgradeButtonLabel = getUpgradeButtonLabel('pro');
-  const iosManageNote = getIosManageNote();
-
-  return (
-    <View className="flex-1 bg-background items-center justify-center px-6">
-      <View className="w-16 h-16 rounded-2xl bg-orange-500/20 items-center justify-center mb-4">
-        <Ionicons name="play-circle" size={32} color="#f97316" />
-      </View>
-      <Text className="text-white text-xl font-semibold text-center mb-2">
-        Session Replay
-      </Text>
-      <Text className="text-zinc-500 text-center mb-6">
-        {getUpgradeMessage('Session Replay', 'pro')}
-      </Text>
-
-      {/* WHY: Only render the upgrade button on Android. Apple Reader App rules
-          (§3.1.3(a)) prohibit showing purchase CTAs or external payment links
-          on iOS. On iOS we show an informational note instead. */}
-      {upgradeButtonLabel !== null ? (
-        <Pressable
-          className="bg-brand px-6 py-3 rounded-xl active:opacity-80"
-          onPress={() => Linking.openURL(POLAR_CUSTOMER_PORTAL_URL).catch(() => null)}
-          accessibilityRole="button"
-          accessibilityLabel={upgradeButtonLabel}
-        >
-          <Text className="text-white font-semibold">{upgradeButtonLabel}</Text>
-        </Pressable>
-      ) : (
-        // iOS: informational note only — no button, no price, no external link
-        iosManageNote !== null && (
-          <Text className="text-zinc-600 text-xs text-center">{iosManageNote}</Text>
-        )
-      )}
-
-      {onExit && (
-        <Pressable
-          onPress={onExit}
-          className="mt-4 px-4 py-2"
-          accessibilityRole="button"
-          accessibilityLabel="Go back"
-        >
-          <Text className="text-zinc-500">Go Back</Text>
-        </Pressable>
-      )}
-    </View>
-  );
-}
-
-// ============================================================================
-// Speed Selector Component
-// ============================================================================
-
-/**
- * Dropdown for selecting playback speed.
- */
-function SpeedSelector({
-  speed,
-  onSpeedChange,
-}: {
-  speed: PlaybackSpeed;
-  onSpeedChange: (speed: PlaybackSpeed) => void;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <View className="relative">
-      <Pressable
-        onPress={() => setIsOpen(!isOpen)}
-        className="flex-row items-center px-3 py-1.5 rounded-lg bg-zinc-800"
-        accessibilityRole="button"
-        accessibilityLabel={`Playback speed: ${speed}x`}
-      >
-        <Text className="text-white text-sm font-medium">{speed}x</Text>
-        <Ionicons
-          name={isOpen ? 'chevron-up' : 'chevron-down'}
-          size={16}
-          color="#71717a"
-          style={{ marginLeft: 4 }}
-        />
-      </Pressable>
-
-      {isOpen && (
-        <View className="absolute bottom-full mb-1 right-0 bg-zinc-800 rounded-lg border border-zinc-700 overflow-hidden z-10">
-          {SPEED_OPTIONS.map((option) => (
-            <Pressable
-              key={option}
-              onPress={() => {
-                onSpeedChange(option);
-                setIsOpen(false);
-              }}
-              className={`px-4 py-2 ${speed === option ? 'bg-zinc-700' : ''}`}
-              accessibilityRole="button"
-              accessibilityLabel={`Set speed to ${option}x`}
-            >
-              <Text
-                className={`text-sm ${
-                  speed === option ? 'text-orange-500 font-medium' : 'text-white'
-                }`}
-              >
-                {option}x
-              </Text>
-            </Pressable>
-          ))}
-        </View>
-      )}
-    </View>
-  );
-}
-
-// ============================================================================
-// Main Component
-// ============================================================================
+export type { ReplayMessageData } from './session-replay/types';
 
 /**
  * Session replay component for mobile.
  *
- * WHY: Session replay allows users to review past sessions step-by-step,
- * understanding the flow of conversation and agent actions. The mobile
- * version uses a simplified interface optimized for touch.
+ * WHY: Session replay lets users review past sessions step-by-step,
+ * understanding the flow of conversation and agent actions. The mobile version
+ * uses a simplified interface optimized for touch.
  *
- * @param props - SessionReplay configuration
+ * @param props - SessionReplay configuration.
  */
-export function SessionReplay({
-  messages,
-  userTier,
-  onComplete,
-  onExit,
-}: SessionReplayProps) {
-  // Gate access for free users
+export function SessionReplay({ messages, userTier, onComplete, onExit }: SessionReplayProps) {
+  // Gate access for free users.
   const canAccessReplay = userTier !== 'free';
 
-  // Playback state
-  const [playbackState, setPlaybackState] = useState<PlaybackState>('stopped');
-  const [speed, setSpeed] = useState<PlaybackSpeed>(1);
-  const [currentTimeMs, setCurrentTimeMs] = useState(0);
+  const {
+    playbackState,
+    speed,
+    setSpeed,
+    currentTimeMs,
+    totalDurationMs,
+    currentMessageIndex,
+    progressAnim,
+    scrollRef,
+    togglePlay,
+    jumpToMessage,
+    handleProgressPress,
+    handlePrevMessage,
+    handleNextMessage,
+  } = useReplayPlayback(messages, onComplete);
 
-  // Animation refs
-  const animationRef = useRef<number | null>(null);
-  const lastTickTimeRef = useRef<number>(0);
-  const onCompleteRef = useRef(onComplete);
-  const scrollRef = useRef<ScrollView>(null);
-
-  // Progress bar animation
-  const progressAnim = useRef(new Animated.Value(0)).current;
-
-  // Update onComplete ref
-  useEffect(() => {
-    onCompleteRef.current = onComplete;
-  }, [onComplete]);
-
-  // Calculate timing data
-  const { totalDurationMs, messageTimestamps } = useMemo(() => {
-    if (messages.length === 0) {
-      return { totalDurationMs: 0, messageTimestamps: [] };
-    }
-
-    const startTime = new Date(messages[0].createdAt).getTime();
-    const endTime = new Date(messages[messages.length - 1].createdAt).getTime();
-
-    const timestamps = messages.map(
-      (msg) => new Date(msg.createdAt).getTime() - startTime
-    );
-
-    return {
-      totalDurationMs: endTime - startTime,
-      messageTimestamps: timestamps,
-    };
-  }, [messages]);
-
-  // Calculate visible messages
-  // WHY: visibleMessages is prefixed _ because the replay UI currently renders
-  // all messages and relies on currentMessageIndex for scroll position. The
-  // sliced array is retained in the computed return for future use when the
-  // component gains a windowed-render mode.
-  const { visibleMessages: _visibleMessages, currentMessageIndex } = useMemo(() => {
-    if (messages.length === 0) {
-      return { visibleMessages: [], currentMessageIndex: -1 };
-    }
-
-    let lastVisibleIndex = -1;
-    for (let i = 0; i < messageTimestamps.length; i++) {
-      if (messageTimestamps[i] <= currentTimeMs) {
-        lastVisibleIndex = i;
-      } else {
-        break;
-      }
-    }
-
-    const visible = lastVisibleIndex >= 0 ? messages.slice(0, lastVisibleIndex + 1) : [];
-
-    return {
-      visibleMessages: visible,
-      currentMessageIndex: lastVisibleIndex,
-    };
-  }, [messages, messageTimestamps, currentTimeMs]);
-
-  // Update progress bar animation
-  useEffect(() => {
-    const progress = totalDurationMs > 0 ? currentTimeMs / totalDurationMs : 0;
-    Animated.timing(progressAnim, {
-      toValue: progress,
-      duration: 50,
-      useNativeDriver: false,
-    }).start();
-  }, [currentTimeMs, totalDurationMs, progressAnim]);
-
-  // Animation tick
-  const tick = useCallback(() => {
-    const now = performance.now();
-    const deltaMs = now - lastTickTimeRef.current;
-    lastTickTimeRef.current = now;
-
-    setCurrentTimeMs((prev) => {
-      const newTime = prev + deltaMs * speed;
-
-      if (newTime >= totalDurationMs) {
-        setPlaybackState('stopped');
-        onCompleteRef.current?.();
-        return totalDurationMs;
-      }
-
-      return newTime;
-    });
-
-    animationRef.current = requestAnimationFrame(tick);
-  }, [speed, totalDurationMs]);
-
-  // Start/stop animation based on playback state
-  useEffect(() => {
-    if (playbackState === 'playing') {
-      lastTickTimeRef.current = performance.now();
-      animationRef.current = requestAnimationFrame(tick);
-    } else if (animationRef.current) {
-      cancelAnimationFrame(animationRef.current);
-      animationRef.current = null;
-    }
-
-    return () => {
-      if (animationRef.current) {
-        cancelAnimationFrame(animationRef.current);
-      }
-    };
-  }, [playbackState, tick]);
-
-  // Auto-scroll to current message
-  useEffect(() => {
-    if (currentMessageIndex >= 0 && scrollRef.current) {
-      // Approximate scroll position based on message index
-      // Each message is roughly 100-150px tall
-      const estimatedOffset = currentMessageIndex * 120;
-      scrollRef.current.scrollTo({ y: estimatedOffset, animated: true });
-    }
-  }, [currentMessageIndex]);
-
-  // Control handlers
-  const togglePlay = useCallback(() => {
-    if (playbackState === 'playing') {
-      setPlaybackState('paused');
-    } else {
-      // If at end, restart
-      if (currentTimeMs >= totalDurationMs) {
-        setCurrentTimeMs(0);
-      }
-      setPlaybackState('playing');
-    }
-  }, [playbackState, currentTimeMs, totalDurationMs]);
-
-  const jumpToMessage = useCallback(
-    (index: number) => {
-      if (index >= 0 && index < messageTimestamps.length) {
-        setCurrentTimeMs(messageTimestamps[index]);
-      }
-    },
-    [messageTimestamps]
-  );
-
-  const handleProgressPress = useCallback(
-    (event: { nativeEvent: { locationX: number } }) => {
-      const { locationX } = event.nativeEvent;
-      const progress = locationX / (SCREEN_WIDTH - 32); // Account for padding
-      const newTime = progress * totalDurationMs;
-      setCurrentTimeMs(Math.max(0, Math.min(newTime, totalDurationMs)));
-    },
-    [totalDurationMs]
-  );
-
-  const handlePrevMessage = useCallback(() => {
-    if (currentMessageIndex > 0) {
-      jumpToMessage(currentMessageIndex - 1);
-    }
-  }, [currentMessageIndex, jumpToMessage]);
-
-  const handleNextMessage = useCallback(() => {
-    if (currentMessageIndex < messages.length - 1) {
-      jumpToMessage(currentMessageIndex + 1);
-    }
-  }, [currentMessageIndex, messages.length, jumpToMessage]);
-
-  // Show upgrade prompt for free users
+  // Show upgrade prompt for free users.
   if (!canAccessReplay) {
     return <UpgradePrompt onExit={onExit} />;
   }
 
-  // Empty state
+  // Empty state.
   if (messages.length === 0) {
     return (
       <View className="flex-1 bg-background items-center justify-center px-6">
         <Ionicons name="chatbubbles-outline" size={48} color="#3f3f46" />
-        <Text className="text-zinc-400 text-lg font-semibold mt-4">
-          No Messages to Replay
-        </Text>
+        <Text className="text-zinc-400 text-lg font-semibold mt-4">No Messages to Replay</Text>
         <Text className="text-zinc-500 text-center mt-2">
           This session has no recorded messages.
         </Text>
@@ -551,13 +167,9 @@ export function SessionReplay({
         <View className="flex-row items-center justify-between">
           {/* Time display */}
           <View className="flex-row items-center min-w-[80px]">
-            <Text className="text-zinc-400 text-xs font-mono">
-              {formatTime(currentTimeMs)}
-            </Text>
+            <Text className="text-zinc-400 text-xs font-mono">{formatTime(currentTimeMs)}</Text>
             <Text className="text-zinc-600 text-xs mx-1">/</Text>
-            <Text className="text-zinc-600 text-xs font-mono">
-              {formatTime(totalDurationMs)}
-            </Text>
+            <Text className="text-zinc-600 text-xs font-mono">{formatTime(totalDurationMs)}</Text>
           </View>
 
           {/* Playback controls */}
@@ -592,9 +204,7 @@ export function SessionReplay({
             <Pressable
               onPress={handleNextMessage}
               disabled={currentMessageIndex >= messages.length - 1}
-              className={`p-2 ${
-                currentMessageIndex >= messages.length - 1 ? 'opacity-30' : ''
-              }`}
+              className={`p-2 ${currentMessageIndex >= messages.length - 1 ? 'opacity-30' : ''}`}
               accessibilityRole="button"
               accessibilityLabel="Next message"
             >
@@ -605,8 +215,7 @@ export function SessionReplay({
           {/* Right side: message count and speed */}
           <View className="flex-row items-center min-w-[80px] justify-end">
             <Text className="text-zinc-500 text-xs mr-3">
-              {currentMessageIndex >= 0 ? currentMessageIndex + 1 : 0}/
-              {messages.length}
+              {currentMessageIndex >= 0 ? currentMessageIndex + 1 : 0}/{messages.length}
             </Text>
             <SpeedSelector speed={speed} onSpeedChange={setSpeed} />
           </View>

--- a/packages/styrby-mobile/src/components/session-replay/SpeedSelector.tsx
+++ b/packages/styrby-mobile/src/components/session-replay/SpeedSelector.tsx
@@ -1,0 +1,73 @@
+/**
+ * SpeedSelector — dropdown for choosing playback speed.
+ *
+ * Extracted from SessionReplay.tsx (Cluster A2 split).
+ *
+ * @module components/session-replay/SpeedSelector
+ */
+
+import { useState } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { PlaybackSpeed } from './types';
+import { SPEED_OPTIONS } from './constants';
+
+/**
+ * Dropdown for selecting playback speed.
+ *
+ * @param props.speed - Current speed.
+ * @param props.onSpeedChange - Called with the newly selected speed.
+ */
+export function SpeedSelector({
+  speed,
+  onSpeedChange,
+}: {
+  speed: PlaybackSpeed;
+  onSpeedChange: (speed: PlaybackSpeed) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <View className="relative">
+      <Pressable
+        onPress={() => setIsOpen(!isOpen)}
+        className="flex-row items-center px-3 py-1.5 rounded-lg bg-zinc-800"
+        accessibilityRole="button"
+        accessibilityLabel={`Playback speed: ${speed}x`}
+      >
+        <Text className="text-white text-sm font-medium">{speed}x</Text>
+        <Ionicons
+          name={isOpen ? 'chevron-up' : 'chevron-down'}
+          size={16}
+          color="#71717a"
+          style={{ marginLeft: 4 }}
+        />
+      </Pressable>
+
+      {isOpen && (
+        <View className="absolute bottom-full mb-1 right-0 bg-zinc-800 rounded-lg border border-zinc-700 overflow-hidden z-10">
+          {SPEED_OPTIONS.map((option) => (
+            <Pressable
+              key={option}
+              onPress={() => {
+                onSpeedChange(option);
+                setIsOpen(false);
+              }}
+              className={`px-4 py-2 ${speed === option ? 'bg-zinc-700' : ''}`}
+              accessibilityRole="button"
+              accessibilityLabel={`Set speed to ${option}x`}
+            >
+              <Text
+                className={`text-sm ${
+                  speed === option ? 'text-orange-500 font-medium' : 'text-white'
+                }`}
+              >
+                {option}x
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/components/session-replay/UpgradePrompt.tsx
+++ b/packages/styrby-mobile/src/components/session-replay/UpgradePrompt.tsx
@@ -1,0 +1,75 @@
+/**
+ * UpgradePrompt — shown to free users who lack access to session replay.
+ *
+ * Extracted from SessionReplay.tsx (Cluster A2 split).
+ *
+ * @module components/session-replay/UpgradePrompt
+ */
+
+import { View, Text, Pressable, Linking } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  getUpgradeMessage,
+  getUpgradeButtonLabel,
+  getIosManageNote,
+  POLAR_CUSTOMER_PORTAL_URL,
+} from '../../lib/platform-billing';
+
+/**
+ * Shown to free users who don't have access to replay.
+ *
+ * WHY platform-conditional rendering:
+ * Apple App Store §3.1.3(a) classifies Styrby as a Reader App and prohibits
+ * showing upgrade buttons, pricing, or links to external payment flows on iOS.
+ * Android has no such restriction, so the full upgrade CTA is shown there.
+ *
+ * @param props.onExit - Optional callback when user presses "Go Back".
+ */
+export function UpgradePrompt({ onExit }: { onExit?: () => void }) {
+  const upgradeButtonLabel = getUpgradeButtonLabel('pro');
+  const iosManageNote = getIosManageNote();
+
+  return (
+    <View className="flex-1 bg-background items-center justify-center px-6">
+      <View className="w-16 h-16 rounded-2xl bg-orange-500/20 items-center justify-center mb-4">
+        <Ionicons name="play-circle" size={32} color="#f97316" />
+      </View>
+      <Text className="text-white text-xl font-semibold text-center mb-2">
+        Session Replay
+      </Text>
+      <Text className="text-zinc-500 text-center mb-6">
+        {getUpgradeMessage('Session Replay', 'pro')}
+      </Text>
+
+      {/* WHY: Only render the upgrade button on Android. Apple Reader App rules
+          (§3.1.3(a)) prohibit showing purchase CTAs or external payment links
+          on iOS. On iOS we show an informational note instead. */}
+      {upgradeButtonLabel !== null ? (
+        <Pressable
+          className="bg-brand px-6 py-3 rounded-xl active:opacity-80"
+          onPress={() => Linking.openURL(POLAR_CUSTOMER_PORTAL_URL).catch(() => null)}
+          accessibilityRole="button"
+          accessibilityLabel={upgradeButtonLabel}
+        >
+          <Text className="text-white font-semibold">{upgradeButtonLabel}</Text>
+        </Pressable>
+      ) : (
+        // iOS: informational note only — no button, no price, no external link
+        iosManageNote !== null && (
+          <Text className="text-zinc-600 text-xs text-center">{iosManageNote}</Text>
+        )
+      )}
+
+      {onExit && (
+        <Pressable
+          onPress={onExit}
+          className="mt-4 px-4 py-2"
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
+          <Text className="text-zinc-500">Go Back</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/components/session-replay/__tests__/replay-timing.test.ts
+++ b/packages/styrby-mobile/src/components/session-replay/__tests__/replay-timing.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for session-replay timing math (Cluster A2 split).
+ *
+ * These pure helpers drive playback correctness; they were untestable while
+ * embedded in useMemo bodies inside SessionReplay.tsx.
+ *
+ * @module components/session-replay/__tests__/replay-timing
+ */
+
+import {
+  formatTime,
+  toChatMessageData,
+  computeTiming,
+  computeVisibleIndex,
+} from '../replay-timing';
+import type { ReplayMessageData } from '../types';
+
+function msg(id: string, secondsFromEpoch: number): ReplayMessageData {
+  return {
+    id,
+    role: 'user',
+    content: `m-${id}`,
+    createdAt: new Date(secondsFromEpoch * 1000).toISOString(),
+  };
+}
+
+describe('formatTime', () => {
+  it('formats under an hour as M:SS', () => {
+    expect(formatTime(0)).toBe('0:00');
+    expect(formatTime(5_000)).toBe('0:05');
+    expect(formatTime(65_000)).toBe('1:05');
+  });
+  it('formats an hour or more as H:MM:SS', () => {
+    expect(formatTime(3_661_000)).toBe('1:01:01');
+  });
+});
+
+describe('toChatMessageData', () => {
+  it('wraps content in a single text block and preserves metadata', () => {
+    const data = toChatMessageData({
+      id: 'x',
+      role: 'assistant',
+      agentType: 'claude',
+      content: 'hello',
+      createdAt: '2026-06-12T00:00:00Z',
+      costUsd: 0.02,
+      durationMs: 1200,
+    });
+    expect(data).toMatchObject({
+      id: 'x',
+      role: 'assistant',
+      agentType: 'claude',
+      content: [{ type: 'text', content: 'hello' }],
+      timestamp: '2026-06-12T00:00:00Z',
+      costUsd: 0.02,
+      durationMs: 1200,
+    });
+  });
+});
+
+describe('computeTiming', () => {
+  it('returns zeros for an empty session', () => {
+    expect(computeTiming([])).toEqual({ totalDurationMs: 0, messageTimestamps: [] });
+  });
+
+  it('computes total span and per-message offsets from the first message', () => {
+    const { totalDurationMs, messageTimestamps } = computeTiming([
+      msg('a', 100),
+      msg('b', 110),
+      msg('c', 130),
+    ]);
+    expect(totalDurationMs).toBe(30_000); // 130s - 100s
+    expect(messageTimestamps).toEqual([0, 10_000, 30_000]);
+  });
+});
+
+describe('computeVisibleIndex', () => {
+  const offsets = [0, 10_000, 30_000];
+
+  it('returns -1 before the first message offset', () => {
+    expect(computeVisibleIndex(offsets, -1)).toBe(-1);
+  });
+  it('returns the last reached index at the playhead', () => {
+    expect(computeVisibleIndex(offsets, 0)).toBe(0);
+    expect(computeVisibleIndex(offsets, 15_000)).toBe(1);
+    expect(computeVisibleIndex(offsets, 30_000)).toBe(2);
+  });
+  it('clamps to the final message past the end', () => {
+    expect(computeVisibleIndex(offsets, 999_999)).toBe(2);
+  });
+  it('returns -1 for an empty session', () => {
+    expect(computeVisibleIndex([], 5_000)).toBe(-1);
+  });
+});

--- a/packages/styrby-mobile/src/components/session-replay/constants.ts
+++ b/packages/styrby-mobile/src/components/session-replay/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Constants for the session-replay feature.
+ *
+ * Extracted from SessionReplay.tsx (Cluster A2 split).
+ *
+ * @module components/session-replay/constants
+ */
+
+import { Dimensions } from 'react-native';
+import type { PlaybackSpeed } from './types';
+
+/** Selectable playback speeds, slowest to fastest. */
+export const SPEED_OPTIONS: PlaybackSpeed[] = [0.5, 1, 2, 4];
+
+/** Screen width, used to map a progress-bar tap to a playback position. */
+export const { width: SCREEN_WIDTH } = Dimensions.get('window');

--- a/packages/styrby-mobile/src/components/session-replay/replay-timing.ts
+++ b/packages/styrby-mobile/src/components/session-replay/replay-timing.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure timing math for session replay.
+ *
+ * Extracted from SessionReplay.tsx (Cluster A2 split). The playback engine's
+ * correctness lives entirely here - duration, per-message offsets, and which
+ * message is current at a given playhead time. These were untestable while
+ * embedded in useMemo bodies; as pure functions they can be verified directly.
+ *
+ * @module components/session-replay/replay-timing
+ */
+
+import type { ChatMessageData, ContentBlock } from '../ChatMessage';
+import type { ReplayMessageData } from './types';
+
+/**
+ * Format milliseconds as MM:SS, or HH:MM:SS once past an hour.
+ *
+ * @param ms - Duration in milliseconds.
+ * @returns Clock-style string.
+ */
+export function formatTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+/**
+ * Adapt a ReplayMessageData into the ChatMessageData shape ChatMessage renders.
+ *
+ * @param message - The replay message.
+ * @returns Chat-renderable message data.
+ */
+export function toChatMessageData(message: ReplayMessageData): ChatMessageData {
+  const contentBlock: ContentBlock = { type: 'text', content: message.content };
+
+  return {
+    id: message.id,
+    role: message.role,
+    agentType: message.agentType,
+    content: [contentBlock],
+    timestamp: message.createdAt,
+    costUsd: message.costUsd,
+    durationMs: message.durationMs,
+  };
+}
+
+/** Total replay duration plus each message's offset from the start. */
+export interface ReplayTiming {
+  /** End-to-start span of the session in ms. */
+  totalDurationMs: number;
+  /** Per-message offset from the first message, in ms. */
+  messageTimestamps: number[];
+}
+
+/**
+ * Compute the total duration and per-message offsets from message timestamps.
+ *
+ * WHY offsets-from-start (not absolute): the playhead runs from 0, so each
+ * message's reveal time is its createdAt minus the first message's createdAt.
+ *
+ * @param messages - Messages sorted by createdAt.
+ * @returns Total duration + offset array (empty for no messages).
+ */
+export function computeTiming(messages: ReplayMessageData[]): ReplayTiming {
+  if (messages.length === 0) {
+    return { totalDurationMs: 0, messageTimestamps: [] };
+  }
+
+  const startTime = new Date(messages[0].createdAt).getTime();
+  const endTime = new Date(messages[messages.length - 1].createdAt).getTime();
+  const timestamps = messages.map((msg) => new Date(msg.createdAt).getTime() - startTime);
+
+  return { totalDurationMs: endTime - startTime, messageTimestamps: timestamps };
+}
+
+/**
+ * Find the index of the latest message whose offset has been reached.
+ *
+ * WHY linear scan + early break: offsets are monotonically non-decreasing, so
+ * the first offset past the playhead means every later one is too.
+ *
+ * @param messageTimestamps - Per-message offsets from computeTiming.
+ * @param currentTimeMs - Current playhead position in ms.
+ * @returns Index of the current message, or -1 if none are visible yet.
+ */
+export function computeVisibleIndex(messageTimestamps: number[], currentTimeMs: number): number {
+  let lastVisibleIndex = -1;
+  for (let i = 0; i < messageTimestamps.length; i++) {
+    if (messageTimestamps[i] <= currentTimeMs) {
+      lastVisibleIndex = i;
+    } else {
+      break;
+    }
+  }
+  return lastVisibleIndex;
+}

--- a/packages/styrby-mobile/src/components/session-replay/types.ts
+++ b/packages/styrby-mobile/src/components/session-replay/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared types for the session-replay feature.
+ *
+ * Extracted from SessionReplay.tsx (Cluster A2 split) so the hook, the pure
+ * timing helpers, and the sub-components share one set of definitions.
+ *
+ * @module components/session-replay/types
+ */
+
+import type { AgentType } from 'styrby-shared';
+
+/** Message data from the session_messages table. */
+export interface ReplayMessageData {
+  /** Unique message identifier. */
+  id: string;
+  /** Message role. */
+  role: 'user' | 'assistant' | 'system' | 'error';
+  /** Agent type for assistant messages. */
+  agentType?: AgentType;
+  /** Message content (decrypted). */
+  content: string;
+  /** Message timestamp. */
+  createdAt: string;
+  /** Cost in USD. */
+  costUsd?: number;
+  /** Duration in milliseconds. */
+  durationMs?: number;
+}
+
+/** Props for the SessionReplay component. */
+export interface SessionReplayProps {
+  /** All messages in the session, sorted by createdAt. */
+  messages: ReplayMessageData[];
+  /** User's subscription tier. */
+  userTier: 'free' | 'pro' | 'growth';
+  /** Callback when replay completes. */
+  onComplete?: () => void;
+  /** Callback when user exits replay. */
+  onExit?: () => void;
+}
+
+/** Playback speed options. */
+export type PlaybackSpeed = 0.5 | 1 | 2 | 4;
+
+/** Playback transport state. */
+export type PlaybackState = 'playing' | 'paused' | 'stopped';

--- a/packages/styrby-mobile/src/components/session-replay/useReplayPlayback.ts
+++ b/packages/styrby-mobile/src/components/session-replay/useReplayPlayback.ts
@@ -1,0 +1,196 @@
+/**
+ * useReplayPlayback — the requestAnimationFrame playback engine for SessionReplay.
+ *
+ * Extracted verbatim from SessionReplay.tsx (Cluster A2 split). Owns the
+ * transport state, the rAF tick loop, the progress-bar animation, auto-scroll,
+ * and every control handler. The refs (animation handle, last-tick time,
+ * onComplete, scroll target) are preserved exactly as the original to keep the
+ * timing behavior identical.
+ *
+ * @module components/session-replay/useReplayPlayback
+ */
+
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { Animated, ScrollView } from 'react-native';
+import type { ReplayMessageData, PlaybackState, PlaybackSpeed } from './types';
+import { SCREEN_WIDTH } from './constants';
+import { computeTiming, computeVisibleIndex } from './replay-timing';
+
+/** Everything the SessionReplay view needs to render + drive playback. */
+export interface UseReplayPlayback {
+  playbackState: PlaybackState;
+  speed: PlaybackSpeed;
+  setSpeed: (speed: PlaybackSpeed) => void;
+  currentTimeMs: number;
+  totalDurationMs: number;
+  currentMessageIndex: number;
+  progressAnim: Animated.Value;
+  scrollRef: React.RefObject<ScrollView | null>;
+  togglePlay: () => void;
+  jumpToMessage: (index: number) => void;
+  handleProgressPress: (event: { nativeEvent: { locationX: number } }) => void;
+  handlePrevMessage: () => void;
+  handleNextMessage: () => void;
+}
+
+/**
+ * Drive step-through playback of a recorded session.
+ *
+ * @param messages - Messages sorted by createdAt.
+ * @param onComplete - Optional callback fired when the playhead reaches the end.
+ * @returns Playback state + control handlers.
+ */
+export function useReplayPlayback(
+  messages: ReplayMessageData[],
+  onComplete?: () => void,
+): UseReplayPlayback {
+  // Playback state
+  const [playbackState, setPlaybackState] = useState<PlaybackState>('stopped');
+  const [speed, setSpeed] = useState<PlaybackSpeed>(1);
+  const [currentTimeMs, setCurrentTimeMs] = useState(0);
+
+  // Animation refs
+  const animationRef = useRef<number | null>(null);
+  const lastTickTimeRef = useRef<number>(0);
+  const onCompleteRef = useRef(onComplete);
+  const scrollRef = useRef<ScrollView>(null);
+
+  // Progress bar animation
+  const progressAnim = useRef(new Animated.Value(0)).current;
+
+  // Keep the onComplete ref current without restarting the tick loop.
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  // Timing data (total span + per-message offsets).
+  const { totalDurationMs, messageTimestamps } = useMemo(() => computeTiming(messages), [messages]);
+
+  // Index of the message at the current playhead position.
+  // WHY index-only (the original also computed a sliced visibleMessages array
+  // that was never rendered): the UI renders all messages and dims the
+  // not-yet-reached ones by index, so the slice was dead weight. Dropping it
+  // preserves behavior exactly.
+  const currentMessageIndex = useMemo(
+    () => computeVisibleIndex(messageTimestamps, currentTimeMs),
+    [messageTimestamps, currentTimeMs],
+  );
+
+  // Animate the progress bar toward the current fraction.
+  useEffect(() => {
+    const progress = totalDurationMs > 0 ? currentTimeMs / totalDurationMs : 0;
+    Animated.timing(progressAnim, {
+      toValue: progress,
+      duration: 50,
+      useNativeDriver: false,
+    }).start();
+  }, [currentTimeMs, totalDurationMs, progressAnim]);
+
+  // Animation tick — advances the playhead by elapsed-wall-time * speed.
+  const tick = useCallback(() => {
+    const now = performance.now();
+    const deltaMs = now - lastTickTimeRef.current;
+    lastTickTimeRef.current = now;
+
+    setCurrentTimeMs((prev) => {
+      const newTime = prev + deltaMs * speed;
+
+      if (newTime >= totalDurationMs) {
+        setPlaybackState('stopped');
+        onCompleteRef.current?.();
+        return totalDurationMs;
+      }
+
+      return newTime;
+    });
+
+    animationRef.current = requestAnimationFrame(tick);
+  }, [speed, totalDurationMs]);
+
+  // Start/stop the rAF loop based on transport state.
+  useEffect(() => {
+    if (playbackState === 'playing') {
+      lastTickTimeRef.current = performance.now();
+      animationRef.current = requestAnimationFrame(tick);
+    } else if (animationRef.current) {
+      cancelAnimationFrame(animationRef.current);
+      animationRef.current = null;
+    }
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, [playbackState, tick]);
+
+  // Auto-scroll to the current message.
+  useEffect(() => {
+    if (currentMessageIndex >= 0 && scrollRef.current) {
+      // Approximate scroll position: each message is roughly 100-150px tall.
+      const estimatedOffset = currentMessageIndex * 120;
+      scrollRef.current.scrollTo({ y: estimatedOffset, animated: true });
+    }
+  }, [currentMessageIndex]);
+
+  // ── Control handlers ──────────────────────────────────────────────────────
+
+  const togglePlay = useCallback(() => {
+    if (playbackState === 'playing') {
+      setPlaybackState('paused');
+    } else {
+      // If at the end, restart from zero.
+      if (currentTimeMs >= totalDurationMs) {
+        setCurrentTimeMs(0);
+      }
+      setPlaybackState('playing');
+    }
+  }, [playbackState, currentTimeMs, totalDurationMs]);
+
+  const jumpToMessage = useCallback(
+    (index: number) => {
+      if (index >= 0 && index < messageTimestamps.length) {
+        setCurrentTimeMs(messageTimestamps[index]);
+      }
+    },
+    [messageTimestamps],
+  );
+
+  const handleProgressPress = useCallback(
+    (event: { nativeEvent: { locationX: number } }) => {
+      const { locationX } = event.nativeEvent;
+      const progress = locationX / (SCREEN_WIDTH - 32); // Account for padding.
+      const newTime = progress * totalDurationMs;
+      setCurrentTimeMs(Math.max(0, Math.min(newTime, totalDurationMs)));
+    },
+    [totalDurationMs],
+  );
+
+  const handlePrevMessage = useCallback(() => {
+    if (currentMessageIndex > 0) {
+      jumpToMessage(currentMessageIndex - 1);
+    }
+  }, [currentMessageIndex, jumpToMessage]);
+
+  const handleNextMessage = useCallback(() => {
+    if (currentMessageIndex < messages.length - 1) {
+      jumpToMessage(currentMessageIndex + 1);
+    }
+  }, [currentMessageIndex, messages.length, jumpToMessage]);
+
+  return {
+    playbackState,
+    speed,
+    setSpeed,
+    currentTimeMs,
+    totalDurationMs,
+    currentMessageIndex,
+    progressAnim,
+    scrollRef,
+    togglePlay,
+    jumpToMessage,
+    handleProgressPress,
+    handlePrevMessage,
+    handleNextMessage,
+  };
+}


### PR DESCRIPTION
## Summary
- Splits the 617-line `SessionReplay.tsx` (over the 400-LOC ceiling) into a co-located `session-replay/` directory; orchestrator down to 226 LOC.
- The playback-correctness math (`computeTiming`, `computeVisibleIndex`) was trapped in `useMemo` bodies that can't run in jsdom; extracted to pure functions with **9 tests** pinning duration, per-message offsets, and the monotonic visible-index scan.
- The `requestAnimationFrame` tick loop + transport state + control handlers moved verbatim into `useReplayPlayback` with every ref preserved.
- Public API unchanged: orchestrator re-exports `ReplayMessageData`, consumed via the direct import in `app/session/[id].tsx`.

## Changes
- `session-replay/replay-timing.ts` - pure timing math (+`formatTime`, `toChatMessageData`)
- `session-replay/useReplayPlayback.ts` - rAF playback engine (verbatim)
- `session-replay/types.ts` / `constants.ts`
- `session-replay/UpgradePrompt.tsx` - free-tier gate (Apple Reader-App §3.1.3(a) WHY comment preserved)
- `session-replay/SpeedSelector.tsx`
- `session-replay/__tests__/replay-timing.test.ts` - +9 tests
- `SessionReplay.tsx` - 617 → 226 LOC orchestrator

Also drops a never-rendered `visibleMessages` slice (was `_`-prefixed "for future use"); WHY-documented as a behavior-preserving removal in the hook.

## Test Plan
- [x] mobile typecheck clean
- [x] mobile lint clean (lone pre-existing unrelated warning)
- [x] full mobile suite 1747 pass (+9), a11y regression guard green
- [ ] CI passes

🤖 Shipped via /gh-ship