### PR TITLE
refactor(mobile): split SessionCheckpoints.tsx 552→147 LOC (Cluster A2)

### DIFF
--- a/packages/styrby-mobile/src/components/SessionCheckpoints.tsx
+++ b/packages/styrby-mobile/src/components/SessionCheckpoints.tsx
@@ -5,182 +5,29 @@
  * new checkpoints, restore to a position, and delete existing ones.
  *
  * Designed for the session detail screen. Checkpoints are fetched from and
- * written to Supabase via the shared REST API (same endpoint as Web).
+ * written to Supabase.
+ *
+ * Orchestrator only (Cluster A2 split): all CRUD + form state lives in
+ * `useSessionCheckpoints`, validation/mapping in `checkpoint-format`, and the
+ * row + save sheet in their own sub-components. This file renders the panel.
  *
  * WHY: Named checkpoints give users a way to mark "known good" states in long
  * AI coding sessions so they can review or restart from that position.
  * Inspired by Gemini CLI's `/resume save [name]` feature.
  */
 
-import { useState, useCallback, useEffect } from 'react';
-import {
-  View,
-  Text,
-  Pressable,
-  TextInput,
-  ActivityIndicator,
-  Alert,
-  Modal,
-} from 'react-native';
+import { View, Text, Pressable, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { supabase } from '../lib/supabase';
-import type { SessionCheckpoint } from 'styrby-shared';
-
-// ============================================================================
-// Types
-// ============================================================================
+import { useSessionCheckpoints } from './session-checkpoints/useSessionCheckpoints';
+import { CheckpointRow } from './session-checkpoints/CheckpointRow';
+import { SaveCheckpointModal } from './session-checkpoints/SaveCheckpointModal';
+import type { SessionCheckpointsProps } from './session-checkpoints/types';
 
 /**
- * Props for the SessionCheckpoints component.
- */
-interface SessionCheckpointsProps {
-  /** Session ID whose checkpoints to display */
-  sessionId: string;
-  /** Current message count for new checkpoint position */
-  currentMessageCount?: number;
-  /** Whether the session is currently active */
-  isSessionActive?: boolean;
-  /**
-   * Called when the user taps "Restore" on a checkpoint.
-   * The parent screen uses this to filter/scroll messages.
-   */
-  onRestore?: (checkpoint: SessionCheckpoint) => void;
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/**
- * Formats a checkpoint timestamp into a short readable string.
+ * Display named checkpoints for a session with save, restore, and delete.
  *
- * @param isoTimestamp - ISO 8601 timestamp
- * @returns Formatted string like "Mar 27, 2:30 PM"
- */
-function formatCheckpointTime(isoTimestamp: string): string {
-  return new Date(isoTimestamp).toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  });
-}
-
-// ============================================================================
-// Sub-components
-// ============================================================================
-
-/**
- * Single checkpoint row in the list.
- */
-interface CheckpointRowProps {
-  checkpoint: SessionCheckpoint;
-  isDeleting: boolean;
-  isRestoring: boolean;
-  onDelete: (cp: SessionCheckpoint) => void;
-  onRestore: (cp: SessionCheckpoint) => void;
-}
-
-/**
- * Renders a single checkpoint item with name, metadata, and action buttons.
- */
-function CheckpointRow({
-  checkpoint,
-  isDeleting,
-  isRestoring,
-  onDelete,
-  onRestore,
-}: CheckpointRowProps) {
-  return (
-    <View className="mb-2 rounded-2xl bg-zinc-900 border border-zinc-800 p-3">
-      {/* Name + description */}
-      <View className="flex-row items-start justify-between">
-        <View className="flex-1 pr-2">
-          <Text className="text-white text-sm font-semibold" numberOfLines={1}>
-            {checkpoint.name}
-          </Text>
-          {checkpoint.description ? (
-            <Text className="text-zinc-500 text-xs mt-0.5" numberOfLines={2}>
-              {checkpoint.description}
-            </Text>
-          ) : null}
-        </View>
-
-        {/* Delete button */}
-        <Pressable
-          onPress={() => onDelete(checkpoint)}
-          disabled={isDeleting}
-          className="p-1 rounded-lg active:opacity-60"
-          accessibilityRole="button"
-          accessibilityLabel={`Delete checkpoint ${checkpoint.name}`}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        >
-          {isDeleting ? (
-            <ActivityIndicator size="small" color="#71717a" />
-          ) : (
-            <Ionicons name="trash-outline" size={16} color="#ef4444" />
-          )}
-        </Pressable>
-      </View>
-
-      {/* Metadata row */}
-      <View className="flex-row items-center mt-2 gap-3">
-        <View className="flex-row items-center gap-1">
-          <Ionicons name="list-outline" size={11} color="#71717a" />
-          <Text className="text-zinc-600 text-xs">
-            Msg {checkpoint.messageSequenceNumber}
-          </Text>
-        </View>
-
-        {checkpoint.contextSnapshot.totalTokens > 0 && (
-          <View className="flex-row items-center gap-1">
-            <Ionicons name="analytics-outline" size={11} color="#71717a" />
-            <Text className="text-zinc-600 text-xs">
-              {checkpoint.contextSnapshot.totalTokens.toLocaleString()} tokens
-            </Text>
-          </View>
-        )}
-
-        <View className="flex-row items-center ml-auto gap-1">
-          <Ionicons name="time-outline" size={11} color="#71717a" />
-          <Text className="text-zinc-600 text-xs">
-            {formatCheckpointTime(checkpoint.createdAt)}
-          </Text>
-        </View>
-      </View>
-
-      {/* Restore button */}
-      <Pressable
-        onPress={() => onRestore(checkpoint)}
-        disabled={isRestoring}
-        className="mt-2 flex-row items-center justify-center bg-zinc-800 rounded-xl py-2 active:opacity-70"
-        accessibilityRole="button"
-        accessibilityLabel={`Restore to checkpoint ${checkpoint.name}`}
-      >
-        {isRestoring ? (
-          <ActivityIndicator size="small" color="#f97316" />
-        ) : (
-          <>
-            <Ionicons name="git-branch-outline" size={14} color="#f97316" />
-            <Text className="text-orange-400 text-xs font-medium ml-1">
-              Restore to here
-            </Text>
-          </>
-        )}
-      </Pressable>
-    </View>
-  );
-}
-
-// ============================================================================
-// Main Component
-// ============================================================================
-
-/**
- * Displays named checkpoints for a session with save, restore, and delete.
- *
- * @param props - Component props
- * @returns React element for the checkpoint panel
+ * @param props - Component props.
+ * @returns React element for the checkpoint panel.
  *
  * @example
  * <SessionCheckpoints
@@ -193,206 +40,30 @@ function CheckpointRow({
 export function SessionCheckpoints({
   sessionId,
   currentMessageCount = 0,
+  // isSessionActive is accepted for API stability but not currently rendered.
   isSessionActive: _isSessionActive = false,
   onRestore,
 }: SessionCheckpointsProps) {
-  const [checkpoints, setCheckpoints] = useState<SessionCheckpoint[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
-  const [restoringId, setRestoringId] = useState<string | null>(null);
-  const [showSaveModal, setShowSaveModal] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [newName, setNewName] = useState('');
-  const [newDescription, setNewDescription] = useState('');
-  const [saveError, setSaveError] = useState<string | null>(null);
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Fetch checkpoints
-  // ──────────────────────────────────────────────────────────────────────────
-
-  /**
-   * Load checkpoints for this session from Supabase.
-   *
-   * WHY: We query Supabase directly rather than the REST API on mobile
-   * because the mobile app already has an authenticated Supabase client
-   * with the user's JWT. This avoids an extra HTTP round-trip.
-   */
-  const fetchCheckpoints = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      setError(null);
-
-      const { data, error: dbError } = await supabase
-        .from('session_checkpoints')
-        .select('*')
-        .eq('session_id', sessionId)
-        .order('created_at', { ascending: false });
-
-      if (dbError) throw dbError;
-
-      const mapped: SessionCheckpoint[] = (data ?? []).map((row) => {
-        const snapshot = (row.context_snapshot ?? {}) as {
-          totalTokens?: number;
-          fileCount?: number;
-        };
-        return {
-          id: row.id as string,
-          sessionId: row.session_id as string,
-          name: row.name as string,
-          description: (row.description as string | null) ?? undefined,
-          messageSequenceNumber: (row.message_sequence_number as number) ?? 0,
-          contextSnapshot: {
-            totalTokens: snapshot.totalTokens ?? 0,
-            fileCount: snapshot.fileCount ?? 0,
-          },
-          createdAt: row.created_at as string,
-        };
-      });
-
-      setCheckpoints(mapped);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to load checkpoints';
-      setError(msg);
-      if (__DEV__) console.error('[SessionCheckpoints] fetch error:', err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [sessionId]);
-
-  useEffect(() => {
-    fetchCheckpoints();
-  }, [fetchCheckpoints]);
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Save checkpoint
-  // ──────────────────────────────────────────────────────────────────────────
-
-  /**
-   * Saves a new checkpoint at the current message position.
-   *
-   * Validates the name, inserts into Supabase, and refreshes the list.
-   */
-  const handleSave = useCallback(async () => {
-    const trimmedName = newName.trim();
-
-    if (!trimmedName) {
-      setSaveError('Name is required');
-      return;
-    }
-    if (trimmedName.length > 80) {
-      setSaveError('Name must be 80 characters or fewer');
-      return;
-    }
-    if (!/^[a-zA-Z0-9 \-_.]+$/.test(trimmedName)) {
-      setSaveError('Name may only contain letters, numbers, spaces, hyphens, underscores, and dots');
-      return;
-    }
-
-    setIsSaving(true);
-    setSaveError(null);
-
-    try {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error('Not authenticated');
-
-      const { error: insertError } = await supabase
-        .from('session_checkpoints')
-        .insert({
-          session_id: sessionId,
-          user_id: user.id,
-          name: trimmedName,
-          description: newDescription.trim() || null,
-          message_sequence_number: currentMessageCount,
-          context_snapshot: { totalTokens: 0, fileCount: 0 },
-        });
-
-      if (insertError) {
-        if (insertError.code === '23505') {
-          throw new Error(`A checkpoint named "${trimmedName}" already exists`);
-        }
-        throw insertError;
-      }
-
-      setNewName('');
-      setNewDescription('');
-      setShowSaveModal(false);
-      await fetchCheckpoints();
-    } catch (err) {
-      setSaveError(err instanceof Error ? err.message : 'Failed to save checkpoint');
-      if (__DEV__) console.error('[SessionCheckpoints] save error:', err);
-    } finally {
-      setIsSaving(false);
-    }
-  }, [sessionId, newName, newDescription, currentMessageCount, fetchCheckpoints]);
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Delete checkpoint
-  // ──────────────────────────────────────────────────────────────────────────
-
-  /**
-   * Deletes a checkpoint after user confirmation.
-   *
-   * @param checkpoint - The checkpoint to delete
-   */
-  const handleDelete = useCallback(
-    (checkpoint: SessionCheckpoint) => {
-      Alert.alert(
-        'Delete Checkpoint',
-        `Delete "${checkpoint.name}"? This cannot be undone.`,
-        [
-          { text: 'Cancel', style: 'cancel' },
-          {
-            text: 'Delete',
-            style: 'destructive',
-            onPress: async () => {
-              setDeletingId(checkpoint.id);
-              try {
-                const { error: deleteError } = await supabase
-                  .from('session_checkpoints')
-                  .delete()
-                  .eq('id', checkpoint.id);
-
-                if (deleteError) throw deleteError;
-                setCheckpoints((prev) => prev.filter((c) => c.id !== checkpoint.id));
-              } catch (err) {
-                Alert.alert(
-                  'Delete Failed',
-                  err instanceof Error ? err.message : 'Failed to delete checkpoint'
-                );
-                if (__DEV__) console.error('[SessionCheckpoints] delete error:', err);
-              } finally {
-                setDeletingId(null);
-              }
-            },
-          },
-        ]
-      );
-    },
-    []
-  );
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Restore checkpoint
-  // ──────────────────────────────────────────────────────────────────────────
-
-  /**
-   * Invokes the onRestore callback and briefly shows a loading indicator.
-   *
-   * @param checkpoint - Checkpoint to restore to
-   */
-  const handleRestore = useCallback(
-    (checkpoint: SessionCheckpoint) => {
-      setRestoringId(checkpoint.id);
-      onRestore?.(checkpoint);
-      setTimeout(() => setRestoringId(null), 800);
-    },
-    [onRestore]
-  );
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Render
-  // ──────────────────────────────────────────────────────────────────────────
+  const {
+    checkpoints,
+    isLoading,
+    error,
+    deletingId,
+    restoringId,
+    showSaveModal,
+    isSaving,
+    newName,
+    newDescription,
+    saveError,
+    setNewName,
+    setNewDescription,
+    openSaveModal,
+    closeSaveModal,
+    fetchCheckpoints,
+    handleSave,
+    handleDelete,
+    handleRestore,
+  } = useSessionCheckpoints(sessionId, currentMessageCount, onRestore);
 
   return (
     <View className="mx-4 mb-4">
@@ -402,10 +73,7 @@ export function SessionCheckpoints({
           Checkpoints
         </Text>
         <Pressable
-          onPress={() => {
-            setShowSaveModal(true);
-            setSaveError(null);
-          }}
+          onPress={openSaveModal}
           className="flex-row items-center bg-zinc-800 rounded-lg px-2 py-1 active:opacity-70"
           accessibilityRole="button"
           accessibilityLabel="Save new checkpoint"
@@ -460,91 +128,18 @@ export function SessionCheckpoints({
       )}
 
       {/* Save modal */}
-      <Modal
+      <SaveCheckpointModal
         visible={showSaveModal}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setShowSaveModal(false)}
-        accessibilityViewIsModal
-      >
-        <View className="flex-1 bg-black/60 justify-end">
-          <View className="bg-zinc-900 rounded-t-3xl px-4 pt-4 pb-8">
-            {/* Handle */}
-            <View className="w-10 h-1 bg-zinc-700 rounded-full self-center mb-4" />
-
-            <Text className="text-white text-lg font-semibold mb-4">
-              Save Checkpoint
-            </Text>
-
-            {/* Name input */}
-            <Text className="text-zinc-400 text-sm mb-1">Name</Text>
-            <TextInput
-              value={newName}
-              onChangeText={(t) => {
-                setNewName(t);
-                setSaveError(null);
-              }}
-              placeholder="e.g. before-refactor"
-              placeholderTextColor="#52525b"
-              maxLength={80}
-              className="bg-zinc-800 text-white rounded-xl px-4 py-3 mb-3 border border-zinc-700"
-              accessibilityLabel="Checkpoint name"
-              autoFocus
-              returnKeyType="next"
-            />
-
-            {/* Description input */}
-            <Text className="text-zinc-400 text-sm mb-1">Description (optional)</Text>
-            <TextInput
-              value={newDescription}
-              onChangeText={setNewDescription}
-              placeholder="What's working at this point?"
-              placeholderTextColor="#52525b"
-              className="bg-zinc-800 text-white rounded-xl px-4 py-3 mb-3 border border-zinc-700"
-              accessibilityLabel="Checkpoint description"
-              returnKeyType="done"
-              onSubmitEditing={handleSave}
-            />
-
-            {/* Error message */}
-            {saveError && (
-              <Text className="text-red-400 text-sm mb-3">{saveError}</Text>
-            )}
-
-            {/* Current position info */}
-            <Text className="text-zinc-600 text-xs mb-4">
-              This checkpoint will mark message {currentMessageCount} in the session.
-            </Text>
-
-            {/* Action buttons */}
-            <Pressable
-              onPress={handleSave}
-              disabled={isSaving || !newName.trim()}
-              className="bg-orange-500 rounded-2xl py-4 items-center mb-3 active:opacity-80 disabled:opacity-50"
-              accessibilityRole="button"
-              accessibilityLabel={isSaving ? 'Saving checkpoint...' : 'Save checkpoint'}
-            >
-              {isSaving ? (
-                <ActivityIndicator color="white" />
-              ) : (
-                <Text className="text-white font-semibold">Save Checkpoint</Text>
-              )}
-            </Pressable>
-
-            <Pressable
-              onPress={() => {
-                setShowSaveModal(false);
-                setSaveError(null);
-              }}
-              className="bg-zinc-800 rounded-2xl py-4 items-center active:opacity-80"
-              accessibilityRole="button"
-              accessibilityLabel="Cancel"
-            >
-              <Text className="text-zinc-300 font-semibold">Cancel</Text>
-            </Pressable>
-          </View>
-        </View>
-      </Modal>
+        newName={newName}
+        newDescription={newDescription}
+        saveError={saveError}
+        isSaving={isSaving}
+        currentMessageCount={currentMessageCount}
+        onChangeName={setNewName}
+        onChangeDescription={setNewDescription}
+        onSave={handleSave}
+        onClose={closeSaveModal}
+      />
     </View>
   );
 }

--- a/packages/styrby-mobile/src/components/session-checkpoints/CheckpointRow.tsx
+++ b/packages/styrby-mobile/src/components/session-checkpoints/CheckpointRow.tsx
@@ -1,0 +1,108 @@
+/**
+ * CheckpointRow — a single checkpoint item with metadata + restore/delete.
+ *
+ * Extracted from SessionCheckpoints.tsx (Cluster A2 split). Pure presentational.
+ *
+ * @module components/session-checkpoints/CheckpointRow
+ */
+
+import { View, Text, Pressable, ActivityIndicator } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { SessionCheckpoint } from 'styrby-shared';
+import { formatCheckpointTime } from './checkpoint-format';
+
+/** Props for a single checkpoint row. */
+export interface CheckpointRowProps {
+  checkpoint: SessionCheckpoint;
+  isDeleting: boolean;
+  isRestoring: boolean;
+  onDelete: (cp: SessionCheckpoint) => void;
+  onRestore: (cp: SessionCheckpoint) => void;
+}
+
+/**
+ * Render a single checkpoint item with name, metadata, and action buttons.
+ *
+ * @param props - Row props.
+ */
+export function CheckpointRow({
+  checkpoint,
+  isDeleting,
+  isRestoring,
+  onDelete,
+  onRestore,
+}: CheckpointRowProps) {
+  return (
+    <View className="mb-2 rounded-2xl bg-zinc-900 border border-zinc-800 p-3">
+      {/* Name + description */}
+      <View className="flex-row items-start justify-between">
+        <View className="flex-1 pr-2">
+          <Text className="text-white text-sm font-semibold" numberOfLines={1}>
+            {checkpoint.name}
+          </Text>
+          {checkpoint.description ? (
+            <Text className="text-zinc-500 text-xs mt-0.5" numberOfLines={2}>
+              {checkpoint.description}
+            </Text>
+          ) : null}
+        </View>
+
+        {/* Delete button */}
+        <Pressable
+          onPress={() => onDelete(checkpoint)}
+          disabled={isDeleting}
+          className="p-1 rounded-lg active:opacity-60"
+          accessibilityRole="button"
+          accessibilityLabel={`Delete checkpoint ${checkpoint.name}`}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          {isDeleting ? (
+            <ActivityIndicator size="small" color="#71717a" />
+          ) : (
+            <Ionicons name="trash-outline" size={16} color="#ef4444" />
+          )}
+        </Pressable>
+      </View>
+
+      {/* Metadata row */}
+      <View className="flex-row items-center mt-2 gap-3">
+        <View className="flex-row items-center gap-1">
+          <Ionicons name="list-outline" size={11} color="#71717a" />
+          <Text className="text-zinc-600 text-xs">Msg {checkpoint.messageSequenceNumber}</Text>
+        </View>
+
+        {checkpoint.contextSnapshot.totalTokens > 0 && (
+          <View className="flex-row items-center gap-1">
+            <Ionicons name="analytics-outline" size={11} color="#71717a" />
+            <Text className="text-zinc-600 text-xs">
+              {checkpoint.contextSnapshot.totalTokens.toLocaleString()} tokens
+            </Text>
+          </View>
+        )}
+
+        <View className="flex-row items-center ml-auto gap-1">
+          <Ionicons name="time-outline" size={11} color="#71717a" />
+          <Text className="text-zinc-600 text-xs">{formatCheckpointTime(checkpoint.createdAt)}</Text>
+        </View>
+      </View>
+
+      {/* Restore button */}
+      <Pressable
+        onPress={() => onRestore(checkpoint)}
+        disabled={isRestoring}
+        className="mt-2 flex-row items-center justify-center bg-zinc-800 rounded-xl py-2 active:opacity-70"
+        accessibilityRole="button"
+        accessibilityLabel={`Restore to checkpoint ${checkpoint.name}`}
+      >
+        {isRestoring ? (
+          <ActivityIndicator size="small" color="#f97316" />
+        ) : (
+          <>
+            <Ionicons name="git-branch-outline" size={14} color="#f97316" />
+            <Text className="text-orange-400 text-xs font-medium ml-1">Restore to here</Text>
+          </>
+        )}
+      </Pressable>
+    </View>
+  );
+}

--- a/packages/styrby-mobile/src/components/session-checkpoints/SaveCheckpointModal.tsx
+++ b/packages/styrby-mobile/src/components/session-checkpoints/SaveCheckpointModal.tsx
@@ -1,0 +1,122 @@
+/**
+ * SaveCheckpointModal — bottom-sheet form for naming a new checkpoint.
+ *
+ * Extracted from SessionCheckpoints.tsx (Cluster A2 split). Presentational:
+ * all form state + the save action live in useSessionCheckpoints; this renders
+ * the sheet and wires the inputs.
+ *
+ * @module components/session-checkpoints/SaveCheckpointModal
+ */
+
+import { View, Text, Pressable, TextInput, ActivityIndicator, Modal } from 'react-native';
+import { CHECKPOINT_NAME_MAX } from './checkpoint-format';
+
+/** Props for the save-checkpoint modal. */
+export interface SaveCheckpointModalProps {
+  visible: boolean;
+  newName: string;
+  newDescription: string;
+  saveError: string | null;
+  isSaving: boolean;
+  currentMessageCount: number;
+  onChangeName: (name: string) => void;
+  onChangeDescription: (desc: string) => void;
+  onSave: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Bottom-sheet modal for creating a checkpoint.
+ *
+ * @param props - Modal props.
+ */
+export function SaveCheckpointModal({
+  visible,
+  newName,
+  newDescription,
+  saveError,
+  isSaving,
+  currentMessageCount,
+  onChangeName,
+  onChangeDescription,
+  onSave,
+  onClose,
+}: SaveCheckpointModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+      accessibilityViewIsModal
+    >
+      <View className="flex-1 bg-black/60 justify-end">
+        <View className="bg-zinc-900 rounded-t-3xl px-4 pt-4 pb-8">
+          {/* Handle */}
+          <View className="w-10 h-1 bg-zinc-700 rounded-full self-center mb-4" />
+
+          <Text className="text-white text-lg font-semibold mb-4">Save Checkpoint</Text>
+
+          {/* Name input */}
+          <Text className="text-zinc-400 text-sm mb-1">Name</Text>
+          <TextInput
+            value={newName}
+            onChangeText={onChangeName}
+            placeholder="e.g. before-refactor"
+            placeholderTextColor="#52525b"
+            maxLength={CHECKPOINT_NAME_MAX}
+            className="bg-zinc-800 text-white rounded-xl px-4 py-3 mb-3 border border-zinc-700"
+            accessibilityLabel="Checkpoint name"
+            autoFocus
+            returnKeyType="next"
+          />
+
+          {/* Description input */}
+          <Text className="text-zinc-400 text-sm mb-1">Description (optional)</Text>
+          <TextInput
+            value={newDescription}
+            onChangeText={onChangeDescription}
+            placeholder="What's working at this point?"
+            placeholderTextColor="#52525b"
+            className="bg-zinc-800 text-white rounded-xl px-4 py-3 mb-3 border border-zinc-700"
+            accessibilityLabel="Checkpoint description"
+            returnKeyType="done"
+            onSubmitEditing={onSave}
+          />
+
+          {/* Error message */}
+          {saveError && <Text className="text-red-400 text-sm mb-3">{saveError}</Text>}
+
+          {/* Current position info */}
+          <Text className="text-zinc-600 text-xs mb-4">
+            This checkpoint will mark message {currentMessageCount} in the session.
+          </Text>
+
+          {/* Action buttons */}
+          <Pressable
+            onPress={onSave}
+            disabled={isSaving || !newName.trim()}
+            className="bg-orange-500 rounded-2xl py-4 items-center mb-3 active:opacity-80 disabled:opacity-50"
+            accessibilityRole="button"
+            accessibilityLabel={isSaving ? 'Saving checkpoint...' : 'Save checkpoint'}
+          >
+            {isSaving ? (
+              <ActivityIndicator color="white" />
+            ) : (
+              <Text className="text-white font-semibold">Save Checkpoint</Text>
+            )}
+          </Pressable>
+
+          <Pressable
+            onPress={onClose}
+            className="bg-zinc-800 rounded-2xl py-4 items-center active:opacity-80"
+            accessibilityRole="button"
+            accessibilityLabel="Cancel"
+          >
+            <Text className="text-zinc-300 font-semibold">Cancel</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/packages/styrby-mobile/src/components/session-checkpoints/__tests__/checkpoint-format.test.ts
+++ b/packages/styrby-mobile/src/components/session-checkpoints/__tests__/checkpoint-format.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for checkpoint formatting, validation, and row mapping (Cluster A2 split).
+ *
+ * The name validator + row mapper were untestable while embedded in
+ * SessionCheckpoints.tsx; extracting them made the rules directly verifiable.
+ *
+ * @module components/session-checkpoints/__tests__/checkpoint-format
+ */
+
+import {
+  validateCheckpointName,
+  rowToCheckpoint,
+  CHECKPOINT_NAME_MAX,
+} from '../checkpoint-format';
+
+describe('validateCheckpointName', () => {
+  it('rejects an empty / whitespace-only name', () => {
+    expect(validateCheckpointName('')).toBe('Name is required');
+    expect(validateCheckpointName('   ')).toBe('Name is required');
+  });
+
+  it('rejects a name over the length cap', () => {
+    const tooLong = 'a'.repeat(CHECKPOINT_NAME_MAX + 1);
+    expect(validateCheckpointName(tooLong)).toBe('Name must be 80 characters or fewer');
+  });
+
+  it('rejects disallowed characters', () => {
+    expect(validateCheckpointName('bad/name')).toMatch(/may only contain/);
+    expect(validateCheckpointName('emoji 🚀')).toMatch(/may only contain/);
+  });
+
+  it('accepts letters, numbers, spaces, hyphens, underscores, and dots', () => {
+    expect(validateCheckpointName('before-refactor_v1.2')).toBeNull();
+    expect(validateCheckpointName('  trimmed ok  ')).toBeNull();
+  });
+});
+
+describe('rowToCheckpoint', () => {
+  it('maps snake_case columns to the camelCase shape', () => {
+    const cp = rowToCheckpoint({
+      id: 'c1',
+      session_id: 's1',
+      name: 'checkpoint',
+      description: 'a note',
+      message_sequence_number: 42,
+      context_snapshot: { totalTokens: 1234, fileCount: 5 },
+      created_at: '2026-06-12T00:00:00Z',
+    });
+    expect(cp).toEqual({
+      id: 'c1',
+      sessionId: 's1',
+      name: 'checkpoint',
+      description: 'a note',
+      messageSequenceNumber: 42,
+      contextSnapshot: { totalTokens: 1234, fileCount: 5 },
+      createdAt: '2026-06-12T00:00:00Z',
+    });
+  });
+
+  it('defaults a missing snapshot + null description', () => {
+    const cp = rowToCheckpoint({
+      id: 'c2',
+      session_id: 's1',
+      name: 'bare',
+      description: null,
+      message_sequence_number: null,
+      created_at: 'now',
+    });
+    expect(cp.description).toBeUndefined();
+    expect(cp.messageSequenceNumber).toBe(0);
+    expect(cp.contextSnapshot).toEqual({ totalTokens: 0, fileCount: 0 });
+  });
+});

--- a/packages/styrby-mobile/src/components/session-checkpoints/checkpoint-format.ts
+++ b/packages/styrby-mobile/src/components/session-checkpoints/checkpoint-format.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure formatting, mapping, and validation for session checkpoints.
+ *
+ * Extracted from SessionCheckpoints.tsx (Cluster A2 split). The name validator
+ * and the row mapper were untestable while embedded in the component; as pure
+ * functions they can be verified directly and the validation rules can't drift
+ * out of sync with their tests.
+ *
+ * @module components/session-checkpoints/checkpoint-format
+ */
+
+import type { SessionCheckpoint } from 'styrby-shared';
+
+/** Allowed characters in a checkpoint name. */
+const CHECKPOINT_NAME_PATTERN = /^[a-zA-Z0-9 \-_.]+$/;
+
+/** Maximum checkpoint name length. */
+export const CHECKPOINT_NAME_MAX = 80;
+
+/**
+ * Format a checkpoint timestamp into a short readable string.
+ *
+ * @param isoTimestamp - ISO 8601 timestamp.
+ * @returns Formatted string like "Mar 27, 2:30 PM".
+ */
+export function formatCheckpointTime(isoTimestamp: string): string {
+  return new Date(isoTimestamp).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Validate a proposed checkpoint name against the same rules the DB enforces.
+ *
+ * WHY validate client-side first: the DB has a unique constraint + a length
+ * cap, but surfacing "name required" / "too long" / "bad chars" before the
+ * round-trip gives instant feedback and avoids a doomed insert.
+ *
+ * @param name - Raw (un-trimmed) name from the input.
+ * @returns An error message, or null when the trimmed name is valid.
+ */
+export function validateCheckpointName(name: string): string | null {
+  const trimmed = name.trim();
+
+  if (!trimmed) return 'Name is required';
+  if (trimmed.length > CHECKPOINT_NAME_MAX) return 'Name must be 80 characters or fewer';
+  if (!CHECKPOINT_NAME_PATTERN.test(trimmed)) {
+    return 'Name may only contain letters, numbers, spaces, hyphens, underscores, and dots';
+  }
+  return null;
+}
+
+/**
+ * Map a raw `session_checkpoints` row to the typed SessionCheckpoint shape.
+ *
+ * @param row - Raw database row (snake_case).
+ * @returns Typed SessionCheckpoint (camelCase).
+ */
+export function rowToCheckpoint(row: Record<string, unknown>): SessionCheckpoint {
+  const snapshot = (row.context_snapshot ?? {}) as { totalTokens?: number; fileCount?: number };
+
+  return {
+    id: row.id as string,
+    sessionId: row.session_id as string,
+    name: row.name as string,
+    description: (row.description as string | null) ?? undefined,
+    messageSequenceNumber: (row.message_sequence_number as number) ?? 0,
+    contextSnapshot: {
+      totalTokens: snapshot.totalTokens ?? 0,
+      fileCount: snapshot.fileCount ?? 0,
+    },
+    createdAt: row.created_at as string,
+  };
+}

--- a/packages/styrby-mobile/src/components/session-checkpoints/types.ts
+++ b/packages/styrby-mobile/src/components/session-checkpoints/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared types for the session-checkpoints feature.
+ *
+ * Extracted from SessionCheckpoints.tsx (Cluster A2 split).
+ *
+ * @module components/session-checkpoints/types
+ */
+
+import type { SessionCheckpoint } from 'styrby-shared';
+
+/** Props for the SessionCheckpoints component. */
+export interface SessionCheckpointsProps {
+  /** Session ID whose checkpoints to display. */
+  sessionId: string;
+  /** Current message count for a new checkpoint's position. */
+  currentMessageCount?: number;
+  /** Whether the session is currently active. */
+  isSessionActive?: boolean;
+  /**
+   * Called when the user taps "Restore" on a checkpoint.
+   * The parent screen uses this to filter/scroll messages.
+   */
+  onRestore?: (checkpoint: SessionCheckpoint) => void;
+}

--- a/packages/styrby-mobile/src/components/session-checkpoints/useSessionCheckpoints.ts
+++ b/packages/styrby-mobile/src/components/session-checkpoints/useSessionCheckpoints.ts
@@ -1,0 +1,241 @@
+/**
+ * useSessionCheckpoints — fetch/save/delete/restore engine for the checkpoint panel.
+ *
+ * Extracted from SessionCheckpoints.tsx (Cluster A2 split). Owns every piece of
+ * state the panel renders (list, loading/error, per-row pending flags, and the
+ * save-modal form) plus the Supabase CRUD. The component consumes the returned
+ * state and only renders.
+ *
+ * @module components/session-checkpoints/useSessionCheckpoints
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import { Alert } from 'react-native';
+import { supabase } from '../../lib/supabase';
+import type { SessionCheckpoint } from 'styrby-shared';
+import { validateCheckpointName, rowToCheckpoint } from './checkpoint-format';
+
+/** State + handlers the SessionCheckpoints panel needs. */
+export interface UseSessionCheckpoints {
+  checkpoints: SessionCheckpoint[];
+  isLoading: boolean;
+  error: string | null;
+  deletingId: string | null;
+  restoringId: string | null;
+  showSaveModal: boolean;
+  isSaving: boolean;
+  newName: string;
+  newDescription: string;
+  saveError: string | null;
+  setNewName: (name: string) => void;
+  setNewDescription: (desc: string) => void;
+  openSaveModal: () => void;
+  closeSaveModal: () => void;
+  fetchCheckpoints: () => Promise<void>;
+  handleSave: () => Promise<void>;
+  handleDelete: (checkpoint: SessionCheckpoint) => void;
+  handleRestore: (checkpoint: SessionCheckpoint) => void;
+}
+
+/**
+ * Drive the checkpoint panel: load, save, delete, and restore.
+ *
+ * @param sessionId - Session whose checkpoints to manage.
+ * @param currentMessageCount - Position a new checkpoint marks.
+ * @param onRestore - Parent callback when a checkpoint is restored.
+ * @returns State + handlers for the panel.
+ */
+export function useSessionCheckpoints(
+  sessionId: string,
+  currentMessageCount: number,
+  onRestore?: (checkpoint: SessionCheckpoint) => void,
+): UseSessionCheckpoints {
+  const [checkpoints, setCheckpoints] = useState<SessionCheckpoint[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+  const [showSaveModal, setShowSaveModal] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // ── Fetch ───────────────────────────────────────────────────────────────────
+
+  /**
+   * Load checkpoints for this session from Supabase.
+   *
+   * WHY query Supabase directly (not the REST API): the mobile app already has
+   * an authenticated Supabase client with the user's JWT, so this avoids an
+   * extra HTTP round-trip.
+   */
+  const fetchCheckpoints = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const { data, error: dbError } = await supabase
+        .from('session_checkpoints')
+        .select('*')
+        .eq('session_id', sessionId)
+        .order('created_at', { ascending: false });
+
+      if (dbError) throw dbError;
+
+      setCheckpoints((data ?? []).map(rowToCheckpoint));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load checkpoints';
+      setError(msg);
+      if (__DEV__) console.error('[SessionCheckpoints] fetch error:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    fetchCheckpoints();
+  }, [fetchCheckpoints]);
+
+  // ── Save ──────────────────────────────────────────────────────────────────--
+
+  /**
+   * Save a new checkpoint at the current message position.
+   *
+   * Validates the name client-side, inserts into Supabase, and refreshes.
+   */
+  const handleSave = useCallback(async () => {
+    const validationError = validateCheckpointName(newName);
+    if (validationError) {
+      setSaveError(validationError);
+      return;
+    }
+    const trimmedName = newName.trim();
+
+    setIsSaving(true);
+    setSaveError(null);
+
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Not authenticated');
+
+      const { error: insertError } = await supabase.from('session_checkpoints').insert({
+        session_id: sessionId,
+        user_id: user.id,
+        name: trimmedName,
+        description: newDescription.trim() || null,
+        message_sequence_number: currentMessageCount,
+        context_snapshot: { totalTokens: 0, fileCount: 0 },
+      });
+
+      if (insertError) {
+        if (insertError.code === '23505') {
+          throw new Error(`A checkpoint named "${trimmedName}" already exists`);
+        }
+        throw insertError;
+      }
+
+      setNewName('');
+      setNewDescription('');
+      setShowSaveModal(false);
+      await fetchCheckpoints();
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save checkpoint');
+      if (__DEV__) console.error('[SessionCheckpoints] save error:', err);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [sessionId, newName, newDescription, currentMessageCount, fetchCheckpoints]);
+
+  // ── Delete ────────────────────────────────────────────────────────────────--
+
+  /**
+   * Delete a checkpoint after user confirmation.
+   *
+   * @param checkpoint - The checkpoint to delete.
+   */
+  const handleDelete = useCallback((checkpoint: SessionCheckpoint) => {
+    Alert.alert('Delete Checkpoint', `Delete "${checkpoint.name}"? This cannot be undone.`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          setDeletingId(checkpoint.id);
+          try {
+            const { error: deleteError } = await supabase
+              .from('session_checkpoints')
+              .delete()
+              .eq('id', checkpoint.id);
+
+            if (deleteError) throw deleteError;
+            setCheckpoints((prev) => prev.filter((c) => c.id !== checkpoint.id));
+          } catch (err) {
+            Alert.alert(
+              'Delete Failed',
+              err instanceof Error ? err.message : 'Failed to delete checkpoint',
+            );
+            if (__DEV__) console.error('[SessionCheckpoints] delete error:', err);
+          } finally {
+            setDeletingId(null);
+          }
+        },
+      },
+    ]);
+  }, []);
+
+  // ── Restore ───────────────────────────────────────────────────────────────--
+
+  /**
+   * Invoke the onRestore callback and briefly show a loading indicator.
+   *
+   * @param checkpoint - Checkpoint to restore to.
+   */
+  const handleRestore = useCallback(
+    (checkpoint: SessionCheckpoint) => {
+      setRestoringId(checkpoint.id);
+      onRestore?.(checkpoint);
+      setTimeout(() => setRestoringId(null), 800);
+    },
+    [onRestore],
+  );
+
+  // ── Save-modal transport ────────────────────────────────────────────────────
+
+  const openSaveModal = useCallback(() => {
+    setShowSaveModal(true);
+    setSaveError(null);
+  }, []);
+
+  const closeSaveModal = useCallback(() => {
+    setShowSaveModal(false);
+    setSaveError(null);
+  }, []);
+
+  // Clear the save error as the user edits the name.
+  const setNewNameAndClearError = useCallback((name: string) => {
+    setNewName(name);
+    setSaveError(null);
+  }, []);
+
+  return {
+    checkpoints,
+    isLoading,
+    error,
+    deletingId,
+    restoringId,
+    showSaveModal,
+    isSaving,
+    newName,
+    newDescription,
+    saveError,
+    setNewName: setNewNameAndClearError,
+    setNewDescription,
+    openSaveModal,
+    closeSaveModal,
+    fetchCheckpoints,
+    handleSave,
+    handleDelete,
+    handleRestore,
+  };
+}


### PR DESCRIPTION
## Summary
- Splits the 552-line `SessionCheckpoints.tsx` (over the 400-LOC ceiling) into a co-located `session-checkpoints/` directory; orchestrator down to 147 LOC.
- The name validator (duplicated against the DB length/charset/unique constraints) + the snake→camel row mapper were untestable while embedded; extracted to pure functions with **6 tests** that keep the client rules in lock-step with the DB.
- All CRUD + form state moved into `useSessionCheckpoints`; row + save sheet became presentational sub-components.
- Public API unchanged: orchestrator keeps both the named + default export, consumed via the barrel and the direct import in `app/session/[id].tsx`.
- **Completes the mobile side of Cluster A2** (5 components split; web's `otel-settings` + `cloud-tasks` remain).

## Changes
- `session-checkpoints/checkpoint-format.ts` - pure validate/map/format (+6 tests)
- `session-checkpoints/useSessionCheckpoints.ts` - CRUD + form state
- `session-checkpoints/CheckpointRow.tsx` / `SaveCheckpointModal.tsx`
- `session-checkpoints/types.ts`
- `SessionCheckpoints.tsx` - 552 → 147 LOC orchestrator

## Test Plan
- [x] mobile typecheck clean
- [x] mobile lint clean (lone pre-existing unrelated warning)
- [x] full mobile suite 1753 pass (+6), a11y regression guard green
- [ ] CI passes

🤖 Shipped via /gh-ship