### PR TITLE
refactor(web): split otel-settings.tsx 506→248 LOC (Cluster A2)

### DIFF
--- a/packages/styrby-web/src/components/dashboard/otel-settings.tsx
+++ b/packages/styrby-web/src/components/dashboard/otel-settings.tsx
@@ -8,24 +8,21 @@
  * and copy the generated environment variables to use with the CLI.
  *
  * This is an enterprise/power-user feature. The section is visually separated
- * from other settings with a clear "Metrics Export" heading and a "Pro" badge.
+ * from other settings with a clear "Metrics Export" heading and a "Power" badge.
+ *
+ * Orchestrator only (Cluster A2 split): form state + save/copy/preset logic
+ * live in `useOtelSettings`, header parsing in `parse-headers`, and the row /
+ * toggle / env-vars / metrics-table pieces in their own sub-components.
  *
  * @module components/dashboard/otel-settings
  */
 
-import { useState, useCallback } from 'react';
-import {
-  type OtelUserConfig,
-  defaultOtelConfig,
-  validateOtelConfig,
-  generateEnvVars,
-  OTEL_PRESETS,
-} from '@/lib/otel-config';
-import { createClient } from '@/lib/supabase/client';
-
-// ============================================================================
-// Types
-// ============================================================================
+import { useOtelSettings } from './otel-settings/useOtelSettings';
+import { SettingRow } from './otel-settings/SettingRow';
+import { Toggle } from './otel-settings/Toggle';
+import { EnvVarsPanel } from './otel-settings/EnvVarsPanel';
+import { MetricsReference } from './otel-settings/MetricsReference';
+import { OTEL_PRESETS, type OtelUserConfig } from '@/lib/otel-config';
 
 /**
  * Props for the OtelSettings component.
@@ -43,91 +40,11 @@ export interface OtelSettingsProps {
   isPowerTier: boolean;
 
   /**
-   * Initial OTEL config loaded from Supabase profiles row.
+   * Initial OTEL config loaded from the Supabase profiles row.
    * null when the user has never configured OTEL before.
    */
   initialConfig: OtelUserConfig | null;
 }
-
-// ============================================================================
-// Header Row Component
-// ============================================================================
-
-/**
- * Renders a settings row with a label, description, and interactive control.
- *
- * @param label - Setting name
- * @param description - Short explanation
- * @param children - The form control (input, toggle, etc.)
- */
-function SettingRow({
-  label,
-  description,
-  error,
-  children,
-}: {
-  label: string;
-  description?: string;
-  error?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <label className="text-sm font-medium text-foreground">{label}</label>
-      {description && <p className="text-xs text-muted-foreground">{description}</p>}
-      {children}
-      {error && <p className="text-xs text-red-400">{error}</p>}
-    </div>
-  );
-}
-
-// ============================================================================
-// Toggle Component
-// ============================================================================
-
-/**
- * Simple accessible toggle switch.
- *
- * @param checked - Whether the toggle is on
- * @param onChange - Callback when toggled
- * @param disabled - Whether the toggle is disabled
- * @param label - Accessible label for screen readers
- */
-function Toggle({
-  checked,
-  onChange,
-  disabled,
-  label,
-}: {
-  checked: boolean;
-  onChange: (value: boolean) => void;
-  disabled?: boolean;
-  label: string;
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={label}
-      disabled={disabled}
-      onClick={() => onChange(!checked)}
-      className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${
-        checked ? 'bg-emerald-500' : 'bg-zinc-700'
-      }`}
-    >
-      <span
-        className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${
-          checked ? 'translate-x-[18px]' : 'translate-x-1'
-        }`}
-      />
-    </button>
-  );
-}
-
-// ============================================================================
-// Main Component
-// ============================================================================
 
 /**
  * OTEL metrics export settings panel.
@@ -136,147 +53,28 @@ function Toggle({
  * and generate the environment variables needed to activate OTEL export
  * in the Styrby CLI.
  *
- * @param props - Component props
+ * @param props - Component props.
  *
  * @example
  * <OtelSettings isPowerTier={true} initialConfig={profile?.otel_config ?? null} />
  */
 export function OtelSettings({ isPowerTier, initialConfig }: OtelSettingsProps) {
-  const supabase = createClient();
-
-  // ── Form state ──────────────────────────────────────────────────────────────
-
-  const [config, setConfig] = useState<OtelUserConfig>(initialConfig ?? defaultOtelConfig());
-  const [selectedPreset, setSelectedPreset] = useState<string>('custom');
-  const [headersRaw, setHeadersRaw] = useState<string>(
-    initialConfig?.headers && Object.keys(initialConfig.headers).length > 0
-      ? JSON.stringify(initialConfig.headers, null, 2)
-      : ''
-  );
-  const [saving, setSaving] = useState(false);
-  const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
-  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
-  const [copied, setCopied] = useState(false);
-
-  // ── Preset Selection ────────────────────────────────────────────────────────
-
-  /**
-   * Apply a preset template to the config form.
-   * Pre-fills the endpoint and headers template when the user picks a provider.
-   *
-   * @param presetId - The preset identifier
-   */
-  const applyPreset = useCallback((presetId: string) => {
-    const preset = OTEL_PRESETS.find((p) => p.id === presetId);
-    if (!preset) return;
-
-    setSelectedPreset(presetId);
-    setConfig((prev) => ({
-      ...prev,
-      endpoint: preset.endpoint,
-      headers: preset.headersTemplate,
-    }));
-    setHeadersRaw(
-      Object.keys(preset.headersTemplate).length > 0
-        ? JSON.stringify(preset.headersTemplate, null, 2)
-        : ''
-    );
-  }, []);
-
-  // ── Header Parsing ──────────────────────────────────────────────────────────
-
-  /**
-   * Parse the raw headers textarea value into a Record<string, string>.
-   * Returns an empty object on parse errors (error shown via validation).
-   */
-  const parseHeaders = useCallback((raw: string): Record<string, string> => {
-    if (!raw.trim()) return {};
-    try {
-      const parsed = JSON.parse(raw);
-      if (typeof parsed === 'object' && parsed !== null) {
-        return parsed as Record<string, string>;
-      }
-    } catch {
-      // validation will surface this error
-    }
-    return {};
-  }, []);
-
-  // ── Save Handler ────────────────────────────────────────────────────────────
-
-  /**
-   * Validate and persist the OTEL config to Supabase.
-   *
-   * WHY: We validate client-side before saving to give instant feedback.
-   * The Supabase upsert is on the `profiles` table `otel_config` JSONB column
-   * which is protected by RLS (users can only write their own row).
-   */
-  const handleSave = useCallback(async () => {
-    const parsedHeaders = parseHeaders(headersRaw);
-    const fullConfig: OtelUserConfig = { ...config, headers: parsedHeaders };
-
-    // Validate headers JSON separately (validateOtelConfig doesn't check JSON syntax)
-    if (headersRaw.trim() && Object.keys(parsedHeaders).length === 0) {
-      setValidationErrors({ headers: 'Headers must be a valid JSON object (e.g., {"Authorization": "Bearer ..."})' });
-      return;
-    }
-
-    const validation = validateOtelConfig(fullConfig);
-    if (!validation.isValid) {
-      setValidationErrors(validation.errors);
-      return;
-    }
-
-    setValidationErrors({});
-    setSaving(true);
-    setSaveMessage(null);
-
-    try {
-      const { error } = await supabase
-        .from('profiles')
-        .update({ otel_config: fullConfig })
-        .eq('id', (await supabase.auth.getUser()).data.user?.id ?? '');
-
-      if (error) throw error;
-
-      setConfig(fullConfig);
-      setSaveMessage({ type: 'success', text: 'OTEL configuration saved.' });
-    } catch (err) {
-      setSaveMessage({
-        type: 'error',
-        text: `Failed to save: ${err instanceof Error ? err.message : 'Unknown error'}`,
-      });
-    } finally {
-      setSaving(false);
-    }
-  }, [config, headersRaw, parseHeaders, supabase]);
-
-  // ── Env Vars Copy ───────────────────────────────────────────────────────────
-
-  /**
-   * Copy the generated env vars to the clipboard.
-   */
-  const handleCopyEnvVars = useCallback(async () => {
-    const parsedHeaders = parseHeaders(headersRaw);
-    const fullConfig: OtelUserConfig = { ...config, headers: parsedHeaders };
-    const envVars = generateEnvVars(fullConfig);
-
-    try {
-      await navigator.clipboard.writeText(envVars);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard API not available (non-HTTPS or denied permission)
-    }
-  }, [config, headersRaw, parseHeaders]);
-
-  // ── Computed env vars preview ────────────────────────────────────────────────
-
-  const parsedHeaders = parseHeaders(headersRaw);
-  const envVarsPreview = generateEnvVars({ ...config, headers: parsedHeaders });
-  const activePreset = OTEL_PRESETS.find((p) => p.id === selectedPreset);
-
-  // ── Render ──────────────────────────────────────────────────────────────────
+  const {
+    config,
+    setConfig,
+    selectedPreset,
+    headersRaw,
+    setHeadersRaw,
+    saving,
+    saveMessage,
+    validationErrors,
+    copied,
+    applyPreset,
+    handleSave,
+    handleCopyEnvVars,
+    envVarsPreview,
+    activePreset,
+  } = useOtelSettings(initialConfig);
 
   return (
     <section aria-labelledby="otel-settings-heading">
@@ -307,7 +105,6 @@ export function OtelSettings({ isPowerTier, initialConfig }: OtelSettingsProps) 
       )}
 
       <div className={`space-y-5 ${!isPowerTier ? 'opacity-50 pointer-events-none select-none' : ''}`}>
-
         {/* Enable/Disable Toggle */}
         <div className="flex items-center justify-between rounded-lg border border-border/40 bg-card/60 px-4 py-3">
           <div>
@@ -441,65 +238,10 @@ export function OtelSettings({ isPowerTier, initialConfig }: OtelSettingsProps) 
         </div>
 
         {/* Generated Env Vars */}
-        <div className="rounded-lg border border-border/40 bg-zinc-950 overflow-hidden">
-          <div className="flex items-center justify-between px-4 py-2.5 border-b border-border/40">
-            <div>
-              <p className="text-xs font-semibold text-foreground">Environment Variables</p>
-              <p className="text-[11px] text-muted-foreground">
-                Add these to your <code className="text-amber-400">~/.zshrc</code> or <code className="text-amber-400">.env</code> file on each machine.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={handleCopyEnvVars}
-              className="rounded-md border border-border/60 px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground hover:border-border transition-colors"
-              aria-label="Copy environment variables to clipboard"
-            >
-              {copied ? 'Copied!' : 'Copy'}
-            </button>
-          </div>
-          <pre className="px-4 py-3 text-[11px] text-emerald-400 font-mono overflow-x-auto whitespace-pre leading-relaxed">
-            {envVarsPreview}
-          </pre>
-        </div>
+        <EnvVarsPanel envVars={envVarsPreview} copied={copied} onCopy={handleCopyEnvVars} />
 
         {/* Metrics Reference */}
-        <details className="rounded-lg border border-border/40">
-          <summary className="px-4 py-3 cursor-pointer text-sm font-medium text-foreground hover:text-muted-foreground transition-colors list-none flex items-center justify-between">
-            Exported Metrics Reference
-            <svg className="h-4 w-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
-          </summary>
-          <div className="px-4 pb-4 border-t border-border/40">
-            <table className="w-full mt-3 text-xs">
-              <thead>
-                <tr className="text-muted-foreground">
-                  <th className="text-left py-1.5 font-medium">Metric</th>
-                  <th className="text-left py-1.5 font-medium">Type</th>
-                  <th className="text-left py-1.5 font-medium">Attributes</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/20">
-                {[
-                  { metric: 'styrby.session.duration_ms', type: 'Gauge', attrs: 'agent, model, status' },
-                  { metric: 'styrby.tokens.input', type: 'Sum', attrs: 'agent, model' },
-                  { metric: 'styrby.tokens.output', type: 'Sum', attrs: 'agent, model' },
-                  { metric: 'styrby.tokens.cache_read', type: 'Sum', attrs: 'agent, model' },
-                  { metric: 'styrby.tokens.cache_write', type: 'Sum', attrs: 'agent, model' },
-                  { metric: 'styrby.cost.usd', type: 'Sum', attrs: 'agent, model' },
-                  { metric: 'styrby.errors.count', type: 'Sum', attrs: 'agent, error_source' },
-                ].map((row) => (
-                  <tr key={row.metric}>
-                    <td className="py-1.5 font-mono text-amber-400">{row.metric}</td>
-                    <td className="py-1.5 text-muted-foreground">{row.type}</td>
-                    <td className="py-1.5 text-muted-foreground">{row.attrs}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </details>
+        <MetricsReference />
       </div>
     </section>
   );

--- a/packages/styrby-web/src/components/dashboard/otel-settings/EnvVarsPanel.tsx
+++ b/packages/styrby-web/src/components/dashboard/otel-settings/EnvVarsPanel.tsx
@@ -1,0 +1,49 @@
+/**
+ * EnvVarsPanel — generated env-vars preview with a copy button.
+ *
+ * Extracted from otel-settings.tsx (Cluster A2 split).
+ *
+ * @module components/dashboard/otel-settings/EnvVarsPanel
+ */
+
+/** Props for the env-vars preview panel. */
+export interface EnvVarsPanelProps {
+  /** The generated env-var block to display + copy. */
+  envVars: string;
+  /** Whether the "Copied!" confirmation is showing. */
+  copied: boolean;
+  /** Copy-to-clipboard handler. */
+  onCopy: () => void;
+}
+
+/**
+ * Render the generated environment variables with a copy control.
+ *
+ * @param props - Panel props.
+ */
+export function EnvVarsPanel({ envVars, copied, onCopy }: EnvVarsPanelProps) {
+  return (
+    <div className="rounded-lg border border-border/40 bg-zinc-950 overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-border/40">
+        <div>
+          <p className="text-xs font-semibold text-foreground">Environment Variables</p>
+          <p className="text-[11px] text-muted-foreground">
+            Add these to your <code className="text-amber-400">~/.zshrc</code> or{' '}
+            <code className="text-amber-400">.env</code> file on each machine.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onCopy}
+          className="rounded-md border border-border/60 px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground hover:border-border transition-colors"
+          aria-label="Copy environment variables to clipboard"
+        >
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+      <pre className="px-4 py-3 text-[11px] text-emerald-400 font-mono overflow-x-auto whitespace-pre leading-relaxed">
+        {envVars}
+      </pre>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/components/dashboard/otel-settings/MetricsReference.tsx
+++ b/packages/styrby-web/src/components/dashboard/otel-settings/MetricsReference.tsx
@@ -1,0 +1,60 @@
+/**
+ * MetricsReference — collapsible table of the metrics OTEL export emits.
+ *
+ * Extracted from otel-settings.tsx (Cluster A2 split). Static reference content.
+ *
+ * @module components/dashboard/otel-settings/MetricsReference
+ */
+
+/** The metrics the Styrby CLI exports over OTLP, with type + attributes. */
+const EXPORTED_METRICS: { metric: string; type: string; attrs: string }[] = [
+  { metric: 'styrby.session.duration_ms', type: 'Gauge', attrs: 'agent, model, status' },
+  { metric: 'styrby.tokens.input', type: 'Sum', attrs: 'agent, model' },
+  { metric: 'styrby.tokens.output', type: 'Sum', attrs: 'agent, model' },
+  { metric: 'styrby.tokens.cache_read', type: 'Sum', attrs: 'agent, model' },
+  { metric: 'styrby.tokens.cache_write', type: 'Sum', attrs: 'agent, model' },
+  { metric: 'styrby.cost.usd', type: 'Sum', attrs: 'agent, model' },
+  { metric: 'styrby.errors.count', type: 'Sum', attrs: 'agent, error_source' },
+];
+
+/**
+ * Collapsible reference table listing every exported metric.
+ */
+export function MetricsReference() {
+  return (
+    <details className="rounded-lg border border-border/40">
+      <summary className="px-4 py-3 cursor-pointer text-sm font-medium text-foreground hover:text-muted-foreground transition-colors list-none flex items-center justify-between">
+        Exported Metrics Reference
+        <svg
+          className="h-4 w-4 text-muted-foreground"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </summary>
+      <div className="px-4 pb-4 border-t border-border/40">
+        <table className="w-full mt-3 text-xs">
+          <thead>
+            <tr className="text-muted-foreground">
+              <th className="text-left py-1.5 font-medium">Metric</th>
+              <th className="text-left py-1.5 font-medium">Type</th>
+              <th className="text-left py-1.5 font-medium">Attributes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/20">
+            {EXPORTED_METRICS.map((row) => (
+              <tr key={row.metric}>
+                <td className="py-1.5 font-mono text-amber-400">{row.metric}</td>
+                <td className="py-1.5 text-muted-foreground">{row.type}</td>
+                <td className="py-1.5 text-muted-foreground">{row.attrs}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}

--- a/packages/styrby-web/src/components/dashboard/otel-settings/SettingRow.tsx
+++ b/packages/styrby-web/src/components/dashboard/otel-settings/SettingRow.tsx
@@ -1,0 +1,36 @@
+/**
+ * SettingRow — labelled form row with optional description + error.
+ *
+ * Extracted from otel-settings.tsx (Cluster A2 split).
+ *
+ * @module components/dashboard/otel-settings/SettingRow
+ */
+
+/**
+ * Render a settings row with a label, description, and interactive control.
+ *
+ * @param label - Setting name.
+ * @param description - Short explanation.
+ * @param error - Validation error to display below the control.
+ * @param children - The form control (input, toggle, etc.).
+ */
+export function SettingRow({
+  label,
+  description,
+  error,
+  children,
+}: {
+  label: string;
+  description?: string;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium text-foreground">{label}</label>
+      {description && <p className="text-xs text-muted-foreground">{description}</p>}
+      {children}
+      {error && <p className="text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/packages/styrby-web/src/components/dashboard/otel-settings/Toggle.tsx
+++ b/packages/styrby-web/src/components/dashboard/otel-settings/Toggle.tsx
@@ -1,0 +1,47 @@
+/**
+ * Toggle — accessible on/off switch.
+ *
+ * Extracted from otel-settings.tsx (Cluster A2 split).
+ *
+ * @module components/dashboard/otel-settings/Toggle
+ */
+
+/**
+ * Simple accessible toggle switch.
+ *
+ * @param checked - Whether the toggle is on.
+ * @param onChange - Callback when toggled.
+ * @param disabled - Whether the toggle is disabled.
+ * @param label - Accessible label for screen readers.
+ */
+export function Toggle({
+  checked,
+  onChange,
+  disabled,
+  label,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed ${
+        checked ? 'bg-emerald-500' : 'bg-zinc-700'
+      }`}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${
+          checked ? 'translate-x-[18px]' : 'translate-x-1'
+        }`}
+      />
+    </button>
+  );
+}

--- a/packages/styrby-web/src/components/dashboard/otel-settings/__tests__/parse-headers.test.ts
+++ b/packages/styrby-web/src/components/dashboard/otel-settings/__tests__/parse-headers.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for the OTEL auth-headers parser (Cluster A2 split).
+ *
+ * WHY: parseHeaders feeds both the env-var preview and the save-time validation
+ * gate. The "empty vs malformed" distinction (both return {}) is relied on by
+ * the save handler, so it must be pinned. Also guards the array-rejection fix.
+ *
+ * @module components/dashboard/otel-settings/__tests__/parse-headers
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseHeaders } from '../parse-headers';
+
+describe('parseHeaders', () => {
+  it('returns {} for empty / whitespace input', () => {
+    expect(parseHeaders('')).toEqual({});
+    expect(parseHeaders('   \n ')).toEqual({});
+  });
+
+  it('parses a valid JSON object of headers', () => {
+    expect(parseHeaders('{"Authorization": "Bearer abc"}')).toEqual({
+      Authorization: 'Bearer abc',
+    });
+  });
+
+  it('returns {} for malformed JSON (validation surfaces the error)', () => {
+    expect(parseHeaders('{not json}')).toEqual({});
+    expect(parseHeaders('{"a":')).toEqual({});
+  });
+
+  it('rejects a JSON array (an array is not a valid headers object)', () => {
+    // WHY: the pre-split inline parser accepted arrays (typeof [] === "object"),
+    // which would pass the save-gate's Object.keys().length check with bogus
+    // data. The Array.isArray guard closes that.
+    expect(parseHeaders('["a", "b"]')).toEqual({});
+  });
+
+  it('returns {} for a JSON primitive (not an object)', () => {
+    expect(parseHeaders('42')).toEqual({});
+    expect(parseHeaders('"just a string"')).toEqual({});
+    expect(parseHeaders('null')).toEqual({});
+  });
+});

--- a/packages/styrby-web/src/components/dashboard/otel-settings/parse-headers.ts
+++ b/packages/styrby-web/src/components/dashboard/otel-settings/parse-headers.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure header-string parsing for the OTEL settings form.
+ *
+ * Extracted from otel-settings.tsx (Cluster A2 split). The auth-headers
+ * textarea holds a JSON object; this is the single place that text becomes a
+ * Record. Kept pure + tested so the "empty vs malformed" distinction the save
+ * handler relies on can't silently drift.
+ *
+ * @module components/dashboard/otel-settings/parse-headers
+ */
+
+/**
+ * Parse the raw headers textarea value into a Record<string, string>.
+ *
+ * Returns an empty object for both an empty input and a parse error. Callers
+ * distinguish the two by checking whether the raw string was non-empty: a
+ * non-empty raw string that yields `{}` means malformed JSON (surfaced as a
+ * validation error), whereas an empty raw string legitimately means "no
+ * headers".
+ *
+ * @param raw - The textarea contents.
+ * @returns Parsed headers, or `{}` when empty or malformed.
+ */
+export function parseHeaders(raw: string): Record<string, string> {
+  if (!raw.trim()) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>;
+    }
+  } catch {
+    // Malformed JSON — validation surfaces this to the user.
+  }
+  return {};
+}

--- a/packages/styrby-web/src/components/dashboard/otel-settings/useOtelSettings.ts
+++ b/packages/styrby-web/src/components/dashboard/otel-settings/useOtelSettings.ts
@@ -1,0 +1,174 @@
+/**
+ * useOtelSettings — form state + save/copy/preset logic for the OTEL panel.
+ *
+ * Extracted from otel-settings.tsx (Cluster A2 split). Owns the config form
+ * state, the Supabase upsert, the preset application, and the env-var clipboard
+ * copy. The component consumes the returned state and only renders.
+ *
+ * @module components/dashboard/otel-settings/useOtelSettings
+ */
+
+import { useState, useCallback } from 'react';
+import {
+  type OtelUserConfig,
+  defaultOtelConfig,
+  validateOtelConfig,
+  generateEnvVars,
+  OTEL_PRESETS,
+} from '@/lib/otel-config';
+import { createClient } from '@/lib/supabase/client';
+import { parseHeaders } from './parse-headers';
+
+/** Save-status banner shown next to the Save button. */
+export interface SaveMessage {
+  type: 'success' | 'error';
+  text: string;
+}
+
+/** State + handlers the OtelSettings panel renders with. */
+export interface UseOtelSettings {
+  config: OtelUserConfig;
+  setConfig: React.Dispatch<React.SetStateAction<OtelUserConfig>>;
+  selectedPreset: string;
+  headersRaw: string;
+  setHeadersRaw: (raw: string) => void;
+  saving: boolean;
+  saveMessage: SaveMessage | null;
+  validationErrors: Record<string, string>;
+  copied: boolean;
+  applyPreset: (presetId: string) => void;
+  handleSave: () => Promise<void>;
+  handleCopyEnvVars: () => Promise<void>;
+  envVarsPreview: string;
+  activePreset: (typeof OTEL_PRESETS)[number] | undefined;
+}
+
+/**
+ * Drive the OTEL settings form.
+ *
+ * @param initialConfig - Config loaded from the profiles row, or null.
+ * @returns Form state + handlers + computed preview.
+ */
+export function useOtelSettings(initialConfig: OtelUserConfig | null): UseOtelSettings {
+  const supabase = createClient();
+
+  const [config, setConfig] = useState<OtelUserConfig>(initialConfig ?? defaultOtelConfig());
+  const [selectedPreset, setSelectedPreset] = useState<string>('custom');
+  const [headersRaw, setHeadersRaw] = useState<string>(
+    initialConfig?.headers && Object.keys(initialConfig.headers).length > 0
+      ? JSON.stringify(initialConfig.headers, null, 2)
+      : '',
+  );
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<SaveMessage | null>(null);
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+  const [copied, setCopied] = useState(false);
+
+  /**
+   * Apply a preset template to the config form.
+   * Pre-fills the endpoint and headers when the user picks a provider.
+   *
+   * @param presetId - The preset identifier.
+   */
+  const applyPreset = useCallback((presetId: string) => {
+    const preset = OTEL_PRESETS.find((p) => p.id === presetId);
+    if (!preset) return;
+
+    setSelectedPreset(presetId);
+    setConfig((prev) => ({ ...prev, endpoint: preset.endpoint, headers: preset.headersTemplate }));
+    setHeadersRaw(
+      Object.keys(preset.headersTemplate).length > 0
+        ? JSON.stringify(preset.headersTemplate, null, 2)
+        : '',
+    );
+  }, []);
+
+  /**
+   * Validate and persist the OTEL config to Supabase.
+   *
+   * WHY: We validate client-side before saving to give instant feedback. The
+   * Supabase upsert targets the `profiles` table `otel_config` JSONB column,
+   * protected by RLS (users can only write their own row).
+   */
+  const handleSave = useCallback(async () => {
+    const parsedHeaders = parseHeaders(headersRaw);
+    const fullConfig: OtelUserConfig = { ...config, headers: parsedHeaders };
+
+    // Validate headers JSON separately (validateOtelConfig doesn't check JSON syntax).
+    // A non-empty raw string that parsed to {} means malformed JSON.
+    if (headersRaw.trim() && Object.keys(parsedHeaders).length === 0) {
+      setValidationErrors({
+        headers: 'Headers must be a valid JSON object (e.g., {"Authorization": "Bearer ..."})',
+      });
+      return;
+    }
+
+    const validation = validateOtelConfig(fullConfig);
+    if (!validation.isValid) {
+      setValidationErrors(validation.errors);
+      return;
+    }
+
+    setValidationErrors({});
+    setSaving(true);
+    setSaveMessage(null);
+
+    try {
+      const { error } = await supabase
+        .from('profiles')
+        .update({ otel_config: fullConfig })
+        .eq('id', (await supabase.auth.getUser()).data.user?.id ?? '');
+
+      if (error) throw error;
+
+      setConfig(fullConfig);
+      setSaveMessage({ type: 'success', text: 'OTEL configuration saved.' });
+    } catch (err) {
+      setSaveMessage({
+        type: 'error',
+        text: `Failed to save: ${err instanceof Error ? err.message : 'Unknown error'}`,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [config, headersRaw, supabase]);
+
+  /**
+   * Copy the generated env vars to the clipboard.
+   */
+  const handleCopyEnvVars = useCallback(async () => {
+    const parsedHeaders = parseHeaders(headersRaw);
+    const fullConfig: OtelUserConfig = { ...config, headers: parsedHeaders };
+    const envVars = generateEnvVars(fullConfig);
+
+    try {
+      await navigator.clipboard.writeText(envVars);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API not available (non-HTTPS or denied permission).
+    }
+  }, [config, headersRaw]);
+
+  // Computed preview — recomputed each render from current config + headers.
+  const parsedHeaders = parseHeaders(headersRaw);
+  const envVarsPreview = generateEnvVars({ ...config, headers: parsedHeaders });
+  const activePreset = OTEL_PRESETS.find((p) => p.id === selectedPreset);
+
+  return {
+    config,
+    setConfig,
+    selectedPreset,
+    headersRaw,
+    setHeadersRaw,
+    saving,
+    saveMessage,
+    validationErrors,
+    copied,
+    applyPreset,
+    handleSave,
+    handleCopyEnvVars,
+    envVarsPreview,
+    activePreset,
+  };
+}


### PR DESCRIPTION
## Summary
- Splits the 506-line `otel-settings.tsx` (over the 400-LOC ceiling) into a co-located `otel-settings/` directory; orchestrator down to 248 LOC. First A2 work in the **web** package.
- The OTEL domain logic was already in `lib/otel-config.ts` (tested); this is the component split. The one untested inline piece, `parseHeaders`, is now pure with **5 tests**.
- **Boy-scout fix:** the inline parser accepted a JSON array as "headers" (`typeof [] === "object"`), which passed the save-gate's `Object.keys().length` check with bogus data. `parseHeaders` now rejects arrays + primitives; tested.
- Public API unchanged: orchestrator keeps `OtelSettings` + `OtelSettingsProps` at the same path, so the `dynamic()` import in `settings-client.tsx` and the perf-regression bundle-ratchet guard are intact.

## Changes
- `otel-settings/parse-headers.ts` - pure parser (+5 tests)
- `otel-settings/useOtelSettings.ts` - form state + handlers + preview
- `otel-settings/SettingRow.tsx` / `Toggle.tsx` - presentational primitives
- `otel-settings/EnvVarsPanel.tsx` / `MetricsReference.tsx`
- `otel-settings.tsx` - 506 → 248 LOC orchestrator

Note: `otel-settings.tsx` (file) resolves before `otel-settings/` (dir) by module-resolution file-priority - verified by a clean `next build`.

## Test Plan
- [x] web typecheck clean
- [x] web lint clean
- [x] full web suite 3910 pass (+5)
- [x] perf-regression dynamic-import guard green (bundle ratchet intact)
- [x] `next build` exit 0 (module resolution + dynamic chunk verified)
- [ ] CI passes

🤖 Shipped via /gh-ship