### PR TITLE
chore(deps): align zod on v3.25.76 across all app packages (Cluster A3)

### DIFF
--- a/packages/styrby-mobile/package.json
+++ b/packages/styrby-mobile/package.json
@@ -65,7 +65,7 @@
     "react-native-svg": "15.12.1",
     "react-native-web": "~0.21.2",
     "tailwind-merge": "^3.4.0",
-    "zod": "4.3.6"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",

--- a/packages/styrby-mobile/src/lib/schemas.ts
+++ b/packages/styrby-mobile/src/lib/schemas.ts
@@ -626,16 +626,22 @@ export type ValidatedUserTeamRow = z.infer<typeof UserTeamRowSchema>;
  * const rawRows = await supabase.from('sessions').select('*');
  * const validSessions = safeParseArray(SessionSchema, rawRows.data, 'sessions');
  */
-export function safeParseArray<T>(
-  schema: z.ZodType<T>,
+export function safeParseArray<S extends z.ZodTypeAny>(
+  schema: S,
   data: unknown[] | null | undefined,
   label: string,
-): T[] {
+): z.output<S>[] {
+  // WHY z.output<S> (not a single z.ZodType<T> param): a schema with .default()
+  // fields has divergent input/output types under zod v3 (input optional, output
+  // required once the default fills). The old z.ZodType<T> signature collapsed
+  // both to the input shape, so callers saw `field?: X | undefined` even though
+  // the parsed value is always present. Returning z.output<S> gives the post-parse
+  // (required) type every consumer actually expects.
   if (!data || !Array.isArray(data)) {
     return [];
   }
 
-  const validItems: T[] = [];
+  const validItems: z.output<S>[] = [];
 
   for (let i = 0; i < data.length; i++) {
     const result = schema.safeParse(data[i]);
@@ -669,11 +675,11 @@ export function safeParseArray<T>(
  * const alert = safeParseSingle(BudgetAlertSchema, raw.data, 'budget_alert');
  * if (!alert) return; // validation failed
  */
-export function safeParseSingle<T>(
-  schema: z.ZodType<T>,
+export function safeParseSingle<S extends z.ZodTypeAny>(
+  schema: S,
   data: unknown | null | undefined,
   label: string,
-): T | null {
+): z.output<S> | null {
   if (data == null) {
     return null;
   }

--- a/packages/styrby-web/package.json
+++ b/packages/styrby-web/package.json
@@ -62,7 +62,7 @@
     "tailwind-merge": "^2.5.5",
     "vaul": "^1.1.2",
     "web-push": "3.6.7",
-    "zod": "^3.24.1"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@asteasolutions/zod-to-openapi": "7.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,7 +221,7 @@ importers:
         version: 0.32.17(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-passkey:
         specifier: 0.3.12
-        version: 0.3.12(expo-application@55.0.14(expo@54.0.35))(expo-crypto@15.0.9(expo@54.0.35))(expo-device@8.0.10(expo@54.0.35))(expo-local-authentication@17.0.8(expo@54.0.35))(expo-secure-store@15.0.8(expo@54.0.35))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(zod@4.3.6)
+        version: 0.3.12(expo-application@55.0.14(expo@54.0.35))(expo-crypto@15.0.9(expo@54.0.35))(expo-device@8.0.10(expo@54.0.35))(expo-local-authentication@17.0.8(expo@54.0.35))(expo-secure-store@15.0.8(expo@54.0.35))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(zod@3.25.76)
       expo-router:
         specifier: ~6.0.24
         version: 6.0.24(f4a4a6e5e2f18004711bf34461d9e881)
@@ -274,8 +274,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       zod:
-        specifier: 4.3.6
-        version: 4.3.6
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@babel/core':
         specifier: ^7.25.0
@@ -552,7 +552,7 @@ importers:
         specifier: 3.6.7
         version: 3.6.7
       zod:
-        specifier: ^3.24.1
+        specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
       '@asteasolutions/zod-to-openapi':
@@ -18686,7 +18686,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -18719,7 +18719,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -18797,7 +18797,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19199,7 +19199,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-passkey@0.3.12(expo-application@55.0.14(expo@54.0.35))(expo-crypto@15.0.9(expo@54.0.35))(expo-device@8.0.10(expo@54.0.35))(expo-local-authentication@17.0.8(expo@54.0.35))(expo-secure-store@15.0.8(expo@54.0.35))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(zod@4.3.6):
+  expo-passkey@0.3.12(expo-application@55.0.14(expo@54.0.35))(expo-crypto@15.0.9(expo@54.0.35))(expo-device@8.0.10(expo@54.0.35))(expo-local-authentication@17.0.8(expo@54.0.35))(expo-secure-store@15.0.8(expo@54.0.35))(expo@54.0.35)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(zod@3.25.76):
     optionalDependencies:
       expo: 54.0.35(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@6.1.2)(@types/react@19.1.17)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-application: 55.0.14(expo@54.0.35)
@@ -19209,7 +19209,7 @@ snapshots:
       expo-secure-store: 15.0.8(expo@54.0.35)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
-      zod: 4.3.6
+      zod: 3.25.76
 
   expo-router@6.0.24(f4a4a6e5e2f18004711bf34461d9e881):
     dependencies:


### PR DESCRIPTION
## Summary
- **Aligns zod across the monorepo.** It was split across a breaking major: `styrby-mobile` pinned **v4** (`4.3.6`) while `styrby-cli`, `styrby-shared`, and `styrby-web` were all on **v3**. `styrby-shared` exports zod schemas consumed across packages, so a v3/v4 split risks two incompatible zod instances and divergent inference/error behavior.
- **Convergence direction = v3**, forced by a hard constraint: web's `@asteasolutions/zod-to-openapi@7.3.4` is zod-v3 only, so web *cannot* move to v4. Mobile uses only v3-compatible APIs (no v4-only feature), so this is an alignment, not a migration.

## Changes
- `styrby-mobile` zod `4.3.6` → `^3.25.76`
- `styrby-web` zod `^3.24.1` → `^3.25.76`
- `pnpm-lock.yaml` regenerated — all 4 app packages now resolve `zod@3.25.76`
- **Root-cause type fix** (`safeParseArray`/`safeParseSingle` in mobile `schemas.ts`): the old `<T>(schema: z.ZodType<T>): T[]` signature collapsed a schema's input + output types into one `T`. For `.default()` fields (divergent input/output under v3) it returned the *input* shape (field optional) even though `.default()` guarantees the value post-parse. Changed to `<S extends z.ZodTypeAny>(schema: S): z.output<S>[]` — returns the post-parse (required) type consumers already expected. Strictly more correct under both majors; no schema/call-site changes.

## Remaining zod@4 (isolated, never our schema code)
- `styrby-videos → @remotion/zod-types` (video rendering tooling)
- web devDeps → `eslint-plugin-react-hooks → zod-validation-error` (lint-time only)

## Test Plan
- [x] cli typecheck + 2676 tests
- [x] mobile typecheck + lint + 1753 tests + `expo export` build
- [x] web typecheck + 3917/3918 (1 pre-existing `waitFor` UI flake, passes in isolation, zero zod usage)
- [x] shared 1322 tests
- [ ] CI passes

🤖 Shipped via /gh-ship