### PR TITLE
docs(api): record ApiError envelope non-adoption decision (Cluster A4)

### DIFF
--- a/packages/styrby-shared/src/api/errors.ts
+++ b/packages/styrby-shared/src/api/errors.ts
@@ -95,6 +95,22 @@ export type ApiErrorCode = (typeof API_ERROR_CODES)[number];
  *   { status: 403 }
  * );
  * ```
+ *
+ * @remarks
+ * ADOPTION STATUS (Cluster A4 decision, 2026-06-13): this envelope is NOT yet
+ * the wire format for existing web API routes, and adopting it on one is a
+ * BREAKING CHANGE. The shipped CLI and mobile clients parse a top-level
+ * `{ error: string }` field, not this `{ code, message, timestamp }` shape:
+ *   - CLI:    cli/handlers/resume.ts (`response.error`),
+ *             commands/privacy.ts (`raw.error` for /api/account/export+delete)
+ *   - Mobile: hooks/useApiKeys.ts + useWebhooks.ts (`.error`),
+ *             lib/handle-invite-deep-link.ts (maps `body.error` -> its `code`)
+ * Each coupled route's tests already assert `data.error`, so swapping a route
+ * to this envelope (which omits `error`) breaks those clients AND their tests.
+ * Migrating is therefore a coordinated, versioned (v2) change that updates the
+ * route + CLI parser + mobile parser in lockstep - not per-route hygiene. Until
+ * then use this helper only for NEW routes with no existing client, or behind a
+ * v2 path. See styrby-backlog.md "A4 disposition".
  */
 export function apiError(
   code: ApiErrorCode | string,


### PR DESCRIPTION
## Summary
Closes out Cluster A4. The native-watcher wiring already shipped (#364); this resolves the two remaining "partials" by **evidence-based disposition**, not mechanical churn.

**ApiError envelope adoption → deferred to v2 (it's a breaking change, not hygiene).** The `apiError()` envelope is `{ code, message, timestamp }` with no top-level `error`, but the shipped CLI + mobile clients parse `{ error: string }`:
- CLI: `handlers/resume.ts` (`response.error`), `commands/privacy.ts` (`raw.error`)
- Mobile: `hooks/useApiKeys.ts` + `useWebhooks.ts` (`.error`), `lib/handle-invite-deep-link.ts` (maps `body.error` → `code`)

Each coupled route's tests **already** assert `data.error`, so the `{ error: string }` contract is already guarded — a naive per-route swap would fail those tests. Adopting the envelope is a coordinated v2 change (route + CLI + mobile in lockstep), deferred until a client needs machine codes.

This PR records that decision as an `@remarks` block on `apiError()` — the exact spot a future engineer reaches for the envelope — so it can't be adopted on a live route unknowingly. **Doc comment only, zero behavior change.**

**events-registry consumption → deferred (feature foundation, not hygiene)** — `@styrby/shared/events` has zero importers/emit sites; wiring it needs a sink (webhook/push/analytics) chosen first. Full reasoning in `styrby-backlog.md` (gitignored).

## Test Plan
- [x] shared typecheck + build clean
- [x] errors.test 10/10
- [ ] CI passes

🤖 Shipped via /gh-ship