### PR TITLE
feat(web): MCP connection-readiness on /dashboard/tools (Cluster B2b)

### DIFF
--- a/packages/styrby-web/src/app/dashboard/tools/McpConnectionStatus.tsx
+++ b/packages/styrby-web/src/app/dashboard/tools/McpConnectionStatus.tsx
@@ -1,0 +1,112 @@
+/**
+ * McpConnectionStatus — renders the user's MCP readiness checklist.
+ *
+ * Presentational. Takes the readiness computed server-side (see
+ * mcp-readiness.ts) and shows, per prerequisite, whether the user is ready and
+ * the exact command to fix any gap. This is the "authorize" half of the
+ * install flow: it tells the user whether their wired-up snippet will actually
+ * work, instead of failing silently.
+ *
+ * @module app/dashboard/tools/McpConnectionStatus
+ */
+
+import { CheckCircle2, AlertCircle, Info, MinusCircle } from 'lucide-react';
+import type { McpReadiness, McpCheck, McpCheckStatus } from './mcp-readiness';
+
+/** Visual treatment per check status. */
+const STATUS_STYLE: Record<
+  McpCheckStatus,
+  { icon: typeof CheckCircle2; iconClass: string; chip: string; chipLabel: string }
+> = {
+  ready: {
+    icon: CheckCircle2,
+    iconClass: 'text-green-400',
+    chip: 'bg-green-500/10 text-green-400 border-green-500/30',
+    chipLabel: 'Ready',
+  },
+  'action-needed': {
+    icon: AlertCircle,
+    iconClass: 'text-amber-400',
+    chip: 'bg-amber-500/10 text-amber-400 border-amber-500/30',
+    chipLabel: 'Action needed',
+  },
+  recommended: {
+    icon: Info,
+    iconClass: 'text-blue-400',
+    chip: 'bg-blue-500/10 text-blue-400 border-blue-500/30',
+    chipLabel: 'Recommended',
+  },
+  optional: {
+    icon: MinusCircle,
+    iconClass: 'text-zinc-500',
+    chip: 'bg-zinc-500/10 text-zinc-400 border-zinc-500/30',
+    chipLabel: 'Optional',
+  },
+};
+
+/** A single readiness row. */
+function CheckRow({ check }: { check: McpCheck }) {
+  const style = STATUS_STYLE[check.status];
+  const Icon = style.icon;
+
+  return (
+    <li className="flex items-start gap-3 rounded-lg border border-border/60 bg-card p-4">
+      <Icon className={`mt-0.5 h-5 w-5 shrink-0 ${style.iconClass}`} aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-sm font-semibold text-foreground">{check.label}</h3>
+          <span className={`shrink-0 rounded-full border px-2 py-0.5 text-xs ${style.chip}`}>
+            {style.chipLabel}
+          </span>
+        </div>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{check.detail}</p>
+        <p className="mt-1.5 font-mono text-[11px] text-muted-foreground/70">
+          gates {check.gates}
+        </p>
+        {check.fix && (
+          <p className="mt-2 text-xs text-foreground">
+            Fix:{' '}
+            <code className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-amber-300">
+              {check.fix}
+            </code>
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Render the MCP connection readiness panel.
+ *
+ * @param props.readiness - Readiness computed by {@link computeMcpReadiness}.
+ */
+export function McpConnectionStatus({ readiness }: { readiness: McpReadiness }) {
+  const connected = readiness.overall === 'ready';
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-card/60 p-5">
+      <div className="flex items-center gap-2">
+        {connected ? (
+          <CheckCircle2 className="h-5 w-5 text-green-400" aria-hidden="true" />
+        ) : (
+          <AlertCircle className="h-5 w-5 text-amber-400" aria-hidden="true" />
+        )}
+        <h3 className="text-sm font-semibold text-foreground">
+          {connected ? 'Your MCP server is ready to serve tools' : 'Finish connecting your MCP server'}
+        </h3>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {connected
+          ? 'Once your agent spawns the snippet below, these tools are callable.'
+          : 'The snippet below will not work until the action-needed item is resolved.'}
+      </p>
+
+      <ul className="mt-4 space-y-2">
+        {readiness.checks.map((check) => (
+          <CheckRow key={check.id} check={check} />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/styrby-web/src/app/dashboard/tools/__tests__/mcp-readiness.test.ts
+++ b/packages/styrby-web/src/app/dashboard/tools/__tests__/mcp-readiness.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for computeMcpReadiness (Cluster B2b).
+ *
+ * The readiness logic decides whether a user's wired-up MCP snippet will work
+ * and what to do about each gap. Pinning it here keeps the "machine is the only
+ * hard gate" rule and the per-tool gating from drifting.
+ *
+ * @module app/dashboard/tools/__tests__/mcp-readiness
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeMcpReadiness } from '../mcp-readiness';
+
+describe('computeMcpReadiness', () => {
+  it('is not-connected and flags the CLI when no machine is registered', () => {
+    const r = computeMcpReadiness({
+      machineCount: 0,
+      hasOnlineMachine: false,
+      deviceTokenCount: 0,
+      hasTeam: false,
+    });
+    expect(r.overall).toBe('not-connected');
+    const cli = r.checks.find((c) => c.id === 'cli')!;
+    expect(cli.status).toBe('action-needed');
+    expect(cli.fix).toBe('styrby onboard');
+  });
+
+  it('is ready once at least one machine exists', () => {
+    const r = computeMcpReadiness({
+      machineCount: 1,
+      hasOnlineMachine: false,
+      deviceTokenCount: 0,
+      hasTeam: false,
+    });
+    expect(r.overall).toBe('ready');
+    expect(r.checks.find((c) => c.id === 'cli')!.status).toBe('ready');
+  });
+
+  it('reflects online vs offline machine in the CLI detail', () => {
+    const online = computeMcpReadiness({ machineCount: 2, hasOnlineMachine: true, deviceTokenCount: 0, hasTeam: false });
+    const offline = computeMcpReadiness({ machineCount: 2, hasOnlineMachine: false, deviceTokenCount: 0, hasTeam: false });
+    expect(online.checks.find((c) => c.id === 'cli')!.detail).toMatch(/online/i);
+    expect(offline.checks.find((c) => c.id === 'cli')!.detail).toMatch(/none currently online/i);
+  });
+
+  it('marks approvals recommended (not blocking) without a push device', () => {
+    const r = computeMcpReadiness({ machineCount: 1, hasOnlineMachine: true, deviceTokenCount: 0, hasTeam: false });
+    const approvals = r.checks.find((c) => c.id === 'approvals')!;
+    expect(approvals.status).toBe('recommended');
+    expect(r.overall).toBe('ready'); // soft gap does not block overall
+  });
+
+  it('marks approvals ready with a push device', () => {
+    const r = computeMcpReadiness({ machineCount: 1, hasOnlineMachine: true, deviceTokenCount: 3, hasTeam: false });
+    const approvals = r.checks.find((c) => c.id === 'approvals')!;
+    expect(approvals.status).toBe('ready');
+    expect(approvals.detail).toMatch(/3 devices/);
+  });
+
+  it('marks team policy optional off a team, ready on a team', () => {
+    const off = computeMcpReadiness({ machineCount: 1, hasOnlineMachine: true, deviceTokenCount: 0, hasTeam: false });
+    const on = computeMcpReadiness({ machineCount: 1, hasOnlineMachine: true, deviceTokenCount: 0, hasTeam: true });
+    expect(off.checks.find((c) => c.id === 'team-policy')!.status).toBe('optional');
+    expect(on.checks.find((c) => c.id === 'team-policy')!.status).toBe('ready');
+  });
+
+  it('pins singular/plural grammar for one machine', () => {
+    const r = computeMcpReadiness({ machineCount: 1, hasOnlineMachine: true, deviceTokenCount: 0, hasTeam: false });
+    expect(r.checks.find((c) => c.id === 'cli')!.detail).toMatch(/1 machine /);
+  });
+
+  it('always returns the three checks gating the three GA tools', () => {
+    const r = computeMcpReadiness({ machineCount: 1, hasOnlineMachine: true, deviceTokenCount: 1, hasTeam: true });
+    expect(r.checks.map((c) => c.id).sort()).toEqual(['approvals', 'cli', 'team-policy']);
+    expect(r.checks.find((c) => c.id === 'approvals')!.gates).toBe('request_approval');
+    expect(r.checks.find((c) => c.id === 'team-policy')!.gates).toBe('get_team_policy');
+  });
+});

--- a/packages/styrby-web/src/app/dashboard/tools/__tests__/tools-registry.test.tsx
+++ b/packages/styrby-web/src/app/dashboard/tools/__tests__/tools-registry.test.tsx
@@ -13,6 +13,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ToolsRegistry } from '../tools-registry';
+import { computeMcpReadiness } from '../mcp-readiness';
+
+// A "fully connected" readiness so the registry renders without action banners
+// in the catalog-focused tests below.
+const readiness = computeMcpReadiness({
+  machineCount: 2,
+  hasOnlineMachine: true,
+  deviceTokenCount: 1,
+  hasTeam: true,
+});
 
 describe('ToolsRegistry', () => {
   beforeEach(() => {
@@ -25,12 +35,12 @@ describe('ToolsRegistry', () => {
   });
 
   it('renders the page header with MCP Tools title', () => {
-    render(<ToolsRegistry />);
+    render(<ToolsRegistry readiness={readiness} />);
     expect(screen.getByRole('heading', { name: /mcp tools/i, level: 1 })).toBeTruthy();
   });
 
   it('shows the GA request_approval tool prominently', () => {
-    render(<ToolsRegistry />);
+    render(<ToolsRegistry readiness={readiness} />);
     // Both the human title and the snake_case tool name should appear
     expect(screen.getByText('Request human approval')).toBeTruthy();
     // request_approval may appear in multiple places - just need at least one match
@@ -39,20 +49,20 @@ describe('ToolsRegistry', () => {
   });
 
   it('shows planned tools in a separate section', () => {
-    render(<ToolsRegistry />);
+    render(<ToolsRegistry readiness={readiness} />);
     expect(screen.getByText(/look up team policy/i)).toBeTruthy();
     expect(screen.getByText(/write to audit log/i)).toBeTruthy();
   });
 
   it('includes the setup snippet with styrby mcp serve command', () => {
-    render(<ToolsRegistry />);
+    render(<ToolsRegistry readiness={readiness} />);
     // Snippet uses literal text - search for unique strings
     expect(screen.getByText(/mcpServers/)).toBeTruthy();
     expect(screen.getByText(/"command": "styrby"/)).toBeTruthy();
   });
 
   it('copy button writes snippet to clipboard and shows confirmation', async () => {
-    render(<ToolsRegistry />);
+    render(<ToolsRegistry readiness={readiness} />);
     const copyButton = screen.getByRole('button', { name: /copy setup snippet/i });
 
     fireEvent.click(copyButton);
@@ -70,10 +80,28 @@ describe('ToolsRegistry', () => {
   });
 
   it('links to the modelcontextprotocol.io docs', () => {
-    render(<ToolsRegistry />);
+    render(<ToolsRegistry readiness={readiness} />);
     const link = screen.getByRole('link', { name: /learn about model context protocol/i });
     expect(link.getAttribute('href')).toBe('https://modelcontextprotocol.io');
     expect(link.getAttribute('target')).toBe('_blank');
     expect(link.getAttribute('rel')).toContain('noopener');
+  });
+
+  it('shows the ready connection banner when the user has a machine', () => {
+    render(<ToolsRegistry readiness={readiness} />);
+    expect(screen.getByText(/your mcp server is ready to serve tools/i)).toBeTruthy();
+  });
+
+  it('surfaces the onboard fix command when no machine is registered', () => {
+    const notConnected = computeMcpReadiness({
+      machineCount: 0,
+      hasOnlineMachine: false,
+      deviceTokenCount: 0,
+      hasTeam: false,
+    });
+    render(<ToolsRegistry readiness={notConnected} />);
+    expect(screen.getByText(/finish connecting your mcp server/i)).toBeTruthy();
+    // The exact CLI command to fix the hard requirement must be shown verbatim.
+    expect(screen.getByText('styrby onboard')).toBeTruthy();
   });
 });

--- a/packages/styrby-web/src/app/dashboard/tools/mcp-readiness.ts
+++ b/packages/styrby-web/src/app/dashboard/tools/mcp-readiness.ts
@@ -1,0 +1,136 @@
+/**
+ * MCP connection-readiness computation.
+ *
+ * The `/dashboard/tools` page shows a generic `styrby mcp serve` snippet, but
+ * the MCP server has real prerequisites: `styrby mcp serve` refuses to start
+ * unless the user has onboarded AND registered a machine, and its tools call
+ * back into Styrby as the user. A user who wires the snippet without those
+ * prerequisites gets silently-failing tools and no explanation.
+ *
+ * This module turns the user's account state (machines, push devices, team
+ * membership) into an explicit, per-prerequisite readiness checklist with the
+ * exact command to fix each gap. Pure + tested so the logic can't drift.
+ *
+ * @module app/dashboard/tools/mcp-readiness
+ */
+
+/** Account-state inputs that determine MCP readiness. */
+export interface McpReadinessInput {
+  /** Number of machines registered to the user (the `styrby pair` signal). */
+  machineCount: number;
+  /** Whether at least one registered machine is currently online. */
+  hasOnlineMachine: boolean;
+  /** Number of active push devices (the mobile app, for approval delivery). */
+  deviceTokenCount: number;
+  /** Whether the user belongs to a team (gates `get_team_policy`). */
+  hasTeam: boolean;
+}
+
+/**
+ * Per-check status.
+ * - `ready`         — prerequisite satisfied.
+ * - `action-needed` — hard requirement missing; the MCP server won't work.
+ * - `recommended`   — soft gap; core works but a capability is degraded.
+ * - `optional`      — not applicable to this user's plan (informational).
+ */
+export type McpCheckStatus = 'ready' | 'action-needed' | 'recommended' | 'optional';
+
+/** A single readiness check tied to an MCP capability. */
+export interface McpCheck {
+  /** Stable identifier. */
+  id: 'cli' | 'approvals' | 'team-policy';
+  /** Short human label. */
+  label: string;
+  /** Current status. */
+  status: McpCheckStatus;
+  /** Plain-language description of the current state. */
+  detail: string;
+  /** The MCP tool(s) this prerequisite gates. */
+  gates: string;
+  /** CLI command or action to resolve a gap (omitted when `ready`/`optional`). */
+  fix?: string;
+}
+
+/** Overall readiness plus the per-check breakdown. */
+export interface McpReadiness {
+  /**
+   * `ready` once the hard requirement (a registered machine) is met — the MCP
+   * server can start and serve tools. `not-connected` otherwise.
+   */
+  overall: 'ready' | 'not-connected';
+  checks: McpCheck[];
+}
+
+/**
+ * Compute the user's MCP connection readiness.
+ *
+ * WHY the machine check is the only hard gate: `styrby mcp serve` exits early
+ * unless a machine is registered (see CLI commands/mcpServe.ts). The approval
+ * device and team membership only degrade specific tools, so they are surfaced
+ * as recommended/optional rather than blocking.
+ *
+ * @param input - The user's account state.
+ * @returns Overall readiness + per-prerequisite checks.
+ */
+export function computeMcpReadiness(input: McpReadinessInput): McpReadiness {
+  const { machineCount, hasOnlineMachine, deviceTokenCount, hasTeam } = input;
+
+  const cli: McpCheck =
+    machineCount > 0
+      ? {
+          id: 'cli',
+          label: 'CLI connected',
+          status: 'ready',
+          detail: hasOnlineMachine
+            ? `${machineCount} machine${machineCount === 1 ? '' : 's'} registered (at least one online).`
+            : `${machineCount} machine${machineCount === 1 ? '' : 's'} registered (none currently online).`,
+          gates: 'all tools',
+        }
+      : {
+          id: 'cli',
+          label: 'CLI connected',
+          status: 'action-needed',
+          detail: 'No machine registered yet. The MCP server will not start until you onboard the CLI on at least one machine.',
+          gates: 'all tools',
+          fix: 'styrby onboard',
+        };
+
+  const approvals: McpCheck =
+    deviceTokenCount > 0
+      ? {
+          id: 'approvals',
+          label: 'Mobile approvals',
+          status: 'ready',
+          detail: `${deviceTokenCount} device${deviceTokenCount === 1 ? '' : 's'} can receive approval prompts.`,
+          gates: 'request_approval',
+        }
+      : {
+          id: 'approvals',
+          label: 'Mobile approvals',
+          status: 'recommended',
+          detail: 'No mobile device linked. request_approval still works, but you will only see prompts in the web dashboard, not pushed to your phone.',
+          gates: 'request_approval',
+          fix: 'Install the Styrby mobile app and sign in',
+        };
+
+  const teamPolicy: McpCheck = hasTeam
+    ? {
+        id: 'team-policy',
+        label: 'Team policy',
+        status: 'ready',
+        detail: 'You are on a team, so get_team_policy returns the policy rules for your team.',
+        gates: 'get_team_policy',
+      }
+    : {
+        id: 'team-policy',
+        label: 'Team policy',
+        status: 'optional',
+        detail: 'Not on a team. get_team_policy returns no policy, which is expected on an individual plan.',
+        gates: 'get_team_policy',
+      };
+
+  return {
+    overall: machineCount > 0 ? 'ready' : 'not-connected',
+    checks: [cli, approvals, teamPolicy],
+  };
+}

--- a/packages/styrby-web/src/app/dashboard/tools/page.tsx
+++ b/packages/styrby-web/src/app/dashboard/tools/page.tsx
@@ -22,7 +22,10 @@
  */
 
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
 import { ToolsRegistry } from './tools-registry';
+import { computeMcpReadiness } from './mcp-readiness';
 
 export const metadata: Metadata = {
   title: 'MCP Tools | Styrby',
@@ -30,6 +33,41 @@ export const metadata: Metadata = {
     'Catalog of Model Context Protocol tools Styrby exposes to MCP-aware coding agents. Wire Styrby into Claude Code, Codex, Cursor, and more.',
 };
 
-export default function ToolsPage() {
-  return <ToolsRegistry />;
+/**
+ * MCP Tools page (server component).
+ *
+ * Computes the user's MCP connection readiness from their account state
+ * (machines, push devices, team membership) so the registry can show whether
+ * the wired-up snippet will actually work, then delegates rendering to the
+ * client {@link ToolsRegistry}.
+ */
+export default async function ToolsPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    redirect('/login');
+  }
+
+  // Readiness inputs. The machines RLS policy scopes rows to the current user
+  // automatically; team_members + device_tokens are filtered by user_id.
+  const [machinesResult, devicesResult, teamResult] = await Promise.all([
+    supabase.from('machines').select('id, is_online'),
+    supabase.from('device_tokens').select('id').eq('user_id', user.id).eq('is_active', true),
+    supabase.from('team_members').select('team_id').eq('user_id', user.id).limit(1).maybeSingle(),
+  ]);
+
+  const machines = machinesResult.data ?? [];
+  const readiness = computeMcpReadiness({
+    machineCount: machines.length,
+    hasOnlineMachine: machines.some((m) => m.is_online === true),
+    deviceTokenCount: devicesResult.data?.length ?? 0,
+    hasTeam: Boolean(teamResult.data?.team_id),
+  });
+
+  return <ToolsRegistry readiness={readiness} />;
 }

--- a/packages/styrby-web/src/app/dashboard/tools/tools-registry.tsx
+++ b/packages/styrby-web/src/app/dashboard/tools/tools-registry.tsx
@@ -21,6 +21,8 @@ import {
   type MCPToolDescriptor,
   type MCPToolStatus,
 } from '@styrby/shared';
+import { McpConnectionStatus } from './McpConnectionStatus';
+import type { McpReadiness } from './mcp-readiness';
 import {
   KeyRound,
   ShieldCheck,
@@ -192,7 +194,7 @@ function SetupSnippet() {
  * Top-level registry view: header, setup instructions, GA tools, planned
  * tools (collapsed by default).
  */
-export function ToolsRegistry() {
+export function ToolsRegistry({ readiness }: { readiness: McpReadiness }) {
   const { gaTools, plannedTools } = useMemo(() => {
     return {
       gaTools: STYRBY_MCP_TOOLS.filter((t) => t.status === 'ga' || t.status === 'beta'),
@@ -216,10 +218,24 @@ export function ToolsRegistry() {
         </p>
       </header>
 
+      {/* Connection readiness */}
+      <section aria-labelledby="status-heading">
+        <h2 id="status-heading" className="text-sm font-semibold text-foreground">
+          1. Check your connection
+        </h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Whether the snippet below actually works depends on your account state.
+          Here is what is ready and what needs action.
+        </p>
+        <div className="mt-3">
+          <McpConnectionStatus readiness={readiness} />
+        </div>
+      </section>
+
       {/* Setup snippet */}
       <section aria-labelledby="setup-heading">
         <h2 id="setup-heading" className="text-sm font-semibold text-foreground">
-          1. Add Styrby to your agent&apos;s MCP config
+          2. Add Styrby to your agent&apos;s MCP config
         </h2>
         <p className="mt-1 text-xs text-muted-foreground">
           Drop this into <code className="rounded bg-zinc-800 px-1 py-0.5">.mcp.json</code>{' '}
@@ -233,7 +249,7 @@ export function ToolsRegistry() {
       {/* Available tools */}
       <section aria-labelledby="ga-heading">
         <h2 id="ga-heading" className="text-sm font-semibold text-foreground">
-          2. Available tools ({gaTools.length})
+          3. Available tools ({gaTools.length})
         </h2>
         <p className="mt-1 text-xs text-muted-foreground">
           Your agents can call these the moment Styrby&apos;s MCP server is
@@ -250,7 +266,7 @@ export function ToolsRegistry() {
       {plannedTools.length > 0 && (
         <section aria-labelledby="planned-heading">
           <h2 id="planned-heading" className="text-sm font-semibold text-foreground">
-            3. Planned ({plannedTools.length})
+            4. Planned ({plannedTools.length})
           </h2>
           <p className="mt-1 text-xs text-muted-foreground">
             Roadmap items shipping in 0.4. Listed for transparency.


### PR DESCRIPTION
## Summary
Completes the MCP install flow with its missing **authorize** half. The `/dashboard/tools` page had a copy-paste `styrby mcp serve` snippet but no signal whether it will actually work for the user. `styrby mcp serve` refuses to start without a registered machine, and its tools call back into Styrby as the user — so a user who pastes the snippet without onboarding gets silently-failing tools and no explanation.

Adds a **connection-readiness checklist** computed from the user's real account state (machines, active push devices, team membership), with the exact CLI command to fix each gap.

## Changes
- `mcp-readiness.ts` (NEW, pure + tested) — `computeMcpReadiness()` → per-prerequisite status + fix. The registered-machine check is the only **hard** gate (matches `mcpServe.ts`, which exits without one); approvals/team are recommended/optional so they inform without false-blocking.
- `McpConnectionStatus.tsx` (NEW) — presentational checklist with status chips + fix commands.
- `page.tsx` — now a data-fetching server component (machines/device_tokens/team_members, RLS + user_id scoped) → computes readiness → `ToolsRegistry`.
- `tools-registry.tsx` — takes `readiness`, renders status as step 1 (snippet/tools/planned renumbered 2/3/4).

**Scope:** deliberately Styrby's own MCP server only — **not** the Phase-4 third-party marketplace (still deferred). No new mutable state; reads existing tables.

## Test Plan
- [x] web typecheck + lint clean
- [x] tools tests 16 (8 readiness + 8 registry incl 2 new section tests)
- [x] full web suite 3928 pass (+10)
- [x] `next build` exit 0
- [ ] CI passes

🤖 Shipped via /gh-ship