### PR TITLE
feat(analytics): cookieless PostHog product analytics (web) — Cluster B1 PR1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,22 +182,24 @@ SENTRY_AUTH_TOKEN=
 
 
 # ============================================================================
-# POST-MVP: POSTHOG (Product Analytics)
+# POSTHOG (Product Analytics) - Cluster B1
 # ============================================================================
-# Deferred to post-MVP (Key Decision #8). NOT required for launch.
-# These entries are kept for future use — do not set them until PostHog is integrated.
+# Cookieless + identified-only product analytics. The key is the PUBLIC
+# project ingestion key (phc_...) - safe to expose to the browser/app.
+# Leave unset to disable analytics entirely (the SDK wrapper no-ops).
 #
-# For user behavior tracking, feature flags, funnels.
-# Get from: https://app.posthog.com > Project Settings > Project API Key
+# Get from: PostHog > Project Settings > Project API Key.
+# Host: US cloud ingestion endpoint is https://us.i.posthog.com
+#       (EU cloud would be https://eu.i.posthog.com).
 # ============================================================================
 
 # Used by: packages/styrby-web (web dashboard analytics)
 NEXT_PUBLIC_POSTHOG_KEY=phc_xxx
-NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # Used by: packages/styrby-mobile (mobile app analytics)
 EXPO_PUBLIC_POSTHOG_KEY=phc_xxx
-EXPO_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+EXPO_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 
 # ============================================================================

--- a/packages/styrby-shared/src/analytics/__tests__/events.test.ts
+++ b/packages/styrby-shared/src/analytics/__tests__/events.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the product-analytics event catalog.
+ *
+ * These guard the two invariants the rest of the system relies on:
+ *  1. The product super-property is always present and correct (data from the
+ *     shared PostHog project stays filterable by product).
+ *  2. Event names are unique and stable (a duplicate value would silently
+ *     merge two distinct user actions into one funnel step).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ANALYTICS_EVENTS,
+  PRODUCT_TAG,
+  PRODUCT_PROPERTY_KEY,
+  withProduct,
+} from '../events.js';
+
+describe('analytics events catalog', () => {
+  it('tags Styrby as the product', () => {
+    expect(PRODUCT_TAG).toBe('styrby');
+    expect(PRODUCT_PROPERTY_KEY).toBe('product');
+  });
+
+  it('has no duplicate event-name values', () => {
+    const values = Object.values(ANALYTICS_EVENTS);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it('uses snake_case for every event name', () => {
+    for (const name of Object.values(ANALYTICS_EVENTS)) {
+      expect(name).toMatch(/^[a-z][a-z0-9]*(_[a-z0-9]+)*$/);
+    }
+  });
+});
+
+describe('withProduct', () => {
+  it('always stamps the product tag, even with no props', () => {
+    expect(withProduct()).toEqual({ product: 'styrby' });
+  });
+
+  it('merges caller props alongside the product tag', () => {
+    expect(withProduct({ to_tier: 'growth' })).toEqual({
+      product: 'styrby',
+      to_tier: 'growth',
+    });
+  });
+
+  it('forces product to the tag even if a caller tries to override it', () => {
+    // A caller passing product: 'kaulby' must not be able to mislabel a
+    // Styrby event - the tag is forced last so the shared project stays clean.
+    expect(withProduct({ product: 'kaulby' }).product).toBe('styrby');
+  });
+});

--- a/packages/styrby-shared/src/analytics/events.ts
+++ b/packages/styrby-shared/src/analytics/events.ts
@@ -1,0 +1,119 @@
+/**
+ * Product-analytics event catalog (Cluster B1).
+ *
+ * Single source of truth for every PostHog product-analytics event name that
+ * styrby-web and styrby-mobile emit. Centralising the catalog here (rather
+ * than scattering string literals across components) means:
+ *
+ *  1. Web and mobile can never drift on an event name - both import the same
+ *     constant, so `dashboard_viewed` is spelled identically everywhere.
+ *  2. A single grep enumerates the entire analytics surface.
+ *  3. The `AnalyticsEventName` union gives compile-time safety at every
+ *     `capture()` call site - a typo is a type error, not a silently-dropped
+ *     event that only shows up as a gap in a funnel weeks later.
+ *
+ * WHY this is separate from `events/registry.ts`: that registry models
+ * *outbound domain events* (session.created -> webhooks/realtime) for SOC2
+ * audit. This file models *product-analytics events* (what the user did) for
+ * PostHog. Different consumers, different lifecycle - deliberately decoupled
+ * so the compliance log is never tangled with growth metrics.
+ *
+ * @module analytics/events
+ */
+
+/**
+ * Super-property stamped on every Styrby analytics event.
+ *
+ * WHY: the PostHog project ("Styrby-App") is shared with a sibling product on
+ * the free tier, which caps projects per organization. Tagging every event
+ * with `product: 'styrby'` keeps the two products' data cleanly filterable in
+ * every insight, funnel, and cohort. It also future-proofs a migration: if we
+ * later split to a dedicated project, swapping the ingestion key is the only
+ * change - the events already carry their product origin.
+ */
+export const PRODUCT_TAG = 'styrby' as const;
+
+/** The key under which {@link PRODUCT_TAG} is registered as a super-property. */
+export const PRODUCT_PROPERTY_KEY = 'product' as const;
+
+/**
+ * Curated catalog of product-analytics events.
+ *
+ * Keys are SCREAMING_SNAKE semantic identifiers used in code; values are the
+ * snake_case event names PostHog stores. Keep this list intentional - every
+ * entry should answer a real product question. Add events as flows are
+ * instrumented; do not pre-register events that nothing emits yet.
+ */
+export const ANALYTICS_EVENTS = {
+  // --- Navigation / page views (custom, in addition to PostHog $pageview) ---
+  /** Dashboard home opened. */
+  DASHBOARD_VIEWED: 'dashboard_viewed',
+  /** Sessions list opened. */
+  SESSIONS_VIEWED: 'sessions_viewed',
+  /** A single session detail opened. */
+  SESSION_VIEWED: 'session_viewed',
+  /** Costs / analytics page opened. */
+  COSTS_VIEWED: 'costs_viewed',
+  /** Team management page opened. */
+  TEAM_VIEWED: 'team_viewed',
+  /** Tools / MCP registry page opened. */
+  TOOLS_VIEWED: 'tools_viewed',
+  /** Settings page opened. */
+  SETTINGS_VIEWED: 'settings_viewed',
+  /** Public pricing page opened. */
+  PRICING_VIEWED: 'pricing_viewed',
+
+  // --- Conversion / monetization ---
+  /** User clicked an upgrade CTA (carries `from_tier` / `to_tier`). */
+  PLAN_UPGRADE_CLICKED: 'plan_upgrade_clicked',
+  /** Checkout flow entered. */
+  CHECKOUT_STARTED: 'checkout_started',
+
+  // --- Team collaboration ---
+  /** A team member invite was sent. */
+  MEMBER_INVITED: 'member_invited',
+
+  // --- Tools / MCP ---
+  /** An MCP server config snippet was copied. */
+  MCP_CONFIG_COPIED: 'mcp_config_copied',
+
+  // --- Auth lifecycle ---
+  /** Signup flow started. */
+  SIGNUP_STARTED: 'signup_started',
+  /** Login flow started. */
+  LOGIN_STARTED: 'login_started',
+} as const;
+
+/** Union of every valid analytics event name. */
+export type AnalyticsEventName =
+  (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
+
+/**
+ * Arbitrary event properties. PostHog accepts any JSON-serialisable map;
+ * we constrain to primitives + arrays to keep payloads small and queryable.
+ */
+export type AnalyticsProperties = Record<
+  string,
+  string | number | boolean | null | undefined | string[] | number[]
+>;
+
+/**
+ * Merge caller-supplied properties with the mandatory product tag.
+ *
+ * Centralising this guarantees the `product` super-property is never
+ * forgotten on a one-off `capture()` call, even before the SDK-level
+ * super-property registration has run (e.g. the very first event in a
+ * memory-persistence session).
+ *
+ * @param props - Event-specific properties (optional).
+ * @returns A new object with `product: 'styrby'` merged in. Caller props win
+ *   only for non-`product` keys; `product` is always forced to the tag.
+ *
+ * @example
+ * capture(ANALYTICS_EVENTS.PLAN_UPGRADE_CLICKED, withProduct({ to_tier: 'growth' }));
+ */
+export function withProduct(
+  props?: AnalyticsProperties
+): AnalyticsProperties & { product: typeof PRODUCT_TAG } {
+  return { ...props, [PRODUCT_PROPERTY_KEY]: PRODUCT_TAG };
+}

--- a/packages/styrby-shared/src/analytics/index.ts
+++ b/packages/styrby-shared/src/analytics/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Analytics barrel.
+ *
+ * Product-analytics event catalog + helpers shared by styrby-web and
+ * styrby-mobile. Pure data and pure functions only - no SDK, no platform
+ * code - so it is safe to re-export from the package root without pulling
+ * any weight into consumer bundles.
+ *
+ * @module analytics
+ */
+
+export * from './events.js';

--- a/packages/styrby-shared/src/index.ts
+++ b/packages/styrby-shared/src/index.ts
@@ -48,6 +48,10 @@ export * from './api/index.js';
 export * from './events/index.js';
 export * from './hooks/index.js';
 
+// Cluster B1 — product-analytics catalog (event names + product tag + helpers).
+// Safe to barrel: pure data + pure functions, no SDK, zero bundle weight.
+export * from './analytics/index.js';
+
 // Phase 1.1 — honest token counting (lazy-loads anthropic/openai tokenizers
 // when present, falls back to the words*1.3 heuristic everywhere else).
 export * from './tokenizers/index.js';

--- a/packages/styrby-web/.env.example
+++ b/packages/styrby-web/.env.example
@@ -88,3 +88,10 @@ STYRBY_WEBHOOK_SECRET=your-webhook-secret
 # legitimate users from CLI auth.
 # Default behaviour (unset or any non-'false' value): enforcement enabled.
 EXCHANGE_REQUIRE_AAL2_IF_ENROLLED=true
+
+# ─── PostHog product analytics (Cluster B1) ───────────────────────────────
+# Cookieless + identified-only. PUBLIC project ingestion key (phc_...).
+# Leave unset to disable analytics (the SDK wrapper no-ops). US cloud host
+# is https://us.i.posthog.com.
+NEXT_PUBLIC_POSTHOG_KEY=phc_xxx
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/packages/styrby-web/package.json
+++ b/packages/styrby-web/package.json
@@ -50,6 +50,7 @@
     "lucide-react": "^0.563.0",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
+    "posthog-js": "1.386.8",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/styrby-web/src/app/dashboard/layout.tsx
+++ b/packages/styrby-web/src/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ import { DashboardShell } from './dashboard-shell';
 import { PlanCheckout } from './plan-checkout';
 import { getOnboardingState } from '@/lib/onboarding';
 import { PWAInstallPrompt } from '@/components/pwa-install-prompt';
+import { AnalyticsIdentify } from '@/components/providers/analytics-identify';
 
 /**
  * Prevents all dashboard routes from being indexed by search engines.
@@ -51,6 +52,7 @@ export default async function DashboardLayout({
 
   return (
     <DashboardShell onboardingState={onboardingState.isComplete ? undefined : onboardingState}>
+      <AnalyticsIdentify userId={user.id} />
       <Suspense>
         <PlanCheckout />
       </Suspense>

--- a/packages/styrby-web/src/app/layout.tsx
+++ b/packages/styrby-web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { CookieConsent } from '@/components/cookie-consent';
 import { SWRegister } from '@/components/sw-register';
+import { PostHogProvider } from '@/components/providers/posthog-provider';
 
 /**
  * WHY Outfit: geometric sans-serif with tight tracking and optical weight that
@@ -136,9 +137,11 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          {children}
-          <CookieConsent />
-          <SWRegister />
+          <PostHogProvider>
+            {children}
+            <CookieConsent />
+            <SWRegister />
+          </PostHogProvider>
         </ThemeProvider>
         <Toaster
           position="bottom-right"

--- a/packages/styrby-web/src/app/privacy/page.tsx
+++ b/packages/styrby-web/src/app/privacy/page.tsx
@@ -171,9 +171,12 @@ export default function PrivacyPolicyPage() {
           <h3 className="scroll-mt-20" id="what-we-do-not-collect">What We Do Not Collect</h3>
           <ul>
             <li>
-              We do not use analytics services (no Mixpanel, Amplitude,
-              Segment, Google Analytics, or similar). We do not track your
-              behavior across the app.
+              We do not use advertising or cross-site tracking networks (no
+              Google Analytics, no ad pixels, no Segment). We do not track you
+              across other websites, and we never sell or share your behavioral
+              data. We use a single privacy-preserving product-analytics tool,
+              configured cookielessly - see{' '}
+              <a href="#product-analytics">Product Analytics</a> below.
             </li>
             <li>
               We do not collect your AI API keys or credentials. You configure
@@ -220,12 +223,44 @@ export default function PrivacyPolicyPage() {
             purposes.
           </p>
 
+          {/* ── Product Analytics ─────────────────────────────── */}
+          <h2 className="scroll-mt-20" id="product-analytics">Product Analytics</h2>
+
+          <p>
+            We use PostHog to understand which features are used and where the
+            product can improve. We configure it to be privacy-preserving:
+          </p>
+
+          <ul>
+            <li>
+              <strong>Cookieless</strong>: PostHog is run in memory-only mode -
+              it sets no cookies and writes nothing to your browser&apos;s
+              storage. This is why we can still say we use no analytics cookies.
+            </li>
+            <li>
+              <strong>No anonymous profiles</strong>: visitors who are not
+              logged in are counted only in aggregate (for example, page views);
+              we do not build a profile of an anonymous visitor.
+            </li>
+            <li>
+              <strong>Logged-in usage</strong>: when you are signed in, product
+              events (such as which dashboard pages you open) are associated
+              with your account id so we can measure real product usage. We do
+              not record the contents of your AI sessions.
+            </li>
+            <li>
+              <strong>No cross-site tracking</strong>: PostHog here cannot follow
+              you to other websites.
+            </li>
+          </ul>
+
           {/* ── Cookies ───────────────────────────────────────── */}
           <h2 className="scroll-mt-20" id="3-cookies">3. Cookies</h2>
 
           <p>
             Styrby uses only two cookies. No tracking cookies. No analytics
-            cookies. No third-party advertising cookies.
+            cookies. No third-party advertising cookies. (Our product analytics
+            is cookieless - see <a href="#product-analytics">Product Analytics</a>.)
           </p>
 
           <ul>

--- a/packages/styrby-web/src/components/providers/analytics-identify.tsx
+++ b/packages/styrby-web/src/components/providers/analytics-identify.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+/**
+ * Authenticated-user analytics identifier (Cluster B1).
+ *
+ * Bridges the server-verified Supabase user id into client-side PostHog. The
+ * dashboard layout already does the authoritative `getUser()` on the server;
+ * this client component receives that id as a prop and calls `identifyUser`,
+ * which is what makes authenticated product analytics work fully under
+ * cookieless persistence (identity comes from the DB, not a cookie).
+ *
+ * Renders nothing. Mounted inside the dashboard layout where a user is
+ * guaranteed to exist.
+ *
+ * @module components/providers/analytics-identify
+ */
+
+import { useEffect } from 'react';
+import { identifyUser } from '@/lib/analytics/posthog';
+
+/**
+ * @param userId - The authenticated Supabase user id (PostHog distinct_id).
+ */
+export function AnalyticsIdentify({ userId }: { userId: string }) {
+  useEffect(() => {
+    identifyUser(userId);
+  }, [userId]);
+
+  return null;
+}

--- a/packages/styrby-web/src/components/providers/posthog-provider.tsx
+++ b/packages/styrby-web/src/components/providers/posthog-provider.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+/**
+ * PostHog analytics provider (Cluster B1).
+ *
+ * Initialises cookieless PostHog once on mount and captures a `$pageview` on
+ * every App Router navigation. Renders nothing visible - it's a behavioural
+ * wrapper mounted high in the tree.
+ *
+ * WHY a manual pageview tracker (not the SDK's autocapture): Next's App Router
+ * does client-side navigation that the SDK's history-API hook double-counts
+ * and mistimes. Subscribing to `usePathname` / `useSearchParams` gives one
+ * accurate pageview per route change. `useSearchParams` requires a Suspense
+ * boundary, so the tracker is isolated in its own Suspense-wrapped component.
+ *
+ * @module components/providers/posthog-provider
+ */
+
+import { Suspense, useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { initAnalytics, capturePageview } from '@/lib/analytics/posthog';
+
+/**
+ * Fires one `$pageview` per route change. Isolated so the `useSearchParams`
+ * Suspense requirement doesn't suspend the whole app.
+ */
+function PageviewTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!pathname) return;
+    const query = searchParams?.toString();
+    const url = query ? `${pathname}?${query}` : pathname;
+    capturePageview(url);
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+/**
+ * Mounts analytics. Wrap the app once (in the root layout). No-ops entirely
+ * when no PostHog key is configured, so local dev without a key is unaffected.
+ *
+ * @param children - The app tree. Rendered unchanged.
+ */
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <PageviewTracker />
+      </Suspense>
+      {children}
+    </>
+  );
+}

--- a/packages/styrby-web/src/lib/analytics/__tests__/posthog.test.ts
+++ b/packages/styrby-web/src/lib/analytics/__tests__/posthog.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the web PostHog wrapper.
+ *
+ * The wrapper's contract is: no-op safely when disabled, and when enabled,
+ * lazy-load + initialise cookielessly + identified-only and stamp the product
+ * tag on every event. These tests pin that contract so a future refactor can't
+ * silently start setting cookies, drop the product tag, or pull the SDK back
+ * into the first-load bundle (the lazy `import()` is load-bearing for bundle size).
+ *
+ * The module reads NEXT_PUBLIC_POSTHOG_KEY at import time, so each test resets
+ * modules and re-imports under a stubbed env. Calls flush asynchronously
+ * (behind the dynamic import), so assertions use `vi.waitFor`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the posthog-js singleton (resolved via dynamic import in the wrapper).
+// The `loaded` callback is invoked with this same mock so we can assert the
+// super-property registration.
+const mockPosthog = {
+  init: vi.fn(
+    (
+      _key: string,
+      opts: { loaded?: (ph: unknown) => void; [k: string]: unknown }
+    ) => {
+      opts.loaded?.(mockPosthog);
+    }
+  ),
+  capture: vi.fn(),
+  identify: vi.fn(),
+  register: vi.fn(),
+  reset: vi.fn(),
+};
+vi.mock('posthog-js', () => ({ default: mockPosthog }));
+
+// Keep shared deps deterministic (don't depend on the built dist).
+vi.mock('@styrby/shared', () => ({
+  PRODUCT_TAG: 'styrby',
+  PRODUCT_PROPERTY_KEY: 'product',
+  withProduct: (p?: Record<string, unknown>) => ({ ...p, product: 'styrby' }),
+}));
+
+async function loadModule() {
+  vi.resetModules();
+  return import('../posthog.js');
+}
+
+/** Let any queued microtasks (the dynamic-import .then chain) settle. */
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('when no PostHog key is configured', () => {
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', '');
+  });
+
+  it('reports analytics disabled and never initialises', async () => {
+    const m = await loadModule();
+    expect(m.isAnalyticsEnabled()).toBe(false);
+    m.initAnalytics();
+    await flush();
+    expect(mockPosthog.init).not.toHaveBeenCalled();
+  });
+
+  it('no-ops capture and identify', async () => {
+    const m = await loadModule();
+    m.capture('dashboard_viewed' as never);
+    m.identifyUser('user-123');
+    await flush();
+    expect(mockPosthog.capture).not.toHaveBeenCalled();
+    expect(mockPosthog.identify).not.toHaveBeenCalled();
+  });
+});
+
+describe('when a PostHog key is configured', () => {
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'phc_test_key');
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_HOST', 'https://us.i.posthog.com');
+  });
+
+  it('lazily initialises cookielessly + identified-only and registers the product tag', async () => {
+    const m = await loadModule();
+    m.initAnalytics();
+    await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalledTimes(1));
+    const opts = mockPosthog.init.mock.calls[0][1];
+    expect(opts.persistence).toBe('memory');
+    expect(opts.person_profiles).toBe('identified_only');
+    expect(opts.capture_pageview).toBe(false);
+    expect(opts.api_host).toBe('https://us.i.posthog.com');
+    // loaded() ran and stamped the product super-property
+    expect(mockPosthog.register).toHaveBeenCalledWith({ product: 'styrby' });
+  });
+
+  it('only initialises once even if called repeatedly', async () => {
+    const m = await loadModule();
+    m.initAnalytics();
+    m.initAnalytics();
+    m.initAnalytics();
+    await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalledTimes(1));
+    await flush();
+    expect(mockPosthog.init).toHaveBeenCalledTimes(1);
+  });
+
+  it('stamps the product tag on captured events', async () => {
+    const m = await loadModule();
+    m.capture('plan_upgrade_clicked' as never, { to_tier: 'growth' });
+    await vi.waitFor(() =>
+      expect(mockPosthog.capture).toHaveBeenCalledWith('plan_upgrade_clicked', {
+        to_tier: 'growth',
+        product: 'styrby',
+      })
+    );
+  });
+
+  it('identifies by user id with the product tag', async () => {
+    const m = await loadModule();
+    m.identifyUser('user-123');
+    await vi.waitFor(() =>
+      expect(mockPosthog.identify).toHaveBeenCalledWith('user-123', {
+        product: 'styrby',
+      })
+    );
+  });
+
+  it('ignores an empty user id', async () => {
+    const m = await loadModule();
+    m.identifyUser('');
+    await flush();
+    expect(mockPosthog.identify).not.toHaveBeenCalled();
+  });
+});

--- a/packages/styrby-web/src/lib/analytics/posthog.ts
+++ b/packages/styrby-web/src/lib/analytics/posthog.ts
@@ -1,0 +1,155 @@
+/**
+ * Web PostHog client wrapper (Cluster B1).
+ *
+ * A thin, SSR-safe, lazy-loaded layer over `posthog-js`. Every export is a
+ * no-op when PostHog is not configured (no key, or running on the server),
+ * so call sites never null-check - they just call `capture(...)`.
+ *
+ * WHY lazy (dynamic import): the full `posthog-js` SDK is ~100KB gzipped.
+ * Statically importing it would push it into the route's first-load JS and
+ * blow the bundle-size budget (and hurt first paint). Analytics is
+ * non-critical, so we `import('posthog-js')` only after mount - webpack
+ * splits it into a separate async chunk that loads after hydration. First-load
+ * JS stays at baseline; analytics initialises a beat later.
+ *
+ * WHY a shared load-promise: because the SDK arrives asynchronously, a
+ * `capture()` fired before the chunk lands would otherwise be dropped. Every
+ * call routes through {@link ensureLoaded}, so early events queue behind the
+ * single in-flight load and flush once PostHog is ready - no race, no loss.
+ *
+ * Privacy posture (operator decision, cookieless + identified-only):
+ *  - `persistence: 'memory'` - PostHog sets NO cookies and writes NO
+ *    localStorage. Keeps the "no tracking or analytics cookies" promise true.
+ *  - `person_profiles: 'identified_only'` - profiles exist only for users we
+ *    explicitly {@link identifyUser} by their first-party Supabase id.
+ *
+ * @module lib/analytics/posthog
+ */
+
+'use client';
+
+import type { PostHog } from 'posthog-js';
+import {
+  PRODUCT_PROPERTY_KEY,
+  PRODUCT_TAG,
+  withProduct,
+  type AnalyticsEventName,
+  type AnalyticsProperties,
+} from '@styrby/shared';
+
+/**
+ * Public (client-side) PostHog ingestion key (the `phc_...` value).
+ * Absent in environments where analytics is intentionally off (wrapper
+ * then no-ops). Public by design - safe to expose to the browser.
+ */
+const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+/** PostHog ingestion host. US cloud is `us.i.posthog.com`; default when unset. */
+const POSTHOG_HOST =
+  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+
+/** Resolved SDK instance once the async chunk has loaded + initialised. */
+let phInstance: PostHog | null = null;
+
+/** Single in-flight load+init promise; also the queue behind which early calls wait. */
+let loadPromise: Promise<PostHog | null> | null = null;
+
+/**
+ * Whether analytics is active: a key is configured and we're in the browser.
+ * @returns true when `capture`/`identify` will actually reach PostHog.
+ */
+export function isAnalyticsEnabled(): boolean {
+  return Boolean(POSTHOG_KEY) && typeof window !== 'undefined';
+}
+
+/**
+ * Lazily load `posthog-js`, initialise it cookielessly, and cache the
+ * instance. Idempotent - repeated calls return the same in-flight/settled
+ * promise, so the SDK is fetched and initialised exactly once.
+ *
+ * @returns The initialised PostHog instance, or null if analytics is disabled.
+ */
+function ensureLoaded(): Promise<PostHog | null> {
+  if (!isAnalyticsEnabled()) return Promise.resolve(null);
+  if (loadPromise) return loadPromise;
+
+  loadPromise = import('posthog-js').then(({ default: posthog }) => {
+    posthog.init(POSTHOG_KEY as string, {
+      api_host: POSTHOG_HOST,
+      // Cookieless: no cookies, no localStorage. See module docblock.
+      persistence: 'memory',
+      // No anonymous person profiles - only users we explicitly identify.
+      person_profiles: 'identified_only',
+      // App Router fires its own route-change pageviews; disable the SDK's
+      // history autocapture so we don't double-count navigations.
+      capture_pageview: false,
+      // Respect Do Not Track at the SDK level as a second guard.
+      respect_dnt: true,
+      loaded: (ph) => {
+        // Stamp the product tag on every event for the shared "Styrby-App"
+        // project so Styrby data stays filterable from the sibling product.
+        ph.register({ [PRODUCT_PROPERTY_KEY]: PRODUCT_TAG });
+      },
+    });
+    phInstance = posthog;
+    return posthog;
+  });
+
+  return loadPromise;
+}
+
+/**
+ * Begin loading + initialising analytics (fire-and-forget). Call once high in
+ * the tree. No-ops when analytics is disabled.
+ */
+export function initAnalytics(): void {
+  void ensureLoaded();
+}
+
+/**
+ * Capture a product-analytics event. Queues behind the SDK load if it hasn't
+ * finished yet, so events fired early are not lost.
+ *
+ * @param event - A name from the shared {@link AnalyticsEventName} catalog.
+ * @param properties - Optional event properties; the product tag is merged in.
+ */
+export function capture(
+  event: AnalyticsEventName,
+  properties?: AnalyticsProperties
+): void {
+  void ensureLoaded().then((ph) => ph?.capture(event, withProduct(properties)));
+}
+
+/**
+ * Capture a manual pageview (App Router route change).
+ * @param url - The full URL (pathname + search) of the viewed page.
+ */
+export function capturePageview(url: string): void {
+  void ensureLoaded().then((ph) =>
+    ph?.capture('$pageview', withProduct({ $current_url: url }))
+  );
+}
+
+/**
+ * Associate subsequent events with an authenticated user, keyed by their
+ * stable Supabase id. This is what makes authenticated product analytics work
+ * fully under cookieless persistence (identity comes from the DB, not a cookie).
+ *
+ * @param userId - The Supabase `auth.users` id (used as PostHog distinct_id).
+ * @param properties - Optional person properties to set.
+ */
+export function identifyUser(
+  userId: string,
+  properties?: AnalyticsProperties
+): void {
+  if (!userId) return;
+  void ensureLoaded().then((ph) => ph?.identify(userId, withProduct(properties)));
+}
+
+/**
+ * Clear the identified user (call on sign-out) so the next session starts
+ * anonymous - prevents a just-signed-out user's events landing on their profile.
+ */
+export function resetUser(): void {
+  void ensureLoaded().then((ph) => ph?.reset());
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,13 +304,13 @@ importers:
         version: 20.51.0(@jest/environment@29.7.0)(@jest/types@29.6.3)(expect@29.7.0)(jest-environment-jsdom@29.7.0)(jest-environment-node@29.7.0)(jest@29.7.0(@types/node@22.15.35))
       eslint:
         specifier: ^9.0.0
-        version: 9.39.2(jiti@1.21.7)
+        version: 9.39.2(jiti@2.6.1)
       eslint-config-expo:
         specifier: ~10.0.0
-        version: 10.0.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 10.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
-        version: 5.2.0(eslint@9.39.2(jiti@1.21.7))
+        version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.15.35)
@@ -328,7 +328,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.30.0
-        version: 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
 
   packages/styrby-native:
     dependencies:
@@ -519,6 +519,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      posthog-js:
+        specifier: 1.386.8
+        version: 1.386.8
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.4)
@@ -600,19 +603,19 @@ importers:
         version: 3.6.4
       '@vitejs/plugin-react':
         specifier: 5.1.3
-        version: 5.1.3(vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 5.1.3(vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/coverage-v8':
         specifier: ^3.2.6
-        version: 3.2.6(vitest@3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 3.2.6(vitest@3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.24(postcss@8.5.14)
       eslint:
         specifier: ^9.18.0
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@1.21.7)
       eslint-config-next:
         specifier: ^16.2.4
-        version: 16.2.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.2.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       jsdom:
         specifier: 28.0.0
         version: 28.0.0
@@ -633,7 +636,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
       yaml:
         specifier: 2.8.4
         version: 2.8.4
@@ -3056,6 +3059,12 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@posthog/core@1.32.5':
+    resolution: {integrity: sha512-Vmr6LZms7QEP1ljfTRRBVtLkeEHMrTmLECt0FXPLwUIgPwxOgvBdAYwRMWyP13WuN/XQweo1tJ9J1DxHNAF3qg==}
+
+  '@posthog/types@1.386.4':
+    resolution: {integrity: sha512-UgE9+5+wkZg7yc2MpW5G32/6zYW8fAbXJkG8WGnrb4X8OKWzNa9cWeNCd82vKok+TSoRpM4qiYQFtBSpJS1dsw==}
 
   '@prisma/instrumentation@5.22.0':
     resolution: {integrity: sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==}
@@ -6287,6 +6296,9 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -6604,6 +6616,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -7316,6 +7331,9 @@ packages:
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -9500,9 +9518,15 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-js@1.386.8:
+    resolution: {integrity: sha512-L4cJD1sleUULE7K4mZQI5wpS24NHGtNmFw1rPHruc579unVzHuooHiVDEHp/qyNnhNxtNE6alBTiVORbYnRTSw==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -9613,6 +9637,9 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
@@ -11099,6 +11126,9 @@ packages:
     resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
     engines: {node: '>= 16'}
     hasBin: true
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -14098,6 +14128,12 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@posthog/core@1.32.5':
+    dependencies:
+      '@posthog/types': 1.386.4
+
+  '@posthog/types@1.386.4': {}
+
   '@prisma/instrumentation@5.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -16816,7 +16852,7 @@ snapshots:
       '@urql/core': 5.2.0
       wonka: 6.3.6
 
-  '@vitejs/plugin-react@5.1.3(vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitejs/plugin-react@5.1.3(vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -16824,7 +16860,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.2
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -16847,7 +16883,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -16862,7 +16898,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vitest: 3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -16901,13 +16937,13 @@ snapshots:
     optionalDependencies:
       vite: 8.0.10(@types/node@22.15.35)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@3.2.6(vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitest/mocker@3.2.6(vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/mocker@3.2.6(vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -17875,6 +17911,8 @@ snapshots:
     dependencies:
       browserslist: 4.28.1
 
+  core-js@3.49.0: {}
+
   core-util-is@1.0.3: {}
 
   cors@2.8.6:
@@ -18209,6 +18247,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.4.10:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -18453,16 +18495,16 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-expo@10.0.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
+  eslint-config-expo@10.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@1.21.7))
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -18470,18 +18512,18 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-config-next@16.2.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.2.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.4
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@1.21.7))
       globals: 16.4.0
-      typescript-eslint: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18498,21 +18540,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
-      get-tsconfig: 4.13.6
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -18524,41 +18551,56 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@2.6.1)
+      get-tsconfig: 4.13.6
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-expo@1.0.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
+  eslint-plugin-expo@1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.54.0
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -18567,9 +18609,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -18581,13 +18623,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -18596,9 +18638,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -18614,7 +18656,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -18624,7 +18666,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -18633,15 +18675,15 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       hermes-parser: 0.25.1
       zod: 3.25.76
       zod-validation-error: 4.0.2(zod@3.25.76)
@@ -19231,6 +19273,8 @@ snapshots:
       picomatch: 4.0.4
 
   fecha@4.2.3: {}
+
+  fflate@0.4.8: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -21961,7 +22005,20 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  posthog-js@1.386.8:
+    dependencies:
+      '@posthog/core': 1.32.5
+      '@posthog/types': 1.386.4
+      core-js: 3.49.0
+      dompurify: 3.4.10
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
   powershell-utils@0.1.0: {}
+
+  preact@10.29.2: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -22068,6 +22125,8 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   query-string@7.1.3:
     dependencies:
@@ -23340,7 +23399,7 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.16(esbuild@0.28.1)(webpack@5.105.0):
+  terser-webpack-plugin@5.3.16(esbuild@0.28.1)(webpack@5.105.0(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -23844,13 +23903,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
+  vite-node@3.2.4(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -23904,7 +23963,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
+  vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -23915,7 +23974,7 @@ snapshots:
       '@types/node': 22.19.9
       esbuild: 0.28.1
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 1.21.7
       terser: 5.47.1
       tsx: 4.21.0
       yaml: 2.8.4
@@ -23979,11 +24038,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
+  vitest@3.2.6(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(jsdom@28.0.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      '@vitest/mocker': 3.2.6(vite@8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -24001,8 +24060,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
-      vite-node: 3.2.4(@types/node@22.19.9)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@22.19.9)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.9
@@ -24100,6 +24159,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  web-vitals@5.3.0: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@4.0.2: {}
@@ -24155,7 +24216,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.28.1)(webpack@5.105.0)
+      terser-webpack-plugin: 5.3.16(esbuild@0.28.1)(webpack@5.105.0(esbuild@0.28.1))
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Privacy-preserving product analytics for the web dashboard (Cluster B1, PR1 of 2).
- **Cookieless + identified-only**: `persistence:'memory'` (no cookies/localStorage) + `person_profiles:'identified_only'`. Anonymous = aggregate pageviews; logged-in users identified by first-party Supabase `user.id`. Keeps the privacy policy's "no analytics cookies" promise literally true.
- **Lazy-loaded** so the ~100KB `posthog-js` SDK stays in an async chunk — first-load JS unaffected (CI-representative build: 798.27KB < 800 limit).
- Events tagged `product:'styrby'` for the shared "Styrby-App" PostHog project (free-tier project cap); clean migration path to a dedicated project later.

## Changes
- `@styrby/shared/analytics`: event catalog + `PRODUCT_TAG` + `withProduct` (+6 tests)
- web `lib/analytics/posthog.ts`: SSR-safe lazy wrapper (+7 tests)
- `PostHogProvider` (root layout, App-Router pageview tracker) + `AnalyticsIdentify` (dashboard layout)
- `posthog-js@1.386.8`; `.env.example` (root + web) host → `us.i.posthog.com`
- **Privacy page updated honestly**: removed the now-false "no analytics services" line, added a Product Analytics disclosure; cookie banner stays true.

## Test Plan
- [x] shared 1328/1328, web 3935/3935 (+13 net) — local
- [x] typecheck + lint + build green
- [x] bundle CI-representative 798.27KB < 800
- [ ] CI passes
- [ ] Vercel preview verified

🤖 Shipped via /gh-ship