### PR TITLE
feat(analytics): mobile PostHog product analytics — Cluster B1 PR2

### DIFF
--- a/packages/styrby-mobile/.env.example
+++ b/packages/styrby-mobile/.env.example
@@ -66,3 +66,9 @@ EXPO_PUBLIC_WEB_URL=https://styrbyapp.com
 # reporting at runtime even when DSN is configured. Useful when a noisy
 # release is shipping and we want the SDK to stay silent until next deploy.
 # EXPO_PUBLIC_STYRBY_SENTRY_MUTED=
+
+# ─── PostHog product analytics (Cluster B1) ───────────────────────────────
+# PUBLIC project ingestion key (phc_...). Leave unset to disable analytics
+# (the thin client no-ops). US cloud host is https://us.i.posthog.com.
+EXPO_PUBLIC_POSTHOG_KEY=phc_xxx
+EXPO_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/packages/styrby-mobile/app/_layout.tsx
+++ b/packages/styrby-mobile/app/_layout.tsx
@@ -34,6 +34,7 @@ import { useNotifications } from '../src/hooks/useNotifications';
 import { startConnectivityListener } from '../src/services/offline-sync';
 import { useInviteLinkHandler } from '../src/hooks/useInviteLinkHandler';
 import { useWidgetSync } from '../src/hooks/useWidgetSync';
+import { useAnalytics } from '../src/hooks/useAnalytics';
 import type { Session } from '@supabase/supabase-js';
 
 import type { ErrorBoundaryProps } from 'expo-router';
@@ -121,6 +122,13 @@ export default function RootLayout() {
    * cold start. useWidgetSync is a no-op off iOS and when signed out.
    */
   useWidgetSync(session?.user?.id ?? null);
+
+  /**
+   * WHY at root layout: analytics identity must follow auth state app-wide,
+   * and screen views are captured on every route change from one place.
+   * useAnalytics no-ops when no PostHog key is configured.
+   */
+  useAnalytics(session?.user?.id ?? null);
 
   // Re-register push token when user signs in (token may have been obtained
   // before auth was available, so savePushToken would have silently failed).

--- a/packages/styrby-mobile/src/hooks/useAnalytics.ts
+++ b/packages/styrby-mobile/src/hooks/useAnalytics.ts
@@ -1,0 +1,40 @@
+/**
+ * useAnalytics — mounts mobile product analytics at the app root.
+ *
+ * Mounted once in the root layout. Two responsibilities:
+ *  1. Identify: when a user id is present, associate analytics with their
+ *     first-party Supabase id; on sign-out, reset to a fresh anonymous id.
+ *  2. Screen views: capture a `$screen` event on every route change (the
+ *     mobile analog of web pageviews).
+ *
+ * Both no-op when no PostHog key is configured (the thin client handles that),
+ * so dev builds without a key are unaffected.
+ *
+ * @module hooks/useAnalytics
+ */
+
+import { useEffect } from 'react';
+import { usePathname } from 'expo-router';
+import { identifyUser, resetUser, captureScreen } from '../lib/analytics/posthog';
+
+/**
+ * Wire analytics identity + screen tracking to auth state and navigation.
+ *
+ * @param userId - Authenticated Supabase user id, or null when signed out.
+ */
+export function useAnalytics(userId: string | null): void {
+  // Identity follows auth state.
+  useEffect(() => {
+    if (userId) {
+      identifyUser(userId);
+    } else {
+      resetUser();
+    }
+  }, [userId]);
+
+  // One screen view per route change.
+  const pathname = usePathname();
+  useEffect(() => {
+    if (pathname) captureScreen(pathname);
+  }, [pathname]);
+}

--- a/packages/styrby-mobile/src/lib/analytics/__tests__/posthog.test.ts
+++ b/packages/styrby-mobile/src/lib/analytics/__tests__/posthog.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the mobile PostHog thin client.
+ *
+ * Pins the wire contract with PostHog's capture endpoint and the privacy
+ * behaviour: no-op without a key, product-tagged events, identity by Supabase
+ * id, ephemeral anonymous id (no persistence), and fire-and-forget that never
+ * throws. The module reads EXPO_PUBLIC_POSTHOG_KEY at import time, so each test
+ * loads it fresh under a stubbed env.
+ */
+
+// Deterministic product tag (don't depend on the built shared dist).
+// Mobile imports the unscoped `styrby-shared` alias (jest moduleNameMapper).
+jest.mock('styrby-shared', () => ({
+  withProduct: (p?: Record<string, unknown>) => ({ ...p, product: 'styrby' }),
+}));
+
+type Client = typeof import('../posthog');
+
+const REAL_FETCH = global.fetch;
+let fetchMock: jest.Mock;
+
+function load(key?: string): Client {
+  if (key) {
+    process.env.EXPO_PUBLIC_POSTHOG_KEY = key;
+  } else {
+    delete process.env.EXPO_PUBLIC_POSTHOG_KEY;
+  }
+  process.env.EXPO_PUBLIC_POSTHOG_HOST = 'https://us.i.posthog.com';
+  let mod: Client;
+  jest.isolateModules(() => {
+    mod = require('../posthog');
+  });
+  return mod!;
+}
+
+/** Let the fire-and-forget post() microtasks settle. */
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/** Parse the JSON body of the Nth fetch call. */
+function bodyOf(call = 0) {
+  return JSON.parse(fetchMock.mock.calls[call][1].body);
+}
+
+beforeEach(() => {
+  fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+  (global as unknown as { fetch: jest.Mock }).fetch = fetchMock;
+});
+
+afterEach(() => {
+  (global as unknown as { fetch: typeof REAL_FETCH }).fetch = REAL_FETCH;
+  delete process.env.EXPO_PUBLIC_POSTHOG_KEY;
+  jest.clearAllMocks();
+});
+
+describe('when no key is configured', () => {
+  it('is disabled and never calls fetch', async () => {
+    const ph = load(undefined);
+    expect(ph.isAnalyticsEnabled()).toBe(false);
+    ph.capture('dashboard_viewed' as never);
+    ph.identifyUser('user-1');
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('when a key is configured', () => {
+  it('POSTs a product-tagged event to the US ingestion endpoint', async () => {
+    const ph = load('phc_test');
+    ph.capture('plan_upgrade_clicked' as never, { to_tier: 'growth' });
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://us.i.posthog.com/i/v0/e/');
+    const body = bodyOf();
+    expect(body.api_key).toBe('phc_test');
+    expect(body.event).toBe('plan_upgrade_clicked');
+    expect(body.properties).toEqual({ to_tier: 'growth', product: 'styrby' });
+    expect(body.distinct_id).toMatch(/^anon-/); // ephemeral, pre-identify
+  });
+
+  it('captures a screen view as $screen with the screen name', async () => {
+    const ph = load('phc_test');
+    ph.captureScreen('/dashboard/sessions');
+    await flush();
+    const body = bodyOf();
+    expect(body.event).toBe('$screen');
+    expect(body.properties.$screen_name).toBe('/dashboard/sessions');
+    expect(body.properties.product).toBe('styrby');
+  });
+
+  it('identifies by Supabase id and attributes later events to it', async () => {
+    const ph = load('phc_test');
+    ph.identifyUser('user-42');
+    await flush();
+    const idBody = bodyOf(0);
+    expect(idBody.event).toBe('$identify');
+    expect(idBody.distinct_id).toBe('user-42');
+    expect(idBody.properties.$set.product).toBe('styrby');
+    expect(ph._getDistinctId()).toBe('user-42');
+
+    ph.capture('settings_viewed' as never);
+    await flush();
+    expect(bodyOf(1).distinct_id).toBe('user-42');
+  });
+
+  it('ignores an empty user id', async () => {
+    const ph = load('phc_test');
+    ph.identifyUser('');
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('resets to a fresh anonymous id on sign-out', async () => {
+    const ph = load('phc_test');
+    ph.identifyUser('user-7');
+    expect(ph._getDistinctId()).toBe('user-7');
+    ph.resetUser();
+    expect(ph._getDistinctId()).toMatch(/^anon-/);
+    expect(ph._getDistinctId()).not.toBe('user-7');
+  });
+
+  it('never throws when the network fails (fire-and-forget)', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+    const ph = load('phc_test');
+    expect(() => ph.capture('dashboard_viewed' as never)).not.toThrow();
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/styrby-mobile/src/lib/analytics/posthog.ts
+++ b/packages/styrby-mobile/src/lib/analytics/posthog.ts
@@ -1,0 +1,156 @@
+/**
+ * Mobile PostHog thin client (Cluster B1 PR2).
+ *
+ * A dependency-free analytics client that POSTs directly to PostHog's public
+ * capture endpoint. Every export is a no-op when no key is configured.
+ *
+ * WHY a thin fetch client instead of `posthog-react-native`:
+ *  - Zero native dependencies. The full SDK pulls expo-application,
+ *    expo-localization, and @react-native-async-storage/async-storage - new
+ *    native modules into a package whose Metro/pnpm build is already delicate
+ *    (see styrby-backlog "KNOWN BLOCKER #2"). A fetch client adds nothing
+ *    native and can't destabilise the build.
+ *  - Shared contract, not a seam. It consumes the SAME @styrby/shared/analytics
+ *    catalog as web, so event names and the product tag can never drift
+ *    between platforms. Only the transport (fetch vs SDK) differs.
+ *  - `/i/v0/e/` is PostHog's official ingestion endpoint - the SDKs wrap it.
+ *  - Consistent with web, which also captures manually (no autocapture).
+ *
+ * Deliberately out of scope for this first cut (NOT debt - documented choice):
+ * autocapture, feature flags, session replay, and an offline/batched queue.
+ * Capture is fire-and-forget; a dropped event when offline is acceptable for
+ * product analytics and never affects the user. Revisit if/when mobile needs
+ * feature flags (that would justify adopting the full SDK).
+ *
+ * Privacy posture (mirrors web): anonymous identity is in-memory only (a fresh
+ * id per app launch, never persisted), so we build no durable anonymous
+ * profile; logged-in users are identified by their first-party Supabase id.
+ *
+ * @module lib/analytics/posthog
+ */
+
+import {
+  withProduct,
+  type AnalyticsEventName,
+  type AnalyticsProperties,
+} from 'styrby-shared';
+
+/**
+ * Public (client-side) PostHog ingestion key (the `phc_...` value). Absent
+ * when analytics is intentionally off (the client then no-ops). EXPO_PUBLIC_*
+ * vars are inlined into the bundle at build time.
+ */
+const POSTHOG_KEY = process.env.EXPO_PUBLIC_POSTHOG_KEY;
+
+/** Ingestion host. US cloud is `us.i.posthog.com`; default when unset. */
+const POSTHOG_HOST =
+  process.env.EXPO_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+
+/**
+ * Current distinct id. Starts as an ephemeral in-memory anonymous id (no
+ * persistence across launches, mirroring web's memory persistence) and is
+ * swapped to the Supabase user id once {@link identifyUser} is called.
+ */
+let distinctId = freshAnonymousId();
+
+/**
+ * Generate a per-launch anonymous id. In-memory only - intentionally not
+ * persisted, so a returning anonymous user is a new id (no durable profile).
+ */
+function freshAnonymousId(): string {
+  // Date.now()+random is sufficient for an ephemeral, non-persisted id; this
+  // is app-runtime code (the Workflow-sandbox Date/Math restriction does not
+  // apply here).
+  return `anon-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Whether analytics is active (a key is configured).
+ * @returns true when capture/identify will actually POST to PostHog.
+ */
+export function isAnalyticsEnabled(): boolean {
+  return Boolean(POSTHOG_KEY);
+}
+
+/**
+ * Low-level POST to PostHog's capture endpoint. Fire-and-forget: never throws,
+ * never blocks the UI, and swallows network errors (analytics must never crash
+ * or stall the app).
+ *
+ * @param event - PostHog event name (catalog event or a `$`-prefixed builtin).
+ * @param properties - Fully-formed event properties (already product-tagged).
+ * @param distinct - The distinct_id to attribute the event to.
+ * @returns A promise that always resolves (exposed for tests; callers fire-and-forget).
+ */
+export async function post(
+  event: string,
+  properties: Record<string, unknown>,
+  distinct: string
+): Promise<void> {
+  if (!isAnalyticsEnabled()) return;
+  try {
+    await fetch(`${POSTHOG_HOST}/i/v0/e/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        api_key: POSTHOG_KEY,
+        event,
+        distinct_id: distinct,
+        properties,
+      }),
+    });
+  } catch {
+    // Swallow: a failed analytics POST must never surface to the user.
+  }
+}
+
+/**
+ * Capture a product-analytics event.
+ *
+ * @param event - A name from the shared {@link AnalyticsEventName} catalog.
+ * @param properties - Optional event properties; the product tag is merged in.
+ */
+export function capture(
+  event: AnalyticsEventName,
+  properties?: AnalyticsProperties
+): void {
+  void post(event, withProduct(properties), distinctId);
+}
+
+/**
+ * Capture a screen view (the mobile analog of a web pageview).
+ * @param screenName - The route/screen name (e.g. a pathname or segment).
+ */
+export function captureScreen(screenName: string): void {
+  void post('$screen', withProduct({ $screen_name: screenName }), distinctId);
+}
+
+/**
+ * Associate subsequent events with an authenticated user, keyed by their
+ * stable Supabase id. Sends a `$identify` that sets the product tag as a
+ * person property.
+ *
+ * @param userId - The Supabase `auth.users` id (used as distinct_id).
+ * @param properties - Optional person properties to set.
+ */
+export function identifyUser(
+  userId: string,
+  properties?: AnalyticsProperties
+): void {
+  if (!userId) return;
+  distinctId = userId;
+  void post('$identify', { $set: withProduct(properties) }, userId);
+}
+
+/**
+ * Clear the identified user (call on sign-out): reset to a fresh anonymous id
+ * so the next session starts unattributed.
+ */
+export function resetUser(): void {
+  distinctId = freshAnonymousId();
+}
+
+/** Test-only: read the current distinct id. */
+export function _getDistinctId(): string {
+  return distinctId;
+}


### PR DESCRIPTION
## Summary
- Completes Cluster B1: product analytics in the Expo mobile app.
- **Thin fetch-based client** (no `posthog-react-native`): zero native deps — avoids destabilising the delicate mobile Metro/pnpm build (backlog blocker #2). POSTs to PostHog's official `/i/v0/e/` ingestion endpoint.
- **Shared contract, no drift**: reuses the same `styrby-shared/analytics` catalog as web (event names + `product:'styrby'` tag). Only the transport differs from web.
- **Privacy mirrors web**: in-memory-only anonymous id (no durable profile); logged-in users identified by first-party Supabase id. Capture is fire-and-forget, never throws.

## Changes
- `src/lib/analytics/posthog.ts` — capture / identify / screen client (+7 tests)
- `src/hooks/useAnalytics.ts` — identify by Supabase id + `$screen` per route change
- `app/_layout.tsx` — mount `useAnalytics(session?.user?.id ?? null)` beside `useWidgetSync`
- `.env.example` — `EXPO_PUBLIC_POSTHOG_*`

Out of scope by design (documented, not debt): autocapture, feature flags, offline queue.

## Test Plan
- [x] mobile typecheck clean
- [x] mobile jest 1766/1772 (+7 new)
- [x] mobile lint clean
- [ ] CI passes (mobile-only, path-filtered)

🤖 Shipped via /gh-ship