### PR TITLE
fix(analytics): disable PostHog optional auto-loaded modules

### DIFF
--- a/packages/styrby-web/src/lib/analytics/__tests__/posthog.test.ts
+++ b/packages/styrby-web/src/lib/analytics/__tests__/posthog.test.ts
@@ -97,6 +97,13 @@ describe('when a PostHog key is configured', () => {
     expect(opts.person_profiles).toBe('identified_only');
     expect(opts.capture_pageview).toBe(false);
     expect(opts.api_host).toBe('https://us.i.posthog.com');
+    // Optional auto-loaded modules disabled (no remote-script CSP errors,
+    // minimal cookieless posture - manual events + pageviews only).
+    expect(opts.autocapture).toBe(false);
+    expect(opts.capture_dead_clicks).toBe(false);
+    expect(opts.capture_performance).toBe(false);
+    expect(opts.disable_session_recording).toBe(true);
+    expect(opts.disable_surveys).toBe(true);
     // loaded() ran and stamped the product super-property
     expect(mockPosthog.register).toHaveBeenCalledWith({ product: 'styrby' });
   });

--- a/packages/styrby-web/src/lib/analytics/posthog.ts
+++ b/packages/styrby-web/src/lib/analytics/posthog.ts
@@ -85,6 +85,18 @@ function ensureLoaded(): Promise<PostHog | null> {
       capture_pageview: false,
       // Respect Do Not Track at the SDK level as a second guard.
       respect_dnt: true,
+      // WHY disable every optional auto-loaded module: by default posthog-js
+      // lazy-fetches recorder/surveys/dead-clicks/web-vitals/autocapture
+      // scripts from us-assets.i.posthog.com. We deliberately want ONLY manual
+      // events + pageviews (minimal, cookieless posture), so these are unwanted
+      // - and our CSP script-src intentionally does not allow remote scripts,
+      // so the browser would block them with console errors. Turning them off
+      // here means zero blocked requests, zero console noise, smaller runtime.
+      autocapture: false,
+      capture_dead_clicks: false,
+      capture_performance: false, // disables the web-vitals module
+      disable_session_recording: true,
+      disable_surveys: true,
       loaded: (ph) => {
         // Stamp the product tag on every event for the shared "Styrby-App"
         // project so Styrby data stays filterable from the sibling product.


### PR DESCRIPTION
## Summary
Live browser verification of B1 (post CSP fix) confirmed analytics works (`POST /e/` → 200) but posthog-js was also auto-fetching optional module scripts (session recorder, surveys, dead-clicks, web-vitals, autocapture) from `us-assets.i.posthog.com` - which `script-src` intentionally blocks → **6 console errors/page**.

We want only manual events + pageviews (minimal cookieless posture), so the fix is to **disable those modules at init**, not widen `script-src`:
`autocapture:false`, `capture_dead_clicks:false`, `capture_performance:false`, `disable_session_recording:true`, `disable_surveys:true`.

## Result
Zero blocked requests, zero console noise, smaller runtime. Core analytics already verified live in prod.

## Test Plan
- [x] typecheck (validates option names) + posthog.test.ts 7/7 (asserts the disable flags)
- [ ] CI green
- [ ] Post-deploy: reload prod, confirm no CSP console errors + `/e/` still 200

🤖 Shipped via /gh-ship