### PR TITLE
fix(analytics): fully stop PostHog remote-script loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ scripts/__pycache__/
 .deps-audit.json
 .sec-ship-reports/
 .sec-ship-history.json
+.playwright-mcp/

--- a/packages/styrby-web/src/lib/analytics/__tests__/posthog.test.ts
+++ b/packages/styrby-web/src/lib/analytics/__tests__/posthog.test.ts
@@ -99,6 +99,7 @@ describe('when a PostHog key is configured', () => {
     expect(opts.api_host).toBe('https://us.i.posthog.com');
     // Optional auto-loaded modules disabled (no remote-script CSP errors,
     // minimal cookieless posture - manual events + pageviews only).
+    expect(opts.disable_external_dependency_loading).toBe(true);
     expect(opts.autocapture).toBe(false);
     expect(opts.capture_dead_clicks).toBe(false);
     expect(opts.capture_performance).toBe(false);

--- a/packages/styrby-web/src/lib/analytics/posthog.ts
+++ b/packages/styrby-web/src/lib/analytics/posthog.ts
@@ -92,6 +92,14 @@ function ensureLoaded(): Promise<PostHog | null> {
       // - and our CSP script-src intentionally does not allow remote scripts,
       // so the browser would block them with console errors. Turning them off
       // here means zero blocked requests, zero console noise, smaller runtime.
+      // Catch-all: never fetch ANY external script from us-assets.i.posthog.com
+      // (recorder, surveys, dead-clicks, web-vitals, remote config.js). The
+      // SDK is bundled via npm; we want zero remote-script loads (our CSP
+      // script-src blocks them anyway). This is the switch that fully clears
+      // the console — the per-feature flags below only stop modules *running*,
+      // not the bootstrap fetch. Event capture + the JSON config fetch
+      // (connect-src) are unaffected.
+      disable_external_dependency_loading: true,
       autocapture: false,
       capture_dead_clicks: false,
       capture_performance: false, // disables the web-vitals module


### PR DESCRIPTION
## Summary
Follow-up to #387 (partial). Live browser re-check showed the per-feature flags cut blocked scripts 6→2 but left `dead-clicks-autocapture.js` + remote `config.js` still fetched (per-feature flags stop a module *running*, not the bootstrap *fetch*) → 2 residual CSP console errors.

Add the catch-all **`disable_external_dependency_loading: true`** - stops the SDK loading ANY external script from `us-assets.i.posthog.com`. Event capture + JSON config fetch unaffected.

## Honesty note
My #387 commit claimed "zero console noise" - that was over-claimed; this is the actual fix. Will re-verify zero in-browser post-deploy before claiming done.

## Test Plan
- [x] typecheck (option valid) + posthog.test.ts 7/7
- [ ] CI green
- [ ] Post-deploy browser: 0 PostHog CSP errors, POST /e/ still 200

🤖 Shipped via /gh-ship