### PR TITLE
fix(security): allow us-assets.i.posthog.com in CSP script-src

### DIFF
--- a/packages/styrby-web/next.config.ts
+++ b/packages/styrby-web/next.config.ts
@@ -65,9 +65,13 @@ const cspHeader = [
   //     injection, all user data goes through parameterized Supabase queries.
   //   - 'unsafe-inline' is a defense-in-depth weakness (CSP won't catch a
   //     future XSS), but with zero current attack surface, the risk is low.
-  //   - Analytics is PostHog loaded as a bundled npm module (not a remote
-  //     <script>), so it needs no script-src allowance — only connect-src for
-  //     its API host (added below). No GTM/GA/Segment remote scripts.
+  //   - Analytics is PostHog: the SDK itself is a bundled npm module, but it
+  //     still fetches a few of its own bootstrap scripts (remote config.js,
+  //     the dead-clicks loader) from us-assets.i.posthog.com even with the
+  //     optional features disabled. Those are allowed in script-src below; our
+  //     init keeps every feature OFF (autocapture/recording/surveys/etc.), so
+  //     the loaded scripts stay inert. us-assets is a trusted vendor CDN and
+  //     this matches PostHog's documented CSP. No GTM/GA/Segment scripts.
   //
   // WHEN TO REVISIT:
   //   - When Next.js ships native nonce propagation for App Router (roadmap item)
@@ -76,7 +80,10 @@ const cspHeader = [
   //
   // 'unsafe-eval' is NOT included — production builds do not require eval().
   // ──────────────────────────────────────────────────────────────────────────
-  "script-src 'self' 'unsafe-inline'",
+  // us-assets.i.posthog.com: PostHog fetches its own bootstrap scripts (remote
+  // config.js + dead-clicks loader) from here even with features disabled.
+  // Allowed so they don't throw CSP errors; they stay inert via the init flags.
+  "script-src 'self' 'unsafe-inline' https://us-assets.i.posthog.com",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: https:",
   "font-src 'self' data:",

--- a/packages/styrby-web/src/lib/analytics/posthog.ts
+++ b/packages/styrby-web/src/lib/analytics/posthog.ts
@@ -92,13 +92,14 @@ function ensureLoaded(): Promise<PostHog | null> {
       // - and our CSP script-src intentionally does not allow remote scripts,
       // so the browser would block them with console errors. Turning them off
       // here means zero blocked requests, zero console noise, smaller runtime.
-      // Catch-all: never fetch ANY external script from us-assets.i.posthog.com
-      // (recorder, surveys, dead-clicks, web-vitals, remote config.js). The
-      // SDK is bundled via npm; we want zero remote-script loads (our CSP
-      // script-src blocks them anyway). This is the switch that fully clears
-      // the console — the per-feature flags below only stop modules *running*,
-      // not the bootstrap fetch. Event capture + the JSON config fetch
-      // (connect-src) are unaffected.
+      // Feature posture: every optional module OFF (manual events + pageviews
+      // only; cookieless). These flags stop the modules from *running* /
+      // capturing. NOTE (verified in a live browser): they do NOT stop the SDK
+      // *fetching* a couple of its own bootstrap scripts (remote config.js, the
+      // dead-clicks loader) from us-assets.i.posthog.com — those are allowed in
+      // the CSP script-src (see next.config.ts) and stay inert because of these
+      // flags. disable_external_dependency_loading is kept as belt-and-suspenders
+      // (it does suppress the heavier recorder/surveys/web-vitals loads).
       disable_external_dependency_loading: true,
       autocapture: false,
       capture_dead_clicks: false,


### PR DESCRIPTION
## Summary
Terminal fix for the 2 residual PostHog CSP console errors. Live-browser checks (#387/#388) proved the disable flags stop optional modules *running* but not *fetching* two bootstrap scripts (`config.js`, dead-clicks loader) from `us-assets.i.posthog.com`.

Allow `https://us-assets.i.posthog.com` in `script-src` (PostHog's documented CSP). Scripts load cleanly but stay **inert** (init keeps all features off) → zero console errors, no behavior change.

Also corrected two now-false comments (the `script-src`-not-needed claim and the `disable_external_dependency_loading` "fully clears" claim).

## Security note
Widens `script-src` to allow the PostHog asset CDN - standard analytics-vendor tradeoff, trusted vendor.

## Test Plan
- [x] posthog.test.ts unchanged + green; CSP is a header string
- [ ] CI build validates next.config.ts
- [ ] Post-deploy browser: 0 PostHog CSP errors, POST /e/ still 200

🤖 Shipped via /gh-ship