### PR TITLE
fix(cron): claim-before-send idempotency for budget-threshold push (LOGIC-002)

### DIFF
--- a/packages/styrby-web/src/app/api/cron/budget-threshold/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/cron/budget-threshold/__tests__/route.test.ts
@@ -32,7 +32,7 @@ function createChainMock() {
   const chain: Record<string, unknown> = {};
   for (const method of [
     'select', 'eq', 'neq', 'gte', 'lte', 'lt', 'gt', 'order', 'limit',
-    'insert', 'update', 'delete', 'is', 'not', 'in', 'single', 'maybeSingle',
+    'insert', 'upsert', 'update', 'delete', 'is', 'not', 'in', 'single', 'maybeSingle',
   ]) {
     chain[method] = vi.fn().mockReturnValue(chain);
   }
@@ -151,8 +151,8 @@ describe('POST /api/cron/budget-threshold', () => {
     fromCallQueue.push({ data: { tier: 'power' }, error: null });
     // MTD spend: $180 (above $160 threshold)
     fromCallQueue.push({ data: [{ cost_usd: 180 }], error: null });
-    // Insert budget_threshold_sends row
-    fromCallQueue.push({ data: null, error: null });
+    // Claim idempotency row (upsert .select) — THIS run won the claim
+    fromCallQueue.push({ data: [{ id: 'claim-3' }], error: null });
     // Insert audit_log row
     fromCallQueue.push({ data: null, error: null });
 
@@ -168,21 +168,46 @@ describe('POST /api/cron/budget-threshold', () => {
     );
   });
 
-  it('skips send when Expo push returns false', async () => {
+  it('releases the claim (compensating delete) when Expo push returns false', async () => {
     mockSendRetentionPush.mockResolvedValueOnce(false);
 
     fromCallQueue.push({
       data: [{ user_id: 'user-4', push_budget_threshold: true, push_enabled: true }],
       error: null,
     });
-    fromCallQueue.push({ data: null, error: null }); // idempotency
+    fromCallQueue.push({ data: null, error: null }); // idempotency fast-path
     fromCallQueue.push({ data: { tier: 'power' }, error: null }); // subscription
     fromCallQueue.push({ data: [{ cost_usd: 180 }], error: null }); // costs
+    fromCallQueue.push({ data: [{ id: 'claim-4' }], error: null }); // claim won
+    fromCallQueue.push({ data: null, error: null }); // compensating delete
 
     const res = await POST(makeRequest(`Bearer ${CRON_SECRET}`));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.skipped).toBe(1);
     expect(body.sent).toBe(0);
+    // push was attempted (returned false), so the claim must be released
+    expect(mockSendRetentionPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT send a duplicate push when the claim is lost to a concurrent run', async () => {
+    // LOGIC-002 regression: two overlapping cron runs both pass the fast-path
+    // SELECT, but the ON CONFLICT DO NOTHING claim returns empty for the loser,
+    // which must skip WITHOUT sending a push.
+    fromCallQueue.push({
+      data: [{ user_id: 'user-5', push_budget_threshold: true, push_enabled: true }],
+      error: null,
+    });
+    fromCallQueue.push({ data: null, error: null }); // idempotency fast-path: not yet recorded
+    fromCallQueue.push({ data: { tier: 'power' }, error: null }); // subscription
+    fromCallQueue.push({ data: [{ cost_usd: 180 }], error: null }); // costs (above threshold)
+    fromCallQueue.push({ data: [], error: null }); // claim LOST (conflict → empty)
+
+    const res = await POST(makeRequest(`Bearer ${CRON_SECRET}`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe(1);
+    expect(body.sent).toBe(0);
+    expect(mockSendRetentionPush).not.toHaveBeenCalled();
   });
 });

--- a/packages/styrby-web/src/app/api/cron/budget-threshold/route.ts
+++ b/packages/styrby-web/src/app/api/cron/budget-threshold/route.ts
@@ -207,7 +207,40 @@ async function checkAndNotifyUser({
 
   const pctUsed = Math.round((mtdSpend / monthlyCap) * 100);
 
-  // Send the push
+  // WHY claim-before-send (not send-then-record):
+  // The early SELECT above is a cheap fast-path skip, NOT a concurrency gate —
+  // two overlapping cron runs can both pass it, both send, and one INSERT then
+  // loses the unique-constraint race. To make the unique constraint the real
+  // gate, atomically claim the idempotency row FIRST via an
+  // ON CONFLICT DO NOTHING upsert and only send if THIS run created the row.
+  // Mirrors the polar_webhook_events claim+compensate pattern used elsewhere.
+  const { data: claimed, error: claimError } = await supabase
+    .from('budget_threshold_sends')
+    .upsert(
+      {
+        user_id: userId,
+        threshold_pct: thresholdPct,
+        billing_period_start: billingPeriodStart,
+      },
+      {
+        // matches CONSTRAINT uq_budget_threshold_send (migration 026)
+        onConflict: 'user_id,threshold_pct,billing_period_start',
+        ignoreDuplicates: true,
+      }
+    )
+    .select('id');
+
+  if (claimError) {
+    throw new Error(
+      `Budget threshold claim failed for user ${userId}: ${claimError.message}`
+    );
+  }
+
+  // Empty result = another concurrent run already claimed this threshold this
+  // period. Skip silently — the run that won the claim sends the push.
+  if (!claimed || claimed.length === 0) return 'skipped';
+
+  // Send the push (claim is held; we are the sole sender for this threshold).
   const pushSent = await sendRetentionPush({
     userId,
     type: 'budget_threshold',
@@ -224,14 +257,17 @@ async function checkAndNotifyUser({
     respectQuietHours: true,
   });
 
-  if (!pushSent) return 'skipped';
-
-  // Record idempotency row
-  await supabase.from('budget_threshold_sends').insert({
-    user_id: userId,
-    threshold_pct: thresholdPct,
-    billing_period_start: billingPeriodStart,
-  });
+  if (!pushSent) {
+    // Compensating delete: release the claim so a later run retries, rather
+    // than leaving a "sent" row for a push that never went out.
+    await supabase
+      .from('budget_threshold_sends')
+      .delete()
+      .eq('user_id', userId)
+      .eq('threshold_pct', thresholdPct)
+      .eq('billing_period_start', billingPeriodStart);
+    return 'skipped';
+  }
 
   // Audit log (SOC2 CC7.2)
   await supabase.from('audit_log').insert({


### PR DESCRIPTION
## Summary
`/sec-ship --comprehensive` finding **LOGIC-002**: the budget-threshold cron sent the push *before* recording the idempotency row, so two overlapping/retried runs both pass the check-SELECT and both send a duplicate push (the unique constraint protects the row, not the push).

## Fix
Atomically **claim** the idempotency row first (ON CONFLICT DO NOTHING upsert + `.select('id')`), send only if this run created the row, and **compensating-delete** the claim if the push fails (so a later run retries). Mirrors the existing `polar_webhook_events` claim+compensate pattern. Claim errors now throw instead of being discarded.

## Test Plan
- [x] +1 regression: claim lost to concurrent run → skip, no push
- [x] +1 compensating delete on push failure
- [x] budget-threshold suite 9/9; web typecheck + lint clean
- [ ] CI green

🤖 Shipped via /gh-ship