### PR TITLE
fix(billing): resolve main sub on multi-row refund lookup (LOGIC-003)

### DIFF
--- a/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/__tests__/route.test.ts
@@ -1057,6 +1057,57 @@ describe('POST /api/webhooks/polar', () => {
       );
     });
 
+    it('LOGIC-003: re-subscribed customer (multi-row .single() PGRST116) resolves latest sub and resets a genuine main refund', async () => {
+      // A churned+re-subscribed customer legitimately has >1 subscriptions rows
+      // under one polar_customer_id, so the primary .single() lookup errors
+      // PGRST116. Previously that fell through to the side-purchase branch and
+      // silently preserved paid tier after a real refund (revenue leak). The
+      // fallback must re-resolve to the latest row and reset to free.
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: {
+          code: 'PGRST116',
+          message: 'JSON object requested, multiple (or no) rows returned',
+        },
+      });
+      // Both the SEC-FOLLOWUP-3 guard lookup and the fallback resolve via
+      // maybeSingle — return the customer's current (latest) main subscription.
+      mockMaybeSingle.mockResolvedValue({
+        data: {
+          user_id: 'user-uuid-123',
+          polar_subscription_id: 'sub_main_xyz',
+          tier: 'pro',
+        },
+        error: null,
+      });
+
+      const event = {
+        id: 'evt_refund_multirow_001',
+        type: 'order.refunded',
+        data: {
+          id: 'ord_refund_multirow_001',
+          customer_id: 'cust_test_456',
+          subscription_id: 'sub_main_xyz', // refund of the current main sub
+        },
+      };
+
+      const response = await sendSignedRefund(event);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      // Must NOT be misclassified as a side-purchase refund.
+      expect(body.side_purchase_refund).toBeUndefined();
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ tier: 'free', status: 'canceled' })
+      );
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            event_subtype: 'order_refunded_main',
+          }),
+        })
+      );
+    });
+
     it('side-purchase refund (subscription_id !== main): preserves main tier, audit event_subtype=order_refunded_side_purchase, response side_purchase_refund=true', async () => {
       // Subscription lookup returns the user's main sub with a DIFFERENT id
       // than the refunded subscription_id.

--- a/packages/styrby-web/src/app/api/webhooks/polar/route.ts
+++ b/packages/styrby-web/src/app/api/webhooks/polar/route.ts
@@ -2127,6 +2127,7 @@ export async function POST(request: Request) {
         // a side-purchase, refundedSubscriptionId !== mainSubscriptionId by
         // definition, so a SELECT keyed on it would miss the user entirely.
         // polar_customer_id is stable across all of a customer's purchases.
+        //
         type MainSubLookup = {
           user_id: string;
           polar_subscription_id: string;
@@ -2142,10 +2143,28 @@ export async function POST(request: Request) {
             .single<MainSubLookup>();
 
           if (subLookupErr) {
-            // Not fatal: customer may have been hard-deleted or this is a refund
-            // for a customer who never had a stored subscription (test order,
-            // pre-Styrby-era purchase). Audit and acknowledge.
-            if (isDev) {
+            // .single() returns PGRST116 for BOTH zero rows AND multiple rows.
+            // LOGIC-003: a customer who churned and re-subscribed legitimately
+            // has >1 subscriptions rows under one polar_customer_id (the
+            // created.upsert conflicts on polar_subscription_id, NOT
+            // customer_id). The naive .single() then errored on multi-row and
+            // fell through to the side-purchase branch, silently preserving
+            // paid tier after a genuine main-sub refund (revenue leak). On the
+            // ambiguous error, re-resolve deterministically to the customer's
+            // most-recent (current main) subscription. If this still finds
+            // nothing, it was a genuine zero-row case (deleted customer / test
+            // order) — fall through to the conservative side-purchase path.
+            const { data: latestSub } = await supabase
+              .from('subscriptions')
+              .select('user_id, polar_subscription_id, tier')
+              .eq('polar_customer_id', refundedCustomerId)
+              .order('created_at', { ascending: false })
+              .limit(1)
+              .maybeSingle<MainSubLookup>();
+
+            if (latestSub) {
+              mainSubscription = latestSub;
+            } else if (isDev) {
               console.log(
                 `polar/route: order.refunded — no subscription row for customer ${refundedCustomerId}: ${subLookupErr.message}`
               );


### PR DESCRIPTION
## Summary
`/sec-ship --comprehensive` finding **LOGIC-003**: `order.refunded` resolved the main subscription with `.single()` on `polar_customer_id`. A re-subscribed customer legitimately has >1 rows under one customer id, so `.single()` errors (PGRST116) and the handler fell through to the side-purchase branch - silently **preserving paid tier after a real refund** (revenue leak).

## Fix
Keep `.single()` as the primary (common single-row) path; on its PGRST116 error, re-resolve deterministically to the customer's most-recent subscription via `.order('created_at', desc).limit(1).maybeSingle()`. A genuine zero-row case still → null → conservative side-purchase path. PGRST116-fallback chosen to keep the heavily-`.single()`-mocked billing suite stable.

## Test Plan
- [x] +1 regression: multi-row customer → main refund resets to free
- [x] polar suite 65/65; web typecheck + lint clean
- [ ] CI green

🤖 Shipped via /gh-ship