### PR TITLE
fix(billing): correct false seat-lock invariant comments (LOGIC-001)

### DIFF
--- a/packages/styrby-web/src/app/api/billing/seats/route.ts
+++ b/packages/styrby-web/src/app/api/billing/seats/route.ts
@@ -680,13 +680,25 @@ export async function PATCH(request: Request): Promise<Response> {
   //   team_members row between this count read and the Polar update below,
   //   leaving the team with fewer paid seats than active members. The RPC
   //   acquires a per-team advisory lock and reads the count in the SAME
-  //   transaction, so any concurrent invite-accept (which uses
-  //   acquire_team_invite_lock with the same lock id) is serialized against
-  //   us. The lock releases at the RPC's transaction end — the residual
-  //   window between count and Polar update is closed by (a) the
-  //   invitation-accept path also taking the same lock at its critical
-  //   section and (b) the Unit B Polar webhook reconciling seat_cap
-  //   asynchronously.
+  //   transaction.
+  //
+  //   CORRECTION (LOGIC-003 audit 2026-06): a prior version of this comment
+  //   claimed the invite-ACCEPT path "also takes the same lock id" so the two
+  //   serialize on the advisory lock. That is FALSE - accept_team_invitation
+  //   (migration 073) only does FOR UPDATE on the single invitation row; it
+  //   never calls acquire_team_invite_lock. The path that DOES hold this lock
+  //   is invite-SEND (the teams-invite edge function, migration 030), which
+  //   acquires acquire_team_invite_lock(teamIdHash) before its seat-cap check.
+  //
+  //   Why the seat count is nonetheless safe against a concurrent accept: the
+  //   seat is reserved at SEND time (a pending invitation already increments
+  //   teams.active_seats via fn_team_invitations_seat_delta, under the lock and
+  //   gated by the cap), and accept is net-zero on the reservation
+  //   (pending -> accepted = -1, team_member insert = +1). So accept does not
+  //   over-provision; the worst case is a transient 1-row skew in this live
+  //   member count that (b) the Unit B Polar webhook reconciles asynchronously.
+  //   This advisory lock genuinely serializes SEND vs this PATCH; ACCEPT relies
+  //   on its per-invitation FOR UPDATE + the send-time reservation instead.
 
   const teamLockKey = await teamIdToSeatLockKey(team_id);
 
@@ -810,13 +822,17 @@ export async function PATCH(request: Request): Promise<Response> {
   // ── Step 9: Update Polar subscription quantity ────────────────────────────
 
   // WHY: WAVE-E-001 mitigation — by this point the count_team_members_with_seat_lock
-  // RPC has already serialized us against any concurrent seat change OR
-  // invitation accept on this team (see Step 6). Two concurrent PATCHes for
-  // the same team will see the second one return CONCURRENT_SEAT_CHANGE 409,
-  // forcing client retry rather than allowing both to call Polar simultaneously.
-  // The lock has technically released at the RPC's transaction end, but the
-  // invitation-accept path also takes the same lock id, and the Polar webhook
-  // reconciles seat_cap asynchronously, closing the residual window.
+  // RPC has serialized us against any concurrent invite-SEND and any concurrent
+  // seat PATCH on this team (both hold acquire_team_invite_lock with the same
+  // team-derived lock id; see Step 6). Two concurrent PATCHes for the same team
+  // will see the second one return CONCURRENT_SEAT_CHANGE 409, forcing client
+  // retry rather than allowing both to call Polar simultaneously.
+  // The lock has technically released at the RPC's transaction end. The residual
+  // window is closed by: invite-ACCEPT being net-zero on the seat reservation
+  // (the seat was already reserved at send under the lock), and the Polar
+  // webhook reconciling seat_cap asynchronously. (ACCEPT itself does NOT hold
+  // this advisory lock - it serializes per-invitation via FOR UPDATE; see the
+  // corrected note in Step 6.)
   try {
     await polar.subscriptions.update({
       id: team.polar_subscription_id!,

--- a/supabase/migrations/075_seat_change_lock.sql
+++ b/supabase/migrations/075_seat_change_lock.sql
@@ -16,15 +16,22 @@
 -- WHY we still need API-side serialization with the Polar update:
 --   The lock CANNOT span the Polar HTTP call — that's a network round-trip
 --   outside Postgres. The mitigation is layered:
---     (1) This RPC serializes the count read against any other holder of
---         the same lock id (concurrent invite-accepts that use
---         acquire_team_invite_lock with the same hash, OR a parallel PATCH
---         on the same team).
---     (2) The teams-invite edge function already calls
+--     (1) This RPC serializes the count read against any other holder of the
+--         same lock id: a parallel seat PATCH on the same team, AND the
+--         invite-SEND path (the teams-invite edge function). NOTE (corrected
+--         per LOGIC-001 audit 2026-06): invite-ACCEPT does NOT hold this lock.
+--         accept_team_invitation (migration 073) only does FOR UPDATE on the
+--         single invitation row; it never calls acquire_team_invite_lock. An
+--         earlier version of this comment wrongly listed "invite-accepts" as
+--         holders of the lock.
+--     (2) The teams-invite edge function (invite-SEND) calls
 --         acquire_team_invite_lock(teamIdHash) before its seat-cap check
 --         (migration 030, line 502 of supabase/functions/teams-invite/index.ts).
---         Both paths must use the SAME lock id (derived from team_id) so they
---         serialize against each other.
+--         SEND and this PATCH must use the SAME lock id (derived from team_id)
+--         so they serialize against each other. The seat is RESERVED at send
+--         time (a pending invitation increments teams.active_seats under the
+--         lock, gated by the cap), so a later ACCEPT is net-zero on that
+--         reservation and cannot over-provision even though it skips the lock.
 --     (3) The Polar webhook (Unit B) reconciles teams.seat_cap with Polar's
 --         canonical state asynchronously — even if a transient skew slips
 --         through, it converges.


### PR DESCRIPTION
## Summary
`/sec-ship --comprehensive` finding **LOGIC-001**: comments in `billing/seats/route.ts` and migration 075 claimed invite-**ACCEPT** holds the per-team advisory lock so it serializes with the seat PATCH. That's **false** - `accept_team_invitation` (073) only does `FOR UPDATE` on the invitation row; the lock is held by invite-**SEND** (edge fn). A documented-but-false security invariant is a latent footgun.

## This is a documentation-accuracy fix (no behavior change)
The code is already safe: the seat is **reserved at send-time** (pending invitation increments `active_seats` under the lock, gated by the cap), so a later accept is net-zero on the reservation and can't over-provision; per-invitation `FOR UPDATE` prevents double-accept. Comments now say this accurately in both places.

## Why not add the lock to make the comment true
The lock id is `parseInt(sha256(team_id).slice(0,8),16)` computed in **TS**. Re-deriving that exact unsigned-32-bit value in PL/pgSQL is error-prone (sign-extension); a mismatch would create a **non-contending** lock - the exact silent failure the comment warns about. Making the docs match the safe code is the correct, low-risk fix.

## Test Plan
- [x] comment-only, zero behavior delta; web typecheck clean
- [x] seats + invitations suites green (34/34)
- [ ] CI green (incl. Postgres Migrations re-apply of 075 — comment no-op)

🤖 Shipped via /gh-ship