### PR TITLE
fix(sessions): extend agent_type enum + surface session-insert error (INV Phase 0)

### DIFF
--- a/packages/styrby-cli/src/api/apiSession.ts
+++ b/packages/styrby-cli/src/api/apiSession.ts
@@ -141,10 +141,28 @@ export class ApiSessionManager {
       });
 
     if (insertError) {
-      logger.error('Failed to create session in Supabase', { error: insertError.message });
-      // Non-fatal: session works without remote record, just log and continue
-      // WHY: The relay bridge is more important than the database record.
-      // If Supabase is temporarily unavailable, we still want the session to work.
+      // Surface the FULL Postgrest error (code/details/hint), not just the bare
+      // message. INV token-tracking (2026-06): a swallowed message hid WHY
+      // sessions never persisted — and a missing sessions row silently breaks
+      // cost aggregation, because the cost_records AFTER INSERT trigger does
+      // `UPDATE sessions ... WHERE id = session_id` (no row → no token totals).
+      // Common causes: agent_type enum value missing (code 22P02 — extended in
+      // migration 103), or an RLS WITH CHECK failure if the client JWT uid does
+      // not match user_id.
+      logger.error(
+        'Failed to persist session row in Supabase — durable session + token/cost tracking will NOT work for this session',
+        {
+          sessionId,
+          agentType,
+          userId,
+          code: insertError.code,
+          message: insertError.message,
+          details: insertError.details,
+          hint: insertError.hint,
+        }
+      );
+      // Non-fatal: the relay bridge (live mirror to mobile) still works even if
+      // the durable record fails. We keep the session alive rather than abort.
     }
 
     // Track locally

--- a/supabase/migrations/103_extend_agent_type_enum.sql
+++ b/supabase/migrations/103_extend_agent_type_enum.sql
@@ -1,0 +1,29 @@
+-- ============================================================================
+-- Migration 103: Extend agent_type enum to all 11 supported agents
+-- ============================================================================
+-- ROOT CAUSE (INV token-tracking, 2026-06): the `agent_type` enum was created
+-- in migration 001 with only ('claude','codex','gemini'). Styrby now supports
+-- 11 agents (see packages/styrby-shared/src/types.ts). Every persistence write
+-- keyed on agent_type — the `sessions` row insert (api/apiSession.ts) and the
+-- `cost_records` insert (/api/v1/cost-records) — is REJECTED by Postgres for
+-- the 8 missing agents (invalid_text_representation, 22P02), and on the CLI
+-- side that error was swallowed. Net effect: sessions and token/cost rows for
+-- opencode/aider/goose/amp/crush/kilo/kiro/droid never persisted at all.
+--
+-- This adds the 8 missing values so persistence works uniformly across every
+-- supported agent. (claude/codex/gemini already exist and are untouched.)
+--
+-- WHY ADD VALUE IF NOT EXISTS: idempotent + safe to re-run (CI db-reset
+-- re-applies all migrations). ADD VALUE is non-transactional-sensitive in
+-- PG12+ when the new value is not USED in the same migration — we only add
+-- values here; no statement in this migration references them.
+-- ============================================================================
+
+ALTER TYPE agent_type ADD VALUE IF NOT EXISTS 'opencode';
+ALTER TYPE agent_type ADD VALUE IF NOT EXISTS 'aider';
+ALTER TYPE agent_type ADD VALUE IF NOT EXISTS 'goose';
+ALTER TYPE agent_type ADD VALUE IF NOT EXISTS 'amp';
+ALTER TYPE agent_type ADD VALUE IF NOT EXISTS 'crush';
+ALTER TYPE agent_type ADD VALUE IF NOT EXISTS 'kilo';
+ALTER TYPE agent_type ADD VALUE IF NOT EXISTS 'kiro';
+ALTER TYPE agent_type ADD VALUE IF NOT EXISTS 'droid';


### PR DESCRIPTION
## Summary
Phase 0 of the token-tracking investigation (`.investigate/INV-token-tracking.md`). Production has **0 sessions / 0 cost_records / 0 session_messages** despite an active machine. Two confirmed prerequisite fixes:

1. **`agent_type` enum** was only `('claude','codex','gemini')` (migration 001) but 11 agents are supported → `sessions` and `cost_records` inserts are **rejected (22P02)** for the other 8 agents and the error was swallowed. **Migration 103** adds the missing values.
2. **Session-insert error** in `api/apiSession.ts` was a swallowed bare message → now logs the full Postgrest error (code/details/hint) and flags that token/cost tracking breaks. A missing `sessions` row silently breaks cost aggregation (the `cost_records` trigger updates `sessions` by id). Kept non-fatal.

Prerequisite for **Phase 1** (wire the orphaned CostExtractor→CostReporter→cost_records pipeline into the live session loop so token totals actually move).

## Test Plan
- [x] CLI typecheck + apiSession test green
- [ ] CI (incl. Postgres Migrations applies 103 on fresh DB)
- [ ] Operator: `supabase db push` to apply 103 to prod

🤖 Shipped via /gh-ship